### PR TITLE
chore: review cleanup — dead-code removal + PokéAPI URL hardening

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -73,12 +73,6 @@ struct EvoNode: Codable, Sendable {
 
     /// 최장 경로 길이(형태 수). 분기는 보통 같은 깊이라 대표값으로 사용.
     var depth: Int { 1 + (children.map(\.depth).max() ?? 0) }
-    /// 첫 분기를 따라간 선형 경로의 종 id (목업/표시용)
-    var linearIDs: [Int] {
-        var ids = [speciesID]; var n = self
-        while let c = n.children.first { ids.append(c.speciesID); n = c }
-        return ids
-    }
     func node(withID id: Int) -> EvoNode? {
         if speciesID == id { return self }
         for c in children { if let f = c.node(withID: id) { return f } }

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -75,7 +75,6 @@ struct L {
     var onlyOnPress: String { t("누를 때만 Keychain 확인", "Checks Keychain only when pressed", "押した時のみKeychain確認") }
     var launchAtLogin: String { t("로그인 시 자동 시작", "Launch at login", "ログイン時に自動起動") }
     var bundledOnly: String { t(".app 번들로 설치된 경우에만 사용 가능 (scripts/build-app.sh)", "Available only when installed as an .app bundle (scripts/build-app.sh)", ".appバンドルでインストールした場合のみ利用可能 (scripts/build-app.sh)") }
-    var limitAlertThresholds: String { t("한도 알림 임계값", "Limit alert thresholds", "上限通知のしきい値") }
     var notificationsSection: String { t("알림", "Notifications", "通知") }
     var limitNotificationsLabel: String { t("한도 알림", "Limit alerts", "上限通知") }
     var companionNotificationsLabel: String { t("Companion 이벤트 (부화·진화·졸업)", "Companion events (hatch / evolve / graduate)", "コンパニオンイベント（孵化・進化・卒業）") }
@@ -94,7 +93,6 @@ struct L {
     // MARK: 컴패니언
     var finalForm: String { t("최종 진화체", "Final form", "最終進化") }
     func stage(_ i: Int, _ k: Int) -> String { t("진화 단계 \(i) / \(k)", "Stage \(i) / \(k)", "進化段階 \(i) / \(k)") }
-    var waitingFirstToken: String { t("설치 후 첫 토큰을 기다리는 중…", "Waiting for your first tokens…", "最初のトークンを待っています…") }
     var eggIncubating: String { t("🥚 부화 준비 중", "🥚 Incubating", "🥚 孵化の準備中") }
     func eggToHatch(_ amount: String) -> String { t("부화까지 \(amount)", "\(amount) to hatch", "孵化まで \(amount)") }
     func toNextEvolution(_ amount: String) -> String { t("다음 진화까지 \(amount)", "\(amount) to next evolution", "次の進化まで \(amount)") }

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -15,7 +15,10 @@ actor PokeAPIClient: PokeProviding {
 
     func line(baseSpeciesID: Int) async throws -> EvoLine {
         let baseSpecies = try await species(baseSpeciesID)
-        let chainURL = URL(string: baseSpecies.evolution_chain.url)!
+        // PokéAPI 응답의 URL — 비정상/빈 값이면 force-unwrap 대신 throw(앱은 알 상태 유지).
+        guard let chainURL = URL(string: baseSpecies.evolution_chain.url) else {
+            throw URLError(.badURL)
+        }
         let chainDTO: ChainDTO = try await get(chainURL)
         let tree = node(from: chainDTO.chain)
         let rarity = Rarity.from(captureRate: baseSpecies.capture_rate,


### PR DESCRIPTION
## 배경

전체 구현 코드 검토(미사용 코드·보안 취약점·프로덕트 품질) 결과 조치. 1인 로컬 위협 모델 기준으로 트리아지 — 컴플라이언스/멀티유저/동시성-경합 등 위협 모델 밖 항목은 제외.

## 검토 범위 (22 소스 · ~4.3K LOC)

전 파일 직접 검토. 보안/프로세스 핵심부는 **clean** 확인:

| 영역 | 판정 |
|---|---|
| `ProcessRunner` (서브프로세스 실행 단일 지점) | temp-file 캡처, SIGTERM→SIGKILL 타임아웃, stdin null 차단 — 안전 |
| `UpdateChecker.relaunch` | 번들 경로를 `$1` positional 인자로 전달 — 셸 인젝션 없음 |
| `UpdateChecker.brewUpgrade` | resolve된 절대경로 + 고정 인자 — 안전 |
| `OAuthLimitsProvider` / Keychain | no-UI 쿼리, 토큰 미로깅, 단일 프롬프트 경로 |
| `BinaryLocator.shellResolve` | `binary` 인자는 항상 하드코딩 리터럴(ccusage/codex/brew), 사용자 입력 아님 |
| `AppLog` | OAuth 토큰·시크릿 로깅 없음 (utilization 숫자·에러 설명만) |

## 변경

### 🟠 Robustness — 네트워크 URL force-unwrap 제거
`PokeAPIClient.line`에서 `URL(string: baseSpecies.evolution_chain.url)!` 가 **네트워크 응답에서 온** URL을 force-unwrap 했다. PokéAPI가 비정상/빈 `evolution_chain.url`을 반환하면 앱 전체가 크래시. `line()` 이 이미 `throws` 라 `guard let … else { throw URLError(.badURL) }` 로 전환 — 크래시 대신 알(egg) 상태 유지.

### 🟢 Dead code — 참조 0개 심볼 제거
- `L.waitingFirstToken` — 알 인큐베이션 UI 문자열(`eggIncubating`/`eggToHatch`)로 대체되어 미사용.
- `L.limitAlertThresholds` — 설정 화면이 `notificationsSection` 구조로 개편되며 미사용.
- `EvoNode.linearIDs` — 초기 목업용 헬퍼, 현재 코드에서 미참조.

> `CompanionState.usedSinceInstall` 은 write-only 누적 카운터지만 영속 필드 + 하위호환 디코딩 + 테스트 커버 대상 — 제거는 스키마 변경 음(-)ROI라 보존.

## 검증
- `swift build` clean
- `swift test` — 51 tests, 0 failures

(UI 영향 없음 — 제거한 L 문자열은 어느 뷰에서도 렌더되지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)