### PR TITLE
chore: 용량 감축 — 바이너리 -57%·캐시 -72%·로그 상한·데드코드 -117줄

### DIFF
--- a/Sources/PokeTokenBar/Core/AppLog.swift
+++ b/Sources/PokeTokenBar/Core/AppLog.swift
@@ -11,9 +11,18 @@ enum AppLog {
 
     private static let queue = DispatchQueue(label: "poketokenbar.log")
 
+    /// 로그 상한 — 초과 시 .old 로 1세대 회전(무한 증가 방지, 디스크 상한 ≈ 2×512KB).
+    private static let maxBytes = 512 * 1024
+
     static func write(_ message: String) {
         let line = "[\(ISO8601DateFormatter().string(from: Date()))] \(message)\n"
         queue.async {
+            if let size = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int,
+               size > maxBytes {
+                let old = url.deletingPathExtension().appendingPathExtension("old.log")
+                try? FileManager.default.removeItem(at: old)
+                try? FileManager.default.moveItem(at: url, to: old)
+            }
             if let data = line.data(using: .utf8) {
                 if let handle = try? FileHandle(forWritingTo: url) {
                     defer { try? handle.close() }

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -89,8 +89,10 @@ actor LocalUsageCache {
     private func ensureLoaded() {
         guard !loaded else { return }
         loaded = true
-        guard let data = try? Data(contentsOf: fileURL),
-              let snap = try? JSONDecoder().decode(Snapshot.self, from: data) else { return }
+        guard let raw = try? Data(contentsOf: fileURL) else { return }
+        // zlib 압축 스냅샷(현행) → 실패 시 평문 JSON(구버전 캐시) 폴백
+        let data = (try? (raw as NSData).decompressed(using: .zlib) as Data) ?? raw
+        guard let snap = try? JSONDecoder().decode(Snapshot.self, from: data) else { return }
         claudeCache = snap.claude
         codexCache = snap.codex
     }
@@ -110,7 +112,9 @@ actor LocalUsageCache {
         prune()
         let snap = Snapshot(claude: claudeCache, codex: codexCache)
         if let data = try? JSONEncoder().encode(snap) {
-            try? data.write(to: fileURL)
+            // JSON 은 zlib 로 크게 압축됨(수 MB → 수백 KB). 실패 시 평문 저장(로드가 양쪽 다 처리).
+            let out = (try? (data as NSData).compressed(using: .zlib) as Data) ?? data
+            try? out.write(to: fileURL)
             dirty = false
             lastSave = now()
         }

--- a/Sources/PokeTokenBar/Core/ProcessRunner.swift
+++ b/Sources/PokeTokenBar/Core/ProcessRunner.swift
@@ -3,7 +3,6 @@ import Foundation
 enum RunnerError: Error, CustomStringConvertible {
     case timeout(String)
     case nonZeroExit(Int32, String)
-    case noJSON(String)
     case missingResponse(String)
     case rpcError(String)
 
@@ -11,7 +10,6 @@ enum RunnerError: Error, CustomStringConvertible {
         switch self {
         case .timeout(let bin): return "timeout: \(bin)"
         case .nonZeroExit(let code, let bin): return "exit \(code): \(bin)"
-        case .noJSON(let bin): return "no JSON output: \(bin)"
         case .missingResponse(let bin): return "missing JSON-RPC response: \(bin)"
         case .rpcError(let message): return "JSON-RPC error: \(message)"
         }
@@ -19,68 +17,8 @@ enum RunnerError: Error, CustomStringConvertible {
 }
 
 /// Process 실행 지점은 이 파일 하나로 제한한다.
-/// usage 집계는 ccusage* 파서만 호출하고, Codex CLI 는 app-server rate-limit read만 사용한다.
+/// 현재 유일한 용도는 Codex app-server rate-limit read(JSON-RPC) — usage 집계는 로컬 로그 직파싱.
 enum ProcessRunner {
-    /// 바이너리를 실행하고 stdout 의 JSON 부분(Data)을 반환.
-    /// stdout 은 pipe buffer 잘림 방지를 위해 temp file 로 캡처한다.
-    ///
-    /// timeout 기본 180초 — 메뉴바 앱은 백그라운드 QoS 스로틀 + 콜드 파일캐시에서 ccusage 가
-    /// warm 대비 크게 느려질 수 있어 넉넉히 잡는다.
-    static func runJSON(binary: String, arguments: [String], timeout: TimeInterval = 180) async throws -> Data {
-        let outURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("poketokenbar-\(UUID().uuidString).out")
-        FileManager.default.createFile(atPath: outURL.path, contents: nil)
-        defer { try? FileManager.default.removeItem(at: outURL) }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: binary)
-        process.arguments = arguments
-        // App Nap 중인 부모로부터 background QoS 를 상속받아 스로틀되는 것을 방지
-        process.qualityOfService = .userInitiated
-        process.standardOutput = try FileHandle(forWritingTo: outURL)
-        process.standardError = FileHandle.nullDevice
-        // GUI 앱의 stdin 을 상속하면 자식이 입력 대기로 영구 블록될 수 있어 명시적으로 차단
-        process.standardInput = FileHandle.nullDevice
-
-        let status: Int32 = try await withCheckedThrowingContinuation { continuation in
-            let timedOut = OSAllocatedUnfairLockBox(false)
-            process.terminationHandler = { p in
-                if timedOut.value {
-                    continuation.resume(throwing: RunnerError.timeout(binary))
-                } else {
-                    continuation.resume(returning: p.terminationStatus)
-                }
-            }
-            do {
-                try process.run()
-            } catch {
-                process.terminationHandler = nil
-                continuation.resume(throwing: error)
-                return
-            }
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-                if process.isRunning {
-                    timedOut.value = true
-                    process.terminate()
-                    DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
-                        if process.isRunning {
-                            kill(process.processIdentifier, SIGKILL)
-                        }
-                    }
-                }
-            }
-        }
-
-        guard status == 0 else { throw RunnerError.nonZeroExit(status, binary) }
-
-        let raw = try Data(contentsOf: outURL)
-        // 첫 '{' 또는 '[' 이전의 비-JSON 프리픽스(경고 라인 등) 제거
-        guard let start = raw.firstIndex(where: { $0 == UInt8(ascii: "{") || $0 == UInt8(ascii: "[") }) else {
-            throw RunnerError.noJSON(binary)
-        }
-        return raw.subdata(in: start..<raw.endIndex)
-    }
-
     /// newline-delimited JSON-RPC 서버에 요청을 보내고 특정 id의 `result` JSON만 반환.
     /// Codex app-server가 stdout에 로그/notification을 섞어 내보낼 수 있어 line 단위로 필터링한다.
     static func runJSONRPC(
@@ -168,16 +106,5 @@ enum ProcessRunner {
             return try JSONSerialization.data(withJSONObject: result, options: [])
         }
         return nil
-    }
-}
-
-/// Swift 6 Sendable 제약 하에서 terminationHandler/asyncAfter 간 플래그 공유용 잠금 박스
-final class OSAllocatedUnfairLockBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var _value: Bool
-    init(_ value: Bool) { _value = value }
-    var value: Bool {
-        get { lock.lock(); defer { lock.unlock() }; return _value }
-        set { lock.lock(); defer { lock.unlock() }; _value = newValue }
     }
 }

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -100,11 +100,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// 정적 스프라이트로 먼저 보여주고, animated GIF 가 받아지면 교체한다(메뉴바도 GIF로 움직임).
     /// 에너지 통제는 ① delay 하한 0.2s(≈5fps) ② 안 보이면 정지(menuShouldAnimate) ③ 저전력 모드
     /// 에선 GIF 생략(가벼운 bob)로 처리한다 — 통제된 저프레임 + 비가시 시 정지로 저전력.
-    private func ensureMenuAnimation(forceRebuild: Bool = false) {
+    private func ensureMenuAnimation() {
         let id = companion.currentSpeciesID
         let shiny = companion.currentIsShiny
         let key = id.map { "\($0)-\(shiny)" }
-        if !forceRebuild, key == menuSpriteKey, !menuFrames.isEmpty { return }   // 이미 이 개체로 애니메이션 중
+        if key == menuSpriteKey, !menuFrames.isEmpty { return }   // 이미 이 개체로 애니메이션 중
         menuSpriteKey = key
         menuLoadGen += 1
         let gen = menuLoadGen

--- a/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
@@ -95,7 +95,9 @@ final class LocalUsageCacheTests: XCTestCase {
         let entries = await cache.claudeEntries(modifiedSince: since)
         XCTAssertEqual(Set(entries.map(\.output)), [1, 2], "조회 자체는 둘 다 반환")
 
-        let snap = try String(contentsOf: cacheFile, encoding: .utf8)
+        let raw = try Data(contentsOf: cacheFile)
+        let plain = (try? (raw as NSData).decompressed(using: .zlib) as Data) ?? raw
+        let snap = String(decoding: plain, as: UTF8.self)
         XCTAssertFalse(snap.contains("old.jsonl"), "45일 지난 blob 은 스냅샷에서 prune")
         XCTAssertTrue(snap.contains("new.jsonl"))
     }
@@ -129,6 +131,33 @@ final class LocalUsageCacheTests: XCTestCase {
         let cache = makeCache()
         let entries = await cache.claudeEntries(modifiedSince: Date().addingTimeInterval(-86400))
         XCTAssertEqual(entries.map(\.output), [2])
+    }
+
+    /// 구버전 평문 JSON 캐시(압축 도입 전)도 로드된다 — 업그레이드 시 콜드 스타트 재발 방지.
+    func testLegacyPlainJSONCacheLoads() async throws {
+        let t = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970) - 3600)
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 42)], mtime: t)
+        _ = await makeCache().claudeEntries(modifiedSince: since)   // 압축 스냅샷 저장
+
+        // 압축 해제해 평문으로 다운그레이드(구버전 캐시 파일 시뮬레이션)
+        let raw = try Data(contentsOf: cacheFile)
+        let plain = try (raw as NSData).decompressed(using: .zlib) as Data
+        try plain.write(to: cacheFile)
+
+        // 내용을 몰래 바꿔도(길이·mtime 동일) 평문 스냅샷이 로드되면 42 유지
+        try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 43)], mtime: t)
+        let entries = await makeCache().claudeEntries(modifiedSince: since)
+        XCTAssertEqual(entries.map(\.output), [42], "평문(구버전) 캐시가 로드돼야 한다")
+    }
+
+    /// 압축 저장 — 스냅샷이 실제로 zlib 이고 평문 대비 작다.
+    func testSnapshotIsCompressed() async throws {
+        let t = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970) - 3600)
+        try writeFile("a.jsonl", lines: (1...50).map { claudeLine(id: "\($0)", output: $0) }, mtime: t)
+        _ = await makeCache().claudeEntries(modifiedSince: since)
+        let raw = try Data(contentsOf: cacheFile)
+        let plain = try (raw as NSData).decompressed(using: .zlib) as Data   // zlib 아니면 throw
+        XCTAssertLessThan(raw.count, plain.count, "압축본이 평문보다 작아야 한다")
     }
 
     /// 포매터 — grouped/cost/costCompact 경계값(메뉴바·팝오버 표기 계약).

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -15,6 +15,8 @@ echo "==> $APP 조립"
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
 cp ".build/release/$APP_NAME" "$APP/Contents/MacOS/$APP_NAME"
+# 심볼 strip — 릴리스 바이너리 1.84MB → 0.80MB(-57%). codesign 전에 수행(서명 무효화 방지).
+strip -rSTx "$APP/Contents/MacOS/$APP_NAME" 2>/dev/null || strip -rSx "$APP/Contents/MacOS/$APP_NAME"
 cp assets/AppIcon.icns "$APP/Contents/Resources/AppIcon.icns"
 
 cat > "$APP/Contents/Info.plist" <<PLIST


### PR DESCRIPTION
## 탐색 범위와 실측

레포 / 앱 번들 / 바이너리 / 런타임 데이터 4개 영역 전수 실측 + 전 심볼 참조 스캔(데드코드).

## Before → After

| 항목 | Before | After | 감축 |
|---|---|---|---|
| 릴리스 바이너리 | 1.84MB | **0.80MB** | **-57%** (strip -rSTx, codesign 전) |
| 앱 번들 | 2.3MB | **1.3MB** | **-43%** |
| 릴리스 zip | 0.90MB | 0.78MB | -13% (zip 이 이미 압축이라 델타 축소) |
| usage-cache.json | 6.8MB | **1.88MB** | **-72%** (zlib, 평문 폴백 로드) |
| AppLog | 0.9MB 무한 증가 | **상한 ≈1MB** | 512KB 초과 시 .old 1세대 로테이션 — 실동작 확인 |
| 소스 | — | **-117줄** | 데드코드 제거 |

## 데드코드 (전 심볼 0-참조 스캔으로 확정)

- `ProcessRunner.runJSON` + `OSAllocatedUnfairLockBox` + `RunnerError.noJSON` — ccusage 제거(PR #27) 후 호출자 0. `runJSONRPC`(codex 한도)만 잔존.
- `ensureMenuAnimation(forceRebuild:)` 미사용 파라미터 (기존 리뷰 LOW).
- ccusage 언급은 가격 역산 근거 등 **살아있는 주석만** 유지, 스테일 헤더 주석은 갱신.

## 검토했지만 미적용 (근거)

- **git 히스토리 재작성** (.git 12MB) — 공개 레포 force-push, blast radius 대비 이득 미미.
- **아이콘 소스**(icon_1024.png 621KB, icns 463KB) — icns 재생성용 소스라 필요. 빌드 시 iconutil 생성으로 icns 언트래킹하는 안은 이득(463KB) 대비 빌드 의존 추가라 보류.
- **-Osize** — strip 이 이미 -57%; 추가 이득 대비 성능 트레이드오프 불필요.
- **usage-cache 스키마 축약**(per-day 집계 저장) — 압축이 -72%를 무변경으로 달성, 스키마 수술은 over-spec.

## 하위호환

- 구버전 **평문** usage-cache 는 zlib 해제 실패 시 평문으로 폴백 로드 → 업그레이드 시 콜드 스타트(수십 초 재파싱) 재발 없음. 전용 테스트로 고정.

## 검증

- 게이트: **129 테스트 통과, 로직 코어 80.15% ≥ 75%** (신규: 평문 캐시 로드, 압축 확인)
- **E2E 7/7** — strip 된 번들 실행, 실데이터 174.5M, 압축 캐시 마이그레이션 경로 포함
- AppLog 로테이션 실동작 확인 (0.9MB → .old, 새 로그 3.6KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
