### PR TITLE
feat: 색이 다른 포켓몬(1/64) + 성격 + 부화/진화 연출 (v2.2.0 Phase 1)

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -99,6 +99,54 @@ struct EvoLine: Sendable {
     }
 }
 
+/// 성격 — 본가 25종. 부화 시 확정, 능력치 영향 없음(개체 아이덴티티 표시용).
+enum PokemonNature: String, Codable, Sendable, CaseIterable {
+    case hardy, lonely, brave, adamant, naughty
+    case bold, docile, relaxed, impish, lax
+    case timid, hasty, serious, jolly, naive
+    case modest, mild, quiet, bashful, rash
+    case calm, gentle, sassy, careful, quirky
+
+    /// 본가 공식 번역 명칭 (ko/en/ja).
+    func name(_ lang: AppLanguage) -> String {
+        let names: (String, String, String)
+        switch self {
+        case .hardy:   names = ("노력", "Hardy", "がんばりや")
+        case .lonely:  names = ("외로움", "Lonely", "さみしがり")
+        case .brave:   names = ("용감", "Brave", "ゆうかん")
+        case .adamant: names = ("고집", "Adamant", "いじっぱり")
+        case .naughty: names = ("개구쟁이", "Naughty", "やんちゃ")
+        case .bold:    names = ("대담", "Bold", "ずぶとい")
+        case .docile:  names = ("온순", "Docile", "すなお")
+        case .relaxed: names = ("무사태평", "Relaxed", "のんき")
+        case .impish:  names = ("장난꾸러기", "Impish", "わんぱく")
+        case .lax:     names = ("촐랑", "Lax", "のうてんき")
+        case .timid:   names = ("겁쟁이", "Timid", "おくびょう")
+        case .hasty:   names = ("성급", "Hasty", "せっかち")
+        case .serious: names = ("성실", "Serious", "まじめ")
+        case .jolly:   names = ("명랑", "Jolly", "ようき")
+        case .naive:   names = ("천진난만", "Naive", "むじゃき")
+        case .modest:  names = ("조심", "Modest", "ひかえめ")
+        case .mild:    names = ("의젓", "Mild", "おっとり")
+        case .quiet:   names = ("냉정", "Quiet", "れいせい")
+        case .bashful: names = ("수줍음", "Bashful", "てれや")
+        case .rash:    names = ("덜렁", "Rash", "うっかりや")
+        case .calm:    names = ("차분", "Calm", "おだやか")
+        case .gentle:  names = ("얌전", "Gentle", "おとなしい")
+        case .sassy:   names = ("건방", "Sassy", "なまいき")
+        case .careful: names = ("신중", "Careful", "しんちょう")
+        case .quirky:  names = ("변덕", "Quirky", "きまぐれ")
+        }
+        switch lang { case .ko: return names.0; case .en: return names.1; case .ja: return names.2 }
+    }
+}
+
+/// 게임 밸런스 — 개체 롤 확률.
+enum PokemonOdds {
+    /// 색이 다른 포켓몬(shiny) 부화 확률 분모 — 1/64 (본가 1/4096 은 데스크톱 앱 규모에선 평생 못 봄).
+    static let shinyDenominator: UInt64 = 64
+}
+
 /// 현재 키우는 포켓몬.
 struct MonState: Codable, Sendable {
     var baseID: Int
@@ -107,7 +155,34 @@ struct MonState: Codable, Sendable {
     var usedAtStage: Int    // 현재 형태에서 누적 사용량
     var rarity: Rarity
     var totalForms: Int
+    var isShiny = false             // 부화 시 확정, 진화해도 유지
+    var nature: PokemonNature?      // 부화 시 확정 (구버전 저장은 nil)
     var currentID: Int { pathIDs[min(stageIndex, pathIDs.count - 1)] }
+
+    init(baseID: Int, pathIDs: [Int], stageIndex: Int, usedAtStage: Int,
+         rarity: Rarity, totalForms: Int, isShiny: Bool = false, nature: PokemonNature? = nil) {
+        self.baseID = baseID
+        self.pathIDs = pathIDs
+        self.stageIndex = stageIndex
+        self.usedAtStage = usedAtStage
+        self.rarity = rarity
+        self.totalForms = totalForms
+        self.isShiny = isShiny
+        self.nature = nature
+    }
+
+    // 하위호환 디코딩: shiny/nature 는 구버전 저장에 없음 → 기본값.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        baseID = try c.decode(Int.self, forKey: .baseID)
+        pathIDs = try c.decode([Int].self, forKey: .pathIDs)
+        stageIndex = try c.decode(Int.self, forKey: .stageIndex)
+        usedAtStage = try c.decode(Int.self, forKey: .usedAtStage)
+        rarity = try c.decode(Rarity.self, forKey: .rarity)
+        totalForms = try c.decode(Int.self, forKey: .totalForms)
+        isShiny = try c.decodeIfPresent(Bool.self, forKey: .isShiny) ?? false
+        nature = try c.decodeIfPresent(PokemonNature.self, forKey: .nature)
+    }
 }
 
 /// 도감 항목 — 라인 전체(초기→최종) 순서 보존.
@@ -118,6 +193,32 @@ struct DexEntry: Codable, Sendable, Identifiable {
     var chainOrder: [Int]   // 초기→최종 종 id
     var rarity: Rarity
     var caughtAt: Date?
+    var isShiny = false
+    var nature: PokemonNature?
+
+    init(baseID: Int, finalID: Int, chainOrder: [Int], rarity: Rarity,
+         caughtAt: Date?, isShiny: Bool = false, nature: PokemonNature? = nil) {
+        self.baseID = baseID
+        self.finalID = finalID
+        self.chainOrder = chainOrder
+        self.rarity = rarity
+        self.caughtAt = caughtAt
+        self.isShiny = isShiny
+        self.nature = nature
+    }
+
+    // 하위호환 디코딩 (MonState 와 동일 이유).
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(String.self, forKey: .id) ?? UUID().uuidString
+        baseID = try c.decode(Int.self, forKey: .baseID)
+        finalID = try c.decode(Int.self, forKey: .finalID)
+        chainOrder = try c.decode([Int].self, forKey: .chainOrder)
+        rarity = try c.decode(Rarity.self, forKey: .rarity)
+        caughtAt = try c.decodeIfPresent(Date.self, forKey: .caughtAt)
+        isShiny = try c.decodeIfPresent(Bool.self, forKey: .isShiny) ?? false
+        nature = try c.decodeIfPresent(PokemonNature.self, forKey: .nature)
+    }
 }
 
 /// 영속 상태(Application Support JSON). 포켓몬 전환 — 이전 커스텀 캐릭터 상태는 폐기(새로 시작).

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -15,6 +15,14 @@ final class CompanionStore {
     private(set) var justGraduated: String?
     private var eventUntil: Date?
 
+    /// 부화/진화 연출 트리거 — seq 증가로 UI 가 감지, 팝오버가 닫혀 있었어도 다음 오픈에 1회 재생.
+    enum Celebration: Equatable { case hatch(shiny: Bool), evolve }
+    private(set) var celebration: Celebration?
+    private(set) var celebrationSeq = 0
+    private func fireCelebration(_ c: Celebration) { celebration = c; celebrationSeq += 1 }
+    /// 연출 재생 후 UI 가 호출(1회성 보장).
+    func consumeCelebration() { celebration = nil }
+
     private let provider: any PokeProviding
     private let clock: () -> Date
     private let fileURL: URL
@@ -48,6 +56,8 @@ final class CompanionStore {
 
     var hasActive: Bool { state.active != nil }
     var rarity: Rarity? { state.active?.rarity }
+    var currentIsShiny: Bool { state.active?.isShiny ?? false }
+    var currentNature: PokemonNature? { state.active?.nature }
 
     // 알 인큐베이션 (active 없을 때)
     var isEgg: Bool { state.active == nil }
@@ -166,6 +176,7 @@ final class CompanionStore {
                 state.active!.usedAtStage = a.usedAtStage - thr   // 초과분 이월
                 let newName = line.localizedName(next.speciesID, state.language)
                 justEvolvedTo = newName
+                fireCelebration(.evolve)
                 notifyCompanionEvent(l.notifEvolveTitle, l.notifEvolveBody(newName))
             }
         }
@@ -185,7 +196,8 @@ final class CompanionStore {
         let finalID = a.currentID
         state.collectedFinals.insert("\(a.baseID):\(finalID)")
         state.dex.append(DexEntry(baseID: a.baseID, finalID: finalID,
-                                  chainOrder: a.pathIDs, rarity: a.rarity, caughtAt: clock()))
+                                  chainOrder: a.pathIDs, rarity: a.rarity, caughtAt: clock(),
+                                  isShiny: a.isShiny, nature: a.nature))
         let name = currentLine?.localizedName(finalID, state.language) ?? ""
         justGraduated = name
         notifyCompanionEvent(l.notifGraduateTitle, l.notifGraduateBody(name))
@@ -225,11 +237,18 @@ final class CompanionStore {
         // 부화 임계 초과분은 부화체 성장에 이월(낭비 없음).
         let overflow = max(0, state.eggUsage - PokemonBalance.eggHatchThreshold)
         state.eggUsage = 0
+        // 개체 롤 — shiny(1/64)·성격(25종)은 부화 순간 확정, 진화해도 유지.
+        let isShiny = rng.next() % PokemonOdds.shinyDenominator == 0
+        let nature = PokemonNature.allCases[Int(rng.next() % UInt64(PokemonNature.allCases.count))]
         state.active = MonState(baseID: line.baseID, pathIDs: [line.baseID], stageIndex: 0,
-                                usedAtStage: 0, rarity: line.rarity, totalForms: line.totalForms)
-        notifyCompanionEvent(l.notifHatchTitle, l.notifHatchBody(line.localizedName(line.baseID, state.language)))
+                                usedAtStage: 0, rarity: line.rarity, totalForms: line.totalForms,
+                                isShiny: isShiny, nature: nature)
+        let name = line.localizedName(line.baseID, state.language)
+        notifyCompanionEvent(isShiny ? l.notifShinyHatchTitle : l.notifHatchTitle,
+                             isShiny ? l.notifShinyHatchBody(name) : l.notifHatchBody(name))
         displayState = .levelUp
         eventUntil = clock().addingTimeInterval(4)
+        fireCelebration(.hatch(shiny: isShiny))
         if overflow > 0 { applyUsage(overflow) }   // 이월분 즉시 반영(필요 시 진화까지)
         save()
     }

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -135,6 +135,9 @@ struct L {
     // MARK: companion 이벤트 시스템 알림
     var notifHatchTitle: String { t("🥚 부화!", "🥚 Hatched!", "🥚 孵化！") }
     func notifHatchBody(_ name: String) -> String { t("알에서 \(name)이(가) 나왔어요!", "\(name) hatched from the egg!", "タマゴから \(name) が生まれました！") }
+    var notifShinyHatchTitle: String { t("✨ 색이 다른 포켓몬!", "✨ Shiny Pokémon!", "✨ 色違いポケモン！") }
+    func notifShinyHatchBody(_ name: String) -> String { t("색이 다른 \(name)이(가) 태어났어요! (1/64)", "A shiny \(name) hatched! (1 in 64)", "色違いの \(name) が生まれました！(1/64)") }
+    var eggImminent: String { t("곧 부화해요!", "About to hatch!", "もうすぐ孵化！") }
     var notifEvolveTitle: String { t("✨ 진화!", "✨ Evolved!", "✨ 進化！") }
     func notifEvolveBody(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！") }
     var notifGraduateTitle: String { t("🎓 졸업!", "🎓 Graduated!", "🎓 卒業！") }

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -23,7 +23,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // 메뉴바 캐릭터 애니메이션 — 단일 타이머로 프레임 순환.
     // 프레임 = 이미 22px 로 합성된 이미지 + delay. egg/static 은 2프레임 bob, animated 는 GIF 실제 프레임.
-    private var menuSpriteID: Int?
+    private var menuSpriteKey: String?   // "id-shiny" — 같은 종이라도 shiny 여부가 바뀌면 재로딩
     private var menuFrames: [(image: NSImage, delay: TimeInterval)] = []
     private var menuIndex = 0
     private var menuTimer: Timer?
@@ -102,8 +102,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// 에선 GIF 생략(가벼운 bob)로 처리한다 — 통제된 저프레임 + 비가시 시 정지로 저전력.
     private func ensureMenuAnimation(forceRebuild: Bool = false) {
         let id = companion.currentSpeciesID
-        if !forceRebuild, id == menuSpriteID, !menuFrames.isEmpty { return }   // 이미 이 종으로 애니메이션 중
-        menuSpriteID = id
+        let shiny = companion.currentIsShiny
+        let key = id.map { "\($0)-\(shiny)" }
+        if !forceRebuild, key == menuSpriteKey, !menuFrames.isEmpty { return }   // 이미 이 개체로 애니메이션 중
+        menuSpriteKey = key
         menuLoadGen += 1
         let gen = menuLoadGen
 
@@ -112,13 +114,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         // 정적 스프라이트 bob 을 먼저(없으면 받아와서). GIF 가 받아지면 아래에서 교체.
-        if let cached = SpriteLoader.cachedImage(speciesID: id) {
+        if let cached = SpriteLoader.cachedImage(speciesID: id, shiny: shiny) {
             setMenuFrames(Self.bobFrames(from: cached))
         } else {
             setMenuFrames(Self.eggFrames())
             Task { @MainActor [weak self] in
                 guard let self, gen == self.menuLoadGen,
-                      let sprite = await SpriteLoader.image(speciesID: id) else { return }
+                      let sprite = await SpriteLoader.image(speciesID: id, shiny: shiny) else { return }
                 guard gen == self.menuLoadGen else { return }
                 self.setMenuFrames(Self.bobFrames(from: sprite))
             }
@@ -127,8 +129,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // 풀 GIF 애니메이션(저전력 모드에서는 생략하고 bob 유지). delay 하한 0.1s(≤10fps)로 redraw 통제.
         guard !ProcessInfo.processInfo.isLowPowerModeEnabled else { return }
         Task { @MainActor [weak self] in
-            guard let self, gen == self.menuLoadGen,
-                  let data = await SpriteStore.shared.data(speciesID: id, animated: true) else { return }
+            guard let self, gen == self.menuLoadGen else { return }
+            // shiny GIF 미제공 종이면 일반 GIF 폴백
+            var data = await SpriteStore.shared.data(speciesID: id, animated: true, shiny: shiny)
+            if data == nil, shiny {
+                data = await SpriteStore.shared.data(speciesID: id, animated: true, shiny: false)
+            }
+            guard let data else { return }
             let raw = GIFDecoder.frames(from: data)
             guard raw.count > 1, gen == self.menuLoadGen else { return }
             // 메뉴바 GIF 는 delay 하한 0.2s(≈5fps)로 캡 — 22px 스프라이트엔 충분하고 저전력.

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -16,19 +16,21 @@ struct SpriteView: View {
     var size: CGFloat = 84
     var bob: Bool = false
     var animated: Bool = false
+    var shiny: Bool = false
     @State private var img: NSImage?
     @State private var up = false
     @State private var loadedID: Int?   // img 가 어느 speciesID 것인지(id 변경 시 갱신 판단)
     @State private var frames: [(image: NSImage, delay: TimeInterval)] = []
     @State private var frameIndex = 0
 
-    init(speciesID: Int?, size: CGFloat = 84, bob: Bool = false, animated: Bool = false) {
+    init(speciesID: Int?, size: CGFloat = 84, bob: Bool = false, animated: Bool = false, shiny: Bool = false) {
         self.speciesID = speciesID
         self.size = size
         self.bob = bob
         self.animated = animated
+        self.shiny = shiny
         // 캐시에 있으면 즉시(동기) 표시 — 재렌더 플래시 방지 + 정적 스냅샷에서도 보임
-        let cached = speciesID.flatMap { SpriteLoader.cachedImage(speciesID: $0) }
+        let cached = speciesID.flatMap { SpriteLoader.cachedImage(speciesID: $0, shiny: shiny) }
         _img = State(initialValue: cached)
         _loadedID = State(initialValue: cached != nil ? speciesID : nil)
     }
@@ -49,19 +51,23 @@ struct SpriteView: View {
         }
         // GIF 재생 중엔 bob 정지(프레임 자체가 움직임) — 폴백/정적일 때만 상하 움직임
         .offset(y: bob && frames.isEmpty && up ? -3 : 0)
-        .task(id: speciesID) {
-            // animated 프레임은 id 변경 시 항상 초기화(이전 종 프레임 잔상 방지)
+        .task(id: "\(speciesID.map(String.init) ?? "nil")-\(shiny)") {
+            // animated 프레임은 id/shiny 변경 시 항상 초기화(이전 개체 프레임 잔상 방지)
             frames = []
             frameIndex = 0
             guard let id = speciesID else { img = nil; loadedID = nil; return }
             // 정적 스프라이트 먼저(즉시 표시 + 폴백 보장). 캐시 시드로 이미 같은 id 면 재요청 생략(플래시 방지)
             if loadedID != id {
-                img = await SpriteLoader.image(speciesID: id, animated: false)
+                img = await SpriteLoader.image(speciesID: id, animated: false, shiny: shiny)
                 loadedID = id
             }
             guard animated else { return }
-            // animated GIF 시도 → 프레임 2개 이상이면 순환 루프, 아니면 정적 유지
-            guard let data = await SpriteStore.shared.data(speciesID: id, animated: true) else { return }
+            // animated GIF 시도(shiny 미제공 종은 일반 GIF 폴백) → 프레임 2개 이상이면 순환 루프
+            var gifData = await SpriteStore.shared.data(speciesID: id, animated: true, shiny: shiny)
+            if gifData == nil, shiny {
+                gifData = await SpriteStore.shared.data(speciesID: id, animated: true, shiny: false)
+            }
+            guard let data = gifData else { return }
             let raw = GIFDecoder.frames(from: data)
             guard raw.count > 1 else { return }   // 단일 프레임/디코드 실패 → 정적 폴백
             frames = raw
@@ -84,11 +90,12 @@ struct SpriteView: View {
 struct EvoLineView: View {
     let nodes: [(id: Int, kind: String)]
     var thumb: CGFloat = 40
+    var shiny: Bool = false     // 개체가 shiny 면 라인 전체를 shiny 스프라이트로
     var body: some View {
         HStack(spacing: 2) {
             ForEach(Array(nodes.enumerated()), id: \.offset) { i, node in
                 if i > 0 { Image(systemName: "arrow.right").font(.system(size: thumb * 0.2)).foregroundStyle(.tertiary) }
-                SpriteView(speciesID: node.id, size: thumb)
+                SpriteView(speciesID: node.id, size: thumb, shiny: shiny)
                     .opacity(node.kind == "future" ? 0.32 : 1)
                     .saturation(node.kind == "future" ? 0.4 : 1)
                     .overlay(alignment: .bottom) {
@@ -101,20 +108,41 @@ struct EvoLineView: View {
     }
 }
 
-/// 팝오버 상단 — 현재 포켓몬 + 진화 진행.
+/// 팝오버 상단 — 현재 포켓몬 + 진화 진행 + 부화/진화 연출.
 struct CompanionHeader: View {
     let store: CompanionStore
+    // 연출 상태 — 부화/진화 순간 흰 플래시 + 스프링 스케일(본가 진화 신 오마주)
+    @State private var flashOpacity: Double = 0
+    @State private var celebScale: CGFloat = 1
+    @State private var shinyBurst = false
+    @State private var seenSeq = -1     // 재생 완료한 celebrationSeq (팝오버 재오픈 시 1회 재생 보장)
+    @State private var eggWiggle = false
+
+    /// 부화 임박(90%+) — 알이 흔들리고 문구가 바뀐다.
+    private var eggImminent: Bool { store.isEgg && store.eggProgress >= 0.9 }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .center, spacing: 12) {
-                SpriteView(speciesID: store.currentSpeciesID, size: 76, bob: true, animated: true)
+                SpriteView(speciesID: store.currentSpeciesID, size: 76, bob: true, animated: true,
+                           shiny: store.currentIsShiny)
                     .frame(width: 76, height: 76)
                     .background(Color.secondary.opacity(0.06))
                     .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .rotationEffect(.degrees(eggImminent && eggWiggle ? 5 : (eggImminent ? -5 : 0)))
+                    .scaleEffect(celebScale)
+                    .overlay(RoundedRectangle(cornerRadius: 12).fill(.white).opacity(flashOpacity))
+                    .overlay(alignment: .topTrailing) {
+                        if shinyBurst {
+                            Text("✨").font(.system(size: 22))
+                                .transition(.scale.combined(with: .opacity))
+                                .offset(x: 6, y: -6)
+                        }
+                    }
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 6) {
                         Text(store.displayName).font(.callout.weight(.semibold))
+                        if store.currentIsShiny { Text("✨").font(.system(size: 11)) }
                         if let r = store.rarity {
                             Text(r.rawValue.uppercased()).font(.system(size: 8, weight: .bold))
                                 .padding(.horizontal, 5).padding(.vertical, 1)
@@ -123,7 +151,9 @@ struct CompanionHeader: View {
                         }
                     }
                     if store.hasActive {
-                        Text(store.stageText).font(.caption2).foregroundStyle(.secondary)
+                        // 단계 + 성격(부화 시 확정된 개체 아이덴티티)
+                        let nature = store.currentNature.map { " · \($0.name(store.language))" } ?? ""
+                        Text(store.stageText + nature).font(.caption2).foregroundStyle(.secondary)
                         ProgressView(value: store.progress).controlSize(.small).tint(.orange)
                         if store.tokensToNext > 0 {
                             let amount = TokenFormatter.compact(store.tokensToNext)
@@ -131,8 +161,10 @@ struct CompanionHeader: View {
                                 .font(.caption2).foregroundStyle(.tertiary)
                         }
                     } else {
-                        // 알 인큐베이션 — 부화까지 진행
-                        Text(store.l.eggIncubating).font(.caption2).foregroundStyle(.secondary)
+                        // 알 인큐베이션 — 부화까지 진행 (임박 시 문구·색 전환)
+                        Text(eggImminent ? store.l.eggImminent : store.l.eggIncubating)
+                            .font(.caption2)
+                            .foregroundStyle(eggImminent ? AnyShapeStyle(.orange) : AnyShapeStyle(.secondary))
                         ProgressView(value: store.eggProgress).controlSize(.small).tint(.orange)
                         Text(store.l.eggToHatch(TokenFormatter.compact(store.eggTokensToHatch)))
                             .font(.caption2).foregroundStyle(.tertiary)
@@ -142,12 +174,44 @@ struct CompanionHeader: View {
                 Spacer()
             }
             if store.hasActive, !store.lineNodes.isEmpty {
-                EvoLineView(nodes: store.lineNodes)
+                EvoLineView(nodes: store.lineNodes, shiny: store.currentIsShiny)
             }
             if let g = store.justGraduated {
                 Text(store.l.graduated(g))
                     .font(.caption2).foregroundStyle(.orange)
             }
+        }
+        .onAppear {
+            playCelebrationIfNeeded()
+            syncEggWiggle()
+        }
+        .onChange(of: store.celebrationSeq) { playCelebrationIfNeeded() }
+        .onChange(of: eggImminent) { syncEggWiggle() }
+    }
+
+    /// 부화/진화 연출 1회 재생 — 흰 플래시 페이드아웃 + 스프링 팝. shiny 부화는 ✨ 버스트 추가.
+    private func playCelebrationIfNeeded() {
+        guard let c = store.celebration, store.celebrationSeq != seenSeq else { return }
+        seenSeq = store.celebrationSeq
+        store.consumeCelebration()
+        flashOpacity = 0.85
+        celebScale = 0.6
+        withAnimation(.easeOut(duration: 0.8)) { flashOpacity = 0 }
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.55)) { celebScale = 1 }
+        if case .hatch(shiny: true) = c {
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.5).delay(0.3)) { shinyBurst = true }
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 2_600_000_000)
+                withAnimation(.easeOut(duration: 0.5)) { shinyBurst = false }
+            }
+        }
+    }
+
+    private func syncEggWiggle() {
+        if eggImminent {
+            withAnimation(.easeInOut(duration: 0.35).repeatForever(autoreverses: true)) { eggWiggle = true }
+        } else {
+            withAnimation(.default) { eggWiggle = false }
         }
     }
 
@@ -223,10 +287,13 @@ struct CollectionView: View {
                                     .padding(.horizontal, 5).padding(.vertical, 1)
                                     .background(rarityColor(entry.rarity)).foregroundStyle(.white)
                                     .clipShape(Capsule())
+                                if entry.isShiny { Text("✨").font(.system(size: 10)) }
                                 Spacer()
-                                Text(store.l.formsComplete(entry.chainOrder.count)).font(.system(size: 9)).foregroundStyle(.secondary)
+                                let nature = entry.nature.map { "\($0.name(store.language)) · " } ?? ""
+                                Text(nature + store.l.formsComplete(entry.chainOrder.count))
+                                    .font(.system(size: 9)).foregroundStyle(.secondary)
                             }
-                            EvoLineView(nodes: entry.chainOrder.map { ($0, "done") }, thumb: 56)
+                            EvoLineView(nodes: entry.chainOrder.map { ($0, "done") }, thumb: 56, shiny: entry.isShiny)
                             if let caughtAt = entry.caughtAt {
                                 Text(caughtAt, style: .relative).font(.system(size: 9)).foregroundStyle(.tertiary)
                             }

--- a/Sources/PokeTokenBar/UI/SpriteLoader.swift
+++ b/Sources/PokeTokenBar/UI/SpriteLoader.swift
@@ -12,15 +12,24 @@ actor SpriteStore {
         return d
     }()
 
-    func data(speciesID: Int, animated: Bool) async -> Data? {
-        let key = "\(speciesID)-\(animated ? "a" : "s")"
+    /// 캐시 파일명 키 — 기존 "\(id)-a"/"\(id)-s" 유지, shiny 는 "sh" 접두(구캐시 그대로 유효).
+    static func cacheKey(speciesID: Int, animated: Bool, shiny: Bool) -> String {
+        "\(speciesID)-\(shiny ? "sh" : "")\(animated ? "a" : "s")"
+    }
+
+    func data(speciesID: Int, animated: Bool, shiny: Bool = false) async -> Data? {
+        let key = Self.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny)
         if let d = mem[key] { return d }
         let ext = animated ? "gif" : "png"
         let file = dir.appendingPathComponent("\(key).\(ext)")
         if let d = try? Data(contentsOf: file) { mem[key] = d; return d }
-        let urlStr = animated
-            ? "\(base)/versions/generation-v/black-white/animated/\(speciesID).gif"
-            : "\(base)/\(speciesID).png"
+        let urlStr: String
+        switch (animated, shiny) {
+        case (true, false):  urlStr = "\(base)/versions/generation-v/black-white/animated/\(speciesID).gif"
+        case (true, true):   urlStr = "\(base)/versions/generation-v/black-white/animated/shiny/\(speciesID).gif"
+        case (false, false): urlStr = "\(base)/\(speciesID).png"
+        case (false, true):  urlStr = "\(base)/shiny/\(speciesID).png"
+        }
         guard let url = URL(string: urlStr),
               let (d, resp) = try? await URLSession.shared.data(from: url),
               (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
@@ -38,19 +47,27 @@ enum SpriteLoader {
     }()
 
     /// 디스크 캐시에 이미 있으면 동기 반환(네트워크 없음). 없으면 nil.
-    static func cachedImage(speciesID: Int, animated: Bool = false) -> NSImage? {
+    static func cachedImage(speciesID: Int, animated: Bool = false, shiny: Bool = false) -> NSImage? {
         let ext = animated ? "gif" : "png"
-        let f = cacheDir.appendingPathComponent("\(speciesID)-\(animated ? "a" : "s").\(ext)")
+        let key = SpriteStore.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny)
+        let f = cacheDir.appendingPathComponent("\(key).\(ext)")
         guard let d = try? Data(contentsOf: f) else { return nil }
         return NSImage(data: d)
     }
 
     /// 정적 스프라이트. animated=true 면 Gen-V 움직이는 스프라이트(없으면 정적으로 폴백).
-    static func image(speciesID: Int, animated: Bool = false) async -> NSImage? {
-        if animated, let d = await SpriteStore.shared.data(speciesID: speciesID, animated: true), let img = NSImage(data: d) {
+    /// shiny=true 는 색이 다른 스프라이트 — 미제공 종이면 일반으로 폴백.
+    static func image(speciesID: Int, animated: Bool = false, shiny: Bool = false) async -> NSImage? {
+        if animated, let d = await SpriteStore.shared.data(speciesID: speciesID, animated: true, shiny: shiny),
+           let img = NSImage(data: d) {
             return img
         }
-        guard let d = await SpriteStore.shared.data(speciesID: speciesID, animated: false) else { return nil }
-        return NSImage(data: d)
+        if let d = await SpriteStore.shared.data(speciesID: speciesID, animated: false, shiny: shiny),
+           let img = NSImage(data: d) {
+            return img
+        }
+        // shiny 미제공 → 일반 폴백
+        guard shiny else { return nil }
+        return await image(speciesID: speciesID, animated: animated, shiny: false)
     }
 }

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -311,3 +311,110 @@ private final class MutableProvider: PokeProviding, @unchecked Sendable {
     nonisolated(unsafe) var line: EvoLine = makeLine(base: 1, tree: node(1))
     func line(baseSpeciesID: Int) async throws -> EvoLine { line }
 }
+
+// MARK: 개체 아이덴티티 (shiny / nature) — v2.2.0
+
+@MainActor
+final class CompanionIdentityTests: XCTestCase {
+    private func store(_ line: EvoLine, seed: UInt64) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
+        return CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: seed))
+    }
+
+    /// 직접 hatch(baseID:) 는 rng 를 shiny → nature 순으로 소비한다. 같은 시드 재생으로 기대값 산출.
+    private func expectedRoll(seed: UInt64) -> (shiny: Bool, nature: PokemonNature) {
+        var rng = SeededRNG(seed: seed)
+        let shiny = rng.next() % PokemonOdds.shinyDenominator == 0
+        let nature = PokemonNature.allCases[Int(rng.next() % UInt64(PokemonNature.allCases.count))]
+        return (shiny, nature)
+    }
+
+    /// 임의 시드에서 부화 롤이 결정적이고 성격이 항상 부여되는지.
+    func testHatchAssignsDeterministicShinyAndNature() async {
+        for seed: UInt64 in [1, 7, 42, 12345] {
+            let s = store(linear3, seed: seed)
+            let expected = expectedRoll(seed: seed)
+            await s.hatch(baseID: 1)
+            XCTAssertEqual(s.state.active?.isShiny, expected.shiny, "seed \(seed)")
+            XCTAssertEqual(s.state.active?.nature, expected.nature, "seed \(seed)")
+        }
+    }
+
+    /// shiny 가 실제로 나오는 시드를 탐색해 true 경로를 검증(1/64 확률이 코드에 존재함을 보장).
+    func testShinyPathReachable() async {
+        var shinySeed: UInt64?
+        for seed: UInt64 in 0..<5000 where expectedRoll(seed: seed).shiny { shinySeed = seed; break }
+        guard let seed = shinySeed else { return XCTFail("5000개 시드 중 shiny 없음 — 분모 확인") }
+        let s = store(linear3, seed: seed)
+        await s.hatch(baseID: 1)
+        XCTAssertEqual(s.state.active?.isShiny, true)
+        XCTAssertTrue(s.currentIsShiny)
+    }
+
+    /// 진화를 거쳐 졸업해도 shiny/nature 가 도감 항목에 보존되는지.
+    func testGraduateCarriesIdentityToDex() async {
+        let s = store(noEvo, seed: 3)   // 무진화 → 임계 도달 시 바로 졸업
+        await s.hatch(baseID: 20)
+        let shiny = s.state.active!.isShiny
+        let nature = s.state.active!.nature
+        XCTAssertNotNil(nature)
+        s.applyUsage(PokemonBalance.graduationTotal(.common))
+        XCTAssertNil(s.state.active)   // 졸업
+        XCTAssertEqual(s.state.dex.count, 1)
+        XCTAssertEqual(s.state.dex[0].isShiny, shiny)
+        XCTAssertEqual(s.state.dex[0].nature, nature)
+    }
+
+    /// 구버전 저장(shiny/nature 키 없음) 디코딩 — 기본값(false/nil)으로 로드.
+    func testBackwardCompatibleDecode() throws {
+        let old = """
+        {"installBaselineSet":true,"usedSinceInstall":100,"eggUsage":0,
+         "claimedTodayTokens":100,"lastDate":"d1",
+         "active":{"baseID":1,"pathIDs":[1],"stageIndex":0,"usedAtStage":5,"rarity":"common","totalForms":3},
+         "dex":[{"id":"x","baseID":4,"finalID":6,"chainOrder":[4,5,6],"rarity":"rare"}],
+         "collectedFinals":["4:6"],"language":"ko"}
+        """
+        let s = try JSONDecoder().decode(CompanionState.self, from: Data(old.utf8))
+        XCTAssertEqual(s.active?.isShiny, false)
+        XCTAssertNil(s.active?.nature)
+        XCTAssertEqual(s.dex[0].isShiny, false)
+        XCTAssertNil(s.dex[0].nature)
+        // 재인코딩 후 재디코딩도 안정적(라운드트립)
+        let round = try JSONDecoder().decode(CompanionState.self, from: JSONEncoder().encode(s))
+        XCTAssertEqual(round.active?.isShiny, false)
+    }
+
+    /// 부화/진화가 연출 트리거(celebrationSeq)를 올리고, consume 후 비워지는지.
+    func testCelebrationFiresOnHatchAndEvolve() async {
+        let s = store(linear3, seed: 9)
+        XCTAssertEqual(s.celebrationSeq, 0)
+        await s.hatch(baseID: 1)
+        XCTAssertEqual(s.celebrationSeq, 1)
+        if case .hatch = s.celebration {} else { XCTFail("hatch 연출이어야 함: \(String(describing: s.celebration))") }
+        s.consumeCelebration()
+        XCTAssertNil(s.celebration)
+        // 1단계 임계 도달 → 진화 연출
+        let thr = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0)
+        s.applyUsage(thr)
+        XCTAssertEqual(s.celebrationSeq, 2)
+        XCTAssertEqual(s.celebration, .evolve)
+    }
+
+    /// 스프라이트 캐시 키 — 기존 키("25-a"/"25-s") 불변 + shiny 접두.
+    func testSpriteCacheKeyScheme() {
+        XCTAssertEqual(SpriteStore.cacheKey(speciesID: 25, animated: true, shiny: false), "25-a")
+        XCTAssertEqual(SpriteStore.cacheKey(speciesID: 25, animated: false, shiny: false), "25-s")
+        XCTAssertEqual(SpriteStore.cacheKey(speciesID: 25, animated: true, shiny: true), "25-sha")
+        XCTAssertEqual(SpriteStore.cacheKey(speciesID: 25, animated: false, shiny: true), "25-shs")
+    }
+
+    /// 성격 25종 — 3개 언어 명칭이 전부 비어있지 않고 중복 없는지.
+    func testNatureNamesComplete() {
+        XCTAssertEqual(PokemonNature.allCases.count, 25)
+        for lang in AppLanguage.allCases {
+            let names = PokemonNature.allCases.map { $0.name(lang) }
+            XCTAssertEqual(Set(names).count, 25, "\(lang) 중복/누락")
+            XCTAssertFalse(names.contains(where: \.isEmpty))
+        }
+    }
+}


### PR DESCRIPTION
## Phase 1 — 포켓몬다움 강화 (성장 계획 v2.2.0 묶음)

성장 계획(2026-07-02)의 Phase 1: **Shiny + 부화/진화 연출 + 성격**. 통계 방향 대신
게임성으로 차별화하는 첫 단계.

## 변경

### ✨ 색이 다른 포켓몬 (Shiny, 1/64)
- 부화 순간 `rng` 롤로 확정(`CompanionStore.hatch`), 진화해도 유지, 졸업 시 도감에 보존.
- 본가 1/4096 은 데스크톱 앱 규모에서 평생 못 보므로 1/64 (`PokemonOdds.shinyDenominator`).
- 스프라이트: PokéAPI `shiny/{id}.png` + Gen-V `animated/shiny/{id}.gif`. **모든 표시면 적용** —
  메뉴바 애니메이션, 홈 카드, 진화 라인 썸네일, 도감. 미제공 종은 일반 폴백.
- 캐시 키: 기존 `25-a`/`25-s` 불변, shiny 는 `25-sha`/`25-shs` (구캐시 유효).
- UI 표기: 이름 옆 ✨, 도감 항목 ✨ 배지. shiny 부화는 전용 알림("✨ 색이 다른 포켓몬!").

### 성격 (Nature, 25종)
- 부화 시 확정, 능력치 영향 없음(개체 아이덴티티). 본가 공식 번역 ko/en/ja.
- 홈 단계줄("Stage 2/3 · 고집"), 도감 항목에 표기. 구버전 저장은 nil → 미표시.

### 부화/진화 연출
- `CompanionStore.Celebration` + `celebrationSeq` — 부화/진화 시 발화, UI 가 1회 재생 후
  consume. **팝오버가 닫혀 있었으면 다음 오픈에 재생**(놓친 순간 보상).
- 연출: 흰 플래시 페이드(0.8s) + 스프링 스케일 팝(본가 진화 신 오마주). shiny 부화는
  ✨ 버스트 추가.
- 부화 임박(진행 90%+): 알 흔들림(±5° wiggle) + "곧 부화해요!" 문구 전환.

### 하위호환
- `MonState`/`DexEntry` 커스텀 `init(from:)` — 구버전 companion-state.json 의 누락 키를
  기본값(false/nil)으로 디코딩. 기존 사용자 저장 무손상.

## 검증

| 항목 | 결과 |
|---|---|
| 신규 테스트 7종 (`CompanionIdentityTests`) | 통과 — 결정적 롤 재생, shiny 경로 도달, 도감 이월, 구버전 디코딩+라운드트립, 연출 시퀀스, 캐시 키, 성격 25종×3언어 완결성 |
| test-gate (전체 115 테스트 + 커버리지) | 통과 — 로직 코어 77.74% ≥ 70% |
| PokéAPI shiny 자산 | HTTP 200 확인 (5/25 정적·애니메이션) |
| **실기기 E2E** | 상태를 shiny 로 마킹 후 실행 → 메뉴바에 보라색 shiny Lapras 렌더 + `131-sha.gif` 캐시 생성 확인, 원상 복원 완료 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
