### PR TITLE
feat: companion collection + max-graduation loop (Phase 2)

### DIFF
--- a/Sources/TokenMac/Core/CompanionModel.swift
+++ b/Sources/TokenMac/Core/CompanionModel.swift
@@ -5,26 +5,55 @@ enum CompanionStateKind: String, Sendable {
     case egg, idle, working, focus, tired, sleep, levelUp
 }
 
-/// XP/레벨 밸런스 — 코드 상수가 아니라 한 곳의 테이블로 (README/설정 노출 대비)
+/// 고양이 변종 마킹 (Phase 2: 고양이 3종). 강아지/오브젝트는 후속 PR.
+enum CatMarking: String, Codable, Sendable {
+    case tabby       // 크림 태비 (Mochi)
+    case grayTabby   // 그레이 태비 (Smoke, Pusheen 풍)
+    case points      // 샴 — 다크 포인트 + 블루 눈 (Coco)
+}
+
+/// 카탈로그의 캐릭터 정의(트레이트). 인스턴스(실제 키우는 개체)와 분리.
+struct CompanionTraits: Sendable, Identifiable {
+    let id: String
+    let displayName: String
+    let marking: CatMarking
+    /// 희소도 — 낮을수록 흔함(먼저 부화). Phase 3 등급 가중의 씨앗.
+    let rarity: Int
+}
+
+enum CompanionCatalog {
+    static let all: [CompanionTraits] = [
+        CompanionTraits(id: "mochi", displayName: "Mochi", marking: .tabby, rarity: 0),
+        CompanionTraits(id: "smoke", displayName: "Smoke", marking: .grayTabby, rarity: 1),
+        CompanionTraits(id: "coco",  displayName: "Coco",  marking: .points, rarity: 1),
+    ]
+    static func traits(for id: String) -> CompanionTraits {
+        all.first { $0.id == id } ?? all[0]
+    }
+    /// 수집 단계: 미보유 중에서 희소도 낮은 군을 우선, 그 안에서 랜덤. 중복 없음.
+    static func nextUnowned(ownedIDs: Set<String>, using rng: inout any RandomNumberGenerator) -> CompanionTraits? {
+        let pool = all.filter { !ownedIDs.contains($0.id) }
+        guard let minRarity = pool.map(\.rarity).min() else { return nil }
+        let tier = pool.filter { $0.rarity == minRarity }
+        return tier[Int(rng.next() % UInt64(tier.count))]
+    }
+}
+
+/// XP/레벨 밸런스 — 한 곳의 테이블로.
 enum CompanionBalance {
     static let tokenXPDivisor = 1_000.0
     static let xpMultiplier = 4.0
     static let maxLevel = 50
 
-    /// 토큰량 → XP. sqrt 곡선 — 많이 쓰면 늘지만 선형은 아니다(10배 써도 10배 성장 X).
     static func xp(forTokens tokens: Int) -> Int {
         guard tokens > 0 else { return 0 }
         return Int((sqrt(Double(tokens) / tokenXPDivisor) * xpMultiplier).rounded(.down))
     }
-
-    /// 레벨 L 에 도달하기 위한 누적 XP. 레벨이 오를수록 필요 XP 증가.
     static func cumulativeXP(toReach level: Int) -> Int {
         let l = max(1, level)
         if l <= 1 { return 0 }
         return Int((20.0 * pow(Double(l - 1), 1.85)).rounded())
     }
-
-    /// 누적 XP → 레벨 (1...maxLevel).
     static func level(forXP xp: Int) -> Int {
         var lvl = 1
         while lvl < maxLevel && cumulativeXP(toReach: lvl + 1) <= xp { lvl += 1 }
@@ -32,16 +61,62 @@ enum CompanionBalance {
     }
 }
 
-/// 영속되는 캐릭터 상태(Application Support JSON).
-/// Phase 0/1 은 단일 캐릭터. ownedCompanions/eggInventory/등급은 Phase 2+ 에서 추가.
+/// 컬렉션에 보존되는 졸업(maxed) 개체. 도감 표시용.
+struct CompanionInstance: Codable, Sendable, Identifiable {
+    var id = UUID().uuidString
+    var companionID: String
+    var finalXP: Int
+    var maxed: Bool = true
+    var hatchedAt: Date?
+    var maxedAt: Date?
+    var level: Int { CompanionBalance.level(forXP: finalXP) }
+}
+
+/// 영속 상태. Phase 1(단일 totalXP) → Phase 2(active + collection) 마이그레이션 안전.
 struct CompanionState: Codable, Sendable {
-    var displayName = "Mochi"
-    var totalXP = 0
-    /// 오늘 이미 XP로 환산한 양(중복 지급 방지). 자정에 0으로 리셋.
+    // 토큰 적립 부기 (졸업과 무관하게 지속)
     var claimedTodayXP = 0
     var didApplyInitialBackfill = false
-    /// "오늘" 버킷 날짜(로컬). 바뀌면 claimedTodayXP 리셋.
     var lastDate = ""
     var streakDays = 0
     var hatched = false
+    // 현재 키우는 개체
+    var activeCompanionID = "mochi"
+    var activeXP = 0
+    // 졸업 보관함(도감)
+    var collection: [CompanionInstance] = []
+
+    init() {}
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        claimedTodayXP = try c.decodeIfPresent(Int.self, forKey: .claimedTodayXP) ?? 0
+        didApplyInitialBackfill = try c.decodeIfPresent(Bool.self, forKey: .didApplyInitialBackfill) ?? false
+        lastDate = try c.decodeIfPresent(String.self, forKey: .lastDate) ?? ""
+        streakDays = try c.decodeIfPresent(Int.self, forKey: .streakDays) ?? 0
+        hatched = try c.decodeIfPresent(Bool.self, forKey: .hatched) ?? false
+        activeCompanionID = try c.decodeIfPresent(String.self, forKey: .activeCompanionID) ?? "mochi"
+        // Phase 1 마이그레이션: 옛 totalXP → activeXP
+        activeXP = try c.decodeIfPresent(Int.self, forKey: .activeXP)
+            ?? c.decodeIfPresent(Int.self, forKey: .totalXP) ?? 0
+        collection = try c.decodeIfPresent([CompanionInstance].self, forKey: .collection) ?? []
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(claimedTodayXP, forKey: .claimedTodayXP)
+        try c.encode(didApplyInitialBackfill, forKey: .didApplyInitialBackfill)
+        try c.encode(lastDate, forKey: .lastDate)
+        try c.encode(streakDays, forKey: .streakDays)
+        try c.encode(hatched, forKey: .hatched)
+        try c.encode(activeCompanionID, forKey: .activeCompanionID)
+        try c.encode(activeXP, forKey: .activeXP)
+        try c.encode(collection, forKey: .collection)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case claimedTodayXP, didApplyInitialBackfill, lastDate, streakDays, hatched
+        case activeCompanionID, activeXP, collection
+        case totalXP   // legacy(Phase 1) — decode 전용
+    }
 }

--- a/Sources/TokenMac/Core/CompanionStore.swift
+++ b/Sources/TokenMac/Core/CompanionStore.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Observation
 
-/// 게임 상태의 출처. UsageStore(사용량 출처)의 값을 읽어 XP/레벨/표시 상태를 갱신한다.
-/// 성장/해금 로직을 UsageStore 에 넣지 않고 분리.
+/// 게임 상태의 출처. UsageStore(사용량 출처)의 값을 읽어 현재 active 캐릭터에 XP/레벨을 적립하고,
+/// max 도달 시 Collection 으로 졸업 + 미보유 캐릭터로 새 알 부화.
 @MainActor
 @Observable
 final class CompanionStore {
@@ -11,16 +11,20 @@ final class CompanionStore {
     private(set) var todayXP = 0
     private(set) var displayState: CompanionStateKind = .egg
     private(set) var justLeveledUp = false
+    /// 직전 졸업한 캐릭터 이름(새 알 안내 문구용). nil 이면 졸업 없음.
+    private(set) var justGraduated: String?
     private var levelUpUntil: Date?
 
     private let clock: () -> Date
     private let fileURL: URL
+    private var rng: any RandomNumberGenerator
 
-    var name: String { state.displayName }
+    var activeTraits: CompanionTraits { CompanionCatalog.traits(for: state.activeCompanionID) }
+    var name: String { activeTraits.displayName }
     var isMaxed: Bool { level >= CompanionBalance.maxLevel }
+    var collectionInstances: [CompanionInstance] { state.collection }
 
-    /// 현재 레벨 진행분 / 다음 레벨까지
-    var xpIntoLevel: Int { state.totalXP - CompanionBalance.cumulativeXP(toReach: level) }
+    var xpIntoLevel: Int { state.activeXP - CompanionBalance.cumulativeXP(toReach: level) }
     var xpForNextLevel: Int {
         guard !isMaxed else { return max(1, xpIntoLevel) }
         return CompanionBalance.cumulativeXP(toReach: level + 1) - CompanionBalance.cumulativeXP(toReach: level)
@@ -29,20 +33,20 @@ final class CompanionStore {
         guard xpForNextLevel > 0 else { return 1 }
         return min(1, max(0, Double(xpIntoLevel) / Double(xpForNextLevel)))
     }
-    /// 다음 레벨까지 남은 토큰 추정 — 팝오버 "다음 낮잠 자리까지 N tokens"
     var tokensToNextLevel: Int {
         guard !isMaxed else { return 0 }
-        let needXP = max(0, CompanionBalance.cumulativeXP(toReach: level + 1) - state.totalXP)
-        // xp = sqrt(tok/divisor)*mult  →  tok = (xp/mult)^2 * divisor
+        let needXP = max(0, CompanionBalance.cumulativeXP(toReach: level + 1) - state.activeXP)
         let x = Double(needXP) / CompanionBalance.xpMultiplier
         return Int((x * x * CompanionBalance.tokenXPDivisor).rounded())
     }
 
-    init(clock: @escaping () -> Date = Date.init, fileURL: URL? = nil) {
+    init(clock: @escaping () -> Date = Date.init, fileURL: URL? = nil,
+         rng: any RandomNumberGenerator = SystemRandomNumberGenerator()) {
         self.clock = clock
         self.fileURL = fileURL ?? Self.defaultURL()
+        self.rng = rng
         load()
-        level = CompanionBalance.level(forXP: state.totalXP)
+        level = CompanionBalance.level(forXP: state.activeXP)
         if state.hatched { displayState = .idle }
     }
 
@@ -53,53 +57,69 @@ final class CompanionStore {
         return dir.appendingPathComponent("companion-state.json")
     }
 
-    /// UsageStore 갱신 후 호출. 토큰 증분 → XP, 표시 상태 결정. 중복 지급 없음.
     func update(todayTokens: Int, todayDate: String, monthTotal: Int,
                 burnTier: SpinTier, limitWarning: Bool, hasUsageData: Bool) {
+        justGraduated = nil   // 이번 update 에서 졸업했을 때만 설정
         let prevLevel = level
         let isBackfillNow = !state.didApplyInitialBackfill
 
         if !state.didApplyInitialBackfill {
-            // 데이터 도착 전(앱 기동 직후 빈 새로고침)에는 부화/소급하지 않는다 — 알 유지.
-            // 이걸 막지 않으면 빈 데이터로 backfill 이 소진돼 기존 사용량 소급 성장이 사라진다.
             guard hasUsageData, monthTotal > 0 || todayTokens > 0 else {
                 displayState = .egg
                 return
             }
-            // 최초 소급: 월 누적으로 초기 레벨 부여(근사), 알 부화
-            state.totalXP = CompanionBalance.xp(forTokens: max(monthTotal, todayTokens))
+            state.activeXP = CompanionBalance.xp(forTokens: max(monthTotal, todayTokens))
             state.claimedTodayXP = CompanionBalance.xp(forTokens: todayTokens)
             state.lastDate = todayDate
             state.didApplyInitialBackfill = true
-            state.hatched = todayTokens > 0 || monthTotal > 0
+            state.hatched = true
         } else {
-            if todayDate != state.lastDate {           // 자정 경계
+            if todayDate != state.lastDate {
                 state.lastDate = todayDate
                 state.claimedTodayXP = 0
                 if todayTokens > 0 { state.streakDays += 1 }
             }
-            // 오늘 XP 증분만 적립 (sqrt 곡선 일관성 유지)
             let todayXPNow = CompanionBalance.xp(forTokens: todayTokens)
             if todayXPNow > state.claimedTodayXP {
-                state.totalXP += todayXPNow - state.claimedTodayXP
+                state.activeXP += todayXPNow - state.claimedTodayXP
                 state.claimedTodayXP = todayXPNow
                 state.hatched = true
             }
         }
 
-        level = CompanionBalance.level(forXP: state.totalXP)
-        todayXP = CompanionBalance.xp(forTokens: todayTokens)
+        level = CompanionBalance.level(forXP: state.activeXP)
 
-        if level > prevLevel && !isBackfillNow {   // 최초 소급 부화는 레벨업 연출 아님
+        // Max → 졸업 + 새 알 (소급 부화 시엔 졸업 보류, 다음 실제 갱신에서)
+        if level >= CompanionBalance.maxLevel && !isBackfillNow {
+            graduateIfPossible()
+        } else if level > prevLevel && !isBackfillNow {
             justLeveledUp = true
             levelUpUntil = clock().addingTimeInterval(4)
         } else if let until = levelUpUntil, clock() > until {
             justLeveledUp = false; levelUpUntil = nil
         }
 
+        todayXP = CompanionBalance.xp(forTokens: todayTokens)
         displayState = computeState(burnTier: burnTier, limitWarning: limitWarning,
                                     hasUsageData: hasUsageData, today: todayTokens)
         save()
+    }
+
+    /// active 가 max 도달: Collection 으로 보존하고 미보유 캐릭터로 새 알. 미보유 없으면 maxed 유지.
+    private func graduateIfPossible() {
+        let owned = Set(state.collection.map(\.companionID)).union([state.activeCompanionID])
+        guard let next = CompanionCatalog.nextUnowned(ownedIDs: owned, using: &rng) else {
+            return   // 모든 기본 캐릭터 보유 — maxed 유지(중복/등급은 Phase 3)
+        }
+        state.collection.append(CompanionInstance(
+            companionID: state.activeCompanionID, finalXP: state.activeXP,
+            maxed: true, hatchedAt: nil, maxedAt: clock()))
+        justGraduated = name
+        state.activeCompanionID = next.id
+        state.activeXP = 0
+        level = 1
+        justLeveledUp = true
+        levelUpUntil = clock().addingTimeInterval(5)
     }
 
     private func computeState(burnTier: SpinTier, limitWarning: Bool,
@@ -115,7 +135,6 @@ final class CompanionStore {
         }
     }
 
-    // MARK: 영속
     private func load() {
         guard let data = try? Data(contentsOf: fileURL),
               let s = try? JSONDecoder().decode(CompanionState.self, from: data) else { return }

--- a/Sources/TokenMac/TokenMacApp.swift
+++ b/Sources/TokenMac/TokenMacApp.swift
@@ -109,8 +109,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func renderCompanionFrame() {
         statusItem.button?.image = CompanionRenderer.image(
-            size: 20, state: companion.displayState, level: companion.level,
-            time: Date().timeIntervalSinceReferenceDate)
+            size: 20, traits: companion.activeTraits, state: companion.displayState,
+            level: companion.level, time: Date().timeIntervalSinceReferenceDate)
     }
 
     /// 코인 스핀 — 프레임별 지속시간으로 이징 표현, 캐시된 NSImage 교체만 수행.

--- a/Sources/TokenMac/UI/CompanionRenderer.swift
+++ b/Sources/TokenMac/UI/CompanionRenderer.swift
@@ -1,38 +1,53 @@
 import AppKit
 
 /// 캐릭터 렌더러 — 코드 드로잉(Core Graphics). PNG 스프라이트 없음.
-/// Phase 1 은 기본 캐릭터 Mochi(크림 태비 고양이) 1종. 로스터 확장은 Phase 2+.
-/// 좌표계는 64x64 y-down (프리뷰 JS 엔진과 동일), 표시 크기로 스케일.
+/// Phase 2: 고양이 3변종(트레이트로 팔레트/마킹 분기). 강아지/오브젝트는 후속 PR.
+/// 좌표계 64x64 y-down (프리뷰 JS 엔진과 동일).
 enum CompanionRenderer {
     private static let SZ: CGFloat = 64
 
-    // Mochi(크림) 팔레트
-    private static let o  = hex(0x6f6760), C = hex(0xF7EFE1), S = hex(0xEADCC4)
-    private static let H  = hex(0xFFFFFF), ear = hex(0xF0B7B3), blush = hex(0xF6CCC6)
-    private static let E  = hex(0x6a615c), B = hex(0x8FC0F2), Bd = hex(0xC2E0FF)
-    private static let A  = hex(0xF4C863), stripe = hex(0xE3CFA9)
+    struct Pal {
+        let o, C, S, H, ear, blush, eye, stripe, point: CGColor
+        let stripes: Bool      // 태비 줄무늬
+        let points: Bool       // 샴 다크 포인트(귀/얼굴 마스크)
+    }
 
-    static func image(size: CGFloat, state: CompanionStateKind, level: Int, time: TimeInterval) -> NSImage {
+    private static func palette(_ marking: CatMarking) -> Pal {
+        switch marking {
+        case .tabby:
+            return Pal(o: hex(0x6f6760), C: hex(0xF7EFE1), S: hex(0xEADCC4), H: hex(0xFFFFFF),
+                       ear: hex(0xF0B7B3), blush: hex(0xF6CCC6), eye: hex(0x6a615c),
+                       stripe: hex(0xE3CFA9), point: hex(0x6b5240), stripes: true, points: false)
+        case .grayTabby:
+            return Pal(o: hex(0x74747e), C: hex(0xC5C9D1), S: hex(0xABB1BB), H: hex(0xFFFFFF),
+                       ear: hex(0xF0B7B3), blush: hex(0xF3C3BE), eye: hex(0x5f5d66),
+                       stripe: hex(0x9AA0AB), point: hex(0x6b5240), stripes: true, points: false)
+        case .points:
+            return Pal(o: hex(0x7a6b5f), C: hex(0xF1E7D4), S: hex(0xE0D0B6), H: hex(0xFFFFFF),
+                       ear: hex(0xCAA79A), blush: hex(0xEFC8C0), eye: hex(0x6f9fd8),
+                       stripe: hex(0xE3CFA9), point: hex(0x6b5240), stripes: false, points: true)
+        }
+    }
+
+    static func image(size: CGFloat, traits: CompanionTraits, state: CompanionStateKind,
+                      level: Int, time: TimeInterval) -> NSImage {
+        let pal = palette(traits.marking)
         let img = NSImage(size: NSSize(width: size, height: size))
         img.lockFocus()
         if let ctx = NSGraphicsContext.current?.cgContext {
             ctx.saveGState()
             ctx.interpolationQuality = .high
             let s = size / SZ
-            ctx.translateBy(x: 0, y: size)      // y-down 64좌표로
-            ctx.scaleBy(x: s, y: -s)
-            ctx.setLineJoin(.round)
-            draw(ctx, state: state, t: time)
+            ctx.translateBy(x: 0, y: size); ctx.scaleBy(x: s, y: -s); ctx.setLineJoin(.round)
+            draw(ctx, pal: pal, state: state, t: time)
             ctx.restoreGState()
         }
         img.unlockFocus()
         return img
     }
 
-    // MARK: 엔진
-
-    private static func draw(_ ctx: CGContext, state: CompanionStateKind, t T: TimeInterval) {
-        if state == .egg { drawEgg(ctx, T); return }
+    private static func draw(_ ctx: CGContext, pal: Pal, state: CompanionStateKind, t T: TimeInterval) {
+        if state == .egg { drawEgg(ctx, pal, T); return }
 
         var breathe = 0.0, bounce = 0.0, sway = sin(T * 1.2) * 3, tw = 0.0, loaf = 0.0
         var eye = "open"; var earUp = false, droop = false
@@ -44,7 +59,7 @@ enum CompanionRenderer {
             tw = sin(T * 0.7) * 0.8; sway = sin(T * 1.0) * 3
         case .working:
             bounce = abs(sin(T * 3.2)) * 1.6; breathe = sin(T * 3.2) * 0.5
-            tw = sin(T * 5.5) * 1.0; sway = sin(T * 3.6) * 4
+            tw = sin(T * 5.5); sway = sin(T * 3.6) * 4
         case .focus:
             earUp = true; bounce = abs(sin(T * 6)) * 0.9; breathe = sin(T * 6) * 0.4
             sway = sin(T * 5) * 4.5; charm = sin(T * 6) > 0
@@ -62,34 +77,35 @@ enum CompanionRenderer {
         ctx.translateBy(x: 0, y: -bounce)
         let cx = 32.0, cy = 35 + loaf * 0.5, rx = 21 + loaf, ry = 17 - loaf * 0.6 + breathe
 
-        drawTail(ctx, cx, cy, rx, ry, sway, droop)
-        drawBody(ctx, cx, cy, rx, ry, earUp, droop, tw)
-        drawStripes(ctx, cx, cy, rx, ry)
-        drawFace(ctx, cx, cy, rx, ry, eye)
-        fillEll(ctx, cx, cy + ry * 0.62, 2.4, 2.4, charm ? Bd : B); strokeEll(ctx, cx, cy + ry * 0.62, 2.4, 2.4, o, 1)
-        if sweat { fillEll(ctx, cx + rx * 0.62, cy - ry * 0.44, 1.8, 2.6, A) }
-        if z { drawZ(ctx, cx + rx * 0.6, cy - ry - 3) }
-        if sparkle { drawSparkles(ctx, T) }
+        drawTail(ctx, pal, cx, cy, rx, ry, sway, droop)
+        drawBody(ctx, pal, cx, cy, rx, ry, earUp, droop, tw)
+        if pal.stripes { drawStripes(ctx, pal, cx, cy, rx, ry) }
+        drawFace(ctx, pal, cx, cy, rx, ry, eye)
+        fillEll(ctx, cx, cy + ry * 0.62, 2.4, 2.4, charm ? hex(0xC2E0FF) : hex(0x8FC0F2))
+        strokeEll(ctx, cx, cy + ry * 0.62, 2.4, 2.4, pal.o, 1)
+        if sweat { fillEll(ctx, cx + rx * 0.62, cy - ry * 0.44, 1.8, 2.6, hex(0xF4C863)) }
+        if z { drawZ(ctx, pal, cx + rx * 0.6, cy - ry - 3) }
+        if sparkle { drawSparkles(ctx, cx, cy, T) }
     }
 
-    private static func drawBody(_ ctx: CGContext, _ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double,
+    private static func drawBody(_ ctx: CGContext, _ pal: Pal, _ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double,
                                  _ up: Bool, _ droop: Bool, _ tw: Double) {
-        // 1) 어두운 통합 실루엣(귀+몸 부풀려)
-        fillPath(ctx, earPath(cx, cy, rx, ry, -1, up, droop, tw, 1.8), o)
-        fillPath(ctx, earPath(cx, cy, rx, ry,  1, up, droop, tw, 1.8), o)
-        fillEll(ctx, cx, cy, rx + 1.7, ry + 1.7, o)
-        // 2) 몸
-        fillEll(ctx, cx, cy, rx, ry, C)
-        // 3) 바닥 그림자
+        fillPath(ctx, earPath(cx, cy, rx, ry, -1, up, droop, tw, 1.8), pal.o)
+        fillPath(ctx, earPath(cx, cy, rx, ry,  1, up, droop, tw, 1.8), pal.o)
+        fillEll(ctx, cx, cy, rx + 1.7, ry + 1.7, pal.o)
+        fillEll(ctx, cx, cy, rx, ry, pal.C)
         ctx.saveGState()
         ctx.addPath(ellPath(cx, cy, rx, ry)); ctx.clip()
-        ctx.setAlpha(0.5); ctx.setFillColor(S); ctx.fill(CGRect(x: 0, y: cy + ry * 0.5, width: SZ, height: SZ))
+        ctx.setAlpha(0.5); ctx.setFillColor(pal.S); ctx.fill(CGRect(x: 0, y: cy + ry * 0.5, width: SZ, height: SZ))
         ctx.restoreGState()
-        // 4) 뾰족 귀(통합) + 안쪽 핑크
-        fillPath(ctx, earPath(cx, cy, rx, ry, -1, up, droop, tw, 0), C)
-        fillPath(ctx, earPath(cx, cy, rx, ry,  1, up, droop, tw, 0), C)
-        fillPath(ctx, innerEar(cx, cy, rx, ry, -1, up, droop, tw), ear)
-        fillPath(ctx, innerEar(cx, cy, rx, ry,  1, up, droop, tw), ear)
+        // 뾰족 귀: 샴은 다크 포인트, 그 외 크림 + 안쪽 핑크
+        let earFill = pal.points ? pal.point : pal.C
+        fillPath(ctx, earPath(cx, cy, rx, ry, -1, up, droop, tw, 0), earFill)
+        fillPath(ctx, earPath(cx, cy, rx, ry,  1, up, droop, tw, 0), earFill)
+        if !pal.points {
+            fillPath(ctx, innerEar(cx, cy, rx, ry, -1, up, droop, tw), pal.ear)
+            fillPath(ctx, innerEar(cx, cy, rx, ry,  1, up, droop, tw), pal.ear)
+        }
     }
 
     private static func earPath(_ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double,
@@ -119,102 +135,104 @@ enum CompanionRenderer {
         return p
     }
 
-    private static func drawStripes(_ ctx: CGContext, _ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double) {
+    private static func drawStripes(_ ctx: CGContext, _ pal: Pal, _ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double) {
         let y0 = cy - ry * 0.52, len = ry * 0.22
         for dx in [-rx * 0.26, 0, rx * 0.26] {
-            strokeLine(ctx, [CGPoint(x: cx + dx, y: y0), CGPoint(x: cx + dx * 1.18, y: y0 + len)], stripe, 2.2)
+            strokeLine(ctx, [CGPoint(x: cx + dx, y: y0), CGPoint(x: cx + dx * 1.18, y: y0 + len)], pal.stripe, 2.2)
         }
     }
 
-    private static func drawTail(_ ctx: CGContext, _ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double,
+    private static func drawTail(_ ctx: CGContext, _ pal: Pal, _ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double,
                                  _ sway: Double, _ droop: Bool) {
         let bx = cx + rx * 0.72, by = cy + ry * 0.42, c0 = cx + rx * 1.2
         let tx = cx + rx * (droop ? 0.96 : 1.12) + sway * 0.5, ty = (droop ? cy + ry * 0.62 : cy - ry * 0.42) + sway * 0.7
         let q = CGMutablePath(); q.move(to: CGPoint(x: bx, y: by))
         q.addQuadCurve(to: CGPoint(x: tx, y: ty), control: CGPoint(x: c0, y: cy))
-        strokePath(ctx, q, o, 6); strokePath(ctx, q, C, 3.4)
-        // 태비 꼬리 줄
-        for tparam in [0.5, 0.78] {
-            let u = 1 - tparam
-            let qx = u * u * bx + 2 * u * tparam * c0 + tparam * tparam * tx
-            let qy = u * u * by + 2 * u * tparam * cy + tparam * tparam * ty
-            strokeLine(ctx, [CGPoint(x: qx - 2.2, y: qy), CGPoint(x: qx + 2.2, y: qy)], stripe, 2)
+        strokePath(ctx, q, pal.o, 6); strokePath(ctx, q, pal.C, 3.4)
+        if pal.stripes {
+            for tparam in [0.5, 0.78] {
+                let u = 1 - tparam
+                let qx = u * u * bx + 2 * u * tparam * c0 + tparam * tparam * tx
+                let qy = u * u * by + 2 * u * tparam * cy + tparam * tparam * ty
+                strokeLine(ctx, [CGPoint(x: qx - 2.2, y: qy), CGPoint(x: qx + 2.2, y: qy)], pal.stripe, 2)
+            }
         }
     }
 
-    private static func drawFace(_ ctx: CGContext, _ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double, _ eye: String) {
+    private static func drawFace(_ ctx: CGContext, _ pal: Pal, _ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double, _ eye: String) {
         let fy = cy + ry * 0.12, eyeDX = rx * 0.40
         ctx.saveGState(); ctx.setAlpha(0.4)
-        fillEll(ctx, cx - rx * 0.6, fy + 3, 3.2, 2.1, blush); fillEll(ctx, cx + rx * 0.6, fy + 3, 3.2, 2.1, blush)
+        fillEll(ctx, cx - rx * 0.6, fy + 3, 3.2, 2.1, pal.blush); fillEll(ctx, cx + rx * 0.6, fy + 3, 3.2, 2.1, pal.blush)
         ctx.restoreGState()
-        // 수염
-        for sd in [-1.0, 1.0] {
-            strokeLine(ctx, [CGPoint(x: cx + sd * rx * 0.46, y: fy + 2), CGPoint(x: cx + sd * rx * 0.82, y: fy + 1)], S, 1)
-            strokeLine(ctx, [CGPoint(x: cx + sd * rx * 0.46, y: fy + 4), CGPoint(x: cx + sd * rx * 0.82, y: fy + 5)], S, 1)
+        if pal.points {   // 샴 얼굴 마스크
+            ctx.saveGState(); ctx.setAlpha(0.42)
+            fillEll(ctx, cx, fy + ry * 0.2, rx * 0.5, ry * 0.42, pal.point)
+            ctx.restoreGState()
         }
-        drawEye(ctx, cx - eyeDX, fy, eye); drawEye(ctx, cx + eyeDX, fy, eye)
-        // 코
+        for sd in [-1.0, 1.0] {
+            strokeLine(ctx, [CGPoint(x: cx + sd * rx * 0.46, y: fy + 2), CGPoint(x: cx + sd * rx * 0.82, y: fy + 1)], pal.S, 1)
+            strokeLine(ctx, [CGPoint(x: cx + sd * rx * 0.46, y: fy + 4), CGPoint(x: cx + sd * rx * 0.82, y: fy + 5)], pal.S, 1)
+        }
+        drawEye(ctx, pal, cx - eyeDX, fy, eye); drawEye(ctx, pal, cx + eyeDX, fy, eye)
         let n = CGMutablePath()
         n.move(to: CGPoint(x: cx - 1.7, y: fy + 4)); n.addLine(to: CGPoint(x: cx + 1.7, y: fy + 4))
         n.addLine(to: CGPoint(x: cx, y: fy + 5.8)); n.closeSubpath()
-        fillPath(ctx, n, ear)
-        // 미소
+        fillPath(ctx, n, pal.ear)
         if eye != "closed" {
             let m = CGMutablePath(); m.move(to: CGPoint(x: cx - 2.0, y: fy + 7))
             m.addQuadCurve(to: CGPoint(x: cx + 2.0, y: fy + 7), control: CGPoint(x: cx, y: fy + 8.5))
-            strokePath(ctx, m, o, 1.2)
+            strokePath(ctx, m, pal.o, 1.2)
         }
     }
 
-    private static func drawEye(_ ctx: CGContext, _ x: Double, _ y: Double, _ mode: String) {
+    private static func drawEye(_ ctx: CGContext, _ pal: Pal, _ x: Double, _ y: Double, _ mode: String) {
         if mode == "closed" || mode == "half" {
             let dip = mode == "closed" ? 2.6 : 1.2
             let p = CGMutablePath(); p.move(to: CGPoint(x: x - 2.8, y: y))
             p.addQuadCurve(to: CGPoint(x: x + 2.8, y: y), control: CGPoint(x: x, y: y + dip))
-            strokePath(ctx, p, E, 2.0); return
+            strokePath(ctx, p, pal.eye, 2.0); return
         }
         let ery = mode == "blink" ? 0.6 : mode == "wide" ? 3.9 : mode == "narrow" ? 2.4 : 3.2
-        fillEll(ctx, x, y, 2.6, ery, E)
+        fillEll(ctx, x, y, 2.6, ery, pal.eye)
         if mode != "blink" {
-            fillEll(ctx, x - 0.9, y - ery * 0.42, 1.2, 1.4, H)
-            fillEll(ctx, x + 0.9, y + ery * 0.34, 0.55, 0.62, H)
+            fillEll(ctx, x - 0.9, y - ery * 0.42, 1.2, 1.4, pal.H)
+            fillEll(ctx, x + 0.9, y + ery * 0.34, 0.55, 0.62, pal.H)
         }
     }
 
-    private static func drawZ(_ ctx: CGContext, _ x: Double, _ y: Double) {
+    private static func drawZ(_ ctx: CGContext, _ pal: Pal, _ x: Double, _ y: Double) {
         for (s, off) in [(4.4, 0.0), (3.0, 6.0)] {
             strokeLine(ctx, [CGPoint(x: x + off, y: y + off), CGPoint(x: x + off + s, y: y + off),
-                             CGPoint(x: x + off, y: y + off + s), CGPoint(x: x + off + s, y: y + off + s)], o, 1.6)
+                             CGPoint(x: x + off, y: y + off + s), CGPoint(x: x + off + s, y: y + off + s)], pal.o, 1.6)
         }
     }
 
-    private static func drawSparkles(_ ctx: CGContext, _ T: TimeInterval) {
+    private static func drawSparkles(_ ctx: CGContext, _ cx: Double, _ cy: Double, _ T: TimeInterval) {
         for (x, y, ph) in [(14.0, 12.0, 0.0), (50.0, 16.0, 1.4), (34.0, 7.0, 2.6)] {
             let s = 1.4 + abs(sin(T * 4 + ph)) * 1.8
-            strokeLine(ctx, [CGPoint(x: x - s, y: y), CGPoint(x: x + s, y: y)], A, 1.5)
-            strokeLine(ctx, [CGPoint(x: x, y: y - s), CGPoint(x: x, y: y + s)], A, 1.5)
+            strokeLine(ctx, [CGPoint(x: x - s, y: y), CGPoint(x: x + s, y: y)], hex(0xF4C863), 1.5)
+            strokeLine(ctx, [CGPoint(x: x, y: y - s), CGPoint(x: x, y: y + s)], hex(0xF4C863), 1.5)
         }
     }
 
-    private static func drawEgg(_ ctx: CGContext, _ T: TimeInterval) {
+    private static func drawEgg(_ ctx: CGContext, _ pal: Pal, _ T: TimeInterval) {
         let cx = 32.0
         ctx.saveGState(); ctx.translateBy(x: cx, y: 40); ctx.rotate(by: sin(T * 2.6) * 0.06); ctx.translateBy(x: -cx, y: -40)
         let outer = CGMutablePath(); outer.move(to: CGPoint(x: cx, y: 18))
         outer.addCurve(to: CGPoint(x: cx, y: 55), control1: CGPoint(x: cx + 16, y: 21), control2: CGPoint(x: cx + 17, y: 55))
         outer.addCurve(to: CGPoint(x: cx, y: 18), control1: CGPoint(x: cx - 17, y: 55), control2: CGPoint(x: cx - 16, y: 21))
-        fillPath(ctx, outer, o)
+        fillPath(ctx, outer, pal.o)
         let inner = CGMutablePath(); inner.move(to: CGPoint(x: cx, y: 19.6))
         inner.addCurve(to: CGPoint(x: cx, y: 53.4), control1: CGPoint(x: cx + 14.4, y: 22.4), control2: CGPoint(x: cx + 15.3, y: 53.4))
         inner.addCurve(to: CGPoint(x: cx, y: 19.6), control1: CGPoint(x: cx - 14.4, y: 53.4), control2: CGPoint(x: cx - 15.3, y: 22.4))
-        fillPath(ctx, inner, C)
-        fillEll(ctx, cx - 6, 28, 2, 2.8, H)
+        fillPath(ctx, inner, pal.C)
+        fillEll(ctx, cx - 6, 28, 2, 2.8, pal.H)
         let on = sin(T * 3.4) > 0, r = 2.8 + sin(T * 3.4) * 0.8
-        fillEll(ctx, cx, 40, r, r, on ? Bd : B)
+        fillEll(ctx, cx, 40, r, r, on ? hex(0xC2E0FF) : hex(0x8FC0F2))
         ctx.restoreGState()
     }
 
-    // MARK: 저수준 헬퍼
-
+    // MARK: 저수준
     private static func hex(_ v: Int) -> CGColor {
         NSColor(srgbRed: CGFloat((v >> 16) & 0xff) / 255, green: CGFloat((v >> 8) & 0xff) / 255,
                 blue: CGFloat(v & 0xff) / 255, alpha: 1).cgColor

--- a/Sources/TokenMac/UI/CompanionView.swift
+++ b/Sources/TokenMac/UI/CompanionView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// 팝오버용 캐릭터 애니메이션 뷰 — 상태에 따라 코드 드로잉된 NSImage 를 ~12fps 로 갱신.
+/// 팝오버용 active 캐릭터 애니메이션 — 상태별 코드 드로잉 NSImage 를 ~12fps 로 갱신.
 struct CompanionView: View {
     let store: CompanionStore
     var size: CGFloat = 88
@@ -8,12 +8,22 @@ struct CompanionView: View {
     var body: some View {
         TimelineView(.periodic(from: .now, by: 1.0 / 12.0)) { context in
             Image(nsImage: CompanionRenderer.image(
-                size: size,
-                state: store.displayState,
-                level: store.level,
-                time: context.date.timeIntervalSinceReferenceDate))
+                size: size, traits: store.activeTraits, state: store.displayState,
+                level: store.level, time: context.date.timeIntervalSinceReferenceDate))
             .frame(width: size, height: size)
         }
+        .frame(width: size, height: size)
+    }
+}
+
+/// 컬렉션 도감용 정적 썸네일(idle 포즈, 애니메이션 없음).
+struct CompanionThumbnail: View {
+    let traits: CompanionTraits
+    var level: Int = 1
+    var size: CGFloat = 52
+    var body: some View {
+        Image(nsImage: CompanionRenderer.image(
+            size: size, traits: traits, state: .idle, level: level, time: 0.4))
         .frame(width: size, height: size)
     }
 }
@@ -23,41 +33,88 @@ struct CompanionHeader: View {
     let store: CompanionStore
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            CompanionView(store: store, size: 72)
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(store.name).font(.callout.weight(.semibold))
-                    Text(store.isMaxed ? "Lv. \(store.level) · MAX" : "Lv. \(store.level)")
-                        .font(.caption).foregroundStyle(.secondary)
-                }
-                ProgressView(value: store.levelProgress)
-                    .controlSize(.small)
-                    .tint(.orange)
-                HStack(spacing: 8) {
-                    if store.todayXP > 0 {
-                        Text("오늘 +\(store.todayXP) XP").font(.caption2).foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 12) {
+                CompanionView(store: store, size: 72)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text(store.name).font(.callout.weight(.semibold))
+                        Text(store.isMaxed ? "Lv. \(store.level) · MAX" : "Lv. \(store.level)")
+                            .font(.caption).foregroundStyle(.secondary)
                     }
-                    if !store.isMaxed, store.tokensToNextLevel > 0 {
-                        Text("다음 레벨까지 \(TokenFormatter.compact(store.tokensToNextLevel))")
-                            .font(.caption2).foregroundStyle(.tertiary)
+                    ProgressView(value: store.levelProgress).controlSize(.small).tint(.orange)
+                    HStack(spacing: 8) {
+                        if store.todayXP > 0 {
+                            Text("오늘 +\(store.todayXP) XP").font(.caption2).foregroundStyle(.secondary)
+                        }
+                        if !store.isMaxed, store.tokensToNextLevel > 0 {
+                            Text("다음 레벨까지 \(TokenFormatter.compact(store.tokensToNextLevel))")
+                                .font(.caption2).foregroundStyle(.tertiary)
+                        }
                     }
+                    Text(statusLine).font(.caption2).foregroundStyle(.secondary)
                 }
-                Text(statusLine).font(.caption2).foregroundStyle(.secondary)
+                Spacer()
             }
-            Spacer()
+            if let graduated = store.justGraduated {
+                Text("\(graduated)가 졸업했어요. 새 Token Egg가 도착했어요!")
+                    .font(.caption2).foregroundStyle(.orange)
+            }
         }
     }
 
     private var statusLine: String {
         switch store.displayState {
-        case .egg:    return "곧 깨어나요."
-        case .idle:   return "오늘은 조용히 자리를 지켜요."
+        case .egg:     return "곧 깨어나요."
+        case .idle:    return "오늘은 조용히 자리를 지켜요."
         case .working: return "오늘의 작업 흔적이 쌓이고 있어요."
-        case .focus:  return "지금은 집중 모드예요."
-        case .tired:  return "한도에 가까워요. 잠깐 쉬어도 괜찮아요."
-        case .sleep:  return "지금은 자고 있어요."
+        case .focus:   return "지금은 집중 모드예요."
+        case .tired:   return "한도에 가까워요. 잠깐 쉬어도 괜찮아요."
+        case .sleep:   return "지금은 자고 있어요."
         case .levelUp: return "\(store.name)가 한 단계 자랐어요!"
         }
+    }
+}
+
+/// Collection 탭 — 졸업 보관함 도감 + 현재 키우는 캐릭터.
+struct CollectionView: View {
+    let store: CompanionStore
+    private let cols = [GridItem(.adaptive(minimum: 84), spacing: 10)]
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: cols, spacing: 10) {
+                // 현재 active
+                cell(traits: store.activeTraits, level: store.level, maxed: store.isMaxed, active: true)
+                // 졸업 보관함
+                ForEach(store.collectionInstances) { inst in
+                    cell(traits: CompanionCatalog.traits(for: inst.companionID),
+                         level: inst.level, maxed: inst.maxed, active: false)
+                }
+            }
+            .padding(.vertical, 4)
+            Text("토큰을 먹고 자라요. max 달성 캐릭터는 여기 보존돼요.")
+                .font(.caption2).foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxHeight: 240)
+    }
+
+    private func cell(traits: CompanionTraits, level: Int, maxed: Bool, active: Bool) -> some View {
+        VStack(spacing: 2) {
+            ZStack(alignment: .topTrailing) {
+                CompanionThumbnail(traits: traits, level: level, size: 52)
+                if maxed {
+                    Image(systemName: "crown.fill").font(.system(size: 9))
+                        .foregroundStyle(.yellow).padding(2)
+                }
+            }
+            Text(traits.displayName).font(.caption2)
+            Text(active ? "Lv. \(level)" : "Lv. \(level) · MAX")
+                .font(.system(size: 9)).foregroundStyle(.secondary)
+        }
+        .padding(6)
+        .background(active ? Color.orange.opacity(0.10) : Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 }

--- a/Sources/TokenMac/UI/PopoverView.swift
+++ b/Sources/TokenMac/UI/PopoverView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
 
+enum PopoverTab { case home, collection }
+
 struct PopoverView: View {
     @Environment(UsageStore.self) private var store
     @Environment(CompanionStore.self) private var companion
     @State private var showSettings = false
+    @State private var tab: PopoverTab = .home
 
     var body: some View {
         // NOTE: 설정을 .sheet 로 띄우면 transient 팝오버가 닫힐 때 시트가 고아로 남아
@@ -21,13 +24,24 @@ struct PopoverView: View {
 
     private var mainContent: some View {
         VStack(alignment: .leading, spacing: 12) {
-            CompanionHeader(store: companion)
-            Divider()
-            header
-            Divider()
-            if store.hasAnyLimits {
-                limitsSection
+            Picker("", selection: $tab) {
+                Text("홈").tag(PopoverTab.home)
+                Text("컬렉션").tag(PopoverTab.collection)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            if tab == .collection {
+                CollectionView(store: companion)
+            } else {
+                CompanionHeader(store: companion)
                 Divider()
+                header
+                Divider()
+                if store.hasAnyLimits {
+                    limitsSection
+                    Divider()
+                }
             }
             footer
         }

--- a/Tests/TokenMacTests/CompanionTests.swift
+++ b/Tests/TokenMacTests/CompanionTests.swift
@@ -30,13 +30,28 @@ final class CompanionBalanceTests: XCTestCase {
     }
 }
 
+/// 결정론적 RNG (졸업 추첨 테스트용)
+struct SeededRNG: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
 @MainActor
 final class CompanionStoreTests: XCTestCase {
     private func tempStore(now: Date = Date(timeIntervalSince1970: 1_700_000_000)) -> CompanionStore {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("companion-test-\(UUID().uuidString).json")
-        return CompanionStore(clock: { now }, fileURL: url)
+        return CompanionStore(clock: { now }, fileURL: url, rng: SeededRNG(seed: 7))
     }
+    // max 레벨에 닿을 만큼 큰 누적(테스트용 천문학적 토큰)
+    private let hugeMonth = 60_000_000_000
 
     func testBackfillHatchesAndSetsLevel() {
         let s = tempStore()
@@ -52,33 +67,33 @@ final class CompanionStoreTests: XCTestCase {
         let s = tempStore()
         s.update(todayTokens: 1_000_000, todayDate: "2026-06-23", monthTotal: 1_000_000,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
-        let xpAfterFirst = s.state.totalXP
+        let xpAfterFirst = s.state.activeXP
         // 같은 날 같은 값 재호출 → totalXP 불변(중복 지급 없음)
         s.update(todayTokens: 1_000_000, todayDate: "2026-06-23", monthTotal: 1_000_000,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
-        XCTAssertEqual(s.state.totalXP, xpAfterFirst)
+        XCTAssertEqual(s.state.activeXP, xpAfterFirst)
     }
 
     func testTodayIncrementAccrues() {
         let s = tempStore()
         s.update(todayTokens: 1_000_000, todayDate: "2026-06-23", monthTotal: 1_000_000,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
-        let before = s.state.totalXP
+        let before = s.state.activeXP
         // 오늘 토큰이 더 쌓이면 증분만큼 XP 증가
         s.update(todayTokens: 4_000_000, todayDate: "2026-06-23", monthTotal: 4_000_000,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
-        XCTAssertGreaterThan(s.state.totalXP, before)
+        XCTAssertGreaterThan(s.state.activeXP, before)
     }
 
     func testMidnightRolloverResetsClaim() {
         let s = tempStore()
         s.update(todayTokens: 1_000_000, todayDate: "2026-06-23", monthTotal: 1_000_000,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
-        let day1 = s.state.totalXP
+        let day1 = s.state.activeXP
         // 다음 날(오늘 토큰 다시 0부터) → claimedTodayXP 리셋, 새 적립 가능
         s.update(todayTokens: 1_000_000, todayDate: "2026-06-24", monthTotal: 2_000_000,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
-        XCTAssertGreaterThan(s.state.totalXP, day1)
+        XCTAssertGreaterThan(s.state.activeXP, day1)
         XCTAssertEqual(s.state.lastDate, "2026-06-24")
     }
 
@@ -112,6 +127,60 @@ final class CompanionStoreTests: XCTestCase {
         s.update(todayTokens: 0, todayDate: "2026-06-23", monthTotal: 1_000_000,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.displayState, .sleep)
+    }
+
+    func testMaxGraduatesToNewUnownedCompanion() {
+        let s = tempStore()
+        // 소급으로 max 도달(졸업은 보류)
+        s.update(todayTokens: 1, todayDate: "2026-06-23", monthTotal: hugeMonth,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.level, CompanionBalance.maxLevel)
+        XCTAssertTrue(s.collectionInstances.isEmpty)
+        XCTAssertEqual(s.state.activeCompanionID, "mochi")
+        // 다음 실제 갱신에서 졸업 → 미보유 캐릭터 부화
+        s.update(todayTokens: 2_000_000, todayDate: "2026-06-23", monthTotal: hugeMonth,
+                 burnTier: .normal, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.collectionInstances.count, 1)
+        XCTAssertEqual(s.collectionInstances[0].companionID, "mochi")
+        XCTAssertTrue(s.collectionInstances[0].maxed)
+        XCTAssertNotEqual(s.state.activeCompanionID, "mochi")  // 새 캐릭터
+        XCTAssertEqual(s.level, 1)                              // 새 캐릭터는 처음부터
+        XCTAssertEqual(s.justGraduated, "Mochi")
+    }
+
+    func testCollectionPhaseNoDuplicates() {
+        let s = tempStore()
+        s.update(todayTokens: 1, todayDate: "d0", monthTotal: hugeMonth,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)   // backfill: mochi max
+        // 매일 큰 today 로 active 를 다시 max → 졸업 반복 (날짜 바뀌면 claimedTodayXP 리셋)
+        for d in 1...4 {
+            s.update(todayTokens: hugeMonth, todayDate: "d\(d)", monthTotal: hugeMonth,
+                     burnTier: .idle, limitWarning: false, hasUsageData: true)
+        }
+        let ownedIDs = Set(s.collectionInstances.map(\.companionID)).union([s.state.activeCompanionID])
+        XCTAssertEqual(ownedIDs, Set(CompanionCatalog.all.map(\.id)))                 // 모두 수집
+        XCTAssertEqual(s.collectionInstances.count, CompanionCatalog.all.count - 1)   // 졸업 = 전체-1
+        XCTAssertEqual(Set(s.collectionInstances.map(\.companionID)).count,           // 중복 없음
+                       s.collectionInstances.count)
+    }
+
+    func testLegacyPhase1StateMigrates() throws {
+        // Phase 1 JSON(totalXP/hatched) → Phase 2(activeXP/mochi) 마이그레이션
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("companion-legacy-\(UUID().uuidString).json")
+        let legacy = #"{"totalXP":5000,"hatched":true,"didApplyInitialBackfill":true,"displayName":"Mochi","lastDate":"2026-06-20","claimedTodayXP":0,"streakDays":2}"#
+        try legacy.data(using: .utf8)!.write(to: url)
+        let s = CompanionStore(clock: { Date() }, fileURL: url)
+        XCTAssertEqual(s.state.activeXP, 5000)
+        XCTAssertEqual(s.state.activeCompanionID, "mochi")
+        XCTAssertTrue(s.state.hatched)
+        XCTAssertEqual(s.level, CompanionBalance.level(forXP: 5000))
+    }
+
+    func testCatalogHasUniqueIDs() {
+        let ids = CompanionCatalog.all.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
+        XCTAssertGreaterThanOrEqual(ids.count, 3)
     }
 
     func testPersistenceRoundTrip() {


### PR DESCRIPTION
성장형 캐릭터 Phase 2 — **캐릭터 변종 + 컬렉션 도감 + Max→졸업→새 알 루프 + 수집단계 등급(무중복)**. (Phase 1 = PR #3 머지됨)

## 캐릭터 변종 (고양이 3종)
같은 코드 드로잉 엔진을 **트레이트(팔레트+마킹)** 로 파라미터화:
- **Mochi** 크림 태비(기본) · **Smoke** 그레이 태비(Pusheen 풍) · **Coco** 샴(다크 포인트 귀+얼굴 마스크+블루 눈)
- 3종 × 상태별 렌더 직접 시각 확인 완료.

## 수집 메커니즘
- **CompanionStore**: active 캐릭터 + collection 분리. XP는 active에 적립. **Max(Lv50) 도달 → 졸업**: 해당 개체를 Collection에 보존(왕관 배지) + **미보유 캐릭터로 새 알 부화**.
- **수집단계 추첨**: 미보유 중 희소도 낮은 군 우선, **중복 없음**. 주입 가능한 RNG(결정론적 테스트).
- **CompanionCatalog**: 카탈로그/인스턴스 분리, rarity(Phase 3 등급 가중의 씨앗).

## 영속/마이그레이션
- `CompanionState` Codable 마이그레이션 안전 — **Phase 1 `totalXP` → Phase 2 `activeXP`** 자동 변환, collection 영속.

## UI
- 팝오버 **홈 / 컬렉션 탭**. 컬렉션 그리드(썸네일 + 레벨 + maxed 왕관), 졸업 시 "새 Token Egg 도착" 문구.

## 검증
- `swift test` **31개 전부 통과** (신규: catalog 유일성, max→졸업, 무중복 수집, Phase1→2 마이그레이션).
- `swift build`/release OK, 기동 크래시 없음, 3변종 렌더 PNG 직접 확인.

## 범위 밖(Phase 3)
- 강아지/오브젝트/화산 로스터(처진귀 엔진 Swift 포팅), 수집 후 풀 가챠 + 중복→알 조각, 시즌 한정 알. (프리뷰에 프로토타이핑됨, `docs/companion-design-system.md`.)

## 참고
- 실제 사용 흐름: 무거운 사용자는 첫 부화 시 Mochi가 max로 소급되고 다음 갱신에서 1회 졸업 → 이후 신규 캐릭터는 일상 토큰으로 천천히 성장(연쇄 졸업 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)