### PR TITLE
chore: 가드레일 감사 — 보안 하드닝·테스트 격리·커버리지 75% 게이트·E2E 스모크

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,17 @@ PTB_NOTES_FILE=/tmp/notes.md ./scripts/release.sh 2.1.1
 
 검토만 하려면: `./scripts/release.sh --check-only`
 
+## E2E 스모크 (선택 — GUI 세션 필요)
+
+```bash
+./scripts/e2e.sh
+```
+
+실제 앱 번들로 빌드→기동→데이터 파이프라인(스냅샷 갱신·구조 검증·AppLog)→메뉴바
+status item(AX)→팝오버 오픈(AXPress)까지 7개 체크. 5단계는 터미널에 손쉬운 사용
+(Accessibility) 권한 필요 — 미허용이면 해당 단계만 SKIP. release.sh 에 포함하지 않는
+이유: GUI 세션·권한 의존이라 헤드리스 실행이 깨질 수 있음. 릴리스 전 수동 1회 권장.
+
 ## 문서 검토 체크리스트 (내용 변경 시)
 
 `release.sh` 2단계가 출력하는 것 — **기능/동작이 바뀐 릴리스면 반드시 갱신**:

--- a/Sources/PokeTokenBar/Core/BinaryLocator.swift
+++ b/Sources/PokeTokenBar/Core/BinaryLocator.swift
@@ -65,7 +65,8 @@ enum BinaryLocator {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shell)
-        process.arguments = ["-ilc", "printf '<<<BIN:%s:BIN>>>' \"$(command -v \(binary) 2>/dev/null)\""]
+        // binary 를 위치 인자($1)로 전달 — 문자열 보간 금지(향후 호출자가 외부 입력을 넘겨도 주입 불가).
+        process.arguments = ["-ilc", #"printf '<<<BIN:%s:BIN>>>' "$(command -v "$1" 2>/dev/null)""#, "sh", binary]
         process.standardInput = FileHandle.nullDevice
         let output = Pipe()
         process.standardOutput = output

--- a/Sources/PokeTokenBar/Core/KeychainAccess.swift
+++ b/Sources/PokeTokenBar/Core/KeychainAccess.swift
@@ -6,12 +6,12 @@ import LocalAuthentication
 import Security
 
 enum KeychainAccessGate {
-    private static let defaultsKey = "disableKeychainAccess"
-
-    static var isDisabled: Bool {
-        get { UserDefaults.standard.bool(forKey: defaultsKey) }
-        set { UserDefaults.standard.set(newValue, forKey: defaultsKey) }
-    }
+    /// 프로세스 전역 게이트(메모리) — 기동 시 저장값으로 1회 시드하고, 영속은
+    /// UsageStore.disableKeychainAccess(didSet)가 전담한다. UserDefaults.standard 에
+    /// 직접 쓰던 이전 구현은 테스트 실행이 실제 사용자 설정을 오염시켰다.
+    /// (Bool 단일 플래그 — MainActor 쓰기/actor 읽기의 경합은 무해)
+    nonisolated(unsafe) static var isDisabled: Bool =
+        UserDefaults.standard.bool(forKey: "disableKeychainAccess")
 }
 
 enum KeychainNoUIQuery {

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -17,7 +17,21 @@ actor LocalUsageCache {
     private var dirty = false
     private var lastSave: Date?
 
-    private static let fileURL: URL = {
+    // 테스트 시임 — 기본값은 실환경(실 로그 루트·Application Support·실시간).
+    private let claudeRoot: URL?
+    private let codexRoot: URL?
+    private let fileURL: URL
+    private let now: @Sendable () -> Date
+
+    init(claudeRoot: URL? = nil, codexRoot: URL? = nil, fileURL: URL? = nil,
+         now: @escaping @Sendable () -> Date = Date.init) {
+        self.claudeRoot = claudeRoot
+        self.codexRoot = codexRoot
+        self.fileURL = fileURL ?? Self.defaultFileURL
+        self.now = now
+    }
+
+    private static let defaultFileURL: URL = {
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("PokeTokenBar")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -27,7 +41,7 @@ actor LocalUsageCache {
     func claudeEntries(modifiedSince: Date) -> [LocalUsageReader.Entry] {
         ensureLoaded()
         let fmt = LocalUsageReader.localDayFormatter()
-        let all = collect(root: LocalUsageReader.claudeProjectsDir, since: modifiedSince, cache: &claudeCache) {
+        let all = collect(root: claudeRoot ?? LocalUsageReader.claudeProjectsDir, since: modifiedSince, cache: &claudeCache) {
             LocalUsageReader.parseClaudeFile($0, fmt: fmt)
         }
         saveIfNeeded()
@@ -37,7 +51,7 @@ actor LocalUsageCache {
     func codexEntries(modifiedSince: Date) -> [LocalUsageReader.Entry] {
         ensureLoaded()
         let fmt = LocalUsageReader.localDayFormatter()
-        let r = collect(root: LocalUsageReader.codexSessionsDir, since: modifiedSince, cache: &codexCache) {
+        let r = collect(root: codexRoot ?? LocalUsageReader.codexSessionsDir, since: modifiedSince, cache: &codexCache) {
             LocalUsageReader.parseCodexFile($0, fmt: fmt)
         }
         saveIfNeeded()
@@ -75,7 +89,7 @@ actor LocalUsageCache {
     private func ensureLoaded() {
         guard !loaded else { return }
         loaded = true
-        guard let data = try? Data(contentsOf: Self.fileURL),
+        guard let data = try? Data(contentsOf: fileURL),
               let snap = try? JSONDecoder().decode(Snapshot.self, from: data) else { return }
         claudeCache = snap.claude
         codexCache = snap.codex
@@ -84,7 +98,7 @@ actor LocalUsageCache {
     /// 어떤 조회 윈도우(오늘/주/월)에도 들지 않는 오래된 파일 blob 을 제거해 캐시 무한 증가를 막는다.
     /// (가장 넓은 윈도우는 월·주 시작이라 40일이면 충분한 여유. 삭제된 세션 파일 blob 도 함께 정리.)
     private func prune() {
-        let cutoff = Date().addingTimeInterval(-40 * 86400)
+        let cutoff = now().addingTimeInterval(-40 * 86400)
         claudeCache = claudeCache.filter { $0.value.mtime >= cutoff }
         codexCache = codexCache.filter { $0.value.mtime >= cutoff }
     }
@@ -92,13 +106,13 @@ actor LocalUsageCache {
     /// 변경이 있으면 디스크에 저장(최소 60초 간격으로 throttle — 잦은 쓰기 방지).
     private func saveIfNeeded() {
         guard dirty else { return }
-        if let last = lastSave, Date().timeIntervalSince(last) < 60 { return }
+        if let last = lastSave, now().timeIntervalSince(last) < 60 { return }
         prune()
         let snap = Snapshot(claude: claudeCache, codex: codexCache)
         if let data = try? JSONEncoder().encode(snap) {
-            try? data.write(to: Self.fileURL)
+            try? data.write(to: fileURL)
             dirty = false
-            lastSave = Date()
+            lastSave = now()
         }
     }
 }

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -16,7 +16,9 @@ actor PokeAPIClient: PokeProviding {
     func line(baseSpeciesID: Int) async throws -> EvoLine {
         let baseSpecies = try await species(baseSpeciesID)
         // PokéAPI 응답의 URL — 비정상/빈 값이면 force-unwrap 대신 throw(앱은 알 상태 유지).
-        guard let chainURL = URL(string: baseSpecies.evolution_chain.url) else {
+        // 서버 제어 문자열이므로 https + pokeapi.co 로 고정(응답 변조 시 임의 호스트 fetch 방지).
+        guard let chainURL = URL(string: baseSpecies.evolution_chain.url),
+              chainURL.scheme == "https", chainURL.host == "pokeapi.co" else {
             throw URLError(.badURL)
         }
         let chainDTO: ChainDTO = try await get(chainURL)

--- a/Sources/PokeTokenBar/Core/UpdateChecker.swift
+++ b/Sources/PokeTokenBar/Core/UpdateChecker.swift
@@ -34,7 +34,10 @@ final class UpdateChecker {
               (resp as? HTTPURLResponse)?.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let tag = json["tag_name"] as? String,
-              let html = json["html_url"] as? String else { return }
+              let html = json["html_url"] as? String,
+              // 응답 필드가 NSWorkspace.open 으로 가므로 https + github.com 만 허용(스킴 하이재킹 방지)
+              let htmlURL = URL(string: html), htmlURL.scheme == "https", htmlURL.host == "github.com"
+        else { return }
         let latest = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
         let skipped = UserDefaults.standard.string(forKey: "skippedUpdateVersion")
         if Self.isNewer(latest, than: currentVersion), latest != skipped {

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -28,35 +28,36 @@ final class UsageStore {
     /// 0 = manual
     var refreshInterval: TimeInterval {
         didSet {
-            UserDefaults.standard.set(refreshInterval, forKey: "refreshInterval")
+            defaults.set(refreshInterval, forKey: "refreshInterval")
             reschedule()
         }
     }
     var warnThreshold: Double {
-        didSet { UserDefaults.standard.set(warnThreshold, forKey: "warnThreshold") }
+        didSet { defaults.set(warnThreshold, forKey: "warnThreshold") }
     }
     var critThreshold: Double {
-        didSet { UserDefaults.standard.set(critThreshold, forKey: "critThreshold") }
+        didSet { defaults.set(critThreshold, forKey: "critThreshold") }
     }
     // 메뉴바 표시 항목 (복수 선택 가능)
     var showTokensInMenu: Bool {
-        didSet { UserDefaults.standard.set(showTokensInMenu, forKey: "showTokensInMenu") }
+        didSet { defaults.set(showTokensInMenu, forKey: "showTokensInMenu") }
     }
     var showCostInMenu: Bool {
-        didSet { UserDefaults.standard.set(showCostInMenu, forKey: "showCostInMenu") }
+        didSet { defaults.set(showCostInMenu, forKey: "showCostInMenu") }
     }
     var showLimitInMenu: Bool {
-        didSet { UserDefaults.standard.set(showLimitInMenu, forKey: "showLimitInMenu") }
+        didSet { defaults.set(showLimitInMenu, forKey: "showLimitInMenu") }
     }
     // 알림(독립 토글)
     var limitNotifications: Bool {
-        didSet { UserDefaults.standard.set(limitNotifications, forKey: "limitNotifications") }
+        didSet { defaults.set(limitNotifications, forKey: "limitNotifications") }
     }
     var companionNotifications: Bool {
-        didSet { UserDefaults.standard.set(companionNotifications, forKey: "companionNotifications") }
+        didSet { defaults.set(companionNotifications, forKey: "companionNotifications") }
     }
     var disableKeychainAccess: Bool {
         didSet {
+            defaults.set(disableKeychainAccess, forKey: "disableKeychainAccess")   // 저장 누락이던 기존 버그 — 재시작 후 풀렸음
             KeychainAccessGate.isDisabled = disableKeychainAccess
             if disableKeychainAccess {
                 limits = nil
@@ -78,6 +79,8 @@ final class UsageStore {
     private let providers: [any UsageProvider]
     private let limitsProvider: any ClaudeLimitsProviding
     private let codexLimitsProvider: any CodexLimitsProviding
+    /// 설정 저장소 — 테스트는 suite 를 주입해 실제 사용자 설정을 오염시키지 않는다.
+    private let defaults: UserDefaults
     private var timer: Timer?
     private var pollingSuspended = false   // 디스플레이 꺼짐 동안 폴링 정지 (배터리)
     private var emptyUsageRetryTask: Task<Void, Never>?
@@ -193,11 +196,13 @@ final class UsageStore {
     init(providers: [any UsageProvider] = [LocalClaudeProvider(), LocalCodexProvider()],
          claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),
-         autoRefresh: Bool = true) {
+         autoRefresh: Bool = true,
+         defaults: UserDefaults = .standard) {
         self.providers = providers
         self.limitsProvider = claudeLimitsProvider
         self.codexLimitsProvider = codexLimitsProvider
-        let d = UserDefaults.standard
+        self.defaults = defaults
+        let d = defaults
         refreshInterval = d.object(forKey: "refreshInterval") as? TimeInterval ?? 120
         warnThreshold = d.object(forKey: "warnThreshold") as? Double ?? 80
         critThreshold = d.object(forKey: "critThreshold") as? Double ?? 95
@@ -529,6 +534,8 @@ final class UsageStore {
     // MARK: parity-check.sh 용 스냅샷 파일
 
     private func writeParitySnapshot() {
+        // .app 번들에서만 기록 — 테스트가 실제 사용자 데이터 디렉토리의 스냅샷을 덮어쓰지 않도록.
+        guard Bundle.main.bundlePath.hasSuffix(".app") else { return }
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("PokeTokenBar")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// LocalUsageCache — 파일별 증분 캐시의 핵심 계약을 픽스처 디렉토리로 검증.
+/// (재사용/재파싱 판정, 디스크 영속·라운드트립, 40일 prune, 60초 저장 throttle)
+final class LocalUsageCacheTests: XCTestCase {
+    private var root: URL!
+    private var cacheFile: URL!
+
+    override func setUpWithError() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ptb-cache-\(UUID().uuidString)")
+        root = base.appendingPathComponent("projects")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        cacheFile = base.appendingPathComponent("usage-cache.json")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: root.deletingLastPathComponent())
+    }
+
+    /// Claude 로그 한 줄(assistant + usage) 픽스처.
+    private func claudeLine(id: String, output: Int, ts: String = "2026-07-02T01:00:00.000Z") -> String {
+        """
+        {"type":"assistant","requestId":"r-\(id)","timestamp":"\(ts)","message":{"id":"m-\(id)","model":"claude-opus-4-8","usage":{"input_tokens":10,"output_tokens":\(output),"cache_creation_input_tokens":5,"cache_read_input_tokens":100}}}
+        """
+    }
+
+    @discardableResult
+    private func writeFile(_ name: String, lines: [String], mtime: Date? = nil) throws -> URL {
+        let url = root.appendingPathComponent(name)
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        if let mtime {
+            try FileManager.default.setAttributes([.modificationDate: mtime], ofItemAtPath: url.path)
+        }
+        return url
+    }
+
+    private func makeCache(now: @escaping @Sendable () -> Date = Date.init) -> LocalUsageCache {
+        LocalUsageCache(claudeRoot: root, codexRoot: root, fileURL: cacheFile, now: now)
+    }
+
+    private let since = Date(timeIntervalSince1970: 0)
+
+    /// mtime·size 불변이면 재파싱하지 않는다 — 내용을 몰래 바꿔도(같은 길이+같은 mtime) 캐시 값이 나온다.
+    /// mtime 은 정수 초로 고정 — 서브초 정밀도가 attributesOfItem/resourceValues 간 달라 비교가 깨지는 것 방지.
+    func testUnchangedFileIsNotReparsed() async throws {
+        let t = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970) - 3600)
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 111)], mtime: t)
+
+        let cache = makeCache()
+        let first = await cache.claudeEntries(modifiedSince: since)
+        XCTAssertEqual(first.map(\.output), [111])
+
+        // 같은 길이(111→222)·같은 mtime 으로 내용만 교체 → 캐시 히트라면 여전히 111
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 222)], mtime: t)
+        let second = await cache.claudeEntries(modifiedSince: since)
+        XCTAssertEqual(second.map(\.output), [111], "mtime/size 불변이면 재파싱하면 안 된다")
+    }
+
+    /// mtime 이 바뀌면 재파싱한다.
+    func testChangedFileIsReparsed() async throws {
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 111)])
+        let cache = makeCache()
+        _ = await cache.claudeEntries(modifiedSince: since)
+
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 999)],
+                      mtime: Date().addingTimeInterval(10))
+        let second = await cache.claudeEntries(modifiedSince: since)
+        XCTAssertEqual(second.map(\.output), [999])
+    }
+
+    /// 디스크 영속: 새 인스턴스(콜드 스타트 시뮬레이션)가 스냅샷을 로드해 같은 결과를 낸다.
+    func testDiskRoundTripAcrossInstances() async throws {
+        let t = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970) - 3600)
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 42)], mtime: t)
+        let c1 = makeCache()
+        _ = await c1.claudeEntries(modifiedSince: since)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile.path), "스냅샷이 저장돼야 한다")
+
+        // 내용을 몰래 바꿔도(길이·mtime 동일) 새 인스턴스가 디스크 캐시를 쓰면 42 유지
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 43)], mtime: t)
+        let c2 = makeCache()
+        let entries = await c2.claudeEntries(modifiedSince: since)
+        XCTAssertEqual(entries.map(\.output), [42], "새 인스턴스가 디스크 스냅샷을 재사용해야 한다")
+    }
+
+    /// 40일보다 오래된 blob 은 저장 시 prune 되어 스냅샷에서 빠진다.
+    func testPruneDropsBlobsOlderThan40Days() async throws {
+        let old = Date().addingTimeInterval(-45 * 86400)
+        try writeFile("old.jsonl", lines: [claudeLine(id: "o", output: 1)], mtime: old)
+        try writeFile("new.jsonl", lines: [claudeLine(id: "n", output: 2)])
+
+        let cache = makeCache()
+        let entries = await cache.claudeEntries(modifiedSince: since)
+        XCTAssertEqual(Set(entries.map(\.output)), [1, 2], "조회 자체는 둘 다 반환")
+
+        let snap = try String(contentsOf: cacheFile, encoding: .utf8)
+        XCTAssertFalse(snap.contains("old.jsonl"), "45일 지난 blob 은 스냅샷에서 prune")
+        XCTAssertTrue(snap.contains("new.jsonl"))
+    }
+
+    /// 저장 throttle: 60초 내 재저장은 생략, 60초 경과 후 저장된다 (주입 clock 으로 결정적).
+    func testSaveThrottle60s() async throws {
+        nonisolated(unsafe) var fakeNow = Date(timeIntervalSince1970: 1_700_000_000)
+        let cache = makeCache(now: { fakeNow })
+
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 1)], mtime: fakeNow)
+        _ = await cache.claudeEntries(modifiedSince: since)   // 첫 저장
+        let firstSnap = try Data(contentsOf: cacheFile)
+
+        // 30초 뒤 파일 변경 → dirty 지만 throttle 로 저장 생략
+        fakeNow = fakeNow.addingTimeInterval(30)
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 2)], mtime: fakeNow)
+        _ = await cache.claudeEntries(modifiedSince: since)
+        XCTAssertEqual(try Data(contentsOf: cacheFile), firstSnap, "60초 내 재저장은 생략")
+
+        // 61초 경과 → 저장됨
+        fakeNow = fakeNow.addingTimeInterval(61)
+        _ = await cache.claudeEntries(modifiedSince: since)
+        XCTAssertNotEqual(try Data(contentsOf: cacheFile), firstSnap, "throttle 해제 후 저장")
+    }
+
+    /// modifiedSince 이전 파일은 아예 수집하지 않는다.
+    func testModifiedSinceFilters() async throws {
+        try writeFile("old.jsonl", lines: [claudeLine(id: "o", output: 1)],
+                      mtime: Date().addingTimeInterval(-10 * 86400))
+        try writeFile("new.jsonl", lines: [claudeLine(id: "n", output: 2)])
+        let cache = makeCache()
+        let entries = await cache.claudeEntries(modifiedSince: Date().addingTimeInterval(-86400))
+        XCTAssertEqual(entries.map(\.output), [2])
+    }
+
+    /// 포매터 — grouped/cost/costCompact 경계값(메뉴바·팝오버 표기 계약).
+    func testFormatterEdges() {
+        XCTAssertEqual(TokenFormatter.grouped(253_412_890), "253,412,890")
+        XCTAssertEqual(TokenFormatter.cost(48.104), "$48.10")
+        XCTAssertEqual(TokenFormatter.costCompact(9.54), "$9.5")     // < 100 → 소수 1자리
+        XCTAssertEqual(TokenFormatter.costCompact(311.4), "$311")    // < 10K → 정수
+        XCTAssertEqual(TokenFormatter.costCompact(12_340), "$12.3K") // ≥ 10K → K
+        XCTAssertEqual(TokenFormatter.percent(88), "88%")
+        XCTAssertEqual(TokenFormatter.percent(88.35), "88.3%")
+    }
+
+    /// 날짜 유틸 — 주/월 경계와 monthKey (집계 윈도우 계산의 기반).
+    func testDateHelpers() {
+        var c = Calendar.current
+        c.timeZone = .current
+        let d = c.date(from: DateComponents(year: 2026, month: 7, day: 2, hour: 15))!
+        let som = LocalUsageReader.startOfMonth(d)
+        XCTAssertEqual(c.dateComponents([.year, .month, .day], from: som).day, 1)
+        XCTAssertEqual(c.dateComponents([.month], from: som).month, 7)
+        let sow = LocalUsageReader.startOfWeek(d)
+        XCTAssertLessThanOrEqual(sow, d)
+        XCTAssertLessThan(d.timeIntervalSince(sow), 7 * 86400)
+        XCTAssertEqual(LocalUsageReader.monthKey(d), "2026-07")
+    }
+
+    /// Codex 파싱 경로 + 세션 모델 감지(turn_context.model) — cacheRead=cached, input=총-캐시.
+    func testCodexEntriesParseModelAndCachedInput() async throws {
+        let lines = [
+            #"{"timestamp":"2026-07-02T01:00:00.000Z","payload":{"type":"turn_context","model":"gpt-5.5-codex"}}"#,
+            #"{"timestamp":"2026-07-02T01:01:00.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":7}}}}"#,
+        ]
+        try writeFile("rollout-1.jsonl", lines: lines)
+        let cache = makeCache()
+        let entries = await cache.codexEntries(modifiedSince: since)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].model, "gpt-5.5-codex")
+        XCTAssertEqual(entries[0].input, 20)      // 100 - 80
+        XCTAssertEqual(entries[0].cacheRead, 80)
+        XCTAssertEqual(entries[0].output, 7)
+        XCTAssertEqual(entries[0].cacheWrite, 0)
+    }
+}

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -73,15 +73,20 @@ private func codexLimits(primaryUsed: Int? = nil, secondaryUsed: Int? = nil) -> 
 
 @MainActor
 final class UsageStoreTests: XCTestCase {
+    /// 테스트 전용 defaults suite — 실제 사용자 설정(UserDefaults.standard)을 절대 건드리지 않는다.
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+
     override func setUp() {
         super.setUp()
-        // 기본값으로 시작하도록 관련 UserDefaults 키 정리 (테스트 간 오염 방지)
-        for key in ["refreshInterval", "warnThreshold", "critThreshold",
-                    "showTokensInMenu", "showCostInMenu", "showLimitInMenu",
-                    "limitNotifications", "companionNotifications", "disableKeychainAccess"] {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
+        suiteName = "ptb-test-\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)
         KeychainAccessGate.isDisabled = false
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
     }
 
     private func makeStore(
@@ -92,7 +97,8 @@ final class UsageStoreTests: XCTestCase {
         UsageStore(providers: providers,
                    claudeLimitsProvider: FakeClaudeLimits(status: claude),
                    codexLimitsProvider: FakeCodexLimits(status: codex),
-                   autoRefresh: false)
+                   autoRefresh: false,
+                   defaults: testDefaults)
     }
 
     // MARK: 집계

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# e2e.sh — 실제 앱 번들 스모크 E2E (1인 로컬 GUI 세션용).
+#
+# 검증 단계:
+#   1) 빌드 + /Applications 설치   2) 기동(프로세스 생존)
+#   3) 데이터 파이프라인 — last-snapshot.json 이 이번 세션에서 갱신되고 구조/값이 유효
+#   4) 메뉴바 status item — window server 에 앱 소유 status-bar 레이어 윈도우 존재
+#   5) 팝오버 오픈 — Accessibility 권한 있으면 클릭→윈도우 출현 확인(없으면 SKIP)
+#
+# XCUITest 미채택 근거: SwiftPM 단독 레포에 Xcode 프로젝트/테스트 번들 도입 필요 — 1인 로컬 over-spec.
+# 사용:  ./scripts/e2e.sh          (GUI 세션에서 실행. 5단계는 터미널에 손쉬운 사용 권한 필요)
+#
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+APP="/Applications/PokeTokenBar.app"
+LOG="$HOME/Library/Logs/PokeTokenBar.log"
+SNAP="$HOME/Library/Application Support/PokeTokenBar/last-snapshot.json"
+PASS=0; FAIL=0; SKIP=0
+ok()   { echo "  ✓ $1"; PASS=$((PASS+1)); }
+bad()  { echo "  ✗ $1"; FAIL=$((FAIL+1)); }
+skip() { echo "  – SKIP: $1"; SKIP=$((SKIP+1)); }
+
+echo "▶ 1/5 빌드 + 설치"
+if ./scripts/build-app.sh >/tmp/ptb-e2e-build.log 2>&1; then ok "build-app.sh"; else bad "빌드 실패 (/tmp/ptb-e2e-build.log)"; exit 1; fi
+
+echo "▶ 2/5 기동"
+MARK=$(date +%s)
+open "$APP" || sleep 2 && open "$APP" 2>/dev/null   # LaunchServices -600 재시도
+sleep 2
+if pgrep -x PokeTokenBar >/dev/null; then ok "프로세스 생존 (pid $(pgrep -x PokeTokenBar))"; else bad "프로세스 없음"; exit 1; fi
+
+echo "▶ 3/5 데이터 파이프라인 (스냅샷 갱신 대기, 최대 90s)"
+found=""
+for _ in $(seq 1 45); do
+  if [[ -f "$SNAP" && $(stat -f %m "$SNAP") -ge "$MARK" ]]; then found=1; break; fi
+  sleep 2
+done
+if [[ -n "$found" ]]; then ok "last-snapshot.json 이번 세션에 갱신"; else bad "스냅샷 90s 내 미갱신"; fi
+if python3 - "$SNAP" <<'PY'
+import json, sys
+s = json.load(open(sys.argv[1]))
+assert isinstance(s["todayTotalTokens"], int) and s["todayTotalTokens"] >= 0
+assert isinstance(s["providers"], list)
+assert s.get("lastError", "") == "", f"lastError: {s['lastError']}"
+print(f"    today={s['todayTotalTokens']:,} providers={[p['id'] for p in s['providers']]}")
+PY
+then ok "스냅샷 구조·값 유효 + lastError 없음"; else bad "스냅샷 구조/에러 검증 실패"; fi
+if tail -n 100 "$LOG" 2>/dev/null | grep -q "phase1 done"; then ok "AppLog phase1 done"; else bad "AppLog 에 phase1 done 없음"; fi
+
+echo "▶ 4/5 메뉴바 status item (window server)"
+cat > /tmp/ptb-e2e-win.swift <<'SWIFT'
+import CoreGraphics
+let list = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] ?? []
+var status = 0, tall = 0
+for w in list where (w[kCGWindowOwnerName as String] as? String) == "PokeTokenBar" {
+    let layer = w[kCGWindowLayer as String] as? Int ?? 0
+    let bounds = w[kCGWindowBounds as String] as? [String: Any]
+    let h = bounds?["Height"] as? Double ?? 0
+    if layer == 25 { status += 1 }          // NSStatusWindowLevel
+    if h > 200 { tall += 1 }                 // 팝오버 등 본문 윈도우
+}
+print("STATUS=\(status) TALL=\(tall)")
+SWIFT
+# 사전 컴파일 — swift 인터프리터 콜드 스타트(수 초)가 타이밍 검증을 깨지 않도록.
+swiftc -O -o /tmp/ptb-e2e-win /tmp/ptb-e2e-win.swift 2>/dev/null
+winprobe() { /tmp/ptb-e2e-win 2>/dev/null; }
+# 1차: AX 로 status item 존재 확인(결정적). AX 미허용이면 window server 폴백
+# (주의: status 윈도우는 앱 최초 활성화 전 CGWindowList 에 안 잡힐 수 있음 — 관측된 macOS 동작).
+AXCNT=$(osascript -e 'tell application "System Events" to tell process "PokeTokenBar" to get count of menu bar items of menu bar 2' 2>/dev/null)
+if [[ "${AXCNT:-}" =~ ^[0-9]+$ ]]; then
+  if [[ "$AXCNT" -ge 1 ]]; then ok "status item 존재 (AX, count=$AXCNT)"; else bad "status item 없음 (AX count=0)"; fi
+else
+  W=$(winprobe); STATUS=$(echo "$W" | grep -oE 'STATUS=[0-9]+' | cut -d= -f2)
+  if [[ "${STATUS:-0}" -ge 1 ]]; then ok "status item 윈도우 존재 ($W)"
+  else skip "AX 미허용 + 활성화 전 윈도우 미등록 — 손쉬운 사용 권한 부여 시 결정적 검증"; fi
+fi
+
+echo "▶ 5/5 팝오버 오픈 (Accessibility)"
+# click 이 아니라 AXPress — click 은 좌표 기반이라 비활성 앱에서 액션이 발화되지 않는 경우가 있음(관측).
+press() { osascript -e 'tell application "System Events" to tell process "PokeTokenBar" to perform action "AXPress" of menu bar item 1 of menu bar 2' >/dev/null 2>&1; }
+polltall() { # $1=횟수(0.5s 간격)
+  TALL=0
+  for _ in $(seq 1 "$1"); do
+    W2=$(winprobe); TALL=$(echo "$W2" | grep -oE 'TALL=[0-9]+' | cut -d= -f2)
+    [[ "${TALL:-0}" -ge 1 ]] && return 0; sleep 0.5
+  done; return 1
+}
+if press; then
+  # 기동 직후 첫 AXPress 가 무시되는 경우가 있어(AX 트리 워밍업) 미출현 시 1회 재시도.
+  if ! polltall 6; then press; polltall 12 || true; fi
+  if [[ "${TALL:-0}" -ge 1 ]]; then ok "팝오버 윈도우 출현 ($W2)"; else bad "AXPress 후 팝오버 미검출 ($W2)"; fi
+  osascript -e 'tell application "System Events" to key code 53' >/dev/null 2>&1   # ESC 로 닫기
+else
+  skip "Accessibility 미허용 — 시스템 설정 > 손쉬운 사용에서 터미널 허용 시 검증됨"
+fi
+
+echo ""
+echo "결과: PASS=$PASS FAIL=$FAIL SKIP=$SKIP"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-THRESHOLD="${THRESHOLD:-70}"
+THRESHOLD="${THRESHOLD:-75}"
 
 LOGIC_CORE=(
   "Sources/PokeTokenBar/Core/CompanionModel.swift"
@@ -25,6 +25,9 @@ LOGIC_CORE=(
   "Sources/PokeTokenBar/Core/Models.swift"
   "Sources/PokeTokenBar/Core/TokenFormatter.swift"
   "Sources/PokeTokenBar/Core/UsageProvider.swift"
+  "Sources/PokeTokenBar/Core/LocalUsageReader.swift"
+  "Sources/PokeTokenBar/Core/LocalUsageCache.swift"
+  "Sources/PokeTokenBar/Core/ModelPricing.swift"
 )
 
 echo "▶ swift test (--enable-code-coverage)"


### PR DESCRIPTION
## 배경

가드레일(보안·기술·기능) 충분성 감사 + 커버리지 충족 + E2E 도입 요청의 결과물.

## 1. 보안 감사 결과 → 하드닝

security-reviewer 감사: **CRITICAL/HIGH/MEDIUM 0건, LOW 4건.** 기존 방어선 확인 — 디태치 업데이트 스크립트 위치 인자(주입 안전), 시크릿 0(히스토리 포함), 서브프로세스 argv+타임아웃, 전 엔드포인트 HTTPS, Keychain no-UI+device-only, 서드파티 의존성 0.

LOW 4건 중 사이드이펙트 없는 3건 적용:
| 항목 | 패치 |
|---|---|
| PokéAPI `evolution_chain.url` (서버 제어 문자열) fetch | https + `pokeapi.co` 호스트 고정 |
| GitHub `html_url` → `NSWorkspace.open` | https + `github.com` 검증 |
| `BinaryLocator.shellResolve` 문자열 보간(잠재) | 위치 인자 `$1` 전달 + zsh 실검증 |

#4(토큰 Keychain 캐시 사본)는 재시작 간 프롬프트 회피를 위한 의도된 트레이드오프로 수용.

## 2. 기능 버그 (감사 중 발견)

- **`disableKeychainAccess` 저장 누락** — 토글이 didSet 에서 defaults 저장을 안 해 재시작 후 풀렸음. 수정.

## 3. 테스트 격리 (기능 가드레일 구멍 2건)

`swift test` 실행이 **실제 사용자 환경을 오염**시키고 있었다:
- setUp 이 `UserDefaults.standard` 키 삭제 → 매 테스트 실행마다 사용자 설정 초기화
- `writeParitySnapshot` 이 실제 Application Support 의 `last-snapshot.json` 을 가짜 값으로 덮어씀

→ `UsageStore` 에 `defaults:` 주입(테스트는 UUID suite), 스냅샷 쓰기는 `.app` 번들 게이트. 테스트 후 실제 defaults 무손상 실검증.

## 4. 커버리지 충족

전 파일 실측에서 게이트 밖 사각지대 발견: **LocalUsageCache 0%**(디스크 캐시·prune — 배터리/정확성 핵심), LocalUsageReader 80%·ModelPricing 96%는 게이트 미포함.

- `LocalUsageCache` 테스트 시임(claudeRoot/codexRoot/fileURL/clock 주입, 기본값 = 실환경 동일) + **9종 테스트**: mtime/size 재사용·재파싱 판정, 디스크 라운드트립(콜드스타트), 40일 prune, 60s 저장 throttle, modifiedSince 필터, Codex 파싱(turn_context 모델 감지, cached 차감), 포매터/날짜 유틸 경계.
- test-gate `LOGIC_CORE` 6→**9파일**(+Reader/Cache/Pricing), `THRESHOLD` 70→**75** (실측 **80.13%**, 총 127 테스트).

## 5. E2E 스모크 (`scripts/e2e.sh`)

리서치 결론: XCUITest 는 SwiftPM 단독 레포에 Xcode 프로젝트/테스트 번들 도입을 강제 — 1인 로컬에 over-spec. 대신 **실제 앱 번들 스모크** 7체크:

1. 빌드+설치 → 2. 프로세스 생존 → 3. `last-snapshot.json` 이번 세션 갱신 + 구조·lastError 검증 + AppLog `phase1 done` → 4. 메뉴바 status item(AX count) → 5. **AXPress 로 팝오버 실제 오픈**(window server 에서 출현 확인, ESC 닫기)

**7/7 통과** (today=142.5M 실데이터). 구현 중 발견한 macOS 동작 2건을 스크립트에 문서화: status 윈도우는 앱 최초 활성화 전 CGWindowList 미등록 가능 → AX 프로브 사용 / AX `click` 은 비활성 앱에서 무시될 수 있어 `AXPress` + 워밍업 재시도. Accessibility 미허용 환경은 해당 단계만 SKIP(graceful). RELEASE.md 에 선택 단계로 문서화.

## 검증

- 전체 test-gate: **127 테스트 통과, 로직 코어 80.13% ≥ 75%**
- e2e.sh **7/7 PASS**, 테스트 후 실제 사용자 defaults 무손상 확인
- BinaryLocator 위치 인자 방식 zsh -ilc 실검증(brew 해석 + 미존재 바이너리 빈 결과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
