### PR TITLE
fix: popover always reopens on Home

### DIFF
--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -19,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var store: UsageStore!
     private var companion: CompanionStore!
     private var updater: UpdateChecker!
+    private let navigation = PopoverNavigation()
 
     // 메뉴바 캐릭터 애니메이션 — 단일 타이머로 프레임 순환.
     // 프레임 = 이미 22px 로 합성된 이미지 + delay. egg/static 은 2프레임 bob, animated 는 GIF 실제 프레임.
@@ -47,7 +48,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         popover.contentViewController = NSHostingController(
-            rootView: PopoverView().environment(store).environment(companion).environment(updater))
+            rootView: PopoverView()
+                .environment(store).environment(companion).environment(updater).environment(navigation))
         popover.behavior = .transient
 
         observeStore()
@@ -203,6 +205,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if popover.isShown {
             popover.performClose(nil)
         } else {
+            navigation.reset()   // 닫혔다 열리면 항상 Home 으로 (설정 화면 잔류 방지)
             // LSUIElement 앱이 비활성이면 팝오버 내부 버튼 클릭이 무시됨 — show 전에 활성화 보장
             NSApp.activate(ignoringOtherApps: true)
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -2,21 +2,36 @@ import SwiftUI
 
 enum PopoverTab { case home, collection }
 
+/// 팝오버 내부 내비게이션 상태(현재 탭 / 설정 표시 여부).
+/// NSHostingController 는 팝오버를 닫아도 재사용되어 @State 가 유지되므로, 화면 상태를 이
+/// Observable 로 분리해 AppDelegate 가 팝오버를 열 때마다 reset() 한다 — 닫혔다 열리면 항상 Home.
+@MainActor
+@Observable
+final class PopoverNavigation {
+    var showSettings = false
+    var tab: PopoverTab = .home
+
+    func reset() {
+        showSettings = false
+        tab = .home
+    }
+}
+
 struct PopoverView: View {
     @Environment(UsageStore.self) private var store
     @Environment(CompanionStore.self) private var companion
     @Environment(UpdateChecker.self) private var updater
-    @State private var showSettings = false
-    @State private var tab: PopoverTab = .home
+    @Environment(PopoverNavigation.self) private var nav
 
     private var l: L { companion.l }
 
     var body: some View {
         // NOTE: 설정을 .sheet 로 띄우면 transient 팝오버가 닫힐 때 시트가 고아로 남아
         // 이후 팝오버의 모든 버튼 클릭을 차단할 수 있음 — 팝오버 내부 화면 전환으로 처리
+        @Bindable var nav = nav
         Group {
-            if showSettings {
-                SettingsView(onClose: { showSettings = false })
+            if nav.showSettings {
+                SettingsView(onClose: { nav.showSettings = false })
                     .environment(store)
                     .environment(companion)
             } else {
@@ -50,16 +65,17 @@ struct PopoverView: View {
     }
 
     private var mainContent: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        @Bindable var nav = nav
+        return VStack(alignment: .leading, spacing: 12) {
             updateBanner
-            Picker("", selection: $tab) {
+            Picker("", selection: $nav.tab) {
                 Text(l.home).tag(PopoverTab.home)
                 Text(l.collection).tag(PopoverTab.collection)
             }
             .pickerStyle(.segmented)
             .labelsHidden()
 
-            if tab == .collection {
+            if nav.tab == .collection {
                 CollectionView(store: companion)
             } else {
                 CompanionHeader(store: companion)
@@ -371,7 +387,7 @@ struct PopoverView: View {
             }
             Spacer()
             Button {
-                showSettings = true
+                nav.showSettings = true
             } label: {
                 Image(systemName: "gearshape")
             }

--- a/Tests/PokeTokenBarTests/PopoverNavigationTests.swift
+++ b/Tests/PokeTokenBarTests/PopoverNavigationTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import PokeTokenBar
+
+// 팝오버 내비게이션 리셋 계약 — 닫혔다 열릴 때 AppDelegate.togglePopover 가 reset()을 불러
+// 항상 Home 으로 돌아가게 한다(설정 화면 잔류 방지).
+@MainActor
+final class PopoverNavigationTests: XCTestCase {
+    func testDefaultsToHome() {
+        let nav = PopoverNavigation()
+        XCTAssertFalse(nav.showSettings)
+        XCTAssertEqual(nav.tab, .home)
+    }
+
+    func testResetReturnsToHomeFromSettings() {
+        let nav = PopoverNavigation()
+        nav.showSettings = true
+        nav.tab = .collection
+        nav.reset()
+        XCTAssertFalse(nav.showSettings)   // 설정 화면 닫힘
+        XCTAssertEqual(nav.tab, .home)     // 탭도 Home 으로
+    }
+}


### PR DESCRIPTION
## 증상

설정 화면에 들어간 채로 팝오버를 닫으면, **다음에 팝오버를 열 때 설정 화면이 그대로 떠 있음.** 기대 동작: 팝오버가 닫혔다 열리면 무조건 Home.

## 원인

`NSPopover`의 `NSHostingController`는 팝오버를 닫아도 (앱 기동 시 1회 생성된 채) **재사용**된다. 그래서 `PopoverView`의 `@State`(`showSettings`, `tab`)가 닫힘 이후에도 **유지**되어 마지막 화면이 잔류한다.

## 수정 (결정적 방식)

화면 상태를 `@Observable PopoverNavigation`(`showSettings`, `tab`, `reset()`)으로 분리하고, **팝오버를 여는 지점**(`AppDelegate.togglePopover`의 열기 분기)에서 `popover.show` 직전에 `navigation.reset()`을 호출 → 닫혔다 열리면 **항상 Home**.

> `onAppear`/`onDisappear` 같은 NSPopover 라이프사이클 콜백은 재사용 컨트롤러에서 발화가 불안정해 의존하지 않음. `togglePopover`는 팝오버를 여는 유일한 경로(transient 외부클릭 닫힘 → 재오픈도 버튼 경유)라, show 직전 리셋이 **모든 오픈을 결정적으로 커버**한다.

### 변경
| 파일 | 내용 |
|---|---|
| `PopoverView.swift` | `@State showSettings/tab` → `@Environment(PopoverNavigation)`. 설정 토글·세그먼트 탭은 observable 경유(`@Bindable`). 새 `PopoverNavigation` 클래스 추가 |
| `PokeTokenBarApp.swift` | `navigation` 소유 + hosting controller 환경 주입 + 열기 직전 `reset()` |
| `PopoverNavigationTests.swift` | reset 계약 테스트 2건 |

## 검증
- `swift build` clean · `swift test` **99 tests, 0 failures**(+2)
- 실제 팝오버 동작은 GUI라 자동 검증 불가 → 다음 빌드에서 수동 확인 필요. 단, reset 이 매 오픈 시 동기 호출되므로 동작은 결정적(라이프사이클 콜백 비의존).

🤖 Generated with [Claude Code](https://claude.com/claude-code)