### PR TITLE
feat: in-app update notification + one-click apply

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -150,6 +150,16 @@ struct L {
           "Claude の上限取得に失敗しました。しばらくして再試行してください。")
     }
 
+    // MARK: 업데이트 알림
+    func updateAvailable(_ version: String, current: String) -> String {
+        t("🆕 v\(version) 사용 가능 (현재 \(current))",
+          "🆕 v\(version) available (you have \(current))",
+          "🆕 v\(version) が利用可能（現在 \(current)）")
+    }
+    var updateButton: String { t("업데이트", "Update", "更新") }
+    var updateLater: String { t("나중에", "Later", "後で") }
+    var updating: String { t("업데이트 중…", "Updating…", "更新中…") }
+
     // MARK: 알림
     var notifCritical: String { t("한도 임박", "Limit imminent", "上限切迫") }
     var notifWarning: String { t("한도 경고", "Limit warning", "上限警告") }

--- a/Sources/PokeTokenBar/Core/UpdateChecker.swift
+++ b/Sources/PokeTokenBar/Core/UpdateChecker.swift
@@ -1,0 +1,119 @@
+import AppKit
+import Observation
+
+/// GitHub 릴리스 최신 버전을 확인해 새 버전이 있으면 팝오버에 알린다.
+/// 실제 설치는 brew 사용자면 `brew upgrade`, 그 외엔 릴리스 페이지 열기(저위험·인프라 0).
+@MainActor
+@Observable
+final class UpdateChecker {
+    struct Available: Equatable { let version: String; let url: String }
+
+    private(set) var available: Available?
+    private(set) var isUpdating = false
+
+    let currentVersion: String
+    private let repo = "chattymin/poke-token-bar"
+    private let clock: () -> Date
+    private var lastChecked: Date?
+
+    init(currentVersion: String? = nil, clock: @escaping () -> Date = Date.init) {
+        self.currentVersion = currentVersion
+            ?? (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "0"
+        self.clock = clock
+    }
+
+    /// 최신 릴리스 조회 → 새 버전이고 사용자가 그 버전을 'skip' 하지 않았으면 available 설정.
+    /// minInterval 보다 자주 호출되면 무시(레이트리밋 보호).
+    func check(minInterval: TimeInterval = 1800) async {
+        if let last = lastChecked, clock().timeIntervalSince(last) < minInterval { return }
+        lastChecked = clock()
+        guard let url = URL(string: "https://api.github.com/repos/\(repo)/releases/latest") else { return }
+        var req = URLRequest(url: url, timeoutInterval: 15)
+        req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        guard let (data, resp) = try? await URLSession.shared.data(for: req),
+              (resp as? HTTPURLResponse)?.statusCode == 200,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tag = json["tag_name"] as? String,
+              let html = json["html_url"] as? String else { return }
+        let latest = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
+        let skipped = UserDefaults.standard.string(forKey: "skippedUpdateVersion")
+        if Self.isNewer(latest, than: currentVersion), latest != skipped {
+            available = Available(version: latest, url: html)
+        } else {
+            available = nil
+        }
+    }
+
+    /// 이 버전은 다시 알리지 않음.
+    func skipCurrent() {
+        if let v = available?.version { UserDefaults.standard.set(v, forKey: "skippedUpdateVersion") }
+        available = nil
+    }
+
+    /// 업데이트 적용: brew cask 설치본이면 `brew upgrade` 후 재시작, 아니면 릴리스 페이지.
+    func applyUpdate() {
+        guard let update = available else { return }
+        guard !isUpdating else { return }
+        isUpdating = true
+        Task { @MainActor in
+            let upgraded = await Task.detached { Self.brewUpgradeIfInstalled() }.value
+            isUpdating = false
+            if upgraded {
+                Self.relaunch()
+            } else if let u = URL(string: update.url) {
+                AppLog.write("update: brew upgrade unavailable/failed → opening release page")
+                NSWorkspace.shared.open(u)
+            }
+        }
+    }
+
+    // MARK: 버전 비교
+
+    /// a 가 b 보다 높은 semver 인가. ("2.0.10" > "2.0.9" 등 숫자 비교)
+    nonisolated static func isNewer(_ a: String, than b: String) -> Bool {
+        let pa = a.split(separator: ".").map { Int($0) ?? 0 }
+        let pb = b.split(separator: ".").map { Int($0) ?? 0 }
+        for i in 0..<max(pa.count, pb.count) {
+            let x = i < pa.count ? pa[i] : 0
+            let y = i < pb.count ? pb[i] : 0
+            if x != y { return x > y }
+        }
+        return false
+    }
+
+    // MARK: brew 적용 (nonisolated — 블로킹 Process 는 detached 에서)
+
+    /// brew cask 설치본이면 업그레이드. 설치본이 아니거나 brew 없으면 false(→ 릴리스 페이지 폴백).
+    private nonisolated static func brewUpgradeIfInstalled() -> Bool {
+        guard let brew = BinaryLocator.resolve("brew", staticPaths: [
+            "/opt/homebrew/bin/brew", "/usr/local/bin/brew",
+        ]) else { return false }
+        guard run(brew, ["list", "--cask", "poke-token-bar"], timeout: 20) else { return false }
+        return run(brew, ["upgrade", "--cask", "poke-token-bar"], timeout: 300)
+    }
+
+    private nonisolated static func run(_ binary: String, _ args: [String], timeout: TimeInterval) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.arguments = args
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do { try process.run() } catch { return false }
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning && Date() < deadline { Thread.sleep(forTimeInterval: 0.1) }
+        if process.isRunning { process.terminate(); return false }
+        return process.terminationStatus == 0
+    }
+
+    /// 교체된 새 번들을 다시 띄우고 현재 인스턴스 종료(분리된 sh 가 종료를 기다렸다 open).
+    private static func relaunch() {
+        let path = Bundle.main.bundlePath
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/sh")
+        // 경로를 스크립트 문자열에 보간하지 않고 positional 인자($1)로 전달 — 셸 인젝션 차단.
+        task.arguments = ["-c", "sleep 2; open \"$1\"", "sh", path]
+        try? task.run()
+        NSApp.terminate(nil)
+    }
+}

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -18,6 +18,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let popover = NSPopover()
     private var store: UsageStore!
     private var companion: CompanionStore!
+    private var updater: UpdateChecker!
 
     // 메뉴바 캐릭터 애니메이션 — 단일 타이머로 프레임 순환.
     // 프레임 = 이미 22px 로 합성된 이미지 + delay. egg/static 은 2프레임 bob, animated 는 GIF 실제 프레임.
@@ -32,7 +33,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Self.migrateLegacyStorageIfNeeded()   // TokenMac → PokeTokenBar 리네임: 기존 companion/캐시 보존
         store = UsageStore()
         companion = CompanionStore()
+        updater = UpdateChecker()
         store.localizationLanguage = companion.language   // 알림 현지화용 미러 시드
+        Task { await updater.check() }                    // 기동 시 1회 업데이트 확인
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem.button {
@@ -44,7 +47,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         popover.contentViewController = NSHostingController(
-            rootView: PopoverView().environment(store).environment(companion))
+            rootView: PopoverView().environment(store).environment(companion).environment(updater))
         popover.behavior = .transient
 
         observeStore()
@@ -204,6 +207,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.activate(ignoringOtherApps: true)
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             popover.contentViewController?.view.window?.makeKeyAndOrderFront(nil)
+            Task { await updater.check() }   // 팝오버 열 때 재확인(내부 minInterval 디바운스)
         }
     }
 }

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -5,6 +5,7 @@ enum PopoverTab { case home, collection }
 struct PopoverView: View {
     @Environment(UsageStore.self) private var store
     @Environment(CompanionStore.self) private var companion
+    @Environment(UpdateChecker.self) private var updater
     @State private var showSettings = false
     @State private var tab: PopoverTab = .home
 
@@ -25,8 +26,32 @@ struct PopoverView: View {
         .frame(width: 360)
     }
 
+    @ViewBuilder
+    private var updateBanner: some View {
+        if let update = updater.available {
+            HStack(spacing: 8) {
+                Text(l.updateAvailable(update.version, current: updater.currentVersion))
+                    .font(.caption)
+                Spacer()
+                if updater.isUpdating {
+                    Text(l.updating).font(.caption2).foregroundStyle(.secondary)
+                    ProgressView().controlSize(.small)
+                } else {
+                    Button(l.updateButton) { updater.applyUpdate() }
+                        .buttonStyle(.borderedProminent).controlSize(.small)
+                    Button(l.updateLater) { updater.skipCurrent() }
+                        .buttonStyle(.borderless).controlSize(.small).foregroundStyle(.secondary)
+                }
+            }
+            .padding(8)
+            .background(Color.accentColor.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
     private var mainContent: some View {
         VStack(alignment: .leading, spacing: 12) {
+            updateBanner
             Picker("", selection: $tab) {
                 Text(l.home).tag(PopoverTab.home)
                 Text(l.collection).tag(PopoverTab.collection)

--- a/Tests/PokeTokenBarTests/UpdateCheckerTests.swift
+++ b/Tests/PokeTokenBarTests/UpdateCheckerTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import PokeTokenBar
+
+final class UpdateCheckerTests: XCTestCase {
+    func testNewerPatch() {
+        XCTAssertTrue(UpdateChecker.isNewer("2.0.2", than: "2.0.1"))
+    }
+    func testSameIsNotNewer() {
+        XCTAssertFalse(UpdateChecker.isNewer("2.0.1", than: "2.0.1"))
+    }
+    func testOlderIsNotNewer() {
+        XCTAssertFalse(UpdateChecker.isNewer("2.0.0", than: "2.0.1"))
+        XCTAssertFalse(UpdateChecker.isNewer("2.0.9", than: "2.1.0"))
+    }
+    func testNumericNotLexical() {
+        // "2.0.10" 은 "2.0.9" 보다 높다 (문자열 비교면 반대로 틀림)
+        XCTAssertTrue(UpdateChecker.isNewer("2.0.10", than: "2.0.9"))
+    }
+    func testMinorAndMajor() {
+        XCTAssertTrue(UpdateChecker.isNewer("2.1.0", than: "2.0.9"))
+        XCTAssertTrue(UpdateChecker.isNewer("3.0.0", than: "2.9.9"))
+    }
+    func testDifferentComponentCounts() {
+        XCTAssertTrue(UpdateChecker.isNewer("2.0.1", than: "2.0"))   // 2.0.1 > 2.0.0
+        XCTAssertFalse(UpdateChecker.isNewer("2.0", than: "2.0.0"))  // 동일
+    }
+}


### PR DESCRIPTION
자동 업데이트 문의 대응 — Homebrew·ad-hoc 서명 배포에 맞춘 **저위험 인앱 알림** 방식(Sparkle 같은 키/appcast/프레임워크 인프라 불필요).

## 동작
- **`UpdateChecker`**: GitHub `releases/latest` 조회 → 현재 버전(CFBundleShortVersionString)과 **숫자 semver 비교**(`2.0.10` > `2.0.9`) → 새 버전이고 'skip' 안 한 버전이면 **팝오버 상단 배너**. 기동 시 + 팝오버 열 때(30분 디바운스, 레이트리밋 보호) 확인.
- **배너**: `🆕 v2.1.0 사용 가능 (현재 2.0.1)` + [업데이트] / [나중에]. 한/영/일.
- **[업데이트]**: brew cask 설치본이면 `brew upgrade --cask poke-token-bar` 실행 후 자동 재시작, 아니면(직접 다운로드/그 외) **릴리스 페이지** 열기. brew 경로는 `BinaryLocator` 재사용.
- **[나중에]**: 그 버전 skip(다음 버전엔 다시 알림).

## 검증
- ImageRenderer 로 배너 렌더 확인(텍스트 + Update 버튼). GitHub API `tag_name=v2.0.1` 확인 → 현재 2.0.1 이라 배너 미표시(정상). `isNewer` 테스트 6건 포함 **46 tests** 통과.
- **code-reviewer**: [HIGH] `relaunch()` 셸 인젝션(경로 보간) → **수정**(경로를 `$1` positional 인자로 전달, 스크립트에 미보간). 그 외 차단 이슈 없음.

## 비고
배너는 **새 릴리스가 있을 때만** 보임 — 다음 릴리스부터 기존 2.0.1 사용자에게 표시됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)