### PR TITLE
fix: 딥리뷰 확정 결함 3건 — 델타 유실(HIGH)·shiny 버스트(HIGH)·오프라인 폴백

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -157,9 +157,12 @@ final class CompanionStore {
     }
 
     /// 토큰 증분을 현재 포켓몬에 적용 — 임계 도달 시 진화/졸업.
+    /// 라인 미로딩(재시작 직후·오프라인)이어도 사용량은 항상 적립한다 — 여기서 드롭하면
+    /// claimedTodayTokens 는 이미 전진해 델타가 영구 유실된다. 진화 판정만 라인 로드 후로 미룬다.
     func applyUsage(_ delta: Int) {
-        guard state.active != nil, let line = currentLine else { return }
+        guard state.active != nil else { return }
         state.active!.usedAtStage += delta
+        guard let line = currentLine else { save(); return }
         var guardCount = 0
         while state.active != nil, guardCount < 50 {
             guardCount += 1
@@ -248,8 +251,10 @@ final class CompanionStore {
                              isShiny ? l.notifShinyHatchBody(name) : l.notifHatchBody(name))
         displayState = .levelUp
         eventUntil = clock().addingTimeInterval(4)
-        fireCelebration(.hatch(shiny: isShiny))
         if overflow > 0 { applyUsage(overflow) }   // 이월분 즉시 반영(필요 시 진화까지)
+        // 연출은 이월 진화 뒤에 발화 — 이월 evolve 가 shiny 부화 버스트를 덮지 않도록
+        // 마지막 이벤트를 hatch 로 유지한다. 이월로 즉시 졸업한 극단 케이스면 생략(이미 도감행).
+        if state.active != nil { fireCelebration(.hatch(shiny: isShiny)) }
         save()
     }
 
@@ -257,7 +262,10 @@ final class CompanionStore {
         guard let a = state.active, currentLine == nil, !isHatching else { return }
         isHatching = true
         defer { isHatching = false }
-        if let line = try? await provider.line(baseSpeciesID: a.baseID) { currentLine = line }
+        if let line = try? await provider.line(baseSpeciesID: a.baseID) {
+            currentLine = line
+            applyUsage(0)   // 라인 미로딩 동안 적립된 사용량이 임계를 넘었으면 지금 진화 판정
+        }
     }
 
     private func chooseBase() -> Int {

--- a/Sources/PokeTokenBar/UI/SpriteLoader.swift
+++ b/Sources/PokeTokenBar/UI/SpriteLoader.swift
@@ -47,12 +47,14 @@ enum SpriteLoader {
     }()
 
     /// 디스크 캐시에 이미 있으면 동기 반환(네트워크 없음). 없으면 nil.
+    /// shiny 캐시 미스는 일반 캐시로 폴백 — 오프라인에서 live mon 이 알 글리프로 보이는 것 방지.
     static func cachedImage(speciesID: Int, animated: Bool = false, shiny: Bool = false) -> NSImage? {
         let ext = animated ? "gif" : "png"
         let key = SpriteStore.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny)
         let f = cacheDir.appendingPathComponent("\(key).\(ext)")
-        guard let d = try? Data(contentsOf: f) else { return nil }
-        return NSImage(data: d)
+        if let d = try? Data(contentsOf: f), let img = NSImage(data: d) { return img }
+        guard shiny else { return nil }
+        return cachedImage(speciesID: speciesID, animated: animated, shiny: false)
     }
 
     /// 정적 스프라이트. animated=true 면 Gen-V 움직이는 스프라이트(없으면 정적으로 폴백).

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -400,6 +400,67 @@ final class CompanionIdentityTests: XCTestCase {
         XCTAssertEqual(s.celebration, .evolve)
     }
 
+    /// [회귀] 라인 미로딩(재시작 직후/오프라인) 중 델타가 유실되지 않고 적립, 라인 로드 후 진화 판정.
+    func testUsageAccruesWhileLineUnloadedThenEvolvesOnLoad() async {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
+        // 1차 스토어: 부화 후 저장
+        let s1 = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow },
+                                fileURL: url, rng: SeededRNG(seed: 5))
+        s1.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        await s1.hatch(baseID: 1)
+        XCTAssertNotNil(s1.state.active)
+
+        // 2차 스토어(재시작 시뮬레이션): active 는 로드됐지만 currentLine 은 nil
+        let s2 = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow },
+                                fileURL: url, rng: SeededRNG(seed: 5))
+        XCTAssertNotNil(s2.state.active)
+        XCTAssertNil(s2.currentLine)
+        // 라인 없는 상태에서 stage0 임계(125M) 초과 델타 → 유실 없이 적립, 진화는 보류
+        s2.applyUsage(300_000_000)
+        XCTAssertEqual(s2.state.active?.usedAtStage, 300_000_000, "라인 미로딩 중 델타가 유실되면 안 된다")
+        XCTAssertEqual(s2.state.active?.stageIndex, 0)
+        // update → loadCurrentLine 완료 시 적립분으로 진화 판정(드레인)
+        s2.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        for _ in 0..<50 where s2.currentLine == nil { await Task.yield() }
+        XCTAssertNotNil(s2.currentLine)
+        XCTAssertEqual(s2.state.active?.stageIndex, 1, "라인 로드 후 적립분으로 진화해야 한다")
+        XCTAssertEqual(s2.state.active?.usedAtStage, 300_000_000 - 125_000_000)   // 초과분 이월
+    }
+
+    /// [회귀] 부화 이월(overflow)로 즉시 진화해도 마지막 연출은 hatch(shiny) — evolve 가 버스트를 덮지 않는다.
+    func testShinyBurstSurvivesOverflowEvolve() async {
+        // hatchIfNeeded 경로: chooseBase(1) → shiny(2) → nature(3) 순 rng 소비. shiny 시드 탐색.
+        func rollsShinyViaHatchIfNeeded(_ seed: UInt64) -> Bool {
+            var r = SeededRNG(seed: seed)
+            _ = r.next()   // chooseBase
+            return r.next() % PokemonOdds.shinyDenominator == 0
+        }
+        var seed: UInt64?
+        for s: UInt64 in 0..<20000 where rollsShinyViaHatchIfNeeded(s) { seed = s; break }
+        guard let seed else { return XCTFail("shiny 시드 탐색 실패") }
+
+        let s = store(linear3, seed: seed)
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        // 알 임계(5M) + stage0 임계(125M) 초과 → 부화 즉시 1회 진화하는 이월
+        s.update(todayTokens: 135_000_000, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        await s.hatchIfNeeded()
+        XCTAssertEqual(s.state.active?.isShiny, true)
+        XCTAssertEqual(s.state.active?.stageIndex, 1, "이월로 1회 진화했어야 함")
+        XCTAssertEqual(s.celebration, .hatch(shiny: true), "evolve 가 shiny 부화 버스트를 덮으면 안 된다")
+    }
+
+    /// [회귀] 이월이 졸업 총량을 넘어 부화 즉시 졸업한 극단 케이스 — hatch 연출은 생략(이미 도감행).
+    func testHatchCelebrationSkippedOnInstantGraduate() async {
+        let s = store(noEvo, seed: 11)
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        // 알 임계 + 졸업 총량(750M) 초과
+        s.update(todayTokens: 800_000_000, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        await s.hatchIfNeeded()
+        XCTAssertNil(s.state.active, "즉시 졸업")
+        XCTAssertEqual(s.state.dex.count, 1)
+        XCTAssertNil(s.celebration, "떠난 mon 의 hatch 연출을 재생하면 안 된다")
+    }
+
     /// 스프라이트 캐시 키 — 기존 키("25-a"/"25-s") 불변 + shiny 접두.
     func testSpriteCacheKeyScheme() {
         XCTAssertEqual(SpriteStore.cacheKey(speciesID: 25, animated: true, shiny: false), "25-a")


### PR DESCRIPTION
## 배경

v2.2.0(PR #32) 딥리뷰 2회(정합성/동시성 렌즈 + 상태머신/UX 렌즈)에서 확정된 기능 결함 패치.

## 발견 → 패치

| 심각도 | 발견 | 패치 |
|---|---|---|
| **HIGH** | **콜드스타트 델타 유실** — 재시작 후 `currentLine` 로드 전 창(오프라인이면 무한)에 도착한 델타가 `applyUsage` guard 에서 드롭. `claimedTodayTokens` 는 이미 전진해 영구 유실 | 사용량은 라인 유무와 무관하게 `usedAtStage` 에 항상 적립, 진화 판정만 연기. `loadCurrentLine` 완료 시 `applyUsage(0)` 드레인으로 임계 초과분 즉시 진화 |
| **HIGH** | **shiny 버스트 클로버** — 부화 이월이 stage0 임계(125M)를 넘으면 `.evolve` 연출이 `.hatch(shiny:)` 를 덮어 1/64 의 ✨ 버스트가 소실 | 연출 발화를 이월 적용 뒤로 재배치 — 마지막 이벤트가 항상 hatch. 이월로 즉시 졸업(750M+)한 극단 케이스는 생략(이미 도감행) |
| **MEDIUM** | **오프라인 알 글리프** — shiny 정적 미캐시 + 오프라인이면 live mon 이 메뉴바/홈에서 🥚 로 표시 | `cachedImage` shiny 미스 → 일반 캐시 폴백 |

리뷰어가 제기한 "연출 재생이 @State teardown 에 의존(never-play)" 주장은 **반박 검증** — 재생 완료 시 `consumeCelebration()` 이 store 의 `celebration` 을 nil 로 만들어 가드 첫 조건이 store 상태를 진실로 삼는다. seenSeq 가 보존되든 리셋되든 미재생 이벤트는 항상 `celebration != nil` 로 도달, 재생된 이벤트는 nil 로 차단. 수정 불필요.

## 검증

- 회귀 테스트 3종: 라인 미로딩 적립+로드 후 진화 드레인 / 이월 진화에도 `.hatch(shiny: true)` 최종 / 즉시 졸업 시 연출 생략 — 전부 통과.
- 전체 test-gate 118 테스트 + 커버리지 78.61% ≥ 70%.
- 부화 풀 17종 shiny 자산(정적+애니메이션) HTTP 200 전수 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
