### PR TITLE
chore: release process — automate deploy + docs consistency review

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,52 @@
+# 릴리스 프로세스
+
+버전 배포 시 **코드뿐 아니라 문서(README·웹페이지·cask)까지 일관되게** 갱신하기 위한 런북.
+기계적 단계는 `scripts/release.sh` 가 자동화하고, 내용 판단이 필요한 부분은 아래 체크리스트로 검토한다.
+
+## 한 줄 배포
+
+```bash
+# (선택) 릴리스 노트를 파일로 작성
+cat > /tmp/notes.md <<'EOF'
+## What's new
+- ...
+EOF
+
+PTB_NOTES_FILE=/tmp/notes.md ./scripts/release.sh 2.1.1
+```
+
+`scripts/release.sh <version>` 가 순서대로 수행:
+
+1. **test-gate** (`./scripts/test-gate.sh`) — 전체 테스트 + 로직 커버리지. 실패 시 중단.
+2. **문서 일관성 검토** — 정적 버전 배지·제거된 의존성(예: `ccusage`) 잔존을 자동 경고 + 아래 수동 체크리스트 출력. 경고 시 진행 여부를 묻는다.
+3. **VERSION 범프** (`scripts/build-app.sh`) + 커밋 + `git push origin main`.
+4. **빌드 + zip** (`build/PokeTokenBar.zip`), 빌드 버전 일치 확인.
+5. **GitHub Release** 생성 (노트는 `PTB_NOTES_FILE` 또는 최소 노트).
+6. **Homebrew cask** 버전 갱신 (`chattymin/homebrew-tap`).
+7. **GitHub Pages 재빌드** 요청 (랜딩 동적 배지 갱신 유도).
+
+검토만 하려면: `./scripts/release.sh --check-only`
+
+## 문서 검토 체크리스트 (내용 변경 시)
+
+`release.sh` 2단계가 출력하는 것 — **기능/동작이 바뀐 릴리스면 반드시 갱신**:
+
+- [ ] **README.md / README.ko.md / README.ja.md** — 기능 목록, 요구사항, 데이터 소스, 스크린샷. 3개 언어 동시.
+- [ ] **랜딩 페이지** (`gh-pages` 브랜치 `index.html`) — hero·features·companion·install·works-with·요구사항·푸터.
+  - 릴리스 배지는 **동적**(`img.shields.io/github/v/release/...`) → 버전 자동 반영. **기능/문구만 수동.**
+  - i18n 사전 **en/ko/ja 동시** 갱신 + 마크업 키 ⊆ 사전, en==ko==ja 키 정합 유지.
+  - 갱신은 worktree 로: `git worktree add /tmp/ptb-gh-pages gh-pages` → 편집 → commit/push → `git worktree remove`.
+- [ ] **homebrew-tap cask** caveats — 설치 요구사항(의존성 등) 최신인지. 버전은 release.sh 가 갱신.
+
+## 자동으로 갱신되는 것 (수동 불필요)
+
+- README·랜딩의 **release 배지** = shields 동적 배지 → 최신 릴리스 자동(캐시로 수 분 지연 가능).
+- 인앱 업데이트 알림 — `releases/latest` 기준 자동.
+
+## 배포 후 검증
+
+```bash
+brew update && brew upgrade --cask poke-token-bar
+```
+
+`brew list --cask --versions poke-token-bar` 와 `/Applications/PokeTokenBar.app` 버전이 새 버전인지 확인.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,11 +19,14 @@ PTB_NOTES_FILE=/tmp/notes.md ./scripts/release.sh 2.1.1
 
 1. **test-gate** (`./scripts/test-gate.sh`) — 전체 테스트 + 로직 커버리지. 실패 시 중단.
 2. **문서 일관성 검토** — 정적 버전 배지·제거된 의존성(예: `ccusage`) 잔존을 자동 경고 + 아래 수동 체크리스트 출력. 경고 시 진행 여부를 묻는다.
-3. **VERSION 범프** (`scripts/build-app.sh`) + 커밋 + `git push origin main`.
-4. **빌드 + zip** (`build/PokeTokenBar.zip`), 빌드 버전 일치 확인.
-5. **GitHub Release** 생성 (노트는 `PTB_NOTES_FILE` 또는 최소 노트).
-6. **Homebrew cask** 버전 갱신 (`chattymin/homebrew-tap`).
-7. **GitHub Pages 재빌드** 요청 (랜딩 동적 배지 갱신 유도).
+3. **VERSION 범프** (`scripts/build-app.sh`, 아직 미커밋).
+4. **빌드 + zip** (`build/PokeTokenBar.zip`) + 빌드 버전 일치 확인 — **push 전 검증**(실패해도 범프 미커밋이라 origin/main 무손상).
+5. **커밋 + push** (`git push origin main`, 빌드 성공 후).
+6. **GitHub Release** 생성 (노트는 `PTB_NOTES_FILE` 또는 최소 노트).
+7. **Homebrew cask** 버전 갱신 (`chattymin/homebrew-tap`).
+8. **GitHub Pages 재빌드** 요청 (랜딩 동적 배지 갱신 유도).
+
+> `main` 브랜치에서만 실행(스크립트가 가드). 비-main 에서 실행 시 즉시 중단.
 
 검토만 하려면: `./scripts/release.sh --check-only`
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# release.sh — 버전 배포 자동화 + 문서(README/웹페이지/cask) 일관성 검토.
+#
+# 사용:
+#   PTB_NOTES_FILE=/tmp/notes.md ./scripts/release.sh 2.1.1
+#   ./scripts/release.sh 2.1.1            # 노트 파일 없으면 최소 노트
+#   ./scripts/release.sh --check-only     # 문서 일관성 검토만(배포 안 함)
+#
+# 단계: 1)test-gate 2)문서 검토 3)VERSION 범프·커밋·push 4)build+zip 5)GitHub Release
+#       6)Homebrew cask 갱신 7)Pages 재빌드. 각 단계 실패 시 즉시 중단(set -e).
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+REPO="chattymin/PokeTokenBar"
+TAP_REPO="chattymin/homebrew-tap"
+CASK_PATH="Casks/poke-token-bar.rb"
+
+# ── 문서 일관성 검토 (배포 전 항상 실행) ───────────────────────────────────
+# 기계적으로 잡을 수 있는 것만 자동 경고. 내용(기능 설명) 변경 여부는 사람이 체크리스트로 판단.
+doc_check() {
+  local warn=0
+  echo "▶ 문서 일관성 검토"
+  # 정적 버전 하드코딩(릴리스마다 수동 갱신 필요 → 동적 배지 권장)
+  if grep -rnE "img.shields.io/badge/release-v[0-9]" README*.md 2>/dev/null; then
+    echo "  ⚠ README 에 정적 버전 배지가 있습니다(동적 github/v/release 배지 권장)."; warn=1
+  fi
+  # 제거된 의존성/도구 흔적 (필요 시 PATTERN 에 추가)
+  for pat in ccusage; do
+    if grep -rniq "$pat" README*.md 2>/dev/null; then
+      echo "  ⚠ README 에 '$pat' 잔존 — 제거된 항목인지 확인."; warn=1
+    fi
+  done
+  cat <<'CHECK'
+  ─ 수동 체크리스트 (내용 변경 시 갱신) ─────────────────────────────
+   [ ] README.md / .ko / .ja : 기능 목록·요구사항·데이터소스·스크린샷
+   [ ] 랜딩(gh-pages/index.html): hero·features·install·works-with·요구사항·푸터
+       · 버전 배지는 동적(github/v/release) → 자동. 기능/문구만 수동.
+       · 3개 언어 i18n 사전(en/ko/ja) 동시 갱신 + 키 정합 유지.
+   [ ] homebrew-tap cask: caveats(설치 요구사항) 최신 상태인지
+  ─────────────────────────────────────────────────────────────────
+CHECK
+  return $warn
+}
+
+if [[ "${1:-}" == "--check-only" ]]; then
+  doc_check || true
+  exit 0
+fi
+
+VERSION="${1:?사용: release.sh <version>  (예: 2.1.1)}"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "✗ 버전 형식 오류: $VERSION"; exit 1; }
+PREV=$(grep -oE 'VERSION="[0-9.]+"' scripts/build-app.sh | grep -oE '[0-9.]+')
+echo "=== PokeTokenBar 릴리스 $PREV → $VERSION ==="
+
+echo "▶ 1/7 릴리스 전 테스트 게이트"
+./scripts/test-gate.sh >/dev/null || { echo "✗ test-gate 실패 — 중단"; exit 1; }
+echo "  ✓ 통과"
+
+if ! doc_check; then
+  read -r -p "  문서 경고가 있습니다. 그래도 계속? [y/N] " a
+  [[ "$a" == "y" || "$a" == "Y" ]] || { echo "중단 — 문서 먼저 갱신하세요."; exit 1; }
+fi
+
+echo "▶ 3/7 VERSION 범프 + 커밋 + push"
+perl -pi -e "s/VERSION=\"[0-9.]+\"/VERSION=\"$VERSION\"/" scripts/build-app.sh
+git add scripts/build-app.sh
+git commit -q -m "release: bump version to $VERSION
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+git push -q origin main
+
+echo "▶ 4/7 빌드 + zip"
+./scripts/build-app.sh >/dev/null
+rm -f build/PokeTokenBar.zip
+ditto -c -k --keepParent build/PokeTokenBar.app build/PokeTokenBar.zip
+BUILT=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" build/PokeTokenBar.app/Contents/Info.plist)
+[[ "$BUILT" == "$VERSION" ]] || { echo "✗ 빌드 버전 불일치: $BUILT"; exit 1; }
+
+echo "▶ 5/7 GitHub Release v$VERSION"
+NOTES_FILE="${PTB_NOTES_FILE:-}"
+if [[ -n "$NOTES_FILE" && -f "$NOTES_FILE" ]]; then
+  gh release create "v$VERSION" build/PokeTokenBar.zip --repo "$REPO" \
+    --title "PokeTokenBar v$VERSION" --target main --notes-file "$NOTES_FILE"
+else
+  gh release create "v$VERSION" build/PokeTokenBar.zip --repo "$REPO" \
+    --title "PokeTokenBar v$VERSION" --target main --notes "Release v$VERSION"
+fi
+
+echo "▶ 6/7 Homebrew cask $VERSION"
+TMP_CASK=$(mktemp)
+gh api "repos/$TAP_REPO/contents/$CASK_PATH" --jq '.content' | base64 -d \
+  | perl -pe "s/version \"[0-9.]+\"/version \"$VERSION\"/" > "$TMP_CASK"
+SHA=$(gh api "repos/$TAP_REPO/contents/$CASK_PATH" --jq '.sha')
+gh api -X PUT "repos/$TAP_REPO/contents/$CASK_PATH" \
+  -f message="cask: poke-token-bar $VERSION" \
+  -f content="$(base64 -i "$TMP_CASK")" -f sha="$SHA" --jq '.commit.html_url'
+rm -f "$TMP_CASK"
+
+echo "▶ 7/7 GitHub Pages 재빌드(랜딩 동적 배지 갱신 유도)"
+gh api -X POST "repos/$REPO/pages/builds" >/dev/null 2>&1 || true
+
+echo "✓ v$VERSION 배포 완료. 검증: brew upgrade --cask poke-token-bar"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,8 +7,8 @@
 #   ./scripts/release.sh 2.1.1            # 노트 파일 없으면 최소 노트
 #   ./scripts/release.sh --check-only     # 문서 일관성 검토만(배포 안 함)
 #
-# 단계: 1)test-gate 2)문서 검토 3)VERSION 범프·커밋·push 4)build+zip 5)GitHub Release
-#       6)Homebrew cask 갱신 7)Pages 재빌드. 각 단계 실패 시 즉시 중단(set -e).
+# 단계: 1)test-gate 2)문서 검토 3)VERSION 범프 4)build+zip 5)커밋·push
+#       6)GitHub Release 7)Homebrew cask 8)Pages 재빌드. 각 단계 실패 시 즉시 중단(set -e).
 #
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -52,9 +52,11 @@ fi
 VERSION="${1:?사용: release.sh <version>  (예: 2.1.1)}"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "✗ 버전 형식 오류: $VERSION"; exit 1; }
 PREV=$(grep -oE 'VERSION="[0-9.]+"' scripts/build-app.sh | grep -oE '[0-9.]+')
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ "$BRANCH" == "main" ]] || { echo "✗ main 브랜치에서 실행하세요 (현재: $BRANCH) — 커밋/push 대상 일치 보장"; exit 1; }
 echo "=== PokeTokenBar 릴리스 $PREV → $VERSION ==="
 
-echo "▶ 1/7 릴리스 전 테스트 게이트"
+echo "▶ 1/8 릴리스 전 테스트 게이트"
 ./scripts/test-gate.sh >/dev/null || { echo "✗ test-gate 실패 — 중단"; exit 1; }
 echo "  ✓ 통과"
 
@@ -63,22 +65,24 @@ if ! doc_check; then
   [[ "$a" == "y" || "$a" == "Y" ]] || { echo "중단 — 문서 먼저 갱신하세요."; exit 1; }
 fi
 
-echo "▶ 3/7 VERSION 범프 + 커밋 + push"
+echo "▶ 3/8 VERSION 범프 $PREV → $VERSION (아직 미커밋)"
 perl -pi -e "s/VERSION=\"[0-9.]+\"/VERSION=\"$VERSION\"/" scripts/build-app.sh
+
+echo "▶ 4/8 빌드 + zip (push 전 검증 — 실패해도 범프 미커밋이라 origin/main 무손상)"
+./scripts/build-app.sh >/dev/null
+rm -f build/PokeTokenBar.zip
+ditto -c -k --keepParent build/PokeTokenBar.app build/PokeTokenBar.zip
+BUILT=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" build/PokeTokenBar.app/Contents/Info.plist)
+[[ "$BUILT" == "$VERSION" ]] || { echo "✗ 빌드 버전 불일치: $BUILT (수동 복구: git checkout scripts/build-app.sh)"; exit 1; }
+
+echo "▶ 5/8 커밋 + push (빌드 성공 후)"
 git add scripts/build-app.sh
 git commit -q -m "release: bump version to $VERSION
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 git push -q origin main
 
-echo "▶ 4/7 빌드 + zip"
-./scripts/build-app.sh >/dev/null
-rm -f build/PokeTokenBar.zip
-ditto -c -k --keepParent build/PokeTokenBar.app build/PokeTokenBar.zip
-BUILT=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" build/PokeTokenBar.app/Contents/Info.plist)
-[[ "$BUILT" == "$VERSION" ]] || { echo "✗ 빌드 버전 불일치: $BUILT"; exit 1; }
-
-echo "▶ 5/7 GitHub Release v$VERSION"
+echo "▶ 6/8 GitHub Release v$VERSION"
 NOTES_FILE="${PTB_NOTES_FILE:-}"
 if [[ -n "$NOTES_FILE" && -f "$NOTES_FILE" ]]; then
   gh release create "v$VERSION" build/PokeTokenBar.zip --repo "$REPO" \
@@ -88,7 +92,7 @@ else
     --title "PokeTokenBar v$VERSION" --target main --notes "Release v$VERSION"
 fi
 
-echo "▶ 6/7 Homebrew cask $VERSION"
+echo "▶ 7/8 Homebrew cask $VERSION"
 TMP_CASK=$(mktemp)
 gh api "repos/$TAP_REPO/contents/$CASK_PATH" --jq '.content' | base64 -d \
   | perl -pe "s/version \"[0-9.]+\"/version \"$VERSION\"/" > "$TMP_CASK"
@@ -98,7 +102,7 @@ gh api -X PUT "repos/$TAP_REPO/contents/$CASK_PATH" \
   -f content="$(base64 -i "$TMP_CASK")" -f sha="$SHA" --jq '.commit.html_url'
 rm -f "$TMP_CASK"
 
-echo "▶ 7/7 GitHub Pages 재빌드(랜딩 동적 배지 갱신 유도)"
+echo "▶ 8/8 GitHub Pages 재빌드(랜딩 동적 배지 갱신 유도)"
 gh api -X POST "repos/$REPO/pages/builds" >/dev/null 2>&1 || true
 
 echo "✓ v$VERSION 배포 완료. 검증: brew upgrade --cask poke-token-bar"


### PR DESCRIPTION
## 목적
버전 배포 시 **코드뿐 아니라 README·웹페이지·cask까지 일관되게** 갱신하도록 프로세스화(이번 2.1.0 때 수동으로 한 작업을 재현 가능하게).

## 추가
- **`scripts/release.sh <version>`** — 7단계 자동화:
  1. test-gate (전체 테스트+커버리지)
  2. **문서 일관성 검토** — 정적 버전 배지·제거된 의존성(ccusage 등) 잔존 자동 경고 + 수동 체크리스트, 경고 시 진행 확인
  3. VERSION 범프·커밋·push
  4. build+zip (버전 일치 확인)
  5. GitHub Release (`PTB_NOTES_FILE` 노트)
  6. Homebrew cask 갱신
  7. Pages 재빌드
  - `--check-only` 로 문서 검토만 실행 가능.
- **`RELEASE.md`** — 런북 + 문서 검토 체크리스트(README ×3, 랜딩 i18n 정합, cask caveat).

## 검증
- `bash -n` 문법 OK, `--check-only` 동작 확인(현재 README 깨끗 → 경고 0).
- 안전: test-gate 실패 시 중단, 빌드 버전 불일치 시 중단, `set -euo pipefail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
