### PR TITLE
feat: egg incubation threshold (anticipation before hatch)

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -45,6 +45,9 @@ enum Rarity: String, Codable, Sendable {
 /// 졸업 총량 T 는 같은 희귀도면 진화 단계 수와 무관하게 동일.
 /// 형태 k개 라인에서 i번째 형태 성장 비용 = T·i / (k(k+1)/2) → 합 = T, 단계↑일수록 비용↑.
 enum PokemonBalance {
+    /// 알 부화 임계 — 이만큼 토큰을 써야 알이 깨진다(즉시 부화 대신 기대감). 초과분은 부화체 성장에 이월.
+    static let eggHatchThreshold = 5_000_000
+
     static func graduationTotal(_ rarity: Rarity) -> Int {
         switch rarity {
         case .common:    return    750_000_000
@@ -128,6 +131,8 @@ struct CompanionState: Codable, Sendable {
     // 토큰: 설치 이후만 측정
     var installBaselineSet = false
     var usedSinceInstall = 0
+    // 현재 알이 생긴 뒤 쓴 토큰(부화 인큐베이션). 누적(usedSinceInstall)과 별개 — 졸업 후 새 알마다 0.
+    var eggUsage = 0
     var claimedTodayTokens = 0
     var lastDate = ""
     // 현재 포켓몬(없으면 알)
@@ -139,6 +144,20 @@ struct CompanionState: Codable, Sendable {
     var language: AppLanguage = .ko
 
     init() {}
+
+    // 하위호환 디코딩: 누락 키는 기본값(필드 추가가 기존 저장을 깨지 않도록).
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        installBaselineSet = try c.decodeIfPresent(Bool.self, forKey: .installBaselineSet) ?? false
+        usedSinceInstall = try c.decodeIfPresent(Int.self, forKey: .usedSinceInstall) ?? 0
+        eggUsage = try c.decodeIfPresent(Int.self, forKey: .eggUsage) ?? 0
+        claimedTodayTokens = try c.decodeIfPresent(Int.self, forKey: .claimedTodayTokens) ?? 0
+        lastDate = try c.decodeIfPresent(String.self, forKey: .lastDate) ?? ""
+        active = try c.decodeIfPresent(MonState.self, forKey: .active)
+        dex = try c.decodeIfPresent([DexEntry].self, forKey: .dex) ?? []
+        collectedFinals = try c.decodeIfPresent(Set<String>.self, forKey: .collectedFinals) ?? []
+        language = try c.decodeIfPresent(AppLanguage.self, forKey: .language) ?? .ko
+    }
 }
 
 /// 부화 후보 base 종 — (PokéAPI 식별자, 선택 가중 tier). 3단/2단/무진화/분기 골고루.

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -48,6 +48,12 @@ final class CompanionStore {
     var hasActive: Bool { state.active != nil }
     var rarity: Rarity? { state.active?.rarity }
 
+    // 알 인큐베이션 (active 없을 때)
+    var isEgg: Bool { state.active == nil }
+    var eggStarted: Bool { state.eggUsage > 0 }
+    var eggProgress: Double { min(1, max(0, Double(state.eggUsage) / Double(PokemonBalance.eggHatchThreshold))) }
+    var eggTokensToHatch: Int { max(0, PokemonBalance.eggHatchThreshold - state.eggUsage) }
+
     var displayName: String {
         guard let a = state.active, let line = currentLine else { return "Token Egg" }
         return line.localizedName(a.currentID, state.language)
@@ -117,13 +123,17 @@ final class CompanionStore {
                 let delta = todayTokens - state.claimedTodayTokens
                 state.claimedTodayTokens = todayTokens
                 state.usedSinceInstall += delta
-                applyUsage(delta)
+                if state.active == nil {
+                    state.eggUsage += delta   // 알 인큐베이션 누적
+                } else {
+                    applyUsage(delta)
+                }
             }
         }
         // 이벤트 만료
         if let until = eventUntil, clock() > until { justGraduated = nil; eventUntil = nil }
-        // 알이면 부화(첫 사용량 후 / 졸업 후)
-        if state.active == nil, state.usedSinceInstall > 0, !isHatching {
+        // 알이 부화 임계에 도달하면 부화
+        if state.active == nil, state.eggUsage >= PokemonBalance.eggHatchThreshold, !isHatching {
             Task { await hatchIfNeeded() }
         }
         // active 인데 라인 미로딩(앱 재시작) → 로드
@@ -177,12 +187,13 @@ final class CompanionStore {
         eventUntil = clock().addingTimeInterval(6)
         state.active = nil
         currentLine = nil
+        state.eggUsage = 0   // 새 알은 처음부터 인큐베이션
     }
 
     // MARK: 부화
 
     func hatchIfNeeded() async {
-        guard state.active == nil, !isHatching, state.usedSinceInstall > 0 else { return }
+        guard state.active == nil, !isHatching, state.eggUsage >= PokemonBalance.eggHatchThreshold else { return }
         await hatch(baseID: chooseBase())
     }
 
@@ -192,10 +203,14 @@ final class CompanionStore {
         defer { isHatching = false }
         guard let line = try? await provider.line(baseSpeciesID: baseID) else { return }
         currentLine = line
+        // 부화 임계 초과분은 부화체 성장에 이월(낭비 없음).
+        let overflow = max(0, state.eggUsage - PokemonBalance.eggHatchThreshold)
+        state.eggUsage = 0
         state.active = MonState(baseID: line.baseID, pathIDs: [line.baseID], stageIndex: 0,
                                 usedAtStage: 0, rarity: line.rarity, totalForms: line.totalForms)
         displayState = .levelUp
         eventUntil = clock().addingTimeInterval(4)
+        if overflow > 0 { applyUsage(overflow) }   // 이월분 즉시 반영(필요 시 진화까지)
         save()
     }
 

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -92,6 +92,8 @@ struct L {
     var finalForm: String { t("최종 진화체", "Final form", "最終進化") }
     func stage(_ i: Int, _ k: Int) -> String { t("진화 단계 \(i) / \(k)", "Stage \(i) / \(k)", "進化段階 \(i) / \(k)") }
     var waitingFirstToken: String { t("설치 후 첫 토큰을 기다리는 중…", "Waiting for your first tokens…", "最初のトークンを待っています…") }
+    var eggIncubating: String { t("🥚 부화 준비 중", "🥚 Incubating", "🥚 孵化の準備中") }
+    func eggToHatch(_ amount: String) -> String { t("부화까지 \(amount)", "\(amount) to hatch", "孵化まで \(amount)") }
     func toNextEvolution(_ amount: String) -> String { t("다음 진화까지 \(amount)", "\(amount) to next evolution", "次の進化まで \(amount)") }
     func toGraduation(_ amount: String) -> String { t("졸업까지 \(amount)", "\(amount) to graduation", "卒業まで \(amount)") }
     func graduated(_ name: String) -> String {

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -131,7 +131,11 @@ struct CompanionHeader: View {
                                 .font(.caption2).foregroundStyle(.tertiary)
                         }
                     } else {
-                        Text(store.l.waitingFirstToken).font(.caption2).foregroundStyle(.secondary)
+                        // 알 인큐베이션 — 부화까지 진행
+                        Text(store.l.eggIncubating).font(.caption2).foregroundStyle(.secondary)
+                        ProgressView(value: store.eggProgress).controlSize(.small).tint(.orange)
+                        Text(store.l.eggToHatch(TokenFormatter.compact(store.eggTokensToHatch)))
+                            .font(.caption2).foregroundStyle(.tertiary)
                     }
                     Text(statusLine).font(.caption2).foregroundStyle(.secondary)
                 }

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -134,6 +134,62 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(s.state.usedSinceInstall, 100_000_000)
     }
 
+    private func base(_ s: CompanionStore) {
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+    }
+    private func use(_ s: CompanionStore, _ today: Int) {
+        s.update(todayTokens: today, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+    }
+
+    func testEggDoesNotHatchBelowThreshold() async {
+        let s = store(linear3)
+        base(s)
+        use(s, 500_000)   // < 1M
+        XCTAssertEqual(s.state.eggUsage, 500_000)
+        XCTAssertTrue(s.isEgg)
+        await s.hatchIfNeeded()
+        XCTAssertNil(s.state.active)   // 임계 미만 → 미부화
+    }
+
+    func testEggHatchesAtThreshold() async {
+        let s = store(linear3)
+        base(s)
+        use(s, PokemonBalance.eggHatchThreshold)   // = 1M
+        XCTAssertEqual(s.state.eggUsage, PokemonBalance.eggHatchThreshold)
+        await s.hatchIfNeeded()
+        XCTAssertNotNil(s.state.active)
+        XCTAssertEqual(s.state.eggUsage, 0)
+    }
+
+    func testEggOverflowCarriesToHatchedMon() async {
+        let s = store(linear3)
+        base(s)
+        use(s, PokemonBalance.eggHatchThreshold + 500_000)   // 임계 초과 0.5M
+        await s.hatchIfNeeded()
+        XCTAssertEqual(s.state.active?.usedAtStage, 500_000)   // 초과분 이월
+    }
+
+    func testNewEggAfterGraduationReincubates() async {
+        let s = store(noEvo)
+        base(s)
+        use(s, PokemonBalance.eggHatchThreshold)
+        await s.hatchIfNeeded()
+        XCTAssertNotNil(s.state.active)
+        s.applyUsage(PokemonBalance.graduationTotal(.common))   // 무진화 졸업
+        XCTAssertNil(s.state.active)
+        XCTAssertEqual(s.state.eggUsage, 0)                     // 새 알 인큐베이션 리셋
+        await s.hatchIfNeeded()                                 // eggUsage=0 → 즉시 부화 안 함
+        XCTAssertNil(s.state.active)
+    }
+
+    func testStateDecodesWithoutEggUsage() throws {
+        // 기존 저장(필드 없음)도 깨지지 않고 eggUsage=0 으로 로드
+        let json = #"{"installBaselineSet":true,"usedSinceInstall":5,"claimedTodayTokens":5,"lastDate":"d","active":null,"dex":[],"collectedFinals":[],"language":"ko"}"#
+        let state = try JSONDecoder().decode(CompanionState.self, from: Data(json.utf8))
+        XCTAssertEqual(state.eggUsage, 0)
+        XCTAssertEqual(state.usedSinceInstall, 5)
+    }
+
     func testEvolvesThroughLineAndGraduatesWithFullChain() async {
         let s = store(linear3)
         await s.hatch(baseID: 1)


### PR DESCRIPTION
## 무엇을

알이 **첫 토큰 즉시 깨지던** 것 → **임계(5M 토큰) 도달 시 부화**. 알이 차오르는 동안 "부화까지 X" 진행바로 *어떤 포켓몬이 나올까* 기대하게 만든다.

| Before | After |
|---|---|
| `usedSinceInstall > 0` 이면 즉시 부화 | `eggUsage >= 5,000,000` 도달 시 부화, 진행바 표시 |

## 동작
- **`eggUsage`**(신규 상태 필드): *현재 알이 생긴 뒤* 쓴 토큰. 누적 `usedSinceInstall` 과 별개 — **졸업 후 새 알마다 0** (안 그러면 누적값이 커서 새 알이 즉시 깨짐).
- `update()`: active 없으면 delta 를 `eggUsage` 로 누적, 임계 도달 시 부화. **초과분은 부화체 성장에 이월**(낭비 없음).
- `graduate()`: `eggUsage=0` → 새 알도 처음부터 인큐베이션.
- **`PokemonBalance.eggHatchThreshold = 5_000_000`** — 한 줄 튜닝 가능 상수.
- **하위호환 디코딩**: `CompanionState.init(from:)` 가 모든 필드 `decodeIfPresent` — 기존 저장에 `eggUsage` 없어도 깨지지 않고 보존(기존 사용자 companion 유지).

## UI
팝오버 알 상태: 🥚 + "Token Egg" + **"🥚 부화 준비 중" + 진행바 + "부화까지 X"** + "곧 깨어나요." (한/영/일). ImageRenderer 로 확인.

## 검증
`swift test` **51건**(기존 46 + 신규 5). code-reviewer APPROVE(Encodable 라운드트립·new-egg 게이트·overflow 순서). 5M @ 평균 253M/day ≈ 30분 인큐베이션.

🤖 Generated with [Claude Code](https://claude.com/claude-code)