### PR TITLE
fix: codex-only UX — resolve ccusage/codex via PATH, friendly Claude 401

### DIFF
--- a/Sources/PokeTokenBar/Core/BinaryLocator.swift
+++ b/Sources/PokeTokenBar/Core/BinaryLocator.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// CLI 바이너리(ccusage, codex 등) 절대경로 탐색.
+/// GUI 앱(launchd 실행)은 사용자 셸 PATH 를 상속하지 않아, Homebrew 외 버전매니저
+/// (mise/nvm/fnm/asdf/volta/bun)로 설치한 도구를 하드코딩 경로만으로는 못 찾는다.
+/// 전략: 수동 지정(UserDefaults "<binary>Path") → 정적 경로(빠름) → 로그인+인터랙티브 셸 PATH 해석.
+/// 바이너리별로 1회 캐시(셸 호출 비용 회피).
+enum BinaryLocator {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var cache: [String: String?] = [:]
+
+    /// `binary` 의 절대경로(없으면 nil). 스레드 세이프, 1회 해석 후 캐시.
+    /// `staticPaths`: 셸 해석 전에 먼저 확인할 알려진 설치 경로.
+    static func resolve(_ binary: String, staticPaths: [String]) -> String? {
+        lock.lock(); defer { lock.unlock() }
+        if let hit = cache[binary] { return hit }
+        let result = locate(binary, staticPaths: staticPaths)
+        cache[binary] = result
+        AppLog.write(result.map { "\(binary) resolved: \($0)" } ?? "\(binary) NOT found on PATH")
+        return result
+    }
+
+    /// 설정 변경/재탐지 시 캐시 무효화.
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        cache.removeAll()
+    }
+
+    /// 버전매니저 공통 shim/bin 경로 + 주어진 정적 경로. (절대경로 우선 탐색용)
+    static func commonNodeToolPaths(_ binary: String) -> [String] {
+        let home = NSHomeDirectory()
+        return [
+            "/opt/homebrew/bin/\(binary)",                 // Homebrew (Apple Silicon)
+            "/usr/local/bin/\(binary)",                    // Homebrew (Intel) / npm prefix
+            "\(home)/.local/share/mise/shims/\(binary)",   // mise (shims 모드)
+            "\(home)/.asdf/shims/\(binary)",               // asdf
+            "\(home)/.volta/bin/\(binary)",                // Volta
+            "\(home)/.bun/bin/\(binary)",                  // Bun
+            "\(home)/.npm-global/bin/\(binary)",           // npm prefix=~/.npm-global
+            "\(home)/.local/bin/\(binary)",
+            "/usr/bin/\(binary)",
+        ]
+    }
+
+    private static func locate(_ binary: String, staticPaths: [String]) -> String? {
+        let fm = FileManager.default
+        // 0) 사용자 수동 지정
+        if let override = UserDefaults.standard.string(forKey: "\(binary)Path"),
+           !override.isEmpty, fm.isExecutableFile(atPath: override) {
+            return override
+        }
+        // 1) 정적 경로 (서브프로세스 없이 빠르게)
+        if let hit = staticPaths.first(where: { fm.isExecutableFile(atPath: $0) }) {
+            return hit
+        }
+        // 2) 로그인+인터랙티브 셸 PATH 해석 (mise activate / nvm / fnm 등은 .zshrc 에서 PATH 주입)
+        return shellResolve(binary)
+    }
+
+    /// 사용자 로그인 셸을 인터랙티브+로그인으로 띄워 `command -v <binary>` 결과를 받는다.
+    /// 인터랙티브 프로파일이 stdout 에 noise(neofetch 등)를 찍을 수 있어 마커로 감싸 추출한다.
+    private static func shellResolve(_ binary: String) -> String? {
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        guard FileManager.default.isExecutableFile(atPath: shell) else { return nil }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-ilc", "printf '<<<BIN:%s:BIN>>>' \"$(command -v \(binary) 2>/dev/null)\""]
+        process.standardInput = FileHandle.nullDevice
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+
+        do { try process.run() } catch {
+            AppLog.write("\(binary) shell resolve spawn failed: \(error.localizedDescription)")
+            return nil
+        }
+        let deadline = Date().addingTimeInterval(8)
+        while process.isRunning && Date() < deadline { Thread.sleep(forTimeInterval: 0.05) }
+        if process.isRunning {
+            process.terminate()
+            AppLog.write("\(binary) shell resolve timed out")
+            return nil
+        }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        guard let raw = String(data: data, encoding: .utf8),
+              let path = parseMarkedPath(raw),
+              FileManager.default.isExecutableFile(atPath: path) else {
+            return nil
+        }
+        return path
+    }
+
+    /// `<<<BIN:/path/to/tool:BIN>>>` 에서 경로만 추출. 프로파일 noise 무시.
+    static func parseMarkedPath(_ s: String) -> String? {
+        guard let start = s.range(of: "<<<BIN:"),
+              let end = s.range(of: ":BIN>>>", range: start.upperBound..<s.endIndex) else {
+            return nil
+        }
+        let path = s[start.upperBound..<end.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines)
+        return path.isEmpty ? nil : path
+    }
+}

--- a/Sources/PokeTokenBar/Core/CcusageProvider.swift
+++ b/Sources/PokeTokenBar/Core/CcusageProvider.swift
@@ -1,11 +1,10 @@
 import Foundation
 
-/// ccusage 바이너리 기반 수집.
-/// Homebrew(Apple Silicon/Intel) 설치 경로를 순서대로 탐색한다.
+/// ccusage 바이너리 기반 수집. 바이너리 경로는 CcusageLocator 가 해석한다
+/// (Homebrew 외 mise/nvm/asdf 등 버전매니저 설치도 셸 PATH 로 탐색).
 struct CcusageProvider: UsageProvider {
     let id: String
     let displayName: String
-    let binaryCandidates: [String]
     let commandPrefix: [String]
     let supportsBlocks: Bool
     let supportsWeekly: Bool
@@ -14,10 +13,6 @@ struct CcusageProvider: UsageProvider {
     static let claude = CcusageProvider(
         id: "claude_code",
         displayName: "Claude Code",
-        binaryCandidates: [
-            "/opt/homebrew/bin/ccusage",
-            "/usr/local/bin/ccusage",
-        ],
         commandPrefix: ["claude"],
         supportsBlocks: true,
         supportsWeekly: true,
@@ -27,10 +22,6 @@ struct CcusageProvider: UsageProvider {
     static let codex = CcusageProvider(
         id: "codex",
         displayName: "Codex",
-        binaryCandidates: [
-            "/opt/homebrew/bin/ccusage",
-            "/usr/local/bin/ccusage",
-        ],
         commandPrefix: ["codex"],
         supportsBlocks: false,
         supportsWeekly: false,
@@ -38,7 +29,7 @@ struct CcusageProvider: UsageProvider {
     )
 
     var resolvedBinary: String? {
-        binaryCandidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+        BinaryLocator.resolve("ccusage", staticPaths: BinaryLocator.commonNodeToolPaths("ccusage"))
     }
 
     // MARK: critical path — 오늘 합계

--- a/Sources/PokeTokenBar/Core/CodexRateLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/CodexRateLimitsProvider.swift
@@ -20,7 +20,8 @@ struct CodexRateLimitsProvider {
     }
 
     var resolvedBinary: String? {
-        binaryCandidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+        // 앱 번들/홈 경로 우선, 이후 버전매니저 공통 경로 + 로그인 셸 PATH 해석(mise 등).
+        BinaryLocator.resolve("codex", staticPaths: binaryCandidates + BinaryLocator.commonNodeToolPaths("codex"))
     }
 
     func fetch() async throws -> CodexRateLimitStatus? {

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -129,6 +129,27 @@ struct L {
     func statusEvolved(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！") }
     var statusGrew: String { t("성장했어요!", "It grew!", "成長しました！") }
 
+    // MARK: Claude 한도 토큰 갱신 오류 (친절 안내)
+    func limitRefreshHTTPError(_ status: Int) -> String {
+        if status == 401 || status == 403 {
+            return t(
+                "Claude 자격증명이 만료됐거나 권한이 없어요 (\(status)). Claude Code 로그인을 확인하세요. Codex만 쓴다면 무시해도 됩니다 — Codex 한도는 따로 표시돼요.",
+                "Claude credential is expired or unauthorized (\(status)). Check that you're signed in to Claude Code. If you only use Codex you can ignore this — Codex limits show separately.",
+                "Claude の認証情報が期限切れか権限がありません (\(status))。Claude Code にサインインしているか確認してください。Codex のみ使用する場合は無視できます — Codex の上限は別に表示されます。")
+        }
+        return t("Claude 한도 조회 실패 (\(status)).", "Failed to fetch Claude limits (\(status)).", "Claude の上限取得に失敗しました (\(status))。")
+    }
+    var limitRefreshNoCredential: String {
+        t("Claude 자격증명을 찾지 못했어요. Claude Code 에 로그인하면 한도가 표시됩니다. Codex만 쓴다면 무시해도 돼요.",
+          "No Claude credential found. Sign in to Claude Code to see limits. If you only use Codex you can ignore this.",
+          "Claude の認証情報が見つかりません。Claude Code にサインインすると上限が表示されます。Codex のみなら無視して構いません。")
+    }
+    var limitRefreshGeneric: String {
+        t("Claude 한도 조회에 실패했어요. 잠시 후 다시 시도하세요.",
+          "Couldn't fetch Claude limits. Please try again shortly.",
+          "Claude の上限取得に失敗しました。しばらくして再試行してください。")
+    }
+
     // MARK: 알림
     var notifCritical: String { t("한도 임박", "Limit imminent", "上限切迫") }
     var notifWarning: String { t("한도 경고", "Limit warning", "上限警告") }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -380,9 +380,23 @@ final class UsageStore {
             AppLog.write("limits refreshed by user action fiveHour=\(limits?.fiveHour?.utilization?.description ?? "nil") sevenDay=\(limits?.sevenDay?.utilization?.description ?? "nil")")
             AppLog.write("limits refreshed from keychain by user action")
         } catch {
-            limitTokenRefreshError = "\(error)"
+            limitTokenRefreshError = Self.friendlyLimitError(error, L(localizationLanguage))
             if limits == nil { limitsAvailable = false }
             AppLog.write("limits user refresh failed: \(error)")
+        }
+    }
+
+    /// 한도 갱신 실패를 사용자 친화 메시지로 변환. Codex만 쓰는 사용자는 401 이 정상이라,
+    /// raw "httpStatus(401)" 대신 "무시해도 된다"는 안내를 보여준다.
+    private static func friendlyLimitError(_ error: any Error, _ l: L) -> String {
+        guard let limitsError = error as? LimitsError else { return l.limitRefreshGeneric }
+        switch limitsError {
+        case .httpStatus(let status):
+            return l.limitRefreshHTTPError(status)
+        case .keychainUnavailable, .credentialFormat:
+            return l.limitRefreshNoCredential
+        case .keychainInteractionNotAllowed, .keychainAccessDisabled:
+            return l.limitRefreshGeneric
         }
     }
 

--- a/Tests/PokeTokenBarTests/BinaryLocatorTests.swift
+++ b/Tests/PokeTokenBarTests/BinaryLocatorTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import PokeTokenBar
+
+final class BinaryLocatorTests: XCTestCase {
+    func testParsesCleanMarkedPath() {
+        XCTAssertEqual(
+            BinaryLocator.parseMarkedPath("<<<BIN:/opt/homebrew/bin/ccusage:BIN>>>"),
+            "/opt/homebrew/bin/ccusage")
+    }
+
+    func testIgnoresProfileNoiseAroundMarker() {
+        // 인터랙티브 셸이 neofetch 등 stdout noise 를 찍어도 마커만 추출
+        let noisy = """
+        ⠀⣴⣶⣷ neofetch art line 1
+        OS: macOS / Shell: zsh
+        <<<BIN:/Users/x/.local/share/mise/installs/node/22.14.0/bin/ccusage:BIN>>>
+        """
+        XCTAssertEqual(
+            BinaryLocator.parseMarkedPath(noisy),
+            "/Users/x/.local/share/mise/installs/node/22.14.0/bin/ccusage")
+    }
+
+    func testEmptyPathReturnsNil() {
+        // command -v 가 못 찾으면 마커 사이가 비어 있음
+        XCTAssertNil(BinaryLocator.parseMarkedPath("noise\n<<<BIN::BIN>>>\n"))
+    }
+
+    func testMissingMarkersReturnsNil() {
+        XCTAssertNil(BinaryLocator.parseMarkedPath("just some neofetch output, no marker"))
+        XCTAssertNil(BinaryLocator.parseMarkedPath("<<<BIN:/path/without/closing"))
+    }
+
+    func testTrimsWhitespace() {
+        XCTAssertEqual(BinaryLocator.parseMarkedPath("<<<BIN:  /usr/local/bin/codex \n :BIN>>>"),
+                       "/usr/local/bin/codex")
+    }
+
+    func testCommonPathsIncludeManagersForBinary() {
+        let paths = BinaryLocator.commonNodeToolPaths("ccusage")
+        XCTAssertTrue(paths.contains("/opt/homebrew/bin/ccusage"))
+        XCTAssertTrue(paths.contains { $0.contains("/.local/share/mise/shims/ccusage") })
+        XCTAssertTrue(paths.contains { $0.contains("/.asdf/shims/ccusage") })
+        XCTAssertTrue(paths.contains { $0.contains("/.volta/bin/ccusage") })
+    }
+}


### PR DESCRIPTION
Codex만 쓰는 사용자(친구 제보)의 두 문제 해결.

## 1. 토큰 사용량 집계 안 됨 — 버전매니저 설치 경로 미탐색

**증상**: mise 로 ccusage 를 깐 사용자는 집계가 0. (`/Users/x/.local/share/mise/installs/node/22.14.0/bin/ccusage`)
**원인**: GUI 앱(launchd)은 사용자 셸 PATH 를 상속하지 않는데, ccusage 경로를 `/opt/homebrew/bin`·`/usr/local/bin` **두 곳만** 하드코딩 탐색했음.

**`BinaryLocator`(신규)** — 2층 탐색 후 1회 캐시:
- **정적 fast-path**: homebrew(ARM/Intel), `mise/shims`, `asdf/shims`, `volta/bin`, `bun/bin`, `~/.npm-global/bin`, `~/.local/bin`
- **셸 PATH 해석(범용)**: `$SHELL -ilc 'command -v <binary>'` — 로그인+인터랙티브 셸이 프로파일(.zshrc 등)을 로드 → **mise(activate)·nvm·fnm·n·nodenv·asdf** 등 *PATH 주입형 모든 매니저* 자동 커버. 인터랙티브 셸 stdout noise(neofetch 등)는 마커로 감싸 경로만 추출.
- `ccusage`·`codex` 두 바이너리 모두 적용(`CcusageProvider`·`CodexRateLimitsProvider`). 수동 지정도 가능(`UserDefaults "<binary>Path"`).

**검증**: 실 앱 로그 — `ccusage resolved: …`, `codex resolved: …`, 그리고 `phase1 recv id=codex today=788715` + claude 233M **합산** 확인. homebrew 사용자는 정적 경로 즉시 hit → 회귀/성능 영향 없음.

## 2. 키체인 '한도 토큰 갱신' 401 — 고장처럼 보임

**증상**: Codex만 쓰는 사용자가 설정에서 '한도 토큰 캐시 갱신'을 누르면 raw `httpStatus(401)` 표시.
**원인/판정**: 기능상 **정상** — Claude 한도는 유효한 Claude 자격증명이 있어야 조회 가능. Codex-only 면 401 이 맞음. 단 **raw 401 표시가 나쁜 UX**.
**수정**: `friendlyLimitError` 로 친절 안내(한/영/일) — "Claude 로그인 확인, **Codex만 쓰면 무시 가능 — Codex 한도는 따로 표시됨**".

## 검증
`swift build` + `swift test` **40건**(기존 34 + 신규 6: 마커 파싱·noise 무시·공통 경로). code-reviewer APPROVE(락/서브프로세스·LimitsError 망라성·회귀 점검).

🤖 Generated with [Claude Code](https://claude.com/claude-code)