### PR TITLE
feat: animate menu-bar character with Gen-V sprites (Phase 3c)

### DIFF
--- a/Sources/TokenMac/TokenMacApp.swift
+++ b/Sources/TokenMac/TokenMacApp.swift
@@ -18,10 +18,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let popover = NSPopover()
     private var store: UsageStore!
     private var companion: CompanionStore!
-    private var companionTimer: Timer?
-    private var menuSprite: NSImage?
+
+    // 메뉴바 캐릭터 애니메이션 — 단일 타이머로 프레임 순환.
+    // 프레임 = 이미 22px 로 합성된 이미지 + delay. egg/static 은 2프레임 bob, animated 는 GIF 실제 프레임.
     private var menuSpriteID: Int?
-    private var companionBobUp = false
+    private var menuFrames: [(image: NSImage, delay: TimeInterval)] = []
+    private var menuIndex = 0
+    private var menuTimer: Timer?
+    private var menuLoadGen = 0     // async 로드 경합 방지
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
@@ -67,16 +71,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         button.appearsDisabled = store.isStale
 
         updateCompanion()
-
-        // 메뉴바는 항상 캐릭터(스프라이트/알) — 프레임 타이머로 가벼운 bob 애니메이션.
-        if companionTimer == nil {
-            renderCompanionFrame()
-            let t = Timer(timeInterval: 1.0 / 8.0, repeats: true) { [weak self] _ in
-                Task { @MainActor in self?.renderCompanionFrame() }
-            }
-            RunLoop.main.add(t, forMode: .common)
-            companionTimer = t
-        }
+        ensureMenuAnimation()
     }
 
     /// UsageStore 값 → CompanionStore (사용량 적립 + 표시 상태). 매 관찰 변경 시 호출.
@@ -90,30 +85,84 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             hasUsageData: store.hasUsageData)
     }
 
-    /// 메뉴바: 현재 포켓몬 스프라이트 + 가벼운 상하 bob. 알/로딩 중엔 알 글리프 폴백.
-    private func renderCompanionFrame() {
+    // MARK: 메뉴바 애니메이션
+
+    /// 현재 포켓몬에 맞춰 메뉴바 프레임을 준비. 종이 바뀐 경우에만 재로딩.
+    /// 즉시(캐시/알)로 먼저 보여주고, animated GIF 가 받아지면 교체.
+    private func ensureMenuAnimation() {
         let id = companion.currentSpeciesID
-        if id != menuSpriteID {
-            menuSpriteID = id
-            menuSprite = nil
-            if let id {
-                Task { @MainActor [weak self] in
-                    self?.menuSprite = await SpriteLoader.image(speciesID: id, animated: false)
+        if id == menuSpriteID, !menuFrames.isEmpty { return }   // 이미 이 종으로 애니메이션 중
+        menuSpriteID = id
+        menuLoadGen += 1
+        let gen = menuLoadGen
+
+        guard let id else {                  // 알: 즉시 2프레임 bob
+            setMenuFrames(Self.eggFrames())
+            return
+        }
+        // 캐시된 정적 스프라이트가 있으면 즉시 표시(없으면 알 placeholder)
+        if let cached = SpriteLoader.cachedImage(speciesID: id) {
+            setMenuFrames(Self.bobFrames(from: cached))
+        } else {
+            setMenuFrames(Self.eggFrames())
+        }
+        // animated GIF 우선 시도 → 실패 시 정적 스프라이트
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if let data = await SpriteStore.shared.data(speciesID: id, animated: true) {
+                let raw = GIFDecoder.frames(from: data)
+                if raw.count > 1 {
+                    guard gen == self.menuLoadGen else { return }
+                    self.setMenuFrames(raw.map { (Self.menuBarImage(from: $0.image, up: false), $0.delay) })
+                    return
                 }
             }
+            if let sprite = await SpriteLoader.image(speciesID: id) {
+                guard gen == self.menuLoadGen else { return }
+                self.setMenuFrames(Self.bobFrames(from: sprite))
+            }
         }
-        companionBobUp.toggle()
-        if let sprite = menuSprite {
-            statusItem.button?.image = Self.menuBarImage(from: sprite, up: companionBobUp)
-        } else {
-            statusItem.button?.image = Self.eggImage(up: companionBobUp)
+    }
+
+    private func setMenuFrames(_ frames: [(image: NSImage, delay: TimeInterval)]) {
+        menuFrames = frames
+        menuIndex = 0
+        advanceMenu()
+    }
+
+    /// 현재 프레임을 메뉴바에 올리고, 그 프레임의 delay 후 다음 프레임 예약(자기 재예약).
+    private func advanceMenu() {
+        menuTimer?.invalidate()
+        guard !menuFrames.isEmpty else { return }
+        let frame = menuFrames[menuIndex % menuFrames.count]
+        statusItem.button?.image = frame.image
+        guard menuFrames.count > 1 else { return }   // 단일 프레임이면 정지
+        menuTimer = Timer.scheduledTimer(withTimeInterval: frame.delay, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                self.menuIndex = (self.menuIndex + 1) % self.menuFrames.count
+                self.advanceMenu()
+            }
         }
+    }
+
+    // MARK: 프레임 합성 (22px)
+
+    /// 스프라이트 정적 + 가벼운 상하 bob 2프레임 (animated 미지원/로딩 폴백).
+    private static func bobFrames(from sprite: NSImage) -> [(image: NSImage, delay: TimeInterval)] {
+        [(menuBarImage(from: sprite, up: false), 0.5), (menuBarImage(from: sprite, up: true), 0.5)]
+    }
+
+    /// 부화 전/로딩 중 알 글리프 2프레임 bob.
+    private static func eggFrames() -> [(image: NSImage, delay: TimeInterval)] {
+        [(eggImage(up: false), 0.5), (eggImage(up: true), 0.5)]
     }
 
     private static func menuBarImage(from sprite: NSImage, up: Bool) -> NSImage {
         let h: CGFloat = 22
         let img = NSImage(size: NSSize(width: h, height: h))
         img.lockFocus()
+        NSGraphicsContext.current?.imageInterpolation = .none
         let off: CGFloat = up ? 1 : 0
         sprite.draw(in: NSRect(x: 1, y: off, width: h - 2, height: h - 2),
                     from: .zero, operation: .sourceOver, fraction: 1)

--- a/Sources/TokenMac/UI/SpriteAnimation.swift
+++ b/Sources/TokenMac/UI/SpriteAnimation.swift
@@ -1,0 +1,30 @@
+import AppKit
+import ImageIO
+import UniformTypeIdentifiers
+
+/// GIF 바이트 → 프레임(이미지 + 지속시간) 디코드. Gen-V 움직이는 스프라이트(메뉴바)용.
+enum GIFDecoder {
+    /// 각 프레임의 원본 이미지 + delay(초). 단일 프레임/디코드 실패 시 빈 배열.
+    static func frames(from data: Data) -> [(image: NSImage, delay: TimeInterval)] {
+        guard let src = CGImageSourceCreateWithData(data as CFData, nil) else { return [] }
+        let count = CGImageSourceGetCount(src)
+        guard count > 1 else { return [] }
+        var out: [(NSImage, TimeInterval)] = []
+        for i in 0..<count {
+            guard let cg = CGImageSourceCreateImageAtIndex(src, i, nil) else { continue }
+            let img = NSImage(cgImage: cg, size: NSSize(width: cg.width, height: cg.height))
+            out.append((img, delay(src, i)))
+        }
+        return out
+    }
+
+    /// GIF 프레임 delay. unclamped 우선, 너무 짧으면(브라우저 관행) 0.1s 로 보정.
+    private static func delay(_ src: CGImageSource, _ index: Int) -> TimeInterval {
+        guard let props = CGImageSourceCopyPropertiesAtIndex(src, index, nil) as? [CFString: Any],
+              let gif = props[kCGImagePropertyGIFDictionary] as? [CFString: Any] else { return 0.1 }
+        let unclamped = gif[kCGImagePropertyGIFUnclampedDelayTime] as? Double
+        let clamped = gif[kCGImagePropertyGIFDelayTime] as? Double
+        let d = unclamped ?? clamped ?? 0.1
+        return d < 0.02 ? 0.1 : d
+    }
+}


### PR DESCRIPTION
## 무엇을 (UI 변경)

메뉴바 캐릭터가 **정적 스프라이트 + 가짜 bob → Gen-V 실제 움직이는 GIF 재생**으로 바뀐다. Lapras가 목을 흔들고, Charmander 꼬리불이 일렁이는 식으로 포켓몬이 실제로 살아 움직인다.

### 화면별 변화

| 위치 | Before | After |
|---|---|---|
| **메뉴바 아이콘** | 96px 정적 PNG를 22px로 그려 0.9s 주기 1px 상하 bob | Gen-V 애니메이션 GIF의 실제 프레임을 프레임별 delay로 재생 (예: Charmander 55프레임·5.6s 사이클) |
| **부화 전(알)** | 🥚 글리프 + bob | 🥚 글리프 2프레임 bob (동일) |
| **로딩 중(스프라이트 미수신)** | 코인/알 폴백 | 캐시된 정적 스프라이트 즉시 표시 → GIF 받아지면 교체 |
| **Gen-V 미지원 종** | — | 정적 스프라이트 + bob 폴백 (현재 풀은 전부 Gen-V 지원 ≤649이라 실제로는 항상 애니메이션) |
| 토큰 숫자 표기 | 변화 없음 | 변화 없음 (아이콘 옆 그대로) |

**팝오버 내 스프라이트는 이번 범위 밖** — 기존 정적 + SwiftUI bob 유지. 팝오버도 애니메이션화는 후속 후보.

## 어떻게

- **`Sources/TokenMac/UI/SpriteAnimation.swift` (신규)** — `GIFDecoder.frames(from:)`: ImageIO `CGImageSource`로 GIF를 `[(NSImage, delay)]`로 디코드. `kCGImagePropertyGIFUnclampedDelayTime` 우선, 0.02s 미만은 0.1s로 보정(브라우저 관행), 단일 프레임이면 빈 배열.
- **`TokenMacApp.swift` AppDelegate 메뉴 렌더 통합** — 기존 `companionTimer`(1/8s 고정 bob) + `renderCompanionFrame` 제거하고 **단일 프레임 순환기**로:
  - 상태: `menuFrames:[(NSImage,delay)]`(이미 22px 합성), `menuIndex`, `menuTimer`, `menuLoadGen`.
  - `ensureMenuAnimation()`: 종이 바뀐 경우에만 재로딩. 캐시/알로 즉시 표시 후, `await SpriteStore.shared.data(animated:true)` → `GIFDecoder` → 프레임 >1이면 22px 합성해 교체. 실패 시 정적 bob 폴백.
  - `advanceMenu()`: 프레임별 delay로 자기 재예약하는 Timer(`[weak self]`), 단일 프레임이면 정지. 매 호출 시 이전 타이머 invalidate → 중복 타이머 없음.
  - `menuLoadGen`으로 종 전환 중 async 로드 경합 차단(await 후 세대 비교).
  - nearest-neighbor 보간 유지(픽셀아트 선명도).
- egg↔hatch↔graduate 전환: 졸업 시 `currentSpeciesID`가 nil → 직전 종 id와 달라 알 프레임으로 정상 전환.

## 성능

- 프레임은 종 전환 시 1회만 22px로 사전 합성 → 매 틱 비용은 `button.image` 교체뿐(저비용). ~10 swaps/s(구 코인 ~5/s와 동급), 메모리는 종당 수십 개 22px 이미지로 미미.

## 검증

- **시각 검증**: 실행 중 메뉴바 우측을 0.4s 시차로 2프레임 캡처 → Lapras 포즈 차이 확인(실제 애니메이션).
- ImageIO 디코드 경로 standalone 검증: Charmander GIF 55프레임·41×42·정상 delay·5.6s 사이클.
- Gen-V GIF 다중 프레임 확인(4/144/446 = 55/35/144 프레임).
- `swift test` 32건 통과, 빌드 통과, code-reviewer APPROVE(타이머 누수·경합·egg 전환 가드 점검).

🤖 Generated with [Claude Code](https://claude.com/claude-code)