### PR TITLE
test: thicken test guardrails (unit/view-logic/perf) + coverage gate

### DIFF
--- a/Sources/PokeTokenBar/Core/CodexRateLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/CodexRateLimitsProvider.swift
@@ -1,8 +1,13 @@
 import Foundation
 
+/// Codex 한도 조회 추상화 — 실 구현(CodexRateLimitsProvider) 또는 테스트 스텁 주입.
+protocol CodexLimitsProviding: Sendable {
+    func fetch() async throws -> CodexRateLimitStatus?
+}
+
 /// Codex CLI app-server의 account/rateLimits/read 응답으로 Codex 한도 %를 읽는다.
 /// 모델 turn을 시작하지 않고 account snapshot만 요청한다.
-struct CodexRateLimitsProvider {
+struct CodexRateLimitsProvider: CodexLimitsProviding {
     let binaryCandidates: [String]
 
     init(binaryCandidates: [String] = Self.defaultBinaryCandidates) {

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -9,9 +9,14 @@ enum LimitsError: Error {
     case httpStatus(Int)
 }
 
+/// Claude 한도 조회 추상화 — 실 구현(OAuthLimitsProvider) 또는 테스트 스텁 주입.
+protocol ClaudeLimitsProviding: Sendable {
+    func fetch(allowKeychainPrompt: Bool) async throws -> LimitStatus
+}
+
 /// 공식 한도 % 조회 — Claude Code 자격증명(Keychain)의 OAuth 토큰으로 usage endpoint 호출.
 /// 비공식 endpoint 이므로 실패해도 토큰 표시에는 영향 없음 (한도 섹션만 숨김).
-struct OAuthLimitsProvider: Sendable {
+struct OAuthLimitsProvider: ClaudeLimitsProviding, Sendable {
     private static let usageURL = URL(string: "https://api.anthropic.com/api/oauth/usage")!
     private let accessTokenCache = OAuthAccessTokenCache.shared
 

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -76,8 +76,8 @@ final class UsageStore {
     var localizationLanguage: AppLanguage = .ko
 
     private let providers: [any UsageProvider]
-    private let limitsProvider = OAuthLimitsProvider()
-    private let codexLimitsProvider = CodexRateLimitsProvider()
+    private let limitsProvider: any ClaudeLimitsProviding
+    private let codexLimitsProvider: any CodexLimitsProviding
     private var timer: Timer?
     private var emptyUsageRetryTask: Task<Void, Never>?
     /// 같은 한도 블록(resets_at 기준)에 대해 알림 1회만 발화
@@ -189,8 +189,13 @@ final class UsageStore {
 
     // MARK: 생명주기
 
-    init(providers: [any UsageProvider] = [CcusageProvider.claude, CcusageProvider.codex]) {
+    init(providers: [any UsageProvider] = [CcusageProvider.claude, CcusageProvider.codex],
+         claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
+         codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),
+         autoRefresh: Bool = true) {
         self.providers = providers
+        self.limitsProvider = claudeLimitsProvider
+        self.codexLimitsProvider = codexLimitsProvider
         let d = UserDefaults.standard
         refreshInterval = d.object(forKey: "refreshInterval") as? TimeInterval ?? 120
         warnThreshold = d.object(forKey: "warnThreshold") as? Double ?? 80
@@ -218,7 +223,7 @@ final class UsageStore {
         }
 
         requestNotificationAuthorization()
-        Task { await refresh() }
+        if autoRefresh { Task { await refresh() } }
     }
 
     private func reschedule() {
@@ -397,7 +402,7 @@ final class UsageStore {
 
     /// 한도 갱신 실패를 사용자 친화 메시지로 변환. Codex만 쓰는 사용자는 401 이 정상이라,
     /// raw "httpStatus(401)" 대신 "무시해도 된다"는 안내를 보여준다.
-    private static func friendlyLimitError(_ error: any Error, _ l: L) -> String {
+    static func friendlyLimitError(_ error: any Error, _ l: L) -> String {
         guard let limitsError = error as? LimitsError else { return l.limitRefreshGeneric }
         switch limitsError {
         case .httpStatus(let status):

--- a/Tests/PokeTokenBarTests/CompanionDisplayStateTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionDisplayStateTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import PokeTokenBar
+
+// companion 표시 상태(displayState) 전이 — update() 입력 조합에 따른 결과 검증.
+// SeededRNG / StubProvider 는 CompanionTests.swift 의 내부 헬퍼를 재사용한다.
+
+private func dnode(_ id: Int, _ children: [EvoNode] = []) -> EvoNode { EvoNode(speciesID: id, children: children) }
+private func dline(base: Int, rarity: Rarity = .common) -> EvoLine {
+    EvoLine(baseID: base, tree: dnode(base, [dnode(base + 1, [dnode(base + 2)])]),
+            rarity: rarity, names: [:])
+}
+private let dNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+/// 테스트에서 시계를 전진시키기 위한 가변 박스 (이벤트 윈도우 만료 제어용).
+private final class ClockBox: @unchecked Sendable {
+    nonisolated(unsafe) var now: Date
+    init(_ d: Date) { now = d }
+}
+
+@MainActor
+final class CompanionDisplayStateTests: XCTestCase {
+    private func hatchedStore(rarity: Rarity = .common) async -> (CompanionStore, ClockBox) {
+        let clock = ClockBox(dNow)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-disp-\(UUID().uuidString).json")
+        let s = CompanionStore(provider: StubProvider(value: dline(base: 1, rarity: rarity)),
+                               clock: { clock.now }, fileURL: url, rng: SeededRNG(seed: 5))
+        await s.hatch(baseID: 1)
+        return (s, clock)
+    }
+
+    func testEggWhenNoUsageData() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-disp-\(UUID().uuidString).json")
+        let s = CompanionStore(provider: StubProvider(value: dline(base: 1)),
+                               clock: { dNow }, fileURL: url, rng: SeededRNG(seed: 1))
+        s.update(todayTokens: 0, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: false)
+        XCTAssertEqual(s.displayState, .egg)
+    }
+
+    func testLevelUpDuringEventWindow() async {
+        let (s, _) = await hatchedStore()
+        // 이벤트 윈도우가 살아있는 동안(시계 미전진) → levelUp 유지
+        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.displayState, .levelUp)
+    }
+
+    func testWorkingAfterEventExpires() async {
+        let (s, clock) = await hatchedStore()
+        clock.now = dNow.addingTimeInterval(60)   // 이벤트 만료
+        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.displayState, .working)
+    }
+
+    func testFocusOnHighBurn() async {
+        let (s, clock) = await hatchedStore()
+        clock.now = dNow.addingTimeInterval(60)
+        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .blazing, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.displayState, .focus)
+    }
+
+    func testTiredWhenLimitWarning() async {
+        let (s, clock) = await hatchedStore()
+        clock.now = dNow.addingTimeInterval(60)
+        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: true, hasUsageData: true)
+        XCTAssertEqual(s.displayState, .tired)
+    }
+
+    func testSleepWhenZeroUsageToday() async {
+        let (s, clock) = await hatchedStore()
+        clock.now = dNow.addingTimeInterval(60)
+        s.update(todayTokens: 0, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.displayState, .sleep)
+    }
+
+    // MARK: 알(egg) 인큐베이션 파생값
+
+    func testEggProgressAndTokensToHatch() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-disp-\(UUID().uuidString).json")
+        let s = CompanionStore(provider: StubProvider(value: dline(base: 1)),
+                               clock: { dNow }, fileURL: url, rng: SeededRNG(seed: 1))
+        XCTAssertTrue(s.isEgg)
+        XCTAssertEqual(s.eggProgress, 0)
+        XCTAssertEqual(s.eggTokensToHatch, PokemonBalance.eggHatchThreshold)
+
+        // 임계의 40% 사용
+        s.update(todayTokens: 0, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        let part = PokemonBalance.eggHatchThreshold * 2 / 5
+        s.update(todayTokens: part, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.eggProgress, 0.4, accuracy: 0.001)
+        XCTAssertEqual(s.eggTokensToHatch, PokemonBalance.eggHatchThreshold - part)
+        XCTAssertTrue(s.eggStarted)
+    }
+}

--- a/Tests/PokeTokenBarTests/ModelLogicTests.swift
+++ b/Tests/PokeTokenBarTests/ModelLogicTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+@testable import PokeTokenBar
+
+// 순수 모델/파생 로직 — 네트워크·프로세스 없이 결정적으로 검증.
+
+private func evoNode(_ id: Int, _ children: [EvoNode] = []) -> EvoNode { EvoNode(speciesID: id, children: children) }
+
+// MARK: EvoLine 다국어 이름 폴백
+
+final class EvoLineNameTests: XCTestCase {
+    func testPicksLanguageSpecificThenFallsBackToEnglishThenID() {
+        let line = EvoLine(
+            baseID: 1, tree: evoNode(1), rarity: .common,
+            names: [
+                1: ["ja-Hrkt": "ピカ", "ja": "ピカチュウ", "en": "Pika", "ko": "피카"],
+                2: ["en": "Eevee"],   // ja/ko 없음 → en 폴백
+                3: [:],               // 비어 있음 → #id
+            ])
+        // ja 는 ja-Hrkt 를 ja 보다 먼저 시도
+        XCTAssertEqual(line.localizedName(1, .ja), "ピカ")
+        XCTAssertEqual(line.localizedName(1, .ko), "피카")
+        XCTAssertEqual(line.localizedName(1, .en), "Pika")
+        // 해당 언어 없으면 en 폴백
+        XCTAssertEqual(line.localizedName(2, .ja), "Eevee")
+        XCTAssertEqual(line.localizedName(2, .ko), "Eevee")
+        // en 도 없으면 #id
+        XCTAssertEqual(line.localizedName(3, .ko), "#3")
+        // 아예 없는 id
+        XCTAssertEqual(line.localizedName(99, .en), "#99")
+    }
+
+    func testJaFallsBackFromHrktToPlainJa() {
+        let line = EvoLine(baseID: 1, tree: evoNode(1), rarity: .common,
+                           names: [1: ["ja": "ピカチュウ", "en": "Pika"]])
+        XCTAssertEqual(line.localizedName(1, .ja), "ピカチュウ")   // ja-Hrkt 없음 → ja
+    }
+}
+
+// MARK: EvoNode 트리 연산
+
+final class EvoNodeTests: XCTestCase {
+    // 1 → {2 → 3, 4}  (분기: 3단 경로 + 2단 경로)
+    private let tree = EvoNode(speciesID: 1, children: [
+        EvoNode(speciesID: 2, children: [EvoNode(speciesID: 3, children: [])]),
+        EvoNode(speciesID: 4, children: []),
+    ])
+
+    func testDepthIsLongestPath() {
+        XCTAssertEqual(tree.depth, 3)            // 1-2-3
+        XCTAssertEqual(evoNode(20).depth, 1)     // 무진화
+    }
+
+    func testNodeLookupByID() {
+        XCTAssertEqual(tree.node(withID: 3)?.speciesID, 3)
+        XCTAssertEqual(tree.node(withID: 4)?.speciesID, 4)
+        XCTAssertNil(tree.node(withID: 99))
+    }
+
+    func testFinalIDsAreLeaves() {
+        XCTAssertEqual(Set(tree.finalIDs), [3, 4])
+        XCTAssertEqual(evoNode(20).finalIDs, [20])   // 잎이 곧 최종체
+    }
+}
+
+// MARK: 희귀도 경계
+
+final class RarityBoundaryTests: XCTestCase {
+    func testCaptureRateBoundaries() {
+        XCTAssertEqual(Rarity.from(captureRate: 45, isLegendary: false, isMythical: false), .rare)      // <=45
+        XCTAssertEqual(Rarity.from(captureRate: 46, isLegendary: false, isMythical: false), .uncommon)
+        XCTAssertEqual(Rarity.from(captureRate: 120, isLegendary: false, isMythical: false), .uncommon) // <=120
+        XCTAssertEqual(Rarity.from(captureRate: 121, isLegendary: false, isMythical: false), .common)
+    }
+
+    func testLegendaryAndMythicalOverrideCaptureRate() {
+        XCTAssertEqual(Rarity.from(captureRate: 255, isLegendary: true, isMythical: false), .legendary)
+        XCTAssertEqual(Rarity.from(captureRate: 255, isLegendary: false, isMythical: true), .legendary)
+    }
+}
+
+// MARK: OAuth expiresAt 단위 휴리스틱 (초 vs 밀리초)
+
+final class OAuthExpiresAtTests: XCTestCase {
+    private func credential(expiresAt raw: String) -> OAuthCredentialData.Credential? {
+        let json = "{\"claudeAiOauth\":{\"accessToken\":\"t\",\"expiresAt\":\(raw)}}"
+        return OAuthCredentialData.credential(from: Data(json.utf8))
+    }
+
+    func testSecondsFormNotTreatedAsMillis() {
+        // 10^10 이하면 초 단위로 본다 (밀리초 변환 안 함)
+        let future = Int(Date().addingTimeInterval(3600).timeIntervalSince1970)
+        XCTAssertEqual(credential(expiresAt: "\(future)")?.isExpired, false)
+    }
+
+    func testMillisFormDividedByThousand() {
+        let futureMillis = Int(Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000)
+        XCTAssertEqual(credential(expiresAt: "\(futureMillis)")?.isExpired, false)
+        let pastMillis = Int(Date().addingTimeInterval(-3600).timeIntervalSince1970 * 1000)
+        XCTAssertEqual(credential(expiresAt: "\(pastMillis)")?.isExpired, true)
+    }
+
+    func testStringFormParsed() {
+        let futureMillis = Int(Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000)
+        XCTAssertEqual(credential(expiresAt: "\"\(futureMillis)\"")?.isExpired, false)
+    }
+
+    func testZeroOrMissingExpiryNeverExpires() {
+        XCTAssertEqual(credential(expiresAt: "0")?.isExpired, false)
+        let noExpiry = OAuthCredentialData.credential(from: Data(#"{"claudeAiOauth":{"accessToken":"t"}}"#.utf8))
+        XCTAssertEqual(noExpiry?.isExpired, false)
+    }
+
+    func testRejectsMissingOrEmptyToken() {
+        XCTAssertNil(OAuthCredentialData.credential(from: Data(#"{"claudeAiOauth":{"accessToken":""}}"#.utf8)))
+        XCTAssertNil(OAuthCredentialData.credential(from: Data(#"{"other":{}}"#.utf8)))
+        XCTAssertNil(OAuthCredentialData.credential(from: Data("not json".utf8)))
+    }
+}
+
+// MARK: ISO8601 가변 정밀도 파서
+
+final class ISO8601ParserTests: XCTestCase {
+    func testParsesMicroMilliAndPlainSeconds() {
+        XCTAssertNotNil(ISO8601Parser.date(from: "2026-06-10T11:10:00.034464+00:00")) // 마이크로초
+        XCTAssertNotNil(ISO8601Parser.date(from: "2026-06-10T11:10:00.303Z"))         // 밀리초
+        XCTAssertNotNil(ISO8601Parser.date(from: "2026-06-10T11:10:00Z"))             // 소수점 없음
+    }
+
+    func testReturnsNilForGarbage() {
+        XCTAssertNil(ISO8601Parser.date(from: "not-a-date"))
+        XCTAssertNil(ISO8601Parser.date(from: ""))
+    }
+
+    func testMicroAndMilliResolveToSameInstant() {
+        let micro = ISO8601Parser.date(from: "2026-06-10T11:10:00.000000Z")
+        let plain = ISO8601Parser.date(from: "2026-06-10T11:10:00Z")
+        XCTAssertEqual(micro?.timeIntervalSince1970, plain?.timeIntervalSince1970)
+    }
+}
+
+// MARK: Codex 한도 표시/파생
+
+final class CodexLimitDerivationTests: XCTestCase {
+    func testWindowDisplayName() {
+        func name(_ mins: Int?) -> String {
+            CodexRateLimitWindow(usedPercent: 0, windowDurationMins: mins, resetsAt: nil).displayName
+        }
+        XCTAssertEqual(name(300), "5시간 세션")
+        XCTAssertEqual(name(10_080), "주간")
+        XCTAssertEqual(name(120), "2시간")    // 분 단위 → 시간
+        XCTAssertEqual(name(90), "90분")      // 시간으로 안 떨어짐
+        XCTAssertEqual(name(nil), "한도")
+    }
+
+    func testSpendControlUsedPercentClamped() {
+        func used(_ remaining: Int) -> Int {
+            CodexSpendControlLimit(limit: "$10", remainingPercent: remaining, resetsAt: 0, used: "$3").usedPercent
+        }
+        XCTAssertEqual(used(30), 70)
+        XCTAssertEqual(used(-10), 100)   // 음수 remaining → 100 클램프
+        XCTAssertEqual(used(150), 0)     // >100 → 0 클램프
+    }
+
+    func testHasVisibleLimitReflectsWindows() {
+        let none = CodexRateLimitSnapshot(limitId: nil, limitName: nil, primary: nil, secondary: nil,
+                                          credits: nil, individualLimit: nil, planType: nil, rateLimitReachedType: nil)
+        XCTAssertFalse(none.hasVisibleLimit)
+        let some = CodexRateLimitSnapshot(
+            limitId: nil, limitName: nil,
+            primary: CodexRateLimitWindow(usedPercent: 10, windowDurationMins: 300, resetsAt: nil),
+            secondary: nil, credits: nil, individualLimit: nil, planType: nil, rateLimitReachedType: nil)
+        XCTAssertTrue(some.hasVisibleLimit)
+    }
+}
+
+// MARK: MonState / CompanionState 영속
+
+final class StatePersistenceLogicTests: XCTestCase {
+    func testCurrentIDClampsToPath() {
+        let m = MonState(baseID: 1, pathIDs: [1, 2, 3], stageIndex: 1, usedAtStage: 0, rarity: .common, totalForms: 3)
+        XCTAssertEqual(m.currentID, 2)
+        // stageIndex 가 경로를 넘어가도 마지막으로 클램프 (방어)
+        let over = MonState(baseID: 1, pathIDs: [1], stageIndex: 5, usedAtStage: 0, rarity: .common, totalForms: 1)
+        XCTAssertEqual(over.currentID, 1)
+    }
+
+    func testCompanionStateEncodeDecodeRoundTrip() throws {
+        var st = CompanionState()
+        st.installBaselineSet = true
+        st.usedSinceInstall = 42
+        st.eggUsage = 1234
+        st.claimedTodayTokens = 7
+        st.lastDate = "2026-06-27"
+        st.collectedFinals = ["1:3", "10:12"]
+        st.language = .ja
+        st.dex = [DexEntry(baseID: 1, finalID: 3, chainOrder: [1, 2, 3], rarity: .rare, caughtAt: nil)]
+
+        let data = try JSONEncoder().encode(st)
+        let back = try JSONDecoder().decode(CompanionState.self, from: data)
+
+        XCTAssertEqual(back.installBaselineSet, true)
+        XCTAssertEqual(back.usedSinceInstall, 42)
+        XCTAssertEqual(back.eggUsage, 1234)
+        XCTAssertEqual(back.lastDate, "2026-06-27")
+        XCTAssertEqual(back.collectedFinals, ["1:3", "10:12"])
+        XCTAssertEqual(back.language, .ja)
+        XCTAssertEqual(back.dex.count, 1)
+        XCTAssertEqual(back.dex[0].chainOrder, [1, 2, 3])
+    }
+}

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import PokeTokenBar
+
+// 성능(measure) + 스케일/비퇴화 검증. baseline 은 머신 의존이라 느슨하게(게이트는 정확성에).
+// SeededRNG / StubProvider 는 CompanionTests.swift 의 내부 헬퍼 재사용.
+
+private func pnode(_ id: Int, _ children: [EvoNode] = []) -> EvoNode { EvoNode(speciesID: id, children: children) }
+private func pline(base: Int, rarity: Rarity) -> EvoLine {
+    EvoLine(baseID: base, tree: pnode(base, [pnode(base + 1, [pnode(base + 2)])]), rarity: rarity, names: [:])
+}
+private let pNow = Date(timeIntervalSince1970: 1_700_000_000)
+private func tmpURL() -> URL {
+    FileManager.default.temporaryDirectory.appendingPathComponent("poke-perf-\(UUID().uuidString).json")
+}
+
+// MARK: 순수 계산 핫패스
+
+final class PureComputePerformanceTests: XCTestCase {
+    func testPhaseThresholdAndPickThroughput() {
+        measure {
+            var acc = 0
+            for i in 0..<100_000 {
+                acc &+= PokemonBalance.phaseThreshold(rarity: .rare, totalForms: 3, stageIndex: i % 3)
+                acc &+= PokemonPool.pick(roll: i)
+            }
+            XCTAssertGreaterThan(acc, 0)
+        }
+    }
+
+    func testLargeDailyReportDecode() {
+        let rows = (0..<1000).map {
+            "{\"date\":\"2026-06-\(($0 % 28) + 1)\",\"inputTokens\":\($0),\"outputTokens\":1," +
+            "\"cacheCreationTokens\":2,\"cacheReadTokens\":3,\"totalTokens\":\($0),\"totalCost\":0.1}"
+        }.joined(separator: ",")
+        let json = Data("{\"daily\":[\(rows)]}".utf8)
+        measure {
+            let report = try! JSONDecoder().decode(DailyReport.self, from: json)
+            XCTAssertEqual(report.daily.count, 1000)
+        }
+    }
+}
+
+// MARK: 스토어 핫패스 / 스케일
+
+@MainActor
+final class StorePerformanceTests: XCTestCase {
+    func testUpdateHotPath() async {
+        // legendary(임계 6e9)를 부화시켜 진화 없이 작은 델타를 반복 — refresh 당 update 비용 측정.
+        let s = CompanionStore(provider: StubProvider(value: pline(base: 1, rarity: .legendary)),
+                               clock: { pNow }, fileURL: tmpURL(), rng: SeededRNG(seed: 1))
+        await s.hatch(baseID: 1)
+        var token = 0
+        measure {
+            for _ in 0..<500 {
+                token += 100
+                s.update(todayTokens: token, todayDate: "d", monthTotal: 0,
+                         burnTier: .normal, limitWarning: false, hasUsageData: true)
+            }
+        }
+        XCTAssertNotNil(s.state.active)   // 진화 없이 동일 단계 유지
+    }
+
+    /// 큰 도감을 파일 로드로 주입하고 정렬 비용/정확성을 함께 본다.
+    private func storeWithLargeDex(_ count: Int) throws -> CompanionStore {
+        let entries = (0..<count).map { i -> DexEntry in
+            let r: Rarity = [.common, .uncommon, .rare, .legendary][i % 4]
+            return DexEntry(baseID: i, finalID: i, chainOrder: [i], rarity: r,
+                            caughtAt: pNow.addingTimeInterval(Double(i)))
+        }
+        let dexJSON = String(data: try JSONEncoder().encode(entries), encoding: .utf8)!
+        let url = tmpURL()
+        try Data("{\"dex\":\(dexJSON),\"language\":\"ko\"}".utf8).write(to: url)
+        return CompanionStore(provider: StubProvider(value: pline(base: 1, rarity: .common)),
+                              clock: { pNow }, fileURL: url, rng: SeededRNG(seed: 1))
+    }
+
+    func testLargeDexSortPerformanceAndCorrectness() throws {
+        let s = try storeWithLargeDex(1000)
+        XCTAssertEqual(s.dexEntries.count, 1000)
+        measure {
+            let sorted = s.dexEntriesSorted
+            XCTAssertEqual(sorted.count, 1000)
+        }
+        // 정렬 정확성: 희귀도 sortRank 비증가(내림차순) 유지
+        let sorted = s.dexEntriesSorted
+        XCTAssertEqual(sorted.first?.rarity, .legendary)
+        for i in 1..<sorted.count {
+            XCTAssertGreaterThanOrEqual(sorted[i - 1].rarity.sortRank, sorted[i].rarity.sortRank)
+        }
+        // 동급 내에서는 최신(caughtAt 큰) 우선
+        let legendaries = sorted.filter { $0.rarity == .legendary }
+        for i in 1..<legendaries.count {
+            XCTAssertGreaterThanOrEqual(
+                legendaries[i - 1].caughtAt ?? .distantPast,
+                legendaries[i].caughtAt ?? .distantPast)
+        }
+        XCTAssertEqual(s.dexCount(.legendary), 250)
+    }
+}
+
+// MARK: 비퇴화(터미네이션) 가드
+
+@MainActor
+final class StoreTerminationTests: XCTestCase {
+    func testHugeDeltaGraduatesOnceAndTerminates() async {
+        // 거대한 단일 델타가 무한 루프 없이 라인을 통과해 정확히 1회 졸업하는지 (guardCount 캡 보호).
+        let s = CompanionStore(provider: StubProvider(value: pline(base: 1, rarity: .common)),
+                               clock: { pNow }, fileURL: tmpURL(), rng: SeededRNG(seed: 1))
+        await s.hatch(baseID: 1)
+        s.applyUsage(Int(PokemonBalance.graduationTotal(.common)) * 10)   // 졸업 총량의 10배
+        XCTAssertNil(s.state.active)            // 졸업 완료
+        XCTAssertEqual(s.dexEntries.count, 1)   // 정확히 1회
+        XCTAssertEqual(s.dexEntries[0].chainOrder, [1, 2, 3])
+        XCTAssertEqual(s.state.eggUsage, 0)     // 새 알 인큐베이션 리셋
+    }
+
+    func testRepeatedGraduationGrowsDexLinearly() async {
+        // 무진화 라인을 반복 졸업 — dex 가 선형으로 증가하고 상태가 매번 정합한지.
+        let provider = StubProvider(value: pline(base: 1, rarity: .common))
+        let s = CompanionStore(provider: provider, clock: { pNow }, fileURL: tmpURL(), rng: SeededRNG(seed: 9))
+        for n in 1...20 {
+            await s.hatch(baseID: 1)
+            s.applyUsage(Int(PokemonBalance.graduationTotal(.common)) * 10)
+            XCTAssertEqual(s.dexEntries.count, n)
+            XCTAssertNil(s.state.active)
+        }
+    }
+}

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -1,0 +1,249 @@
+import XCTest
+@testable import PokeTokenBar
+
+// UsageStore 의 refresh 파이프라인 + 파생 표시값을 주입 스텁으로 결정적 검증.
+// (실제 ccusage/Keychain/Codex 바이너리 없이 — 위협 모델: 1인 로컬, CI 없음)
+
+// MARK: 스텁
+
+private enum StubError: Error { case boom }
+
+/// 호출 후에도 동작을 바꿀 수 있는 usage provider (실패 전환 테스트용). 단일 스레드 테스트 한정.
+private final class FakeUsageProvider: UsageProvider, @unchecked Sendable {
+    let id: String
+    let displayName: String
+    nonisolated(unsafe) var daily: DailyUsage?
+    nonisolated(unsafe) var enrichment = ProviderEnrichment()
+    nonisolated(unsafe) var failDaily = false
+
+    init(id: String, displayName: String, daily: DailyUsage? = nil) {
+        self.id = id
+        self.displayName = displayName
+        self.daily = daily
+    }
+    func fetchDaily() async throws -> DailyUsage? {
+        if failDaily { throw StubError.boom }
+        return daily
+    }
+    func fetchEnrichment() async -> ProviderEnrichment { enrichment }
+}
+
+private struct FakeClaudeLimits: ClaudeLimitsProviding {
+    var status: LimitStatus?
+    func fetch(allowKeychainPrompt: Bool) async throws -> LimitStatus {
+        guard let status else { throw LimitsError.keychainInteractionNotAllowed }
+        return status
+    }
+}
+
+private struct FakeCodexLimits: CodexLimitsProviding {
+    var status: CodexRateLimitStatus?
+    func fetch() async throws -> CodexRateLimitStatus? { status }
+}
+
+// MARK: 픽스처 헬퍼
+
+private func todayDaily(_ tokens: Int, cost: Double = 0) -> DailyUsage {
+    DailyUsage(date: CcusageProvider.todayKey(), inputTokens: 0, outputTokens: 0,
+               cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: tokens, totalCost: cost)
+}
+
+private func block(tokensPerMinute tpm: Double) -> BlockUsage {
+    let json = "{\"blocks\":[{\"id\":\"b\",\"startTime\":\"\",\"endTime\":\"\",\"isActive\":true," +
+               "\"totalTokens\":1000,\"costUSD\":1,\"burnRate\":{\"tokensPerMinute\":\(tpm)}}]}"
+    return try! JSONDecoder().decode(BlocksReport.self, from: Data(json.utf8)).blocks[0]
+}
+
+private func claudeLimits(fiveHourUtil: Double, resetsAt: String? = nil) -> LimitStatus {
+    let reset = resetsAt.map { "\"\($0)\"" } ?? "null"
+    let json = "{\"five_hour\":{\"utilization\":\(fiveHourUtil),\"resets_at\":\(reset)}}"
+    return try! JSONDecoder().decode(LimitStatus.self, from: Data(json.utf8))
+}
+
+private func codexLimits(primaryUsed: Int? = nil, secondaryUsed: Int? = nil) -> CodexRateLimitStatus {
+    func win(_ p: Int, _ mins: Int) -> String { "{\"usedPercent\":\(p),\"windowDurationMins\":\(mins)}" }
+    var parts: [String] = []
+    if let primaryUsed { parts.append("\"primary\":\(win(primaryUsed, 300))") }
+    if let secondaryUsed { parts.append("\"secondary\":\(win(secondaryUsed, 10080))") }
+    let json = "{\"rateLimits\":{\(parts.joined(separator: ","))}}"
+    return try! JSONDecoder().decode(CodexRateLimitStatus.self, from: Data(json.utf8))
+}
+
+// MARK: 테스트
+
+@MainActor
+final class UsageStoreTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // 기본값으로 시작하도록 관련 UserDefaults 키 정리 (테스트 간 오염 방지)
+        for key in ["refreshInterval", "warnThreshold", "critThreshold",
+                    "showTokensInMenu", "showCostInMenu", "showLimitInMenu",
+                    "limitNotifications", "companionNotifications", "disableKeychainAccess"] {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        KeychainAccessGate.isDisabled = false
+    }
+
+    private func makeStore(
+        providers: [any UsageProvider],
+        claude: LimitStatus? = nil,
+        codex: CodexRateLimitStatus? = nil
+    ) -> UsageStore {
+        UsageStore(providers: providers,
+                   claudeLimitsProvider: FakeClaudeLimits(status: claude),
+                   codexLimitsProvider: FakeCodexLimits(status: codex),
+                   autoRefresh: false)
+    }
+
+    // MARK: 집계
+
+    func testAggregatesTodayTokensAcrossProviders() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(100_000_000))
+        let codex = FakeUsageProvider(id: "codex", displayName: "Codex", daily: todayDaily(50_000_000))
+        let store = makeStore(providers: [claude, codex])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.todayTotalTokens, 150_000_000)
+        XCTAssertNotNil(store.lastUpdated)
+        XCTAssertNil(store.lastErrorDescription)
+    }
+
+    func testCodexOnlyWhenClaudeHasNoData() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: nil) // 데이터 없음
+        let codex = FakeUsageProvider(id: "codex", displayName: "Codex", daily: todayDaily(50_000_000))
+        let store = makeStore(providers: [claude, codex])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.todayTotalTokens, 50_000_000)
+        XCTAssertTrue(store.hasUsageData)
+        XCTAssertEqual(store.snapshots.count, 1)        // claude 는 today nil → 스냅샷 미생성
+        XCTAssertEqual(store.snapshots.first?.providerID, "codex")
+    }
+
+    func testStaleDatedSnapshotExcludedFromTodayTotal() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(100_000_000))
+        // 어제(다른 날짜) 데이터 — 날짜 가드로 오늘 합계에서 제외돼야 함
+        let codex = FakeUsageProvider(id: "codex", displayName: "Codex",
+            daily: DailyUsage(date: "2000-01-01", inputTokens: 0, outputTokens: 0,
+                              cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 999, totalCost: 0))
+        let store = makeStore(providers: [claude, codex])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.todayTotalTokens, 100_000_000)   // codex 999 제외
+    }
+
+    func testProviderFailureKeepsPreviousTodayValue() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(100_000_000))
+        let store = makeStore(providers: [claude])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.todayTotalTokens, 100_000_000)
+
+        claude.failDaily = true
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.todayTotalTokens, 100_000_000)    // 실패 → 이전 값 유지
+        XCTAssertNotNil(store.lastErrorDescription)            // 에러는 표면화
+    }
+
+    // MARK: 메뉴바 타이틀
+
+    func testMenuTitleReflectsToggles() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(100_000_000, cost: 12.5))
+        let store = makeStore(providers: [claude])
+        store.showTokensInMenu = true
+        store.showCostInMenu = false
+        store.showLimitInMenu = false
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.menuTitle, "100M")
+
+        store.showCostInMenu = true
+        XCTAssertEqual(store.menuTitle, "100M · $12.5")
+    }
+
+    func testMenuTitleShowsLimitPercents() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        let store = makeStore(providers: [claude],
+                              claude: claudeLimits(fiveHourUtil: 42),
+                              codex: codexLimits(primaryUsed: 73))
+        store.showTokensInMenu = false
+        store.showCostInMenu = false
+        store.showLimitInMenu = true
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.menuTitle, "Claude 42% · Codex 73%")
+    }
+
+    // MARK: 한도 경고
+
+    func testLimitWarningWhenClaudeOverCritical() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        let store = makeStore(providers: [claude], claude: claudeLimits(fiveHourUtil: 96))
+        store.critThreshold = 95
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(store.isLimitWarning)
+        XCTAssertTrue(store.hasAnyLimits)
+    }
+
+    func testNoLimitWarningWhenUnderCritical() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        let store = makeStore(providers: [claude], claude: claudeLimits(fiveHourUtil: 50))
+        store.critThreshold = 95
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertFalse(store.isLimitWarning)
+    }
+
+    func testLimitWarningFromCodexSecondary() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        let store = makeStore(providers: [claude], codex: codexLimits(primaryUsed: 10, secondaryUsed: 97))
+        store.critThreshold = 95
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(store.isLimitWarning)
+    }
+
+    func testLimitWarningFromForecastAtFullUtilization() async {
+        // crit 을 100 초과로 올려 임계 분기를 끄고, util 100 → 예측 분기만으로 경고가 켜지는지 확인
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        let store = makeStore(providers: [claude],
+                              claude: claudeLimits(fiveHourUtil: 100, resetsAt: "2099-01-01T00:00:00Z"))
+        store.critThreshold = 101
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(store.isLimitWarning)   // fiveHourForecast(beforeReset:true)
+    }
+
+    // MARK: burn tier
+
+    func testBurnTierThresholds() async {
+        func tier(_ tpm: Double) async -> BurnTier {
+            let p = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+            p.enrichment = ProviderEnrichment(activeBlock: block(tokensPerMinute: tpm), blocksOK: true,
+                                              weekTotal: nil, monthTotal: nil, periodsOK: false)
+            let store = makeStore(providers: [p])
+            await store.refresh(scheduleEmptyRetry: false)
+            return store.burnTier
+        }
+        let idle = await tier(500)         // <=1000 → idle
+        let normal = await tier(50_000)    // <100k → normal
+        let fast = await tier(200_000)     // <400k → fast
+        let blazing = await tier(500_000)  // >=400k → blazing
+        XCTAssertEqual(idle, .idle)
+        XCTAssertEqual(normal, .normal)
+        XCTAssertEqual(fast, .fast)
+        XCTAssertEqual(blazing, .blazing)
+    }
+
+    // MARK: stale
+
+    func testIsStaleBeforeFirstRefreshThenFreshAfter() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        let store = makeStore(providers: [claude])
+        XCTAssertTrue(store.isStale)   // lastUpdated nil
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertFalse(store.isStale)
+    }
+
+    // MARK: friendlyLimitError 매핑
+
+    func testFriendlyLimitErrorMapping() {
+        let l = L(.en)
+        XCTAssertEqual(UsageStore.friendlyLimitError(LimitsError.httpStatus(401), l), l.limitRefreshHTTPError(401))
+        XCTAssertEqual(UsageStore.friendlyLimitError(LimitsError.httpStatus(500), l), l.limitRefreshHTTPError(500))
+        XCTAssertEqual(UsageStore.friendlyLimitError(LimitsError.credentialFormat, l), l.limitRefreshNoCredential)
+        XCTAssertEqual(UsageStore.friendlyLimitError(LimitsError.keychainInteractionNotAllowed, l), l.limitRefreshGeneric)
+        XCTAssertEqual(UsageStore.friendlyLimitError(StubError.boom, l), l.limitRefreshGeneric)   // 비 LimitsError
+    }
+}

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# test-gate.sh — 안정성 가드레일. 커밋/머지 전 수동 실행 (1인 로컬, CI 없음).
+#
+#   1) swift test 전체 통과
+#   2) "로직 코어" 파일 집합의 라인 커버리지 >= THRESHOLD
+#
+# 로직 코어 = 결정적으로 단위 테스트 가능한 파일만 포함. ProcessRunner / PokeAPIClient /
+# CcusageProvider / CodexRateLimitsProvider / OAuthLimitsProvider / UpdateChecker /
+# BinaryLocator 는 실제 서브프로세스·네트워크·Keychain 의존이라 단위 커버리지 대상에서 제외
+# (해당 부분은 파서/순수 헬퍼만 별도로 테스트됨).
+#
+# 사용:  ./scripts/test-gate.sh          # 게이트 실행
+#        THRESHOLD=75 ./scripts/test-gate.sh   # 임계값 임시 상향
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+THRESHOLD="${THRESHOLD:-70}"
+
+LOGIC_CORE=(
+  "Sources/PokeTokenBar/Core/CompanionModel.swift"
+  "Sources/PokeTokenBar/Core/CompanionStore.swift"
+  "Sources/PokeTokenBar/Core/UsageStore.swift"
+  "Sources/PokeTokenBar/Core/Models.swift"
+  "Sources/PokeTokenBar/Core/TokenFormatter.swift"
+  "Sources/PokeTokenBar/Core/UsageProvider.swift"
+)
+
+echo "▶ swift test (--enable-code-coverage)"
+swift test --enable-code-coverage
+
+PROF=$(find .build -name 'default.profdata' | head -1)
+BIN=$(find .build -name 'PokeTokenBarPackageTests' -type f | head -1)
+if [[ -z "$PROF" || -z "$BIN" ]]; then
+  echo "✗ 커버리지 산출물(profdata/binary)을 찾지 못했습니다." >&2
+  exit 1
+fi
+
+echo
+echo "▶ 로직 코어 커버리지 (임계값 ${THRESHOLD}%)"
+REPORT=$(xcrun llvm-cov report "$BIN" -instr-profile="$PROF" "${LOGIC_CORE[@]}" 2>/dev/null)
+echo "$REPORT"
+
+# TOTAL 행의 라인 커버리지(%) 추출 — 컬럼: ... Lines MissedLines Cover(=$10)
+COVER=$(echo "$REPORT" | awk '/^TOTAL/ { gsub("%","",$10); print $10 }')
+if [[ -z "$COVER" ]]; then
+  echo "✗ 커버리지 수치 파싱 실패." >&2
+  exit 1
+fi
+
+echo
+# 소수 비교는 awk 로 (bash 정수 비교 회피)
+if awk "BEGIN { exit !($COVER >= $THRESHOLD) }"; then
+  echo "✓ 게이트 통과 — 로직 코어 라인 커버리지 ${COVER}% >= ${THRESHOLD}%"
+else
+  echo "✗ 게이트 실패 — 로직 코어 라인 커버리지 ${COVER}% < ${THRESHOLD}%" >&2
+  echo "  테스트를 보강하거나, 의도된 하락이면 THRESHOLD 를 조정하세요." >&2
+  exit 1
+fi


### PR DESCRIPTION
## 배경

AI 주도 개발의 코드 품질을 100% 보장할 수 없으므로, **테스트를 두껍게 깔아 잘못된 수정·방향을 회귀로 잡는 가드레일**을 강화한다. unit / 뷰 로직 / 기능 / 성능 테스트 + 커밋 전 커버리지 게이트.

> 방향 결정(사용자 확정): 뷰 로직 테스트(SwiftPM 네이티브) · 커버리지 게이트 스크립트 · 핫패스 measure + 스케일.
> 1인 로컬 위협 모델 — CI 없음, 게이트는 로컬 수동/훅 실행.

## 테스트 (+46건 · 51 → 97, 0 failures)

| 파일 | 커버 영역 |
|---|---|
| `UsageStoreTests` (13) | refresh 파이프라인을 주입 스텁으로 결정적 검증 — 멀티 provider 집계, codex-only(claude 데이터 없음), 날짜 가드 제외, provider 실패 시 이전 값 유지, `menuTitle` 토글 조합, `isLimitWarning` 분기(claude crit / codex secondary / util 100 예측), `burnTier` 임계, `isStale`, `friendlyLimitError` 매핑 |
| `ModelLogicTests` (정렬·파생) | `EvoLine` 다국어 폴백(ja-Hrkt→ja→en→#id), `EvoNode` depth/lookup/finalIDs, `Rarity` 경계(45/120/legendary), OAuth `expiresAt` 초·밀리초 휴리스틱, `ISO8601` 가변 정밀도, Codex `displayName`/`usedPercent` 클램프, `MonState.currentID` 클램프, `CompanionState` 인코드/디코드 라운드트립 |
| `CompanionDisplayStateTests` | `displayState` 전이(egg/levelUp/working/focus/tired/sleep) + 알 인큐베이션 파생값(progress/tokensToHatch) |
| `PerformanceTests` | 핫패스 `measure`(phaseThreshold/pick 10만, `update`, 대용량 decode 1000행, 대형 dex 1000건 정렬) + 비퇴화 가드(거대 델타 1회 졸업·터미네이션, 반복 졸업 선형 증가) |

스텁은 실제 JSON 디코더로 픽스처를 파싱해(BlockUsage/LimitStatus/CodexRateLimitStatus) 프로덕션 파싱 경로를 같이 태운다. 시계(ClockBox)·RNG(SeededRNG)·파일(UUID temp)은 주입해 디스크/시간/순서 비의존.

## 가드레일 — `scripts/test-gate.sh`

커밋/머지 전 실행. ① `swift test` 전체 통과 AND ② **로직 코어 라인 커버리지 ≥ 70%**(현재 75.8%) 미달 시 실패.

```
$ ./scripts/test-gate.sh
✓ 게이트 통과 — 로직 코어 라인 커버리지 75.79% >= 70%
```

로직 코어 = 결정적으로 단위 테스트 가능한 6개 파일(CompanionModel/CompanionStore/UsageStore/Models/TokenFormatter/UsageProvider). `ProcessRunner`/`PokeAPIClient`/`Ccusage`/`Codex`/`OAuth`/`BinaryLocator` 등 **실제 서브프로세스·네트워크·Keychain 의존 래퍼는 단위 커버리지 대상에서 제외**(파서·순수 헬퍼만 별도 테스트). 전체 Core 75% 게이트는 I/O 래퍼 때문에 비현실적이라 의도적으로 로직 코어에 한정.

## 테스트 가능성 seam (프로덕션 최소 변경)

- `UsageStore`: `ClaudeLimitsProviding` / `CodexLimitsProviding` 프로토콜로 한도 provider 주입 가능화 — 기존 `init(providers:)` DI 패턴과 동일. `autoRefresh: Bool = true` 플래그로 초기 refresh 게이트. `friendlyLimitError` internal 노출.
- 기본 인자가 기존 동작을 그대로 보존(실앱은 `UsageStore()` 전부 디폴트 → 변경 전과 동일).

## 검증

- `swift build` clean · 97 tests · 0 failures · 게이트 75.79% ≥ 70%
- code-reviewer 검토: **APPROVE** (BLOCKER/HIGH/MEDIUM 0). LOW 4건은 모두 1인 로컬 위협 모델 밖(테스트 중 디버그 스냅샷 덮어쓰기·공유 UserDefaults·게이트 find 비결정성·awk 포맷 의존)이라 over-spec으로 미적용.

### 알려진 minor (의도적 미적용)
- 테스트 `refresh()`가 실앱 `last-snapshot.json`(디버그 아티팩트)을 덮어쓰나, 다음 refresh(2분)에 자가복구. 1인 로컬 위협 모델 내라 별도 가드 미추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)