### PR TITLE
feat: animate popover companion sprite (Gen-V GIF)

### DIFF
--- a/Sources/TokenMac/UI/CompanionView.swift
+++ b/Sources/TokenMac/UI/CompanionView.swift
@@ -10,34 +10,68 @@ func rarityColor(_ r: Rarity?) -> Color {
 }
 
 /// 스프라이트 1개(런타임 로드 + 캐시). 없으면 알 글리프. bob 으로 가벼운 상하 움직임.
+/// animated=true 면 Gen-V GIF 프레임을 순환(미지원/오프라인이면 정적+bob 으로 폴백).
 struct SpriteView: View {
     let speciesID: Int?
     var size: CGFloat = 84
     var bob: Bool = false
+    var animated: Bool = false
     @State private var img: NSImage?
     @State private var up = false
+    @State private var loadedID: Int?   // img 가 어느 speciesID 것인지(id 변경 시 갱신 판단)
+    @State private var frames: [(image: NSImage, delay: TimeInterval)] = []
+    @State private var frameIndex = 0
 
-    init(speciesID: Int?, size: CGFloat = 84, bob: Bool = false) {
+    init(speciesID: Int?, size: CGFloat = 84, bob: Bool = false, animated: Bool = false) {
         self.speciesID = speciesID
         self.size = size
         self.bob = bob
+        self.animated = animated
         // 캐시에 있으면 즉시(동기) 표시 — 재렌더 플래시 방지 + 정적 스냅샷에서도 보임
-        _img = State(initialValue: speciesID.flatMap { SpriteLoader.cachedImage(speciesID: $0) })
+        let cached = speciesID.flatMap { SpriteLoader.cachedImage(speciesID: $0) }
+        _img = State(initialValue: cached)
+        _loadedID = State(initialValue: cached != nil ? speciesID : nil)
     }
 
     var body: some View {
         Group {
-            if let img {
+            if !frames.isEmpty {
+                // GIF 애니메이션 경로 — 현재 프레임만 렌더
+                Image(nsImage: frames[frameIndex % frames.count].image)
+                    .resizable().interpolation(.none)
+                    .frame(width: size, height: size)
+            } else if let img {
                 Image(nsImage: img).resizable().interpolation(.none)
                     .frame(width: size, height: size)
             } else {
                 Text("🥚").font(.system(size: size * 0.62)).frame(width: size, height: size)
             }
         }
-        .offset(y: bob && up ? -3 : 0)
+        // GIF 재생 중엔 bob 정지(프레임 자체가 움직임) — 폴백/정적일 때만 상하 움직임
+        .offset(y: bob && frames.isEmpty && up ? -3 : 0)
         .task(id: speciesID) {
-            guard let id = speciesID else { img = nil; return }
-            img = await SpriteLoader.image(speciesID: id, animated: false)
+            // animated 프레임은 id 변경 시 항상 초기화(이전 종 프레임 잔상 방지)
+            frames = []
+            frameIndex = 0
+            guard let id = speciesID else { img = nil; loadedID = nil; return }
+            // 정적 스프라이트 먼저(즉시 표시 + 폴백 보장). 캐시 시드로 이미 같은 id 면 재요청 생략(플래시 방지)
+            if loadedID != id {
+                img = await SpriteLoader.image(speciesID: id, animated: false)
+                loadedID = id
+            }
+            guard animated else { return }
+            // animated GIF 시도 → 프레임 2개 이상이면 순환 루프, 아니면 정적 유지
+            guard let data = await SpriteStore.shared.data(speciesID: id, animated: true) else { return }
+            let raw = GIFDecoder.frames(from: data)
+            guard raw.count > 1 else { return }   // 단일 프레임/디코드 실패 → 정적 폴백
+            frames = raw
+            // delay 기반 프레임 advance. .task 취소 시(speciesID 변경/뷰 소멸) 루프 종료 — 누수 없음
+            while !Task.isCancelled {
+                let delay = frames[frameIndex % frames.count].delay
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                if Task.isCancelled { break }
+                frameIndex = (frameIndex + 1) % frames.count
+            }
         }
         .onAppear {
             guard bob else { return }
@@ -74,7 +108,7 @@ struct CompanionHeader: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .center, spacing: 12) {
-                SpriteView(speciesID: store.currentSpeciesID, size: 76, bob: true)
+                SpriteView(speciesID: store.currentSpeciesID, size: 76, bob: true, animated: true)
                     .frame(width: 76, height: 76)
                     .background(Color.secondary.opacity(0.06))
                     .clipShape(RoundedRectangle(cornerRadius: 12))


### PR DESCRIPTION
## 요약
팝오버 상단 컴패니언 캐릭터(대형 76pt 스프라이트)를 Gen-V 움직이는 GIF로 애니메이트한다. #7 의 GIF 파이프라인(`GIFDecoder`)을 재사용한다.

> **의존성:** 본 기능은 **#7 (`GIFDecoder` 추가)** 의 `GIFDecoder.frames(from:)` 에 의존한다. #7 은 이미 `main` 에 머지됨 → base 를 `main` 으로 두고 바로 머지 가능. (GIF 디코딩 로직은 중복 구현하지 않고 재사용.)

## UI 변경 상세 (Before / After)

### 대형 헤더 스프라이트 — `CompanionHeader`, size 76 (변경됨)
| | Before | After |
|---|---|---|
| 표시 | 정적 PNG 1장 (`SpriteLoader.image(animated:false)`) | Gen-V 애니메이션 GIF 프레임 순환 |
| 움직임 | SwiftUI offset "bob"(상하 3pt) 만 | GIF 프레임 자체 애니메이션 (bob 은 GIF 재생 중 정지) |
| 렌더 | `Image(nsImage:).interpolation(.none).resizable()` | 동일 — 현재 프레임만 렌더 |

- 무엇이 애니메이트되나: **팝오버 상단 대형 스프라이트만.** `await SpriteStore.shared.data(speciesID:animated:true)` 로 Gen-V GIF 바이트를 받아 `GIFDecoder.frames` 로 디코딩 → `@State frameIndex` 를 per-frame `delay` 기반 async 루프로 advance 하며 순환.
- 프레임 advance 는 `.task(id: speciesID)` 안의 `while !Task.isCancelled` 루프 + `try? await Task.sleep(delay)`. **speciesID 변경/뷰 소멸 시 `.task` 가 자동 취소 → 루프 종료. 누수·retain cycle 없음.**

### 진화 라인 썸네일 — `EvoLineView` (변경 없음 / 정적 유지)
- 작은 진화 라인 썸네일(`SpriteView(speciesID:size:)`)은 **정적 PNG 그대로.** 비용 통제를 위해 의도적으로 애니메이트하지 않는다 (`animated` 파라미터 기본값 `false` → 기존 동작 유지). 도감(`CollectionView`)의 썸네일도 동일하게 정적.

## 폴백 동작
- `GIFDecoder.frames` 결과가 비었거나 프레임 < 2 (단일 프레임 / 오프라인 / GIF 미지원 종)면 **기존 정적 스프라이트 경로 + bob 애니메이션으로 폴백.** 사용자에게 깨짐 없이 정적 캐릭터가 보인다.
- **첫 페인트 플래시 없음:** `init` 에서 디스크 캐시된 정적 스프라이트를 동기 시드(`SpriteLoader.cachedImage`). GIF 가 도착하기 전엔 정적이 보이고, 도착하면 프레임 순환으로 전환. 같은 speciesID 면 정적 재요청을 생략(`loadedID` 가드).

## CPU 노트
- 대형 스프라이트 **1개만** 애니메이트. 프레임 전환은 GIF 의 native delay(보통 0.1s 내외) 간격으로 `@State` 인덱스만 갱신 — 프레임 이미지는 디코딩 시 1회 생성 후 재사용(매 틱 디코딩 없음).
- 썸네일은 정적이라 추가 비용 0. 팝오버가 닫히면 SwiftUI 가 뷰를 해제하며 `.task` 취소 → 루프 정지.

## 검증
- `swift build` green, `swift test` 32/32 통과.
- 시각 자가검증: Gen-V GIF(예: #25 피카츄)가 58 프레임으로 디코딩되고 첫 프레임이 76pt 에서 non-empty 픽셀로 페인트됨을 확인(모션은 정지 렌더로 확인 불가하므로 단일 프레임 페인트만 확인). 앱 실행/설치는 하지 않음.

## API / 호출부 호환
- `SpriteView` 에 `animated: Bool = false` 파라미터만 추가. 기존 호출부(`EvoLineView`, `CollectionView`)는 인자 미지정으로 기존 정적 동작 그대로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
