### PR TITLE
fix: reliable in-app update + version label in Settings

### DIFF
--- a/Sources/PokeTokenBar/Core/UpdateChecker.swift
+++ b/Sources/PokeTokenBar/Core/UpdateChecker.swift
@@ -52,17 +52,19 @@ final class UpdateChecker {
 
     /// 업데이트 적용: brew cask 설치본이면 `brew upgrade` 후 재시작, 아니면 릴리스 페이지.
     func applyUpdate() {
-        guard let update = available else { return }
-        guard !isUpdating else { return }
+        guard let update = available, !isUpdating else { return }
         isUpdating = true
         Task { @MainActor in
-            let upgraded = await Task.detached { Self.brewUpgradeIfInstalled() }.value
-            isUpdating = false
-            if upgraded {
-                Self.relaunch()
-            } else if let u = URL(string: update.url) {
-                AppLog.write("update: brew upgrade unavailable/failed → opening release page")
-                NSWorkspace.shared.open(u)
+            // brew cask 설치본이면 분리(detached) 스크립트가 앱 종료 후 tap 갱신→업그레이드→재오픈.
+            // 그 외(brew 미설치/비-cask 설치)면 릴리스 페이지를 연다.
+            let brew = await Task.detached { Self.brewCaskPath() }.value
+            if let brew {
+                Self.launchDetachedUpgrade(brew: brew)
+                NSApp.terminate(nil)
+            } else {
+                isUpdating = false
+                AppLog.write("update: brew cask 아님/brew 미설치 → 릴리스 페이지 열기")
+                if let u = URL(string: update.url) { NSWorkspace.shared.open(u) }
             }
         }
     }
@@ -83,13 +85,12 @@ final class UpdateChecker {
 
     // MARK: brew 적용 (nonisolated — 블로킹 Process 는 detached 에서)
 
-    /// brew cask 설치본이면 업그레이드. 설치본이 아니거나 brew 없으면 false(→ 릴리스 페이지 폴백).
-    private nonisolated static func brewUpgradeIfInstalled() -> Bool {
+    /// poke-token-bar 가 brew cask 로 설치돼 있으면 brew 경로 반환, 아니면 nil(→ 릴리스 페이지 폴백).
+    private nonisolated static func brewCaskPath() -> String? {
         guard let brew = BinaryLocator.resolve("brew", staticPaths: [
             "/opt/homebrew/bin/brew", "/usr/local/bin/brew",
-        ]) else { return false }
-        guard run(brew, ["list", "--cask", "poke-token-bar"], timeout: 20) else { return false }
-        return run(brew, ["upgrade", "--cask", "poke-token-bar"], timeout: 300)
+        ]) else { return nil }
+        return run(brew, ["list", "--cask", "poke-token-bar"], timeout: 20) ? brew : nil
     }
 
     private nonisolated static func run(_ binary: String, _ args: [String], timeout: TimeInterval) -> Bool {
@@ -106,14 +107,24 @@ final class UpdateChecker {
         return process.terminationStatus == 0
     }
 
-    /// 교체된 새 번들을 다시 띄우고 현재 인스턴스 종료(분리된 sh 가 종료를 기다렸다 open).
-    private static func relaunch() {
-        let path = Bundle.main.bundlePath
+    /// 앱이 완전히 종료된 뒤 tap 갱신 + cask 업그레이드 + 재오픈을 수행하는 분리(detached) 스크립트.
+    /// - `brew update` 선행: auto-update 빈도 제한(기본 24h)으로 stale 한 로컬 tap 때문에 `brew upgrade`
+    ///   가 no-op(exit 0) 되어 "업데이트 안 됨 + 앱만 종료"가 나던 문제를 막는다.
+    /// - 앱 종료를 기다림(pgrep): 실행 중 번들 교체 레이스 + 재오픈 LaunchServices(-600) 레이스 회피.
+    /// - `open` 재시도: 종료 직후 재오픈이 실패할 수 있어 여러 번 시도.
+    /// 인자는 positional($1=brew, $2=bundlePath)로 전달 — 셸 인젝션 차단.
+    private static func launchDetachedUpgrade(brew: String) {
+        let bundlePath = Bundle.main.bundlePath
+        let script = """
+        for i in $(seq 1 40); do pgrep -x PokeTokenBar >/dev/null 2>&1 || break; sleep 0.5; done
+        export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+        "$1" update
+        "$1" upgrade --cask poke-token-bar
+        for i in $(seq 1 15); do open "$2" && break; sleep 1; done
+        """
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/bin/sh")
-        // 경로를 스크립트 문자열에 보간하지 않고 positional 인자($1)로 전달 — 셸 인젝션 차단.
-        task.arguments = ["-c", "sleep 2; open \"$1\"", "sh", path]
+        task.arguments = ["-c", script, "sh", brew, bundlePath]
         try? task.run()
-        NSApp.terminate(nil)
     }
 }

--- a/Sources/PokeTokenBar/Core/UpdateChecker.swift
+++ b/Sources/PokeTokenBar/Core/UpdateChecker.swift
@@ -111,15 +111,18 @@ final class UpdateChecker {
     /// - `brew update` 선행: auto-update 빈도 제한(기본 24h)으로 stale 한 로컬 tap 때문에 `brew upgrade`
     ///   가 no-op(exit 0) 되어 "업데이트 안 됨 + 앱만 종료"가 나던 문제를 막는다.
     /// - 앱 종료를 기다림(pgrep): 실행 중 번들 교체 레이스 + 재오픈 LaunchServices(-600) 레이스 회피.
-    /// - `open` 재시도: 종료 직후 재오픈이 실패할 수 있어 여러 번 시도.
+    /// - brew 를 백그라운드+워치독(≤300s)으로 감싸 hang 시에도 reopen 이 반드시 실행되게 함
+    ///   (앱이 종료된 채 영영 안 돌아오는 것 방지). 종료 직후 재오픈 실패 대비 `open` 재시도.
     /// 인자는 positional($1=brew, $2=bundlePath)로 전달 — 셸 인젝션 차단.
     private static func launchDetachedUpgrade(brew: String) {
         let bundlePath = Bundle.main.bundlePath
         let script = """
         for i in $(seq 1 40); do pgrep -x PokeTokenBar >/dev/null 2>&1 || break; sleep 0.5; done
         export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
-        "$1" update
-        "$1" upgrade --cask poke-token-bar
+        ( "$1" update; "$1" upgrade --cask poke-token-bar ) &
+        brew_pid=$!
+        for i in $(seq 1 300); do kill -0 "$brew_pid" 2>/dev/null || break; sleep 1; done
+        kill "$brew_pid" 2>/dev/null
         for i in $(seq 1 15); do open "$2" && break; sleep 1; done
         """
         let task = Process()

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -15,6 +15,11 @@ struct SettingsView: View {
         Bundle.main.bundlePath.hasSuffix(".app")
     }
 
+    /// 현재 앱 버전 — 업데이트 적용 여부 확인용으로 설정창 하단에 표기.
+    private static var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
+    }
+
     var body: some View {
         @Bindable var store = store
         VStack(alignment: .leading, spacing: 14) {
@@ -133,6 +138,9 @@ struct SettingsView: View {
                 .foregroundStyle(.tertiary)
 
             HStack {
+                Text("v\(Self.appVersion)")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
                 Spacer()
                 Button(l.close) { onClose() }
                     .keyboardShortcut(.defaultAction)


### PR DESCRIPTION
## 증상
구버전(2.0.2) 사용자가 인앱 **업데이트** 버튼을 누르면 **업데이트가 적용되지 않고 앱이 종료되기만 함**.

## 원인 (진단)
`applyUpdate` → `brewUpgradeIfInstalled` 가 `brew upgrade --cask` 만 호출하고 **`brew update`(로컬 tap 갱신)를 선행하지 않음**.
- Homebrew 는 upgrade 전 auto-update 를 하지만 **빈도 제한(기본 24h)** 이 있어, 최근 brew 를 쓴 사용자는 tap 이 stale(아직 2.0.2 만 앎) → `brew upgrade` 가 **할 게 없어 no-op 으로 exit 0**.
- 코드는 exit 0 을 "업그레이드 성공"으로 보고 `relaunch()` → **앱 종료**.
- 종료 직후 `open` 재오픈이 LaunchServices **-600** 레이스로 실패하면 → **"업데이트 안 됨 + 앱만 꺼짐"** 정확히 그 증상.
- 실행 중 번들을 교체하며 즉시 종료하는 것도 불안정.

## 수정

### ① 견고한 업데이트 플로우
앱 종료 **후** 동작하는 분리(detached) 스크립트로 일원화:
```
앱 종료 대기(pgrep) → brew update → brew upgrade --cask poke-token-bar → open 재시도(최대 15회)
```
- **`brew update` 선행** → stale tap no-op 방지(핵심 fix).
- **앱 종료 후 실행** → 실행 중 번들 교체 레이스 + 재오픈 -600 레이스 회피.
- **`open` 재시도** → 종료 직후 재오픈 실패 대비.
- `PATH` 명시 export → brew 의 git/curl 등 의존 도구 확보.
- brew cask 설치본이 아니면 릴리스 페이지 폴백.
- 인자 positional($1=brew, $2=bundlePath) — 셸 인젝션 차단.

### ② 설정창 버전 표기
설정창 하단 좌측에 현재 버전(`v2.0.3`)을 작게(tertiary) 표기 — 업데이트 적용 여부 확인용.

## ⚠️ 중요 (배포 시 안내 필요)
이 fix 는 **업데이터 자체**를 고치는 거라, **기존 2.0.2 사용자는 자신의 (버그 있는) 2.0.2 업데이터가 돌아가므로 인앱 업데이트가 여전히 실패**한다. 친구는 **한 번만 터미널에서 수동 업그레이드**가 필요:
```bash
brew update && brew upgrade --cask poke-token-bar
```
이후(고쳐진 버전부터)의 인앱 업데이트는 정상 동작.

## 검증
- `swift build` clean · `swift test` **99 tests, 0 failures**
- detached 스크립트 `sh -n` 문법 검증
- (전체 업데이트 플로우는 구버전 필요 → 다음 릴리스 사이클에서 실기기 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)