### PR TITLE
feat: collection UX, animated empty-mascot, single keychain prompt

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -99,7 +99,8 @@ struct L {
           "\(name) graduated → saved to the dex. A new Token Egg has arrived!",
           "\(name) 卒業 → 図鑑に保存。新しいToken Eggが届きました！")
     }
-    var dexEmpty: String { t("아직 졸업한 포켓몬이 없어요. 최종 진화까지 키워보세요.", "No graduated Pokémon yet. Raise one to its final form.", "まだ卒業したポケモンがいません。最終進化まで育ててみましょう。") }
+    var dexEmptyTitle: String { t("아직 잡은 포켓몬이 없어요!", "No Pokémon caught yet!", "まだ捕まえたポケモンがいません！") }
+    var dexEmptyHint: String { t("토큰을 써서 첫 포켓몬을 부화시켜 보세요.", "Spend tokens to hatch your first Pokémon.", "トークンを使って最初のポケモンを孵化させましょう。") }
     func formsComplete(_ n: Int) -> String { t("\(n)단계 · 완성", "\(n) forms · complete", "\(n)段階・完成") }
 
     // MARK: 도감 요약 헤더

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -62,11 +62,10 @@ private actor OAuthAccessTokenCache {
             Self.writePokeTokenBarCache(credential.data)
             return credential.accessToken
         }
-        if let credential = Self.readClaudeKeychainViaSecurityCLI() {
-            cachedCredential = credential
-            Self.writePokeTokenBarCache(credential.data)
-            return credential.accessToken
-        }
+        // Claude Keychain 항목은 앱 직접 read 단일 경로로만 읽는다(프롬프트 1회).
+        // 과거의 `security` CLI 보조 경로는 별도 신원이라 같은 항목에 두 번째 ACL 프롬프트를
+        // 띄웠고(1.5s 타임아웃도 대화형에 부적합) 제거함. 최초 1회 허용 후 앱 자체 Keychain
+        // 캐시(writePokeTokenBarCache)에 저장돼 이후 재프롬프트 없음.
         guard allowKeychainPrompt else {
             throw LimitsError.keychainInteractionNotAllowed
         }
@@ -167,20 +166,6 @@ private actor OAuthAccessTokenCache {
         return credential
     }
 
-    private nonisolated static func readClaudeKeychainViaSecurityCLI() -> OAuthCredentialData.Credential? {
-        if KeychainAccessGate.isDisabled { return nil }
-        let data = SecurityCLIKeychainReader.readPasswordData(
-            service: OAuthCredentialData.claudeKeychainService,
-            timeout: 1.5)
-        guard let data else { return nil }
-        guard let credential = OAuthCredentialData.credential(from: data), !credential.isExpired else {
-            AppLog.write("oauth security cli returned unusable credential")
-            return nil
-        }
-        AppLog.write("oauth security cli credential cached")
-        return credential
-    }
-
     private nonisolated static func readClaudeKeychain(
         allowKeychainPrompt: Bool) throws -> OAuthCredentialData.Credential
     {
@@ -209,51 +194,6 @@ private actor OAuthAccessTokenCache {
             throw LimitsError.credentialFormat
         }
         return credential
-    }
-}
-
-private enum SecurityCLIKeychainReader {
-    private static let securityPath = "/usr/bin/security"
-
-    static func readPasswordData(service: String, timeout: TimeInterval) -> Data? {
-        guard FileManager.default.isExecutableFile(atPath: securityPath) else { return nil }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: securityPath)
-        process.arguments = ["find-generic-password", "-s", service, "-w"]
-        process.standardInput = FileHandle.nullDevice
-
-        let output = Pipe()
-        let errorOutput = Pipe()
-        process.standardOutput = output
-        process.standardError = errorOutput
-
-        do {
-            try process.run()
-        } catch {
-            AppLog.write("oauth security cli unavailable: \(error.localizedDescription)")
-            return nil
-        }
-
-        let deadline = Date().addingTimeInterval(timeout)
-        while process.isRunning && Date() < deadline {
-            Thread.sleep(forTimeInterval: 0.02)
-        }
-
-        if process.isRunning {
-            process.terminate()
-            AppLog.write("oauth security cli timed out")
-            return nil
-        }
-
-        let status = process.terminationStatus
-        guard status == 0 else {
-            let stderrCount = errorOutput.fileHandleForReading.readDataToEndOfFile().count
-            AppLog.write("oauth security cli failed status=\(status) stderrBytes=\(stderrCount)")
-            return nil
-        }
-
-        return output.fileHandleForReading.readDataToEndOfFile()
     }
 }
 

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -203,12 +203,12 @@ struct DexSummaryHeader: View {
 struct CollectionView: View {
     let store: CompanionStore
     var body: some View {
-        ScrollView {
-            if store.dexEntries.isEmpty {
-                Text(store.l.dexEmpty)
-                    .font(.caption).foregroundStyle(.tertiary)
-                    .frame(maxWidth: .infinity, alignment: .leading).padding(.vertical, 8)
-            } else {
+        if store.dexEntries.isEmpty {
+            emptyState
+        } else {
+            // 고정 높이 — maxHeight 는 팝오버 재오픈 시 ScrollView fitting size 가 작게 잡혀
+            // 크기가 줄어드는 문제가 있어 height 로 고정한다.
+            ScrollView {
                 VStack(alignment: .leading, spacing: 8) {
                     DexSummaryHeader(store: store)
                     ForEach(store.dexEntriesSorted) { entry in
@@ -233,7 +233,20 @@ struct CollectionView: View {
                     }
                 }
             }
+            .frame(height: 520)
         }
-        .frame(maxHeight: 520)
+    }
+
+    /// 빈 도감 — 안내 마스코트(피카츄, PokéAPI) + 포켓몬을 모으라는 문구.
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            SpriteView(speciesID: 25, size: 96)   // 피카츄
+            Text(store.l.dexEmptyTitle).font(.callout.weight(.semibold))
+            Text(store.l.dexEmptyHint)
+                .font(.caption).foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 28)
     }
 }

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -240,7 +240,7 @@ struct CollectionView: View {
     /// 빈 도감 — 안내 마스코트(피카츄, PokéAPI) + 포켓몬을 모으라는 문구.
     private var emptyState: some View {
         VStack(spacing: 10) {
-            SpriteView(speciesID: 25, size: 96)   // 피카츄
+            SpriteView(speciesID: 25, size: 96, animated: true)   // 피카츄(움직임)
             Text(store.l.dexEmptyTitle).font(.callout.weight(.semibold))
             Text(store.l.dexEmptyHint)
                 .font(.caption).foregroundStyle(.secondary)

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -87,7 +87,7 @@ struct EvoLineView: View {
     var body: some View {
         HStack(spacing: 2) {
             ForEach(Array(nodes.enumerated()), id: \.offset) { i, node in
-                if i > 0 { Image(systemName: "arrow.right").font(.system(size: 8)).foregroundStyle(.tertiary) }
+                if i > 0 { Image(systemName: "arrow.right").font(.system(size: thumb * 0.2)).foregroundStyle(.tertiary) }
                 SpriteView(speciesID: node.id, size: thumb)
                     .opacity(node.kind == "future" ? 0.32 : 1)
                     .saturation(node.kind == "future" ? 0.4 : 1)
@@ -222,7 +222,7 @@ struct CollectionView: View {
                                 Spacer()
                                 Text(store.l.formsComplete(entry.chainOrder.count)).font(.system(size: 9)).foregroundStyle(.secondary)
                             }
-                            EvoLineView(nodes: entry.chainOrder.map { ($0, "done") }, thumb: 38)
+                            EvoLineView(nodes: entry.chainOrder.map { ($0, "done") }, thumb: 56)
                             if let caughtAt = entry.caughtAt {
                                 Text(caughtAt, style: .relative).font(.system(size: 9)).foregroundStyle(.tertiary)
                             }
@@ -234,6 +234,6 @@ struct CollectionView: View {
                 }
             }
         }
-        .frame(maxHeight: 260)
+        .frame(maxHeight: 520)
     }
 }


### PR DESCRIPTION
> 사용자 요청대로 여러 테스트 피드백을 한 PR에 묶음 (PR 분리 안 함).

## 1. Collection 탭 가독성
| 요소 | Before | After |
|---|---|---|
| 진화 라인 썸네일 | 38pt | **56pt** |
| 진화 화살표 | 고정 8pt | **thumb×0.2**(비례 — 홈 탭 불변) |
| 리스트 높이 | 260 (≈2~3개) | **520**(≈5개) |

## 2. 빈 도감 마스코트 (움직임)
- 빈 컬렉션에 **피카츄(PokéAPI, `animated:true` Gen-V GIF 재생)** + "아직 잡은 포켓몬이 없어요!" / "토큰을 써서 첫 포켓몬을 부화시켜 보세요."(한/영/일).
- 요청은 "오박사"였으나 **PokéAPI에 트레이너(오박사) 미제공**(sprites: badges/items/pokemon/types만, `pokemon/professor-oak`→404) → 포켓몬 마스코트로 대체, 번들 없이 런타임 fetch 유지.

## 3. 재오픈 시 컬렉션 축소 버그 수정
- `ScrollView.frame(maxHeight:520)` → **`.frame(height:520)`**. transient 팝오버 재오픈 시 ScrollView fitting size 가 작게 잡혀 축소되던 문제.

## 4. Keychain 비밀번호 2회 → 1회
- 원인: Claude 자격증명(`Claude Code-credentials`)을 **두 신원**으로 읽어 각각 ACL 프롬프트 발생 — (a) `/usr/bin/security` CLI 서브프로세스, (b) 앱 직접 `SecItemCopyMatching`.
- 수정: **security CLI 리더 제거** → 앱 직접 read **단일 경로(프롬프트 1회)** → 앱 자체 Keychain 캐시에 저장해 재사용. (security CLI는 1.5s 타임아웃이라 대화형 비번 입력에도 부적합)
- 실패해도 한도 섹션만 숨김(graceful). `~/.claude/.credentials.json` 파일 경로가 있으면 프롬프트 0회.
- ⚠️ 단일-프롬프트 효과는 **서명이 안정적인 배포(Homebrew) 앱**에서 확실. 로컬 ad-hoc 재빌드는 서명이 매번 바뀌어 ACL이 유지되지 않을 수 있음(별개 이슈, `create-signing-cert.sh`).

## 검증
`swift build` + `swift test` **34건** 통과. 빈 상태 ImageRenderer 스냅샷 확인, 재설치·실행. code-reviewer APPROVE 각 변경(홈 탭 불변·dangling 참조 없음·단일 프롬프트 경로·401 재시도 루프 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)