### PR TITLE
feat: drop ccusage — read Claude/Codex usage logs directly

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// 파일별 증분 캐시 — `(path, mtime, size)` 가 같으면 재파싱하지 않는다. 디스크에 영속화한다.
+///
+/// 사용자가 매일 코딩하면 사실상 모든 세션 파일이 "이번 달 수정"(수백 MB)이라 mtime 필터만으론
+/// 매 새로고침마다 전수 파싱을 피할 수 없다. 변경된 파일만 다시 읽도록 캐시하고(정상 상태 ~0.1s),
+/// 캐시를 디스크에 저장해 **콜드 스타트(전체 파싱 ~수십초)를 최초 1회로** 제한한다(배터리).
+actor LocalUsageCache {
+    static let shared = LocalUsageCache()
+
+    private struct Blob: Codable { let mtime: Date; let size: Int; let entries: [LocalUsageReader.Entry] }
+    private struct Snapshot: Codable { var claude: [String: Blob]; var codex: [String: Blob] }
+
+    private var claudeCache: [String: Blob] = [:]
+    private var codexCache: [String: Blob] = [:]
+    private var loaded = false
+    private var dirty = false
+    private var lastSave: Date?
+
+    private static let fileURL: URL = {
+        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("PokeTokenBar")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("usage-cache.json")
+    }()
+
+    func claudeEntries(modifiedSince: Date) -> [LocalUsageReader.Entry] {
+        ensureLoaded()
+        let fmt = LocalUsageReader.localDayFormatter()
+        let all = collect(root: LocalUsageReader.claudeProjectsDir, since: modifiedSince, cache: &claudeCache) {
+            LocalUsageReader.parseClaudeFile($0, fmt: fmt)
+        }
+        saveIfNeeded()
+        return LocalUsageReader.dedupKeepMax(all)
+    }
+
+    func codexEntries(modifiedSince: Date) -> [LocalUsageReader.Entry] {
+        ensureLoaded()
+        let fmt = LocalUsageReader.localDayFormatter()
+        let r = collect(root: LocalUsageReader.codexSessionsDir, since: modifiedSince, cache: &codexCache) {
+            LocalUsageReader.parseCodexFile($0, fmt: fmt)
+        }
+        saveIfNeeded()
+        return r
+    }
+
+    private func collect(root: URL, since: Date, cache: inout [String: Blob],
+                         parse: (URL) -> [LocalUsageReader.Entry]) -> [LocalUsageReader.Entry] {
+        let fm = FileManager.default
+        guard let en = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]) else { return [] }
+        var result: [LocalUsageReader.Entry] = []
+        for case let url as URL in en {
+            guard url.pathExtension == "jsonl" else { continue }
+            guard let v = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
+                  let mtime = v.contentModificationDate, mtime >= since else { continue }
+            let size = v.fileSize ?? 0
+            let key = url.path
+            if let blob = cache[key], blob.mtime == mtime, blob.size == size {
+                result.append(contentsOf: blob.entries)            // 변경 없음 → 재파싱 안 함
+            } else {
+                let entries = parse(url)
+                cache[key] = Blob(mtime: mtime, size: size, entries: entries)
+                dirty = true
+                result.append(contentsOf: entries)
+            }
+        }
+        return result
+    }
+
+    // MARK: 영속화
+
+    private func ensureLoaded() {
+        guard !loaded else { return }
+        loaded = true
+        guard let data = try? Data(contentsOf: Self.fileURL),
+              let snap = try? JSONDecoder().decode(Snapshot.self, from: data) else { return }
+        claudeCache = snap.claude
+        codexCache = snap.codex
+    }
+
+    /// 변경이 있으면 디스크에 저장(최소 60초 간격으로 throttle — 잦은 쓰기 방지).
+    private func saveIfNeeded() {
+        guard dirty else { return }
+        if let last = lastSave, Date().timeIntervalSince(last) < 60 { return }
+        let snap = Snapshot(claude: claudeCache, codex: codexCache)
+        if let data = try? JSONEncoder().encode(snap) {
+            try? data.write(to: Self.fileURL)
+            dirty = false
+            lastSave = Date()
+        }
+    }
+}

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -81,10 +81,19 @@ actor LocalUsageCache {
         codexCache = snap.codex
     }
 
+    /// 어떤 조회 윈도우(오늘/주/월)에도 들지 않는 오래된 파일 blob 을 제거해 캐시 무한 증가를 막는다.
+    /// (가장 넓은 윈도우는 월·주 시작이라 40일이면 충분한 여유. 삭제된 세션 파일 blob 도 함께 정리.)
+    private func prune() {
+        let cutoff = Date().addingTimeInterval(-40 * 86400)
+        claudeCache = claudeCache.filter { $0.value.mtime >= cutoff }
+        codexCache = codexCache.filter { $0.value.mtime >= cutoff }
+    }
+
     /// 변경이 있으면 디스크에 저장(최소 60초 간격으로 throttle — 잦은 쓰기 방지).
     private func saveIfNeeded() {
         guard dirty else { return }
         if let last = lastSave, Date().timeIntervalSince(last) < 60 { return }
+        prune()
         let snap = Snapshot(claude: claudeCache, codex: codexCache)
         if let data = try? JSONEncoder().encode(snap) {
             try? data.write(to: Self.fileURL)

--- a/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// 로컬 로그 직접 파싱 기반 Claude provider (ccusage 대체).
+struct LocalClaudeProvider: UsageProvider {
+    let id = "claude_code"
+    let displayName = "Claude Code"
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let now = Date()
+        let entries = await LocalUsageCache.shared.claudeEntries(modifiedSince: Calendar.current.startOfDay(for: now))
+        return LocalUsageReader.daily(entries: entries, localDay: CcusageProvider.todayKey())
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let now = Date()
+        let monthStart = LocalUsageReader.startOfMonth(now)
+        // 월 범위 한 번 스캔으로 블록·주·월을 모두 도출.
+        let entries = await LocalUsageCache.shared.claudeEntries(modifiedSince: monthStart)
+        let fmt = LocalUsageReader.localDayFormatter()
+        var r = ProviderEnrichment()
+        r.activeBlock = LocalUsageReader.activeBlock(entries: entries, now: now)
+        r.blocksOK = true
+        let weekStart = LocalUsageReader.startOfWeek(now)
+        r.weekTotal = LocalUsageReader.period(
+            entries: entries, periodKey: fmt.string(from: weekStart),
+            fromDay: fmt.string(from: weekStart), toDay: fmt.string(from: now))
+        r.monthTotal = LocalUsageReader.period(
+            entries: entries, periodKey: LocalUsageReader.monthKey(now),
+            fromDay: fmt.string(from: monthStart), toDay: fmt.string(from: now))
+        r.periodsOK = true
+        return r
+    }
+}
+
+/// 로컬 로그 직접 파싱 기반 Codex provider. (블록 없음, 주간 = 일별 합산)
+struct LocalCodexProvider: UsageProvider {
+    let id = "codex"
+    let displayName = "Codex"
+
+    // Codex 사용은 구독제라 ccusage codex 가 비용을 $0 로 보고 → 동일하게 비용 0.
+    func fetchDaily() async throws -> DailyUsage? {
+        let now = Date()
+        let entries = await LocalUsageCache.shared.codexEntries(modifiedSince: Calendar.current.startOfDay(for: now))
+        guard let d = LocalUsageReader.daily(entries: entries, localDay: CcusageProvider.todayKey()) else { return nil }
+        return DailyUsage(date: d.date, inputTokens: d.inputTokens, outputTokens: d.outputTokens,
+                          cacheCreationTokens: d.cacheCreationTokens, cacheReadTokens: d.cacheReadTokens,
+                          totalTokens: d.totalTokens, totalCost: 0)
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let now = Date()
+        let monthStart = LocalUsageReader.startOfMonth(now)
+        let entries = await LocalUsageCache.shared.codexEntries(modifiedSince: monthStart)
+        let fmt = LocalUsageReader.localDayFormatter()
+        var r = ProviderEnrichment()
+        let weekStart = LocalUsageReader.startOfWeek(now)
+        let week = LocalUsageReader.period(entries: entries, periodKey: fmt.string(from: weekStart),
+                                           fromDay: fmt.string(from: weekStart), toDay: fmt.string(from: now))
+        let month = LocalUsageReader.period(entries: entries, periodKey: LocalUsageReader.monthKey(now),
+                                            fromDay: fmt.string(from: monthStart), toDay: fmt.string(from: now))
+        r.weekTotal = PeriodUsage(period: week.period, totalTokens: week.totalTokens, totalCost: 0)
+        r.monthTotal = PeriodUsage(period: month.period, totalTokens: month.totalTokens, totalCost: 0)
+        r.periodsOK = true
+        return r
+    }
+}

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -1,0 +1,240 @@
+import Foundation
+
+/// Claude/Codex 로컬 사용 로그를 직접 파싱해 토큰/비용을 집계한다(ccusage CLI 대체).
+///
+/// - Claude: `~/.claude/projects/**/*.jsonl` 의 `type:"assistant"` 라인
+///   (`message.usage` 4종 토큰, `message.model`, `message.id`+`requestId`, `timestamp`).
+///   세션 재개/sidechain 으로 같은 메시지가 여러 파일에 중복 → `(message.id, requestId)` 로 dedup.
+/// - Codex: `~/.codex/sessions/**/rollout-*.jsonl` 의 `event_msg.payload.type:"token_count"`
+///   (`info.last_token_usage` 턴 델타) 합산.
+///
+/// 성능: mtime 윈도우로 스캔 파일을 한정(범위 시작 이전에 수정된 파일은 범위 내 엔트리가 없음).
+enum LocalUsageReader {
+
+    // MARK: 정규화 레코드
+
+    struct Entry: Sendable, Codable {
+        let id: String
+        let date: Date
+        let localDay: String
+        let model: String
+        let input, output, cacheWrite, cacheRead: Int
+        var total: Int { input + output + cacheWrite + cacheRead }
+    }
+
+    struct Bucket {
+        var input = 0, output = 0, cacheWrite = 0, cacheRead = 0
+        var cost = 0.0
+        var total: Int { input + output + cacheWrite + cacheRead }
+        mutating func add(_ e: Entry) {
+            input += e.input; output += e.output; cacheWrite += e.cacheWrite; cacheRead += e.cacheRead
+            cost += ModelPricing.cost(model: e.model, input: e.input, output: e.output,
+                                      cacheWrite: e.cacheWrite, cacheRead: e.cacheRead)
+        }
+    }
+
+    // MARK: 경로
+
+    static var claudeProjectsDir: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude/projects")
+    }
+    static var codexSessionsDir: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex/sessions")
+    }
+
+    // MARK: 스캔 (mtime 윈도우)
+
+    /// `root` 하위(재귀)의 `.jsonl` 파일 중 `modifiedSince` 이후 수정된 것.
+    static func jsonlFiles(in root: URL, modifiedSince: Date) -> [URL] {
+        let fm = FileManager.default
+        guard let en = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]) else { return [] }
+        var out: [URL] = []
+        for case let url as URL in en {
+            guard url.pathExtension == "jsonl" else { continue }
+            let v = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            if let m = v?.contentModificationDate, m >= modifiedSince { out.append(url) }
+        }
+        return out
+    }
+
+    // MARK: Claude 파싱
+
+    /// 같은 `(message.id, requestId)` 가 스트리밍/재개로 여러 번 로깅될 때 cacheRead/input 은 고정이나
+    /// output 은 증가하므로, **id 별 total 이 가장 큰(=완성된) 항목**을 남긴다(전역 dedup).
+    /// (first-occurrence 를 남기면 부분 output 만 잡혀 비용이 크게 과소집계됨.)
+    static func dedupKeepMax(_ entries: [Entry]) -> [Entry] {
+        var byID: [String: Entry] = [:]
+        for e in entries {
+            if let ex = byID[e.id] { if e.total > ex.total { byID[e.id] = e } }
+            else { byID[e.id] = e }
+        }
+        return Array(byID.values)
+    }
+
+    /// Claude 파일 하나를 파싱(파일 내 dedup). 캐시가 파일 단위로 호출.
+    static func parseClaudeFile(_ url: URL, fmt: DateFormatter) -> [Entry] {
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+        var out: [Entry] = []
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard line.contains("\"usage\""), line.contains("\"assistant\"") else { continue }
+            if let e = parseClaudeLine(String(line), fmt: fmt) { out.append(e) }
+        }
+        return dedupKeepMax(out)
+    }
+
+    /// `modifiedSince` 이후 파일에서 Claude 사용 엔트리(전역 dedup) — 테스트/캐시 미사용 경로.
+    static func claudeEntries(modifiedSince: Date, root: URL? = nil) -> [Entry] {
+        let fmt = localDayFormatter()
+        var all: [Entry] = []
+        for file in jsonlFiles(in: root ?? claudeProjectsDir, modifiedSince: modifiedSince) {
+            all.append(contentsOf: parseClaudeFile(file, fmt: fmt))
+        }
+        return dedupKeepMax(all)
+    }
+
+    private static func parseClaudeLine(_ line: String, fmt: DateFormatter) -> Entry? {
+        guard let data = line.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (obj["type"] as? String) == "assistant",
+              let msg = obj["message"] as? [String: Any],
+              let usage = msg["usage"] as? [String: Any],
+              let ts = obj["timestamp"] as? String,
+              let date = ISO8601Parser.date(from: ts) else { return nil }
+        let model = msg["model"] as? String ?? "unknown"
+        let id = (msg["id"] as? String ?? "") + "|" + (obj["requestId"] as? String ?? "")
+        return Entry(
+            id: id, date: date, localDay: fmt.string(from: date), model: model,
+            input: intValue(usage["input_tokens"]),
+            output: intValue(usage["output_tokens"]),
+            cacheWrite: intValue(usage["cache_creation_input_tokens"]),
+            cacheRead: intValue(usage["cache_read_input_tokens"]))
+    }
+
+    // MARK: Codex 파싱
+
+    /// Codex 사용 엔트리. token_count 이벤트의 last_token_usage(턴 델타)를 4종 토큰으로 매핑.
+    /// - input(비캐시) = input_tokens − cached_input_tokens, cacheRead = cached_input_tokens
+    /// - output = output_tokens (reasoning 은 output 에 이미 포함), cacheWrite = 0
+    /// Codex 파일 하나를 파싱(세션 단위 — token_count 이벤트의 턴 델타). 캐시가 파일 단위로 호출.
+    static func parseCodexFile(_ url: URL, fmt: DateFormatter) -> [Entry] {
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+        var entries: [Entry] = []
+        var turn = 0
+        var model = "gpt-5.5"   // 세션 모델(없으면 기본)
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            if line.contains("\"model\""), let m = codexModel(String(line)) { model = m }
+            guard line.contains("token_count") else { continue }
+            guard let e = parseCodexLine(String(line), file: url.lastPathComponent, turn: turn, model: model, fmt: fmt) else { continue }
+            turn += 1
+            entries.append(e)
+        }
+        return entries
+    }
+
+    static func codexEntries(modifiedSince: Date, root: URL? = nil) -> [Entry] {
+        let fmt = localDayFormatter()
+        var entries: [Entry] = []
+        for file in jsonlFiles(in: root ?? codexSessionsDir, modifiedSince: modifiedSince) {
+            entries.append(contentsOf: parseCodexFile(file, fmt: fmt))
+        }
+        return entries
+    }
+
+    private static func parseCodexLine(_ line: String, file: String, turn: Int, model: String, fmt: DateFormatter) -> Entry? {
+        guard let data = line.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let payload = obj["payload"] as? [String: Any],
+              (payload["type"] as? String) == "token_count",
+              let info = payload["info"] as? [String: Any],
+              let last = info["last_token_usage"] as? [String: Any],
+              let ts = obj["timestamp"] as? String,
+              let date = ISO8601Parser.date(from: ts) else { return nil }
+        let inputTotal = intValue(last["input_tokens"])
+        let cached = intValue(last["cached_input_tokens"])
+        let output = intValue(last["output_tokens"])
+        let nonCachedInput = max(0, inputTotal - cached)
+        return Entry(
+            id: "codex|\(file)|\(turn)", date: date, localDay: fmt.string(from: date), model: model,
+            input: nonCachedInput, output: output, cacheWrite: 0, cacheRead: cached)
+    }
+
+    private static func codexModel(_ line: String) -> String? {
+        guard let data = line.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let payload = obj["payload"] as? [String: Any] else { return nil }
+        if let m = payload["model"] as? String { return m }
+        if let tc = payload["turn_context"] as? [String: Any], let m = tc["model"] as? String { return m }
+        return nil
+    }
+
+    // MARK: 집계
+
+    /// 특정 로컬 날짜의 합계 → DailyUsage. 해당 날짜 데이터 없으면 nil.
+    static func daily(entries: [Entry], localDay: String) -> DailyUsage? {
+        var b = Bucket()
+        for e in entries where e.localDay == localDay { b.add(e) }
+        guard b.total > 0 else { return nil }
+        return DailyUsage(date: localDay, inputTokens: b.input, outputTokens: b.output,
+                          cacheCreationTokens: b.cacheWrite, cacheReadTokens: b.cacheRead,
+                          totalTokens: b.total, totalCost: b.cost)
+    }
+
+    /// 로컬 날짜 [start, end] (포함) 범위 합계 → PeriodUsage.
+    static func period(entries: [Entry], periodKey: String, fromDay: String, toDay: String) -> PeriodUsage {
+        var b = Bucket()
+        for e in entries where e.localDay >= fromDay && e.localDay <= toDay { b.add(e) }
+        return PeriodUsage(period: periodKey, totalTokens: b.total, totalCost: b.cost)
+    }
+
+    /// 최근 5시간 롤링 윈도우 기반 활성 블록(번 레이트 추정용).
+    static func activeBlock(entries: [Entry], now: Date) -> BlockUsage? {
+        let windowStart = now.addingTimeInterval(-5 * 3600)
+        let recent = entries.filter { $0.date >= windowStart }.sorted { $0.date < $1.date }
+        guard let first = recent.first else { return nil }
+        var b = Bucket()
+        for e in recent { b.add(e) }
+        let minutes = max(1, now.timeIntervalSince(first.date) / 60)
+        let tpm = Double(b.total) / minutes
+        let iso = ISO8601DateFormatter()
+        return BlockUsage(
+            id: "block-\(Int(first.date.timeIntervalSince1970))",
+            startTime: iso.string(from: first.date),
+            endTime: iso.string(from: first.date.addingTimeInterval(5 * 3600)),
+            isActive: true, totalTokens: b.total, costUSD: b.cost, tokensPerMinute: tpm)
+    }
+
+    // MARK: 유틸
+
+    static func startOfMonth(_ date: Date) -> Date {
+        let c = Calendar.current
+        return c.date(from: c.dateComponents([.year, .month], from: date)) ?? date
+    }
+
+    static func startOfWeek(_ date: Date) -> Date {
+        Calendar.current.dateInterval(of: .weekOfYear, for: date)?.start ?? date
+    }
+
+    static func monthKey(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM"; f.timeZone = .current; f.locale = Locale(identifier: "en_US_POSIX")
+        return f.string(from: date)
+    }
+
+    static func localDayFormatter() -> DateFormatter {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = .current
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }
+
+    private static func intValue(_ v: Any?) -> Int {
+        if let i = v as? Int { return i }
+        if let d = v as? Double { return Int(d) }
+        if let n = v as? NSNumber { return n.intValue }
+        return 0
+    }
+}

--- a/Sources/PokeTokenBar/Core/ModelPricing.swift
+++ b/Sources/PokeTokenBar/Core/ModelPricing.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// 모델별 토큰 단가(USD/토큰). ccusage(--offline, LiteLLM 스냅샷)의 단가를 실측 역산해 동일하게 번들.
+/// 검증: 여러 날 ccusage --breakdown 의 (토큰타입 4종, cost)로 선형 역산 → 적합오차 0.000%.
+struct ModelRate: Equatable {
+    let input: Double        // USD per token
+    let output: Double
+    let cacheWrite: Double   // cache creation
+    let cacheRead: Double
+
+    static let zero = ModelRate(input: 0, output: 0, cacheWrite: 0, cacheRead: 0)
+
+    /// USD per **million** tokens 로 선언(가독성) → per-token 으로 변환.
+    static func perMillion(_ input: Double, _ output: Double, _ cacheWrite: Double, _ cacheRead: Double) -> ModelRate {
+        ModelRate(input: input / 1_000_000, output: output / 1_000_000,
+                  cacheWrite: cacheWrite / 1_000_000, cacheRead: cacheRead / 1_000_000)
+    }
+}
+
+enum ModelPricing {
+    /// 정확 매칭 테이블 (USD/Mtok). ccusage 와 일치(역산 0% 오차).
+    static let table: [String: ModelRate] = [
+        "claude-opus-4-8":            .perMillion(5, 25, 6.25, 0.5),
+        "claude-opus-4-7":            .perMillion(5, 25, 6.25, 0.5),
+        "claude-sonnet-4-6":          .perMillion(3, 15, 3.75, 0.3),
+        "claude-haiku-4-5-20251001":  .perMillion(1, 5, 1.25, 0.1),
+        "claude-fable-5":             .zero,                          // ccusage 미가격 → $0
+        "gpt-5.5":                    .perMillion(5, 30, 0, 0.5),
+    ]
+
+    /// 모델명 → 단가. 정확 매칭 우선, 없으면 패밀리(opus/sonnet/haiku/gpt) 폴백(버전 드리프트 대비),
+    /// 그래도 없으면 0(ccusage 가 미가격 모델을 0 으로 처리하는 것과 동일).
+    static func rate(for model: String) -> ModelRate {
+        if let r = table[model] { return r }
+        let m = model.lowercased()
+        if m.contains("opus")   { return .perMillion(5, 25, 6.25, 0.5) }
+        if m.contains("sonnet") { return .perMillion(3, 15, 3.75, 0.3) }
+        if m.contains("haiku")  { return .perMillion(1, 5, 1.25, 0.1) }
+        if m.contains("gpt") || m.contains("codex") || m.contains("o4") || m.contains("o3") {
+            return .perMillion(5, 30, 0, 0.5)
+        }
+        return .zero
+    }
+
+    static func cost(model: String, input: Int, output: Int, cacheWrite: Int, cacheRead: Int) -> Double {
+        let r = rate(for: model)
+        return Double(input) * r.input
+            + Double(output) * r.output
+            + Double(cacheWrite) * r.cacheWrite
+            + Double(cacheRead) * r.cacheRead
+    }
+}

--- a/Sources/PokeTokenBar/Core/Models.swift
+++ b/Sources/PokeTokenBar/Core/Models.swift
@@ -70,6 +70,17 @@ struct BlockUsage: Decodable, Sendable {
 
     var endDate: Date? { ISO8601Parser.date(from: endTime) }
 
+    init(id: String, startTime: String, endTime: String, isActive: Bool,
+         totalTokens: Int, costUSD: Double, tokensPerMinute: Double?) {
+        self.id = id
+        self.startTime = startTime
+        self.endTime = endTime
+        self.isActive = isActive
+        self.totalTokens = totalTokens
+        self.costUSD = costUSD
+        self.tokensPerMinute = tokensPerMinute
+    }
+
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decodeIfPresent(String.self, forKey: .id) ?? ""

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -190,7 +190,7 @@ final class UsageStore {
 
     // MARK: 생명주기
 
-    init(providers: [any UsageProvider] = [CcusageProvider.claude, CcusageProvider.codex],
+    init(providers: [any UsageProvider] = [LocalClaudeProvider(), LocalCodexProvider()],
          claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),
          autoRefresh: Bool = true) {

--- a/Tests/PokeTokenBarTests/LocalUsageParityTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageParityTests.swift
@@ -1,9 +1,40 @@
 import XCTest
 @testable import PokeTokenBar
 
+// keychain/네트워크 의존 없이 한도 provider 를 비활성화하는 스텁(통합 파이프라인 검증용).
+private struct NoClaudeLimits: ClaudeLimitsProviding {
+    func fetch(allowKeychainPrompt: Bool) async throws -> LimitStatus { throw LimitsError.keychainInteractionNotAllowed }
+}
+private struct NoCodexLimits: CodexLimitsProviding {
+    func fetch() async throws -> CodexRateLimitStatus? { nil }
+}
+
 // 임시 parity 검증 — 실제 ~/.claude, ~/.codex 로그로 집계해 콘솔 출력 → ccusage 와 수동 대조용.
 // (CI 비결정적이므로 환경변수 PTB_PARITY=1 일 때만 실행)
 final class LocalUsageParityTests: XCTestCase {
+
+    /// 실제 LocalProvider 로 UsageStore.refresh 전체 파이프라인을 돌려 기존 기능 회귀 검증.
+    @MainActor
+    func testFullRefreshPipelineWithRealProviders() async throws {
+        guard ProcessInfo.processInfo.environment["PTB_PARITY"] == "1" else { throw XCTSkip("PTB_PARITY != 1") }
+        let store = UsageStore(
+            providers: [LocalClaudeProvider(), LocalCodexProvider()],
+            claudeLimitsProvider: NoClaudeLimits(),
+            codexLimitsProvider: NoCodexLimits(),
+            autoRefresh: false)
+        await store.refresh(scheduleEmptyRetry: false)
+        print("PARITY-PIPE today=\(store.todayTotalTokens) cost=\(String(format: "%.2f", store.todayCostTotal)) menu=[\(store.menuTitle)] week=\(store.weekTotalTokens) month=\(store.monthTotalTokens) snapshots=\(store.snapshots.count) burnTier=\(store.burnTier) stale=\(store.isStale) err=\(store.lastErrorDescription ?? "none")")
+        for s in store.snapshots {
+            print("PARITY-PIPE snapshot \(s.providerID): today=\(s.todayTotalTokens) block=\(s.activeBlock?.totalTokens ?? -1) week=\(s.weekTotal?.totalTokens ?? -1) month=\(s.monthTotal?.totalTokens ?? -1)")
+        }
+        // 회귀 가드: 파이프라인이 실제 값을 산출하고 에러가 없어야 한다.
+        XCTAssertGreaterThan(store.todayTotalTokens, 0, "오늘 토큰이 0 — 파이프라인 단절")
+        XCTAssertFalse(store.snapshots.isEmpty, "스냅샷 없음")
+        XCTAssertNotNil(store.lastUpdated, "lastUpdated 미설정")
+        XCTAssertNil(store.lastErrorDescription, "provider 에러 발생")
+        XCTAssertGreaterThan(store.monthTotalTokens, 0, "월 누적 0 — enrichment 단절")
+    }
+
     func testPrintRealAggregates() throws {
         guard ProcessInfo.processInfo.environment["PTB_PARITY"] == "1" else {
             throw XCTSkip("PTB_PARITY != 1")

--- a/Tests/PokeTokenBarTests/LocalUsageParityTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageParityTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import PokeTokenBar
+
+// 임시 parity 검증 — 실제 ~/.claude, ~/.codex 로그로 집계해 콘솔 출력 → ccusage 와 수동 대조용.
+// (CI 비결정적이므로 환경변수 PTB_PARITY=1 일 때만 실행)
+final class LocalUsageParityTests: XCTestCase {
+    func testPrintRealAggregates() throws {
+        guard ProcessInfo.processInfo.environment["PTB_PARITY"] == "1" else {
+            throw XCTSkip("PTB_PARITY != 1")
+        }
+        let now = Date()
+        let fmt = LocalUsageReader.localDayFormatter()
+        let monthStart = LocalUsageReader.startOfMonth(now)
+        let today = CcusageProvider.todayKey()
+
+        let claude = LocalUsageReader.claudeEntries(modifiedSince: monthStart)
+        let codex = LocalUsageReader.codexEntries(modifiedSince: monthStart)
+
+        print("PARITY ===== today=\(today)")
+        // 최근 5일 일자별
+        for offset in (0..<5).reversed() {
+            let d = Calendar.current.date(byAdding: .day, value: -offset, to: now)!
+            let day = fmt.string(from: d)
+            let c = LocalUsageReader.daily(entries: claude, localDay: day)
+            let x = LocalUsageReader.daily(entries: codex, localDay: day)
+            print("PARITY claude \(day): tokens=\(c?.totalTokens ?? 0) cost=\(String(format: "%.2f", c?.totalCost ?? 0))")
+            print("PARITY codex  \(day): tokens=\(x?.totalTokens ?? 0) cost=\(String(format: "%.2f", x?.totalCost ?? 0))")
+        }
+        let block = LocalUsageReader.activeBlock(entries: claude, now: now)
+        print("PARITY active block: tokens=\(block?.totalTokens ?? 0) tpm=\(String(format: "%.0f", block?.tokensPerMinute ?? 0))")
+        let ws = LocalUsageReader.startOfWeek(now)
+        let week = LocalUsageReader.period(entries: claude, periodKey: "w", fromDay: fmt.string(from: ws), toDay: fmt.string(from: now))
+        let month = LocalUsageReader.period(entries: claude, periodKey: "m", fromDay: fmt.string(from: monthStart), toDay: fmt.string(from: now))
+        print("PARITY claude week tokens=\(week.totalTokens) cost=\(String(format: "%.2f", week.totalCost))")
+        print("PARITY claude month tokens=\(month.totalTokens) cost=\(String(format: "%.2f", month.totalCost))")
+    }
+
+    func testCachePerformance() async throws {
+        guard ProcessInfo.processInfo.environment["PTB_PARITY"] == "1" else { throw XCTSkip("PTB_PARITY != 1") }
+        let monthStart = LocalUsageReader.startOfMonth(Date())
+        var t = Date()
+        _ = await LocalUsageCache.shared.claudeEntries(modifiedSince: monthStart)
+        let cold = Date().timeIntervalSince(t)
+        t = Date()
+        _ = await LocalUsageCache.shared.claudeEntries(modifiedSince: monthStart)
+        let warm = Date().timeIntervalSince(t)
+        print(String(format: "PARITY-PERF claude month scan: cold %.0fms  warm %.0fms", cold * 1000, warm * 1000))
+    }
+}

--- a/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import PokeTokenBar
+
+// LocalUsageReader / ModelPricing 의 파싱·dedup·날짜·비용 로직 — 임시 디렉토리 fixture 로 결정적 검증.
+final class LocalUsageReaderTests: XCTestCase {
+
+    private func tempDir() -> URL {
+        let d = FileManager.default.temporaryDirectory.appendingPathComponent("ptb-local-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+    private func write(_ lines: [String], to dir: URL, name: String = "s.jsonl", sub: String? = nil) {
+        let folder = sub.map { dir.appendingPathComponent($0) } ?? dir
+        try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        try? lines.joined(separator: "\n").write(to: folder.appendingPathComponent(name), atomically: true, encoding: .utf8)
+    }
+
+    // MARK: ModelPricing
+
+    func testPricingExactAndFallbackAndZero() {
+        XCTAssertEqual(ModelPricing.cost(model: "claude-opus-4-8", input: 1_000_000, output: 0, cacheWrite: 0, cacheRead: 0), 5.0, accuracy: 1e-6)
+        XCTAssertEqual(ModelPricing.cost(model: "claude-opus-4-8", input: 0, output: 1_000_000, cacheWrite: 0, cacheRead: 0), 25.0, accuracy: 1e-6)
+        XCTAssertEqual(ModelPricing.cost(model: "claude-haiku-4-5-20251001", input: 1_000_000, output: 0, cacheWrite: 0, cacheRead: 0), 1.0, accuracy: 1e-6)
+        XCTAssertEqual(ModelPricing.cost(model: "claude-fable-5", input: 1_000_000, output: 1_000_000, cacheWrite: 1_000_000, cacheRead: 1_000_000), 0, accuracy: 1e-9)
+        // 미지 모델 → 패밀리 폴백
+        XCTAssertEqual(ModelPricing.cost(model: "claude-opus-4-99", input: 1_000_000, output: 0, cacheWrite: 0, cacheRead: 0), 5.0, accuracy: 1e-6)
+        XCTAssertEqual(ModelPricing.cost(model: "totally-unknown", input: 1_000_000, output: 0, cacheWrite: 0, cacheRead: 0), 0, accuracy: 1e-9)
+    }
+
+    // MARK: Claude 파싱 + dedup(keep-max) + 날짜
+
+    private func claudeLine(id: String, req: String, model: String, ts: String, i: Int, o: Int, cw: Int, cr: Int) -> String {
+        """
+        {"type":"assistant","requestId":"\(req)","timestamp":"\(ts)","message":{"id":"\(id)","model":"\(model)","usage":{"input_tokens":\(i),"output_tokens":\(o),"cache_creation_input_tokens":\(cw),"cache_read_input_tokens":\(cr)}}}
+        """
+    }
+
+    func testClaudeDedupKeepsMaxOutput() {
+        let dir = tempDir()
+        let ts = "2026-06-30T10:00:00.000Z"
+        // 같은 (id,req) 가 스트리밍으로 두 번: output 5 → 200. cacheRead 고정 1000.
+        write([
+            claudeLine(id: "A", req: "R1", model: "claude-opus-4-8", ts: ts, i: 100, o: 5, cw: 0, cr: 1000),
+            claudeLine(id: "A", req: "R1", model: "claude-opus-4-8", ts: ts, i: 100, o: 200, cw: 0, cr: 1000),
+            claudeLine(id: "B", req: "R2", model: "claude-sonnet-4-6", ts: ts, i: 50, o: 10, cw: 0, cr: 0),
+        ], to: dir, sub: "proj/sub")
+
+        let entries = LocalUsageReader.claudeEntries(modifiedSince: .distantPast, root: dir)
+        XCTAssertEqual(entries.count, 2)   // A(dedup), B
+        let a = entries.first { $0.id.hasPrefix("A|") }
+        XCTAssertEqual(a?.output, 200)     // keep-max: 완성된 output
+        XCTAssertEqual(a?.cacheRead, 1000)
+    }
+
+    func testClaudeDailyAndCost() {
+        let dir = tempDir()
+        let ts = "2026-06-30T10:00:00.000Z"
+        let day = LocalUsageReader.localDayFormatter().string(from: ISO8601Parser.date(from: ts)!)
+        write([
+            claudeLine(id: "A", req: "R1", model: "claude-opus-4-8", ts: ts, i: 1_000_000, o: 0, cw: 0, cr: 0),
+        ], to: dir, sub: "p")
+        let entries = LocalUsageReader.claudeEntries(modifiedSince: .distantPast, root: dir)
+        let d = LocalUsageReader.daily(entries: entries, localDay: day)
+        XCTAssertEqual(d?.totalTokens, 1_000_000)
+        XCTAssertEqual(d?.totalCost ?? 0, 5.0, accuracy: 1e-6)   // opus input 5/Mtok
+        XCTAssertNil(LocalUsageReader.daily(entries: entries, localDay: "2000-01-01"))
+    }
+
+    // MARK: Codex 파싱 (input=total−cached, cacheRead=cached, output, cacheWrite=0)
+
+    func testCodexParsing() {
+        let dir = tempDir()
+        let line = """
+        {"type":"event_msg","timestamp":"2026-06-30T11:00:00.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":1050}}}}
+        """
+        write([line], to: dir, name: "rollout-x.jsonl", sub: "2026/06/30")
+        let entries = LocalUsageReader.codexEntries(modifiedSince: .distantPast, root: dir)
+        XCTAssertEqual(entries.count, 1)
+        let e = entries[0]
+        XCTAssertEqual(e.input, 800)       // 1000 - 200
+        XCTAssertEqual(e.cacheRead, 200)
+        XCTAssertEqual(e.output, 50)
+        XCTAssertEqual(e.cacheWrite, 0)
+    }
+
+    // MARK: 기간 집계 + 활성 블록
+
+    func testPeriodAndActiveBlock() {
+        let now = Date()
+        let recent = now.addingTimeInterval(-30 * 60)   // 30분 전
+        let old = now.addingTimeInterval(-10 * 3600)    // 10시간 전(블록 밖)
+        let fmt = LocalUsageReader.localDayFormatter()
+        func entry(_ date: Date, _ tok: Int) -> LocalUsageReader.Entry {
+            LocalUsageReader.Entry(id: UUID().uuidString, date: date, localDay: fmt.string(from: date),
+                                   model: "claude-opus-4-8", input: tok, output: 0, cacheWrite: 0, cacheRead: 0)
+        }
+        let entries = [entry(recent, 600_000), entry(old, 999)]
+        let block = LocalUsageReader.activeBlock(entries: entries, now: now)
+        XCTAssertEqual(block?.totalTokens, 600_000)        // 5h 윈도우 내 항목만
+        XCTAssertEqual(block?.isActive, true)
+        XCTAssertGreaterThan(block?.tokensPerMinute ?? 0, 0)
+        // period: 오늘 범위
+        let today = fmt.string(from: now)
+        let p = LocalUsageReader.period(entries: entries, periodKey: "w", fromDay: today, toDay: today)
+        // recent 는 오늘, old 도 (10h 전이라 같은 날일 수 있음) → 최소 recent 포함
+        XCTAssertGreaterThanOrEqual(p.totalTokens, 600_000)
+    }
+}


### PR DESCRIPTION
## 목표
토큰/비용 집계를 **ccusage CLI 서브프로세스 대신 로컬 로그 직접 파싱**으로 전환 → 런타임 ccusage 의존성 제거.

## 부수 효과
- `npm install -g ccusage` **설치 의존성 제거**(설치 마찰 1순위 해소)
- 매 새로고침 **~8개 Node 서브프로세스 spawn 제거** → CPU/배터리 추가 절감
- self-contained

## 구현
| 파일 | 역할 |
|---|---|
| `LocalUsageReader` | Claude(`~/.claude/projects/**/*.jsonl` assistant) + Codex(`token_count` 이벤트) 직접 파싱·집계·5h 블록 |
| `ModelPricing` | 모델별 단가 번들 (ccusage `--breakdown` 선형 역산으로 동일 단가 복원, 0% 오차). Codex 비용 $0(구독제) |
| `LocalUsageCache` | 파일별 증분 캐시(path,mtime,size) + 디스크 영속화 (배터리 핵심) |
| `LocalUsageProvider` | `UsageProvider` 구현 → UsageStore 에 주입 |

**dedup 핵심:** 같은 `(message.id, requestId)` 가 스트리밍/재개로 중복 로깅될 때 cacheRead/input 은 고정이나 output 은 증가 → **id 별 total 최대(=완성본)** 유지. (first 유지 시 비용이 6~14% 과소집계됨 — 실측으로 발견·수정.)

## 검증 — parity (실데이터 vs ccusage)
| 날짜 | ccusage | 직접 | |
|---|---|---|---|
| 오늘 claude | 210,495,834 / \$250.71 | 동일 | **EXACT** |
| 최근 3일 | … | 동일 | **EXACT** |
| 과거 2일 | … | <1.2% | 스트리밍 dedup 잔여 |
| codex | 788,715 / 4,293,880 | 동일 | **EXACT** |

## 검증 — 성능 (배터리)
사실상 모든 세션이 "이번 달 수정"(이 머신 **771MB**)이라 매 새로고침 전수 파싱은 불가 → 증분 캐시 필수.
```
월 스캔: cold 48s (최초 1회) → 디스크 캐시 로드 342ms (재실행) → warm 138ms (매 새로고침)
```
캐시 파일 6.2MB. 첫 실행 50초는 백그라운드 1회뿐(메뉴바 '오늘' 숫자는 별도·즉시).

## 테스트
- fixture 단위테스트: 파싱·keep-max dedup·날짜 버킷·cost·codex 매핑·5h 블록.
- 실데이터 parity·perf 도구(`PTB_PARITY` 환경변수 게이트 → CI skip).
- `swift build` clean · **106 tests, 0 failures**.

## 미포함 (추후 / 릴리스 시)
- README(en/ko/ja)·랜딩·cask 의 "requires ccusage" 문구 갱신.
- `CcusageProvider` 정리(현재 날짜 헬퍼만 사용 — subprocess 코드 dead).
- 디스크 캐시 cold 50초(최초 1회) 추가 최적화(파서 고속화) — 필요 시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)