### PR TITLE
chore: update repo references after rename to PokeTokenBar

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 **あなたのAIコーディングトークンを、ポケモンに — メニューバーで。**
 
-[![Release](https://img.shields.io/badge/release-v2.0.1-444d56)](https://github.com/chattymin/poke-token-bar/releases)
+[![Release](https://img.shields.io/badge/release-v2.0.1-444d56)](https://github.com/chattymin/PokeTokenBar/releases)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 **당신의 AI 코딩 토큰을 포켓몬으로 — 메뉴바에서.**
 
-[![Release](https://img.shields.io/badge/release-v2.0.1-444d56)](https://github.com/chattymin/poke-token-bar/releases)
+[![Release](https://img.shields.io/badge/release-v2.0.1-444d56)](https://github.com/chattymin/PokeTokenBar/releases)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Your AI coding tokens, hatched into Pokémon — right in your menu bar.**
 
-[![Release](https://img.shields.io/badge/release-v2.0.1-444d56)](https://github.com/chattymin/poke-token-bar/releases)
+[![Release](https://img.shields.io/badge/release-v2.0.1-444d56)](https://github.com/chattymin/PokeTokenBar/releases)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)

--- a/Sources/PokeTokenBar/Core/UpdateChecker.swift
+++ b/Sources/PokeTokenBar/Core/UpdateChecker.swift
@@ -12,7 +12,7 @@ final class UpdateChecker {
     private(set) var isUpdating = false
 
     let currentVersion: String
-    private let repo = "chattymin/poke-token-bar"
+    private let repo = "chattymin/PokeTokenBar"
     private let clock: () -> Date
     private var lastChecked: Date?
 


### PR DESCRIPTION
## 배경

GitHub 레포 이름을 `poke-token-bar` → **`PokeTokenBar`**(하이픈 제거)로 rename. 레포 URL 참조를 새 canonical 이름으로 정정.

## 변경

| 위치 | Before → After |
|---|---|
| `UpdateChecker.swift:15` `repo` | `chattymin/poke-token-bar` → `chattymin/PokeTokenBar` (releases API 경로) |
| README ko/en/ja line 9 | 릴리스 배지 링크 → `github.com/chattymin/PokeTokenBar/releases` |

## 변경하지 않은 것 (의도)

- **Homebrew cask 토큰** — `chattymin/tap/poke-token-bar`(brew 명령) 및 `--cask poke-token-bar`(UpdateChecker 자동 업데이트)는 **tap 레포(`homebrew-tap`)의 cask 식별자**라 앱 레포 rename과 무관. 그대로 유지.
- 번들 ID `io.github.chattymin.poketokenbar`, Application Support 디렉토리 `PokeTokenBar` — 레포 이름과 무관.

> rename 시 GitHub가 리다이렉트를 걸어줘 기존 URL도 동작하지만, 소스/문서는 canonical 이름으로 정정.

## 검증
- `swift build` clean · `swift test` 97 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)