### PR TITLE
feat: Pokédex (도감) UI 고도화 — summary header, sorting, relative dates

### DIFF
--- a/Sources/TokenMac/Core/CompanionModel.swift
+++ b/Sources/TokenMac/Core/CompanionModel.swift
@@ -24,6 +24,15 @@ enum AppLanguage: String, Codable, Sendable, CaseIterable {
 /// 희귀도 — PokéAPI capture_rate / is_legendary 로 판정.
 enum Rarity: String, Codable, Sendable {
     case common, uncommon, rare, legendary
+    /// 정렬 순위(높을수록 희귀). 도감 정렬 — legendary→rare→uncommon→common.
+    var sortRank: Int {
+        switch self {
+        case .common:    return 0
+        case .uncommon:  return 1
+        case .rare:      return 2
+        case .legendary: return 3
+        }
+    }
     static func from(captureRate: Int, isLegendary: Bool, isMythical: Bool) -> Rarity {
         if isLegendary || isMythical { return .legendary }
         if captureRate <= 45 { return .rare }

--- a/Sources/TokenMac/Core/CompanionStore.swift
+++ b/Sources/TokenMac/Core/CompanionStore.swift
@@ -85,6 +85,19 @@ final class CompanionStore {
     }
     var dexEntries: [DexEntry] { state.dex }
 
+    /// 도감 표시 순서 — 희귀도 내림차순(legendary→common), 동급은 잡은 시각 최신순.
+    var dexEntriesSorted: [DexEntry] {
+        state.dex.sorted { a, b in
+            if a.rarity.sortRank != b.rarity.sortRank { return a.rarity.sortRank > b.rarity.sortRank }
+            let ta = a.caughtAt ?? .distantPast
+            let tb = b.caughtAt ?? .distantPast
+            return ta > tb
+        }
+    }
+
+    /// 희귀도별 도감 개수(요약 헤더용).
+    func dexCount(_ rarity: Rarity) -> Int { state.dex.lazy.filter { $0.rarity == rarity }.count }
+
     // MARK: 갱신 (AppDelegate 가 UsageStore 값으로 호출)
 
     func update(todayTokens: Int, todayDate: String, monthTotal: Int,

--- a/Sources/TokenMac/Core/Localization.swift
+++ b/Sources/TokenMac/Core/Localization.swift
@@ -102,6 +102,22 @@ struct L {
     var dexEmpty: String { t("아직 졸업한 포켓몬이 없어요. 최종 진화까지 키워보세요.", "No graduated Pokémon yet. Raise one to its final form.", "まだ卒業したポケモンがいません。最終進化まで育ててみましょう。") }
     func formsComplete(_ n: Int) -> String { t("\(n)단계 · 완성", "\(n) forms · complete", "\(n)段階・完成") }
 
+    // MARK: 도감 요약 헤더
+    var dexTitle: String { t("도감", "Pokédex", "図鑑") }
+    func dexTotal(_ n: Int) -> String { t("총 \(n)마리", "\(n) total", "全\(n)匹") }
+    var rarityCommon: String { t("일반", "Common", "ノーマル") }
+    var rarityUncommon: String { t("고급", "Uncommon", "アンコモン") }
+    var rarityRare: String { t("희귀", "Rare", "レア") }
+    var rarityLegendary: String { t("전설", "Legendary", "伝説") }
+    func rarityLabel(_ r: Rarity) -> String {
+        switch r {
+        case .common:    return rarityCommon
+        case .uncommon:  return rarityUncommon
+        case .rare:      return rarityRare
+        case .legendary: return rarityLegendary
+        }
+    }
+
     // 상태 한 줄
     var statusEgg: String { t("곧 깨어나요.", "Hatching soon.", "もうすぐ孵化します。") }
     var statusIdle: String { t("오늘은 조용히 자리를 지켜요.", "Keeping quiet today.", "今日は静かにしています。") }

--- a/Sources/TokenMac/UI/CompanionView.swift
+++ b/Sources/TokenMac/UI/CompanionView.swift
@@ -127,6 +127,44 @@ struct CompanionHeader: View {
     }
 }
 
+/// 희귀도 1종 요약 캡슐 — 색 점 + 라벨 + 개수. 0이면 흐리게.
+struct RarityTally: View {
+    let label: String
+    let count: Int
+    let color: Color
+    var body: some View {
+        HStack(spacing: 3) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label).font(.system(size: 9, weight: .medium))
+            Text("\(count)").font(.system(size: 9, weight: .bold))
+        }
+        .padding(.horizontal, 6).padding(.vertical, 2)
+        .background(color.opacity(0.12))
+        .clipShape(Capsule())
+        .opacity(count == 0 ? 0.4 : 1)
+    }
+}
+
+/// 도감 요약 헤더 — 총 개수 + 희귀도별 개수 캡슐.
+struct DexSummaryHeader: View {
+    let store: CompanionStore
+    private let order: [Rarity] = [.legendary, .rare, .uncommon, .common]
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 6) {
+                Text(store.l.dexTitle).font(.callout.weight(.semibold))
+                Text(store.l.dexTotal(store.dexEntries.count))
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+            HStack(spacing: 4) {
+                ForEach(order, id: \.self) { r in
+                    RarityTally(label: store.l.rarityLabel(r), count: store.dexCount(r), color: rarityColor(r))
+                }
+            }
+        }
+    }
+}
+
 /// 도감 — 잡은 라인(초기→최종 전부) 목록.
 struct CollectionView: View {
     let store: CompanionStore
@@ -138,7 +176,8 @@ struct CollectionView: View {
                     .frame(maxWidth: .infinity, alignment: .leading).padding(.vertical, 8)
             } else {
                 VStack(alignment: .leading, spacing: 8) {
-                    ForEach(store.dexEntries) { entry in
+                    DexSummaryHeader(store: store)
+                    ForEach(store.dexEntriesSorted) { entry in
                         VStack(alignment: .leading, spacing: 3) {
                             HStack {
                                 Text(entry.rarity.rawValue.uppercased())
@@ -150,6 +189,9 @@ struct CollectionView: View {
                                 Text(store.l.formsComplete(entry.chainOrder.count)).font(.system(size: 9)).foregroundStyle(.secondary)
                             }
                             EvoLineView(nodes: entry.chainOrder.map { ($0, "done") }, thumb: 38)
+                            if let caughtAt = entry.caughtAt {
+                                Text(caughtAt, style: .relative).font(.system(size: 9)).foregroundStyle(.tertiary)
+                            }
                         }
                         .padding(8)
                         .background(Color.secondary.opacity(0.06))

--- a/Tests/TokenMacTests/CompanionTests.swift
+++ b/Tests/TokenMacTests/CompanionTests.swift
@@ -195,3 +195,63 @@ final class CompanionStoreTests: XCTestCase {
         s.setLanguage(.ja); XCTAssertEqual(s.displayName, "ポ1")
     }
 }
+
+// MARK: 도감 정렬 / 요약
+
+@MainActor
+final class DexSortingTests: XCTestCase {
+    func testSortRankOrdersRarityAscendingByValue() {
+        XCTAssertLessThan(Rarity.common.sortRank, Rarity.uncommon.sortRank)
+        XCTAssertLessThan(Rarity.uncommon.sortRank, Rarity.rare.sortRank)
+        XCTAssertLessThan(Rarity.rare.sortRank, Rarity.legendary.sortRank)
+    }
+
+    func testDexEntriesSortedLegendaryFirstThenRecency() async {
+        // common 라인 2개(시각 다름) + legendary 라인 1개를 같은 store 에 졸업시킨다.
+        // StubProvider 는 라인 1개만 주므로, 라인별로 store 를 분리하지 않고
+        // 직접 졸업 흐름을 재현: 무진화(단일 임계) 라인을 hatch→applyUsage 로 졸업.
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
+        var tick = 0
+        // 라인을 바꿔가며 졸업시키기 위해 가변 provider 사용.
+        let provider = MutableProvider()
+        let s = CompanionStore(provider: provider,
+                               clock: { fixedNow.addingTimeInterval(TimeInterval(tick)) },
+                               fileURL: url, rng: SeededRNG(seed: 3))
+
+        // common #1 (가장 먼저)
+        provider.line = makeLine(base: 100, tree: node(100), rarity: .common)
+        tick = 1; await s.hatch(baseID: 100)
+        s.applyUsage(PokemonBalance.graduationTotal(.common))
+
+        // common #2 (더 나중)
+        provider.line = makeLine(base: 101, tree: node(101), rarity: .common)
+        tick = 2; await s.hatch(baseID: 101)
+        s.applyUsage(PokemonBalance.graduationTotal(.common))
+
+        // legendary (가장 나중이지만 희귀도가 더 높음)
+        provider.line = makeLine(base: 200, tree: node(200), rarity: .legendary)
+        tick = 3; await s.hatch(baseID: 200)
+        s.applyUsage(PokemonBalance.graduationTotal(.legendary))
+
+        XCTAssertEqual(s.dexEntries.count, 3)
+        let sorted = s.dexEntriesSorted
+        // legendary 가 맨 앞
+        XCTAssertEqual(sorted[0].rarity, .legendary)
+        XCTAssertEqual(sorted[0].finalID, 200)
+        // 그다음 common 끼리는 최신(101)이 먼저
+        XCTAssertEqual(sorted[1].rarity, .common)
+        XCTAssertEqual(sorted[1].finalID, 101)
+        XCTAssertEqual(sorted[2].finalID, 100)
+
+        // 희귀도별 카운트
+        XCTAssertEqual(s.dexCount(.common), 2)
+        XCTAssertEqual(s.dexCount(.legendary), 1)
+        XCTAssertEqual(s.dexCount(.rare), 0)
+    }
+}
+
+/// 테스트용 — 라인을 호출 전에 갈아끼울 수 있는 provider. 단일 스레드 테스트 한정.
+private final class MutableProvider: PokeProviding, @unchecked Sendable {
+    nonisolated(unsafe) var line: EvoLine = makeLine(base: 1, tree: node(1))
+    func line(baseSpeciesID: Int) async throws -> EvoLine { line }
+}


### PR DESCRIPTION
## Pokédex (도감) UI 고도화 — Collection 탭 한정

Collection 탭에 요약 헤더 / 정렬 / 상대 시각을 추가한다. 게임 로직(부화·진화·졸업)은 변경 없음.

### UI 변경 상세

#### 1. 도감 요약 헤더 (신규 — 목록 맨 위)

| 요소 | Before | After |
|---|---|---|
| 제목 | 없음 | `도감` / `Pokédex` / `図鑑` (callout, semibold) |
| 총 개수 | 없음 | `총 N마리` / `N total` / `全N匹` (caption2, secondary) |
| 희귀도별 카운트 | 없음 | 색 점 + 라벨 + 개수 캡슐 4종, 한 줄 정렬 |

희귀도 캡슐은 **legendary → rare → uncommon → common** 순으로 나열되며, 각 캡슐은 해당 `rarityColor`(legendary=orange, rare=blue, uncommon=green, common=gray)의 6pt 색 점 + 현지화 라벨(전설/희귀/고급/일반) + 굵은 개수로 구성된다. 배경은 같은 색 12% 틴트 캡슐. **개수 0인 희귀도는 40% 투명도로 흐리게** 표시되어 "아직 못 잡음"을 시각적으로 구분한다.

레이아웃: 빈 상태가 아닐 때만 `VStack` 최상단에 `DexSummaryHeader` 1개 → 그 아래 기존 엔트리 카드들.

#### 2. 엔트리 정렬

| | Before | After |
|---|---|---|
| 순서 | `store.dexEntries` (졸업 순 = 추가된 순서) | `store.dexEntriesSorted` |
| 기준 | 없음 | 희귀도 내림차순(legendary 먼저) → 동급은 `caughtAt` 최신순 |

사용자는 가장 희귀한 포켓몬을 항상 목록 맨 위에서 보게 된다. 같은 희귀도 안에서는 최근에 잡은 것이 위로 온다. (`caughtAt` 이 `nil` 인 레거시 엔트리는 `.distantPast` 로 취급해 동급 내 맨 아래.)

#### 3. 엔트리별 상대 시각 (신규)

| 요소 | Before | After |
|---|---|---|
| 잡은 시각 | 표시 없음 | 진화 라인 썸네일 아래 `Text(caughtAt, style: .relative)` (size 9, tertiary) — 예: `2시간 전` |

`caughtAt` 이 있는 엔트리만 표시. 기존 희귀도 배지 / `N단계 · 완성` / EvoLine 썸네일 행은 그대로 유지.

#### 4. 빈 상태

변경 없음 — 도감이 비어 있으면 기존 `dexEmpty` 안내 문구(`아직 졸업한 포켓몬이 없어요…`)를 그대로 표시한다. 헤더는 엔트리가 1개 이상일 때만 렌더된다.

### 미리보기

요약 헤더 + 샘플 엔트리 행을 ImageRenderer 로 렌더해 육안 검증 후 throwaway 제거함. 제목/총합, 4색 tally(희귀 0은 흐림), LEGENDARY 배지 + `3단계 · 완성` + 썸네일 + `2시간 전` 정상 표시 확인.

### 코드 변경

- `CompanionModel.swift`: `Rarity.sortRank` 추가 (common=0 … legendary=3).
- `CompanionStore.swift`: `dexEntriesSorted` (희귀도 desc → caughtAt desc), `dexCount(_:)` 추가.
- `Localization.swift`: `dexTitle`, `dexTotal(_:)`, `rarityCommon/Uncommon/Rare/Legendary`, `rarityLabel(_:)` (ko/en/ja).
- `CompanionView.swift`: `RarityTally`, `DexSummaryHeader` 추가, `CollectionView` 가 정렬 목록 사용 + 상대 시각 표시.
- `CompanionTests.swift`: `DexSortingTests` 추가 (`sortRank` 순서, legendary-first + 동급 최신순 정렬, 희귀도별 카운트).

`swift build` / `swift test` (34 tests) 모두 green.

### Deferred (범위 밖)

- **미수집 실루엣 도감(true uncollected-silhouette dex):** 풀의 모든 라인 진화 트리를 PokéAPI 에서 fetch 해야 하므로 이번 범위에서 제외. 이 도감 뷰에는 네트워크 fetch 를 추가하지 않는다(요구사항). 추후 별도 작업으로 예약.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
