### PR TITLE
docs: auto-updating release badge in READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 **あなたのAIコーディングトークンを、ポケモンに — メニューバーで。**
 
-[![Release](https://img.shields.io/badge/release-v2.0.1-444d56)](https://github.com/chattymin/PokeTokenBar/releases)
+[![Release](https://img.shields.io/github/v/release/chattymin/PokeTokenBar?color=444d56&label=release)](https://github.com/chattymin/PokeTokenBar/releases)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 **당신의 AI 코딩 토큰을 포켓몬으로 — 메뉴바에서.**
 
-[![Release](https://img.shields.io/badge/release-v2.0.1-444d56)](https://github.com/chattymin/PokeTokenBar/releases)
+[![Release](https://img.shields.io/github/v/release/chattymin/PokeTokenBar?color=444d56&label=release)](https://github.com/chattymin/PokeTokenBar/releases)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Your AI coding tokens, hatched into Pokémon — right in your menu bar.**
 
-[![Release](https://img.shields.io/badge/release-v2.0.1-444d56)](https://github.com/chattymin/PokeTokenBar/releases)
+[![Release](https://img.shields.io/github/v/release/chattymin/PokeTokenBar?color=444d56&label=release)](https://github.com/chattymin/PokeTokenBar/releases)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)


### PR DESCRIPTION
## 문제
README release 배지가 **버전 하드코딩 정적 배지**(`badge/release-v2.0.1`)라 릴리스마다 수동 갱신 필요 → v2.0.3 인데도 v2.0.1 로 표시(stale).

## 수정
shields.io **동적 배지**로 교체 — 최신 GitHub 릴리스를 자동 반영:
```
https://img.shields.io/github/v/release/chattymin/PokeTokenBar?color=444d56&label=release
```
README.md / README.ko.md / README.ja.md 3개 모두. 앞으로 릴리스 시 README 수동 수정 불필요(랜딩 페이지는 이미 동적 배지 사용 중).

🤖 Generated with [Claude Code](https://claude.com/claude-code)