### PR TITLE
fix: 홈 갱신 시 주/월 행 깜빡임 + 불필요한 스피너 제거

### DIFF
--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -319,9 +319,15 @@ final class UsageStore {
             // 날짜 가드: 이전 스냅샷의 어제 데이터는 유지하지 않는다 (자정 동결 방지)
             var prevToday: DailyUsage?
             var prevBlock: BlockUsage?
+            var prevWeek: PeriodUsage?
+            var prevMonth: PeriodUsage?
             if let previous = snapshots.first(where: { $0.providerID == provider.id }) {
                 if previous.today?.date == todayKey { prevToday = previous.today }
                 prevBlock = previous.activeBlock
+                // 주/월 누적도 이어받는다 — phase 2 가 다시 채우기 전까지 nil 로 비면
+                // 팝오버의 "이번 주/이번 달" 행이 사라졌다 나타나 깜빡인다.
+                prevWeek = previous.weekTotal
+                prevMonth = previous.monthTotal
             }
 
             let today: DailyUsage?
@@ -339,6 +345,8 @@ final class UsageStore {
                     displayName: provider.displayName,
                     today: today,
                     activeBlock: prevBlock,
+                    weekTotal: prevWeek,
+                    monthTotal: prevMonth,
                     fetchedAt: Date()))
             }
         }

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -363,18 +363,16 @@ struct PopoverView: View {
 
     private var footer: some View {
         HStack(spacing: 10) {
-            if store.isRefreshing {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                Button {
-                    Task { await store.refresh() }
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.borderless)
-                .help(l.refreshNow)
+            // 스피너 스왑을 두지 않는다 — 로컬 파싱이 보이는 오늘 숫자를 즉시 갱신하는데
+            // enrichment/한도(네트워크)까지 기다리는 스피너가 데이터보다 오래 돌아 불필요해 보였다.
+            // 중복 클릭은 refresh() 의 재진입 guard 가 무시하고, 피드백은 아래 "Updated" 시각이 준다.
+            Button {
+                Task { await store.refresh() }
+            } label: {
+                Image(systemName: "arrow.clockwise")
             }
+            .buttonStyle(.borderless)
+            .help(l.refreshNow)
             if let updated = store.lastUpdated {
                 (Text("\(l.updated) ") + Text(updated, style: .relative))
                     .font(.caption)

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -236,6 +236,31 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertFalse(store.isStale)
     }
 
+    // MARK: 주/월 누적 유지 (팝오버 깜빡임 회귀 방지)
+
+    /// phase1 재빌드가 이전 스냅샷의 주/월 누적을 이어받지 않으면, 다음 enrichment 가
+    /// 다시 채우기 전까지 nil 이 되어 팝오버 "이번 주/이번 달" 행이 사라졌다 나타난다.
+    /// enrichment 가 주월을 못 채우는(periodsOK=false) 갱신에서도 이전 값이 유지돼야 한다.
+    func testWeekMonthPersistAcrossRefreshWhenEnrichmentSkips() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(1_000))
+        claude.enrichment = ProviderEnrichment(
+            activeBlock: nil, blocksOK: false,
+            weekTotal: PeriodUsage(period: "2026-06-28", totalTokens: 7_000, totalCost: 0),
+            monthTotal: PeriodUsage(period: "2026-06", totalTokens: 30_000, totalCost: 0),
+            periodsOK: true)
+        let store = makeStore(providers: [claude])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.weekTotalTokens, 7_000)
+        XCTAssertEqual(store.monthTotalTokens, 30_000)
+
+        // 다음 갱신: enrichment 가 주월을 채우지 못함 → 이전 값이 살아있어야 한다.
+        claude.enrichment = ProviderEnrichment(
+            activeBlock: nil, blocksOK: false, weekTotal: nil, monthTotal: nil, periodsOK: false)
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.weekTotalTokens, 7_000, "주 누적이 재빌드에서 사라지면 안 된다")
+        XCTAssertEqual(store.monthTotalTokens, 30_000, "월 누적이 재빌드에서 사라지면 안 된다")
+    }
+
     // MARK: friendlyLimitError 매핑
 
     func testFriendlyLimitErrorMapping() {

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -31,7 +31,8 @@ echo "▶ swift test (--enable-code-coverage)"
 swift test --enable-code-coverage
 
 PROF=$(find .build -name 'default.profdata' | head -1)
-BIN=$(find .build -name 'PokeTokenBarPackageTests' -type f | head -1)
+# dSYM 안에도 같은 이름의 DWARF 바이너리가 있어 head -1 이 그걸 집으면 llvm-cov 가 실패한다 → 제외.
+BIN=$(find .build -name 'PokeTokenBarPackageTests' -type f ! -path '*.dSYM/*' | head -1)
 if [[ -z "$PROF" || -z "$BIN" ]]; then
   echo "✗ 커버리지 산출물(profdata/binary)을 찾지 못했습니다." >&2
   exit 1


### PR DESCRIPTION
## 문제

홈(팝오버)에서 갱신 버튼을 누를 때:
1. **상단 "이번 주/이번 달" 텍스트가 사라졌다 다시 나타나 깜빡인다.**
2. **progress 스피너가 실제 데이터보다 오래 돌아 불필요해 보인다.**

## 원인

**① 깜빡임** — `UsageStore.refresh()` phase1 이 `newSnapshots` 를 새로 만들 때
`activeBlock` 은 이전 스냅샷 값(`prevBlock`)을 이어받지만 `weekTotal`/`monthTotal`
은 이어받지 않아 nil 로 초기화된다. `snapshots = newSnapshots` 순간 주/월 누적이 0 이
되어 `weekTotalTokens>0` 조건의 행이 사라지고, phase2(enrichment)가 다시 채우며
나타난다 → 매 갱신마다 깜빡.

**② 스피너** — `isRefreshing` 이 phase1(빠른 로컬 파싱, 보이는 오늘 숫자) 뿐 아니라
phase2 + 한도(네트워크 ~1–3초)까지 true 다. 보이는 숫자는 phase1 에서 이미 갱신되는데
스피너가 느린 뒷단까지 계속 돌아 "데이터보다 오래 도는" 것처럼 보인다.

## 변경

| 파일 | 내용 |
|---|---|
| `Core/UsageStore.swift` | phase1 재빌드에서 `prevWeek`/`prevMonth` 도 이어받아 주/월 누적 유지 |
| `UI/PopoverView.swift` | 푸터 버튼↔스피너 스왑 제거 → 갱신 버튼 항상 표시. 중복 클릭은 `refresh()` 재진입 guard 가 무시, 피드백은 "Updated N초 전" 시각이 제공 |
| `Tests/…/UsageStoreTests.swift` | 회귀 테스트: enrichment 가 주월을 못 채우는(periodsOK=false) 갱신에서도 이전 주/월 값이 유지되는지 검증 |
| `scripts/test-gate.sh` | (부수) `find` 가 dSYM DWARF 바이너리를 집으면 llvm-cov 실패로 게이트가 flaky 하게 죽던 것 수정 — dSYM 경로 제외 |

## 검증

- `swift test` 108개 통과(3 skip), 신규 테스트 포함.
- test-gate 로직 코어 커버리지 **76.14% ≥ 70%** (dSYM 수정 후 deterministic 통과).
- 앱 빌드·설치·실행 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
