### PR TITLE
fix: auto-refresh official limits via silent keychain read

### DIFF
--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -90,10 +90,18 @@ private actor OAuthAccessTokenCache {
         return credential.accessToken
     }
 
-    /// 무프롬프트 Keychain 읽기 — ACL 미허용·접근 불가·형식 오류는 모두 nil 로 흡수(다이얼로그 없음).
-    /// no-UI 쿼리이므로 권한이 없으면 프롬프트 대신 errSecInteractionNotAllowed 가 나고 try? 가 nil 로 만든다.
+    /// 무프롬프트 Keychain 읽기 — no-UI 쿼리라 권한이 없으면 프롬프트 대신 errSecInteractionNotAllowed.
+    /// '아직 항상 허용 전'(interactionNotAllowed)은 정상 흐름이라 조용히 nil. 그 외(형식 오류·접근 불가)는
+    /// 진단을 위해 로그를 남기고 nil — 자동 경로가 왜 토큰을 못 구했는지 추적 가능하게.
     private nonisolated static func readClaudeKeychainSilently() -> OAuthCredentialData.Credential? {
-        try? readClaudeKeychain(allowKeychainPrompt: false)
+        do {
+            return try readClaudeKeychain(allowKeychainPrompt: false)
+        } catch LimitsError.keychainInteractionNotAllowed {
+            return nil
+        } catch {
+            AppLog.write("silent claude keychain read failed: \(error)")
+            return nil
+        }
     }
 
     func invalidate(removePersistentCache: Bool = false) {

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -67,10 +67,19 @@ private actor OAuthAccessTokenCache {
             Self.writePokeTokenBarCache(credential.data)
             return credential.accessToken
         }
-        // Claude Keychain 항목은 앱 직접 read 단일 경로로만 읽는다(프롬프트 1회).
-        // 과거의 `security` CLI 보조 경로는 별도 신원이라 같은 항목에 두 번째 ACL 프롬프트를
-        // 띄웠고(1.5s 타임아웃도 대화형에 부적합) 제거함. 최초 1회 허용 후 앱 자체 Keychain
-        // 캐시(writePokeTokenBarCache)에 저장돼 이후 재프롬프트 없음.
+        // 무프롬프트(no-UI) Claude Keychain 읽기. 사용자가 과거 한 번 '항상 허용'했다면
+        // 앱 cdhash 가 항목 ACL 에 등록돼 *프롬프트 없이* 성공한다. 아직 허용 전이거나 접근
+        // 불가면 errSecInteractionNotAllowed 로 조용히 실패 — 다이얼로그가 뜨지 않는다.
+        // 이 경로 덕분에 자동 새로고침이 만료된 토큰을 스스로 재취득해 한도(주간 리셋 포함)를
+        // 갱신한다. 수동 버튼 없이 자동 동작하게 하는 핵심.
+        if let credential = Self.readClaudeKeychainSilently() {
+            cachedCredential = credential
+            Self.writePokeTokenBarCache(credential.data)
+            return credential.accessToken
+        }
+        // 무프롬프트로 토큰을 못 구함 → 명시적 사용자 동작(설정의 갱신 버튼)일 때만 프롬프트를
+        // 동반해 읽는다(최초 1회 '항상 허용' 유도). 이후엔 위 무프롬프트 경로로 자동 동작한다.
+        // `security` CLI 보조 경로는 별도 신원이라 두 번째 ACL 프롬프트를 띄워 제거함.
         guard allowKeychainPrompt else {
             throw LimitsError.keychainInteractionNotAllowed
         }
@@ -79,6 +88,12 @@ private actor OAuthAccessTokenCache {
         cachedCredential = credential
         Self.writePokeTokenBarCache(credential.data)
         return credential.accessToken
+    }
+
+    /// 무프롬프트 Keychain 읽기 — ACL 미허용·접근 불가·형식 오류는 모두 nil 로 흡수(다이얼로그 없음).
+    /// no-UI 쿼리이므로 권한이 없으면 프롬프트 대신 errSecInteractionNotAllowed 가 나고 try? 가 nil 로 만든다.
+    private nonisolated static func readClaudeKeychainSilently() -> OAuthCredentialData.Credential? {
+        try? readClaudeKeychain(allowKeychainPrompt: false)
     }
 
     func invalidate(removePersistentCache: Bool = false) {


### PR DESCRIPTION
## 증상

공식 한도(Claude 5h/주간, Codex)가 **수동 '한도 토큰 갱신' 버튼을 누르기 전까지 자동으로 갱신되지 않음**. 특히 어제 주간 Claude 한도가 리셋됐는데 반영되지 않음.

## 원인 (재현 조건)

`UsageStore.refresh()`는 자동 실행 시 `OAuthLimitsProvider.fetch(allowKeychainPrompt: false)`로 호출된다. 이 무프롬프트 경로는 토큰을 **① PokeTokenBar 자체 keychain 캐시 → ② Claude 자격증명 파일**에서만 찾고, **Claude Keychain 항목은 아예 읽지 않았다**.

→ 캐시 토큰이 만료되고 + 자격증명 파일이 없으면(macOS는 keychain-only 저장이 흔함 — [claude-code#44028](https://github.com/anthropics/claude-code/issues/44028)) 토큰을 못 구해 `fetch`가 throw → `refresh()`의 `catch`가 **이전 `limits` 값을 그대로 유지**(주간 리셋 미반영). 수동 버튼만 keychain을 읽어 동작.

## 수정 (권한 최소 · 레퍼런스 패턴)

자동 경로에 **무프롬프트(no-UI) Claude Keychain 읽기**를 추가:

```
PokeTokenBar 캐시 → 자격증명 파일 → [신규] 무프롬프트 Keychain → (버튼일 때만) 프롬프트 Keychain
```

- 사용자가 과거 한 번 **'항상 허용'**한 ACL을 **재사용** → 새 권한을 요구하지 않고, 프롬프트 없이 만료 토큰을 재취득 → 한도 자동 갱신(주간 리셋 포함).
- 아직 미허용/접근 불가면 `kSecUseAuthenticationUIFail`로 인해 **다이얼로그 대신 `errSecInteractionNotAllowed`(-25308)** 가 나고 `try?`가 nil로 흡수 → **조용히 실패**(서프라이즈 프롬프트 없음). 명시적 버튼일 때만 프롬프트로 최초 1회 허용을 유도.
- 401/403 복구 경로(`bypassCache`)도 동일 무프롬프트 keychain 재읽기 혜택을 받아, 토큰 만료 → 401 → 무프롬프트 재취득의 닫힌 루프로 자가 복구.

### 근거 (레퍼런스 확인)
- `kSecUseAuthenticationUIFail` 설정 시 무권한 컨텍스트에서 프롬프트 대신 -25308 반환 — [Apple DevForums 97091](https://developer.apple.com/forums/thread/97091)
- 항목 ACL의 trusted-app 목록 등록(= '항상 허용') 후 동일 cdhash는 무프롬프트 읽기 가능 — [HackTricks: macOS Keychain](https://hacktricks.wiki/en/macos-hardening/macos-red-teaming/macos-keychain.html), [Apple Support](https://support.apple.com/guide/mac-help/allow-apps-to-access-your-keychain-kychn002/mac)

## 알려진 한계

ad-hoc 서명 배포 빌드는 **업데이트 시 cdhash가 바뀌어** 이전 '항상 허용' ACL 등록이 무효화된다. 따라서 새 버전 설치 후 **버튼을 1회** 눌러 재허용하면, 그 버전 동안은 자동 동작한다. (영구 해결은 안정적 Developer ID 서명 필요 — 팬 프로젝트 범위 밖.)

## 검증
- `swift build` clean · `swift test` 97 tests, 0 failures
- 실동작은 keychain ACL 의존이라 단위 테스트 불가 → 빌드 후 실기기 확인 필요(아래 릴리스).

🤖 Generated with [Claude Code](https://claude.com/claude-code)