### PR TITLE
feat: rarity-weighted egg hatching pool (Phase 3b)

### DIFF
--- a/Sources/TokenMac/Core/CompanionModel.swift
+++ b/Sources/TokenMac/Core/CompanionModel.swift
@@ -132,7 +132,42 @@ struct CompanionState: Codable, Sendable {
     init() {}
 }
 
-/// 부화 후보 base 종 id (숫자 = PokéAPI 식별자). 3단/2단/무진화/분기 골고루.
+/// 부화 후보 base 종 — (PokéAPI 식별자, 선택 가중 tier). 3단/2단/무진화/분기 골고루.
+/// tier 는 *선택 확률*만 결정하는 큐레이트 값 — 표시/경제 희귀도는 PokéAPI capture_rate
+/// 에서 별도 파생(EvoLine.rarity, 권위 소스)하며 보통 일치한다.
 enum PokemonPool {
-    static let baseIDs = [1, 4, 7, 10, 16, 172, 133, 129, 66, 92, 280, 128, 131, 446, 304, 252]
+    static let entries: [(id: Int, tier: Rarity)] = [
+        // common — 흔하게 부화
+        (10, .common), (16, .common), (172, .common), (129, .common),
+        (66, .common), (92, .common), (280, .common), (304, .common),
+        // uncommon
+        (446, .uncommon),
+        // rare — 스타터/이브이 등
+        (1, .rare), (4, .rare), (7, .rare), (133, .rare),
+        (128, .rare), (131, .rare), (252, .rare),
+        // legendary — 드물게
+        (144, .legendary),
+    ]
+
+    /// tier 별 선택 가중치(엔트리당). 희귀할수록 작다 → 부화 확률 낮음.
+    static func weight(_ tier: Rarity) -> Int {
+        switch tier {
+        case .common:    return 8
+        case .uncommon:  return 4
+        case .rare:      return 2
+        case .legendary: return 1
+        }
+    }
+
+    static var totalWeight: Int { entries.reduce(0) { $0 + weight($1.tier) } }
+
+    /// 0..<totalWeight 범위 난수로 가중 선택 → base id.
+    static func pick(roll: Int) -> Int {
+        var r = roll % max(1, totalWeight)
+        for e in entries {
+            r -= weight(e.tier)
+            if r < 0 { return e.id }
+        }
+        return entries[0].id
+    }
 }

--- a/Sources/TokenMac/Core/CompanionStore.swift
+++ b/Sources/TokenMac/Core/CompanionStore.swift
@@ -194,8 +194,7 @@ final class CompanionStore {
     }
 
     private func chooseBase() -> Int {
-        let pool = PokemonPool.baseIDs
-        return pool[Int(rng.next() % UInt64(pool.count))]
+        PokemonPool.pick(roll: Int(rng.next() % UInt64(PokemonPool.totalWeight)))
     }
 
     private func computeState(burnTier: BurnTier, limitWarning: Bool, hasUsageData: Bool, today: Int) -> CompanionStateKind {

--- a/Tests/TokenMacTests/CompanionTests.swift
+++ b/Tests/TokenMacTests/CompanionTests.swift
@@ -36,6 +36,47 @@ final class PokemonBalanceTests: XCTestCase {
     }
 }
 
+// MARK: 부화 풀 (가중 선택)
+
+final class PokemonPoolTests: XCTestCase {
+    func testTotalWeightMatchesEntries() {
+        // common 8개×8 + uncommon 1×4 + rare 7×2 + legendary 1×1 = 83
+        XCTAssertEqual(PokemonPool.totalWeight, 83)
+    }
+
+    func testPickMapsEachRollAndRespectsPerEntryWeight() {
+        // 0..<totalWeight 전 구간을 훑으면 각 엔트리는 정확히 weight(tier) 회 선택돼야 한다.
+        var counts: [Int: Int] = [:]
+        for roll in 0..<PokemonPool.totalWeight {
+            counts[PokemonPool.pick(roll: roll), default: 0] += 1
+        }
+        for e in PokemonPool.entries {
+            XCTAssertEqual(counts[e.id], PokemonPool.weight(e.tier), "id=\(e.id) tier=\(e.tier)")
+        }
+        // 모든 엔트리가 한 번 이상 선택 가능
+        XCTAssertEqual(Set(counts.keys), Set(PokemonPool.entries.map(\.id)))
+    }
+
+    func testRarerTierIsLessLikelyThanCommon() {
+        let common = PokemonPool.weight(.common)
+        XCTAssertGreaterThan(common, PokemonPool.weight(.uncommon))
+        XCTAssertGreaterThan(PokemonPool.weight(.uncommon), PokemonPool.weight(.rare))
+        XCTAssertGreaterThan(PokemonPool.weight(.rare), PokemonPool.weight(.legendary))
+        // 집계: common tier 총가중 > rare tier 총가중 > legendary
+        func tierTotal(_ t: Rarity) -> Int {
+            PokemonPool.entries.filter { $0.tier == t }.reduce(0) { $0 + PokemonPool.weight($1.tier) }
+        }
+        XCTAssertGreaterThan(tierTotal(.common), tierTotal(.rare))
+        XCTAssertGreaterThan(tierTotal(.rare), tierTotal(.legendary))
+    }
+
+    func testPickRollWrapsSafely() {
+        // roll 이 범위를 넘어도(% 처리) 유효한 id 반환
+        XCTAssertTrue(PokemonPool.entries.map(\.id).contains(PokemonPool.pick(roll: PokemonPool.totalWeight)))
+        XCTAssertTrue(PokemonPool.entries.map(\.id).contains(PokemonPool.pick(roll: 99_999)))
+    }
+}
+
 // MARK: 헬퍼
 
 struct SeededRNG: RandomNumberGenerator {


### PR DESCRIPTION
## 무엇을

알 부화를 **균등 확률 → 희귀도 가중 선택**으로 바꿔 희귀도 시스템을 완성한다. 기존엔 16종이 모두 같은 확률로 부화해 레전더리가 커먼만큼 자주 나왔고, 희귀도는 졸업 비용에만 영향을 줬다. 이제 희귀한 포켓몬일수록 *드물게* 부화한다.

## 어떻게

| tier | 엔트리당 가중 | 풀 내 엔트리 수 | tier 총가중 |
|---|---|---|---|
| common | 8 | 8 | 64 |
| uncommon | 4 | 1 | 4 |
| rare | 2 | 7 | 14 |
| legendary | 1 | 1 | 1 |

총가중 83 → P(common)≈77%, P(uncommon)≈5%, P(rare)≈17%, P(legendary)≈1.2%.

- `PokemonPool.baseIDs:[Int]` → `entries:[(id:Int, tier:Rarity)]` + `weight(_:)` / `totalWeight` / `pick(roll:)`
- `CompanionStore.chooseBase()` 가중 선택
- legendary 엔트리 **144 Articuno** 추가 — 네 tier 모두 표현 (PokéAPI `is_legendary` 확인)
- 선택 tier 는 큐레이트 값(네트워크 불필요), **표시/경제 희귀도는 PokéAPI `capture_rate` 권위 유지** — 144는 양쪽 일치 확인

## 설계 노트

선택 가중(어느 알이 나오나)과 경제 희귀도(졸업까지 비용)를 분리했다. 큐레이트 tier 는 전자만 결정하고, 후자는 PokéAPI 에서 파생(`EvoLine.rarity`, 기존 로직·테스트 유지). 큐레이트는 부화 직전 네트워크 없이 동작하기 위한 선택 — 오프라인·기동 직후에도 알 선택이 즉시 가능.

## 검증

- 결정적 테스트 4건: `totalWeight==83`, `0..<totalWeight` 전 구간 roll→id 매핑이 엔트리별 정확히 `weight(tier)`회, tier 가중 단조성, 범위 초과 roll wrap
- `swift test` 32건 통과 (기존 28 + 신규 4), 빌드 통과, code-reviewer APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)