### PR TITLE
feat: companion event notifications + selectable notification toggles

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import UserNotifications
 
 /// 게임 상태의 출처. 설치 이후 토큰 사용량으로 포켓몬을 진화시키고, 최종체 + 추가 임계 도달 시
 /// 도감(라인 전체)에 보존 + 새 알. 진화 트리/희귀도/이름은 PokeProviding 으로 런타임 주입.
@@ -163,7 +164,9 @@ final class CompanionStore {
                 state.active!.pathIDs = Array(a.pathIDs.prefix(a.stageIndex + 1)) + [next.speciesID]
                 state.active!.stageIndex += 1
                 state.active!.usedAtStage = a.usedAtStage - thr   // 초과분 이월
-                justEvolvedTo = line.localizedName(next.speciesID, state.language)
+                let newName = line.localizedName(next.speciesID, state.language)
+                justEvolvedTo = newName
+                notifyCompanionEvent(l.notifEvolveTitle, l.notifEvolveBody(newName))
             }
         }
         save()
@@ -183,11 +186,27 @@ final class CompanionStore {
         state.collectedFinals.insert("\(a.baseID):\(finalID)")
         state.dex.append(DexEntry(baseID: a.baseID, finalID: finalID,
                                   chainOrder: a.pathIDs, rarity: a.rarity, caughtAt: clock()))
-        justGraduated = currentLine?.localizedName(finalID, state.language)
+        let name = currentLine?.localizedName(finalID, state.language) ?? ""
+        justGraduated = name
+        notifyCompanionEvent(l.notifGraduateTitle, l.notifGraduateBody(name))
         eventUntil = clock().addingTimeInterval(6)
         state.active = nil
         currentLine = nil
         state.eggUsage = 0   // 새 알은 처음부터 인큐베이션
+    }
+
+    /// companion 이벤트 시스템 알림(.app + 토글 ON 일 때만). 한도 알림과 독립.
+    private var notifSeq = 0
+    private func notifyCompanionEvent(_ title: String, _ body: String) {
+        guard Bundle.main.bundleIdentifier != nil, Bundle.main.bundlePath.hasSuffix(".app") else { return }
+        guard UserDefaults.standard.object(forKey: "companionNotifications") as? Bool ?? true else { return }
+        notifSeq += 1
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        UNUserNotificationCenter.current().add(
+            UNNotificationRequest(identifier: "companion-event-\(notifSeq)", content: content, trigger: nil))
     }
 
     // MARK: 부화
@@ -208,6 +227,7 @@ final class CompanionStore {
         state.eggUsage = 0
         state.active = MonState(baseID: line.baseID, pathIDs: [line.baseID], stageIndex: 0,
                                 usedAtStage: 0, rarity: line.rarity, totalForms: line.totalForms)
+        notifyCompanionEvent(l.notifHatchTitle, l.notifHatchBody(line.localizedName(line.baseID, state.language)))
         displayState = .levelUp
         eventUntil = clock().addingTimeInterval(4)
         if overflow > 0 { applyUsage(overflow) }   // 이월분 즉시 반영(필요 시 진화까지)

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -76,6 +76,9 @@ struct L {
     var launchAtLogin: String { t("로그인 시 자동 시작", "Launch at login", "ログイン時に自動起動") }
     var bundledOnly: String { t(".app 번들로 설치된 경우에만 사용 가능 (scripts/build-app.sh)", "Available only when installed as an .app bundle (scripts/build-app.sh)", ".appバンドルでインストールした場合のみ利用可能 (scripts/build-app.sh)") }
     var limitAlertThresholds: String { t("한도 알림 임계값", "Limit alert thresholds", "上限通知のしきい値") }
+    var notificationsSection: String { t("알림", "Notifications", "通知") }
+    var limitNotificationsLabel: String { t("한도 알림", "Limit alerts", "上限通知") }
+    var companionNotificationsLabel: String { t("Companion 이벤트 (부화·진화·졸업)", "Companion events (hatch / evolve / graduate)", "コンパニオンイベント（孵化・進化・卒業）") }
     var warning: String { t("경고", "Warning", "警告") }
     var critical: String { t("임박", "Critical", "切迫") }
     var aggregationNote: String { t("토큰 집계 기준: ccusage totalTokens (input + output + cache, 로컬 날짜)", "Token basis: ccusage totalTokens (input + output + cache, local date)", "集計基準: ccusage totalTokens (input + output + cache, ローカル日付)") }
@@ -130,6 +133,14 @@ struct L {
     var statusSleep: String { t("지금은 자고 있어요.", "Sleeping now.", "今は眠っています。") }
     func statusEvolved(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！") }
     var statusGrew: String { t("성장했어요!", "It grew!", "成長しました！") }
+
+    // MARK: companion 이벤트 시스템 알림
+    var notifHatchTitle: String { t("🥚 부화!", "🥚 Hatched!", "🥚 孵化！") }
+    func notifHatchBody(_ name: String) -> String { t("알에서 \(name)이(가) 나왔어요!", "\(name) hatched from the egg!", "タマゴから \(name) が生まれました！") }
+    var notifEvolveTitle: String { t("✨ 진화!", "✨ Evolved!", "✨ 進化！") }
+    func notifEvolveBody(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！") }
+    var notifGraduateTitle: String { t("🎓 졸업!", "🎓 Graduated!", "🎓 卒業！") }
+    func notifGraduateBody(_ name: String) -> String { t("\(name) — 도감에 보존! 새 알이 도착했어요.", "\(name) — saved to your Pokédex! A new egg has arrived.", "\(name) — 図鑑に保存！新しいタマゴが届きました。") }
 
     // MARK: Claude 한도 토큰 갱신 오류 (친절 안내)
     func limitRefreshHTTPError(_ status: Int) -> String {

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -48,6 +48,13 @@ final class UsageStore {
     var showLimitInMenu: Bool {
         didSet { UserDefaults.standard.set(showLimitInMenu, forKey: "showLimitInMenu") }
     }
+    // 알림(독립 토글)
+    var limitNotifications: Bool {
+        didSet { UserDefaults.standard.set(limitNotifications, forKey: "limitNotifications") }
+    }
+    var companionNotifications: Bool {
+        didSet { UserDefaults.standard.set(companionNotifications, forKey: "companionNotifications") }
+    }
     var disableKeychainAccess: Bool {
         didSet {
             KeychainAccessGate.isDisabled = disableKeychainAccess
@@ -191,6 +198,8 @@ final class UsageStore {
         showTokensInMenu = d.object(forKey: "showTokensInMenu") as? Bool ?? true
         showCostInMenu = d.object(forKey: "showCostInMenu") as? Bool ?? false
         showLimitInMenu = d.object(forKey: "showLimitInMenu") as? Bool ?? false
+        limitNotifications = d.object(forKey: "limitNotifications") as? Bool ?? true
+        companionNotifications = d.object(forKey: "companionNotifications") as? Bool ?? true
         disableKeychainAccess = d.object(forKey: "disableKeychainAccess") as? Bool ?? false
 
         reschedule()
@@ -421,6 +430,7 @@ final class UsageStore {
     }
 
     private func checkLimitNotifications() {
+        guard limitNotifications else { return }
         guard Bundle.main.bundleIdentifier != nil, Bundle.main.bundlePath.hasSuffix(".app") else { return }
         let l = L(localizationLanguage)
         var windows: [(name: String, utilization: Double, resetKey: String)] = []

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -106,24 +106,26 @@ struct SettingsView: View {
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                Text(l.limitAlertThresholds)
-                    .font(.callout)
-                HStack {
-                    Text(l.warning)
-                    Slider(value: $store.warnThreshold, in: 50...95, step: 5)
-                    Text(TokenFormatter.percent(store.warnThreshold))
-                        .monospacedDigit()
-                        .frame(width: 40, alignment: .trailing)
+                Text(l.notificationsSection).font(.callout)
+                Toggle(l.limitNotificationsLabel, isOn: $store.limitNotifications)
+                if store.limitNotifications {
+                    // 한도 알림 켜진 경우에만 임계값 슬라이더 노출
+                    HStack {
+                        Text(l.warning)
+                        Slider(value: $store.warnThreshold, in: 50...95, step: 5)
+                        Text(TokenFormatter.percent(store.warnThreshold))
+                            .monospacedDigit().frame(width: 40, alignment: .trailing)
+                    }
+                    .font(.caption).padding(.leading, 12)
+                    HStack {
+                        Text(l.critical)
+                        Slider(value: $store.critThreshold, in: 80...100, step: 5)
+                        Text(TokenFormatter.percent(store.critThreshold))
+                            .monospacedDigit().frame(width: 40, alignment: .trailing)
+                    }
+                    .font(.caption).padding(.leading, 12)
                 }
-                .font(.caption)
-                HStack {
-                    Text(l.critical)
-                    Slider(value: $store.critThreshold, in: 80...100, step: 5)
-                    Text(TokenFormatter.percent(store.critThreshold))
-                        .monospacedDigit()
-                        .frame(width: 40, alignment: .trailing)
-                }
-                .font(.caption)
+                Toggle(l.companionNotificationsLabel, isOn: $store.companionNotifications)
             }
 
             Text(l.aggregationNote)


### PR DESCRIPTION
companion 이벤트(부화/진화/졸업) 시 시스템 알림 + 알림 종류를 설정에서 선택.

## 알림
- 부화 → "🥚 부화! / 알에서 X가 나왔어요!", 진화 → "✨ 진화! / X로 진화했어요!", 졸업 → "🎓 졸업! / X — 도감에 보존! 새 알 도착." (한/영/일)
- 기존 한도 알림과 동일한 `UNUserNotificationCenter` 사용(권한은 이미 요청됨). 자리를 비운 사이 *뭐가 나왔는지* 알려줘 — companion 콘셉트의 보상 순간.
- 이벤트당 1회만 발송(부화/진화/졸업 지점에서 직접, update 루프와 무관).

## 설정에서 선택 (요청 반영)
**알림** 섹션에 독립 토글 2개:
- ☑ **한도 알림** — OFF 시 발송 안 함 + **경고/임박 임계값 슬라이더 자동 숨김**
- ☑ **Companion 이벤트** — 부화/진화/졸업 알림

→ 한도만 / 이것만 / 둘 다 / 둘 다 끔 모두 선택 가능. 둘 다 기본 ON.

| 한도 알림 ON | 한도 알림 OFF |
|---|---|
| 임계값 슬라이더 표시 | 슬라이더 숨김 |

## 검증
`swift build` + `swift test` **46건** 통과. 알림 섹션 ON/OFF 렌더 확인(슬라이더 토글). code-reviewer APPROVE(이벤트당 1회·토글 키 일치·게이트·로케일).

> 참고: 이 PR은 main 기반(egg 인큐베이션 PR #16과 독립). hatch 알림은 양쪽 모두와 호환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)