### PR TITLE
feat: Gemini CLI 지원 + 프로바이더 탭 UI

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,9 +16,9 @@
 
 </div>
 
-PokeTokenBar は、今日使ったAIコーディングトークン（Claude Code・Codex）を macOS メニューバーに表示し、その使用量を育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。
+PokeTokenBar は、今日使ったAIコーディングトークン（Claude Code・Codex・Gemini CLI）を macOS メニューバーに表示し、その使用量を育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。
 
-> トークン使用量はローカルの Claude Code・Codex ログから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
+> トークン使用量はローカルの Claude Code・Codex・Gemini CLI ログから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
 
 ## なぜ
 
@@ -32,7 +32,7 @@ PokeTokenBar は、今日使ったAIコーディングトークン（Claude Code
 
 ## しくみ
 
-1. 🥚 **いつも通りコーディング。** Claude Code・Codex で使うトークンがタマゴを温めます — 追加の設定は不要。
+1. 🥚 **いつも通りコーディング。** Claude Code・Codex・Gemini CLI で使うトークンがタマゴを温めます — 追加の設定は不要。
 2. 🐣 **孵化。** [PokéAPI](https://pokeapi.co/) の**第1〜5世代すべての進化系統（起点329種）**から、公式の捕獲率で重み付けされて生まれます — よくいるポケモンは頻繁に、伝説は129回に1回。孵化ごとに25種類のせいかくがひとつ決まり — **64匹に1匹は ✨ 色違い**。
 3. ⚡ **進化。** コーディングを続けると実際の進化ツリー（1/2/3段階、分岐）に沿って育ち、各段階で小さな演出が流れます。
 4. 🎓 **卒業 & 収集。** 最終進化 + 閾値で **図鑑** に保存されます — レアなほど時間がかかり（ヘビーユーザーで common ≈3日 → legendary ≈24日）— 新しいタマゴが届きます。
@@ -80,7 +80,7 @@ PokeTokenBar は、今日使ったAIコーディングトークン（Claude Code
 
 ### 必要条件
 
-macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code / Codex ログから直接読み取り、外部 CLI は不要です。
+macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code / Codex / Gemini CLI ログから直接読み取り、外部 CLI は不要です。
 
 ### Homebrew
 
@@ -103,6 +103,7 @@ swift test                   # ユニットテスト
 | ソース | 用途 | 備考 |
 |---|---|---|
 | `~/.claude/projects/**/*.jsonl` | Claude Code daily/blocks/weekly/monthly | 直接読み取り；メッセージ id で重複排除；増分キャッシュ |
+| `~/.gemini/tmp/**/chats/*.json(l)` | Gemini CLI daily/monthly | セッションレコード（メッセージ別 `tokens`）；週間 = daily 合算 |
 | `~/.codex/sessions/**/*.jsonl` | Codex daily/monthly | `token_count` イベント；週間 = daily 合算 |
 | Keychain → `oauth/usage` | Claude 公式 5h/週間 % | 非公式 endpoint；Keychain プロンプト1回後にキャッシュ |
 | `codex app-server` | Codex 公式 5h/週間 % | アカウント snapshot のみ；モデル turn なし |
@@ -110,7 +111,7 @@ swift test                   # ユニットテスト
 
 ## プライバシー & 権限
 
-- **オンデバイス。** トークン使用量はローカルの Claude Code / Codex ログから直接読み取り、アプリは `claude`/`codex` のモデル turn を実行せず、使用量のみ読み取ります。
+- **オンデバイス。** トークン使用量はローカルの Claude Code / Codex / Gemini CLI ログから直接読み取り、アプリは `claude`/`codex` のモデル turn を実行せず、使用量のみ読み取ります。
 - **Keychain（任意）。** 公式の上限を表示するため、Claude OAuth 資格情報を **1回**（パスワードのプロンプト1回）読み取り、アプリ自身の Keychain 項目にキャッシュして再利用します。設定でオフにすると上限セクションが非表示になります。
 - **ポケモンのアセット** はランタイムに PokéAPI から取得し、`~/Library/Application Support/PokeTokenBar/` にのみキャッシュされます。著作物はこのリポジトリやリリースにバンドルしません。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,9 +16,9 @@
 
 </div>
 
-PokeTokenBar는 오늘 사용한 AI 코딩 토큰(Claude Code · Codex)을 macOS 메뉴바에 보여주고, 그 사용량을 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다.
+PokeTokenBar는 오늘 사용한 AI 코딩 토큰(Claude Code · Codex · Gemini CLI)을 macOS 메뉴바에 보여주고, 그 사용량을 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다.
 
-> 토큰 사용량은 로컬 Claude Code·Codex 로그에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
+> 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI 로그에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
 
 ## 왜
 
@@ -32,7 +32,7 @@ PokeTokenBar는 오늘 사용한 AI 코딩 토큰(Claude Code · Codex)을 macOS
 
 ## 어떻게 자라나요
 
-1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex 에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
+1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex·Gemini CLI 에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
 2. 🐣 **부화.** [PokéAPI](https://pokeapi.co/)의 **1~5세대 모든 진화 계보(시작점 329종)**에서 공식 capture rate 가중으로 태어납니다 — 흔한 포켓몬은 자주, 전설은 부화 129번에 1번. 부화마다 25종 성격 중 하나가 정해지고 — **64마리 중 1마리는 ✨ 색이 다릅니다**.
 3. ⚡ **진화.** 계속 코딩하면 실제 진화 트리(1/2/3단, 분기)를 따라 자라고, 단계마다 작은 연출이 반겨줍니다.
 4. 🎓 **졸업 & 수집.** 최종 진화 + 임계 도달 시 **도감**에 보존됩니다 — 희귀할수록 오래 걸리고(헤비 유저 기준 common ≈3일 → legendary ≈24일) — 새 알이 도착합니다.
@@ -80,7 +80,7 @@ PokeTokenBar는 오늘 사용한 AI 코딩 토큰(Claude Code · Codex)을 macOS
 
 ### 요구사항
 
-macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code/Codex 로그에서 직접 읽으며 외부 CLI가 필요 없습니다.
+macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code/Codex/Gemini CLI 로그에서 직접 읽으며 외부 CLI가 필요 없습니다.
 
 ### Homebrew
 
@@ -103,6 +103,7 @@ swift test                   # 단위 테스트
 | 소스 | 용도 | 비고 |
 |---|---|---|
 | `~/.claude/projects/**/*.jsonl` | Claude Code daily/blocks/weekly/monthly | 직접 읽음; 메시지 id 로 중복제거; 증분 캐시 |
+| `~/.gemini/tmp/**/chats/*.json(l)` | Gemini CLI daily/monthly | 세션 레코드(메시지별 `tokens`); 주간 = daily 합산 |
 | `~/.codex/sessions/**/*.jsonl` | Codex daily/monthly | `token_count` 이벤트; 주간 = daily 합산 |
 | Keychain → `oauth/usage` | Claude 공식 5h/주간 % | 비공식 endpoint; Keychain 프롬프트 1회 후 캐시 |
 | `codex app-server` | Codex 공식 5h/주간 % | 계정 snapshot만; 모델 turn 없음 |
@@ -110,7 +111,7 @@ swift test                   # 단위 테스트
 
 ## 프라이버시 & 권한
 
-- **온디바이스.** 토큰 사용량은 로컬 Claude Code/Codex 로그에서 직접 읽으며, 앱은 `claude`/`codex` 모델 turn을 실행하지 않고 사용량만 읽습니다.
+- **온디바이스.** 토큰 사용량은 로컬 Claude Code/Codex/Gemini CLI 로그에서 직접 읽으며, 앱은 `claude`/`codex` 모델 turn을 실행하지 않고 사용량만 읽습니다.
 - **Keychain(선택).** 공식 한도를 보여주려면 Claude OAuth 자격증명을 **1회**(비밀번호 프롬프트 1번) 읽고, 앱 자체 Keychain 항목에 캐시해 재사용합니다. 설정에서 끄면 한도 섹션만 숨겨집니다.
 - **포켓몬 에셋**은 런타임에 PokéAPI에서 받아오며 `~/Library/Application Support/PokeTokenBar/`에만 캐시됩니다. 저작물은 레포나 릴리스에 번들하지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 </div>
 
-PokeTokenBar shows how many AI coding tokens you've burned today — Claude Code & Codex — in your macOS menu bar, and turns that usage into a growing **Pokémon companion**. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again.
+PokeTokenBar shows how many AI coding tokens you've burned today — Claude Code, Codex & Gemini CLI — in your macOS menu bar, and turns that usage into a growing **Pokémon companion**. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again.
 
-> Token usage is read directly from your local Claude Code & Codex logs (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
+> Token usage is read directly from your local Claude Code, Codex & Gemini CLI logs (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
 
 ## Why
 
@@ -32,7 +32,7 @@ PokeTokenBar shows how many AI coding tokens you've burned today — Claude Code
 
 ## How it works
 
-1. 🥚 **Code as usual.** The tokens you burn in Claude Code & Codex incubate an egg — nothing extra to run.
+1. 🥚 **Code as usual.** The tokens you burn in Claude Code, Codex & Gemini CLI incubate an egg — nothing extra to run.
 2. 🐣 **Hatch.** Eggs hatch into Pokémon with real evolution lines from [PokéAPI](https://pokeapi.co/) — any Gen 1–5 line (329 possible starts), weighted by the official capture rate: commons hatch often, a legendary is a 1-in-129 event. Every hatch rolls one of 25 natures — and **1 in 64 is ✨ shiny**.
 3. ⚡ **Evolve.** Keep coding and it grows through its actual evolution tree (1/2/3 stages, branching), with a little flash celebration at each step.
 4. 🎓 **Graduate & collect.** Final form + threshold sends it to your **Pokédex** — rarer takes longer (≈3 days common → ≈24 days legendary at heavy use) — and a fresh egg arrives.
@@ -80,7 +80,7 @@ Menu-bar items, refresh interval (1–15 min or manual), launch at login, a Keyc
 
 ### Requirements
 
-macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from your local Claude Code / Codex logs, no external CLI required.
+macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from your local Claude Code / Codex / Gemini CLI logs, no external CLI required.
 
 ### Homebrew
 
@@ -103,6 +103,7 @@ swift test                   # unit tests
 | Source | Used for | Notes |
 |---|---|---|
 | `~/.claude/projects/**/*.jsonl` | Claude Code daily/blocks/weekly/monthly | read directly; deduped by message id; cached incrementally |
+| `~/.gemini/tmp/**/chats/*.json(l)` | Gemini CLI daily/monthly | session records (`tokens` per message); weekly = daily sum |
 | `~/.codex/sessions/**/*.jsonl` | Codex daily/monthly | `token_count` events; weekly = daily sum |
 | Keychain → `oauth/usage` | Claude official 5h/weekly % | unofficial endpoint; single Keychain prompt, then cached |
 | `codex app-server` | Codex official 5h/weekly % | account snapshot only; no model turn |
@@ -110,7 +111,7 @@ swift test                   # unit tests
 
 ## Privacy & permissions
 
-- **On-device.** Token usage is read directly from your local Claude Code / Codex logs; the app never runs `claude`/`codex` model turns, only reads usage.
+- **On-device.** Token usage is read directly from your local Claude Code / Codex / Gemini CLI logs; the app never runs `claude`/`codex` model turns, only reads usage.
 - **Keychain (optional).** To show official limits it reads the Claude OAuth credential **once** (a single password prompt), then caches it in the app's own Keychain item for reuse. Turn it off in Settings — the limits section simply hides.
 - **Pokémon assets** are fetched at runtime from PokéAPI and cached only under `~/Library/Application Support/PokeTokenBar/`. Nothing copyrighted is bundled in this repository or its releases.
 

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -9,10 +9,29 @@ actor LocalUsageCache {
     static let shared = LocalUsageCache()
 
     private struct Blob: Codable { let mtime: Date; let size: Int; let entries: [LocalUsageReader.Entry] }
-    private struct Snapshot: Codable { var claude: [String: Blob]; var codex: [String: Blob] }
+    private struct Snapshot: Codable {
+        var claude: [String: Blob]
+        var codex: [String: Blob]
+        var gemini: [String: Blob]
+
+        init(claude: [String: Blob], codex: [String: Blob], gemini: [String: Blob]) {
+            self.claude = claude
+            self.codex = codex
+            self.gemini = gemini
+        }
+
+        // 하위호환: gemini 키가 없는 구버전 스냅샷도 로드(콜드 스타트 재발 방지).
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            claude = try c.decodeIfPresent([String: Blob].self, forKey: .claude) ?? [:]
+            codex = try c.decodeIfPresent([String: Blob].self, forKey: .codex) ?? [:]
+            gemini = try c.decodeIfPresent([String: Blob].self, forKey: .gemini) ?? [:]
+        }
+    }
 
     private var claudeCache: [String: Blob] = [:]
     private var codexCache: [String: Blob] = [:]
+    private var geminiCache: [String: Blob] = [:]
     private var loaded = false
     private var dirty = false
     private var lastSave: Date?
@@ -20,13 +39,15 @@ actor LocalUsageCache {
     // 테스트 시임 — 기본값은 실환경(실 로그 루트·Application Support·실시간).
     private let claudeRoot: URL?
     private let codexRoot: URL?
+    private let geminiRoot: URL?
     private let fileURL: URL
     private let now: @Sendable () -> Date
 
-    init(claudeRoot: URL? = nil, codexRoot: URL? = nil, fileURL: URL? = nil,
+    init(claudeRoot: URL? = nil, codexRoot: URL? = nil, geminiRoot: URL? = nil, fileURL: URL? = nil,
          now: @escaping @Sendable () -> Date = Date.init) {
         self.claudeRoot = claudeRoot
         self.codexRoot = codexRoot
+        self.geminiRoot = geminiRoot
         self.fileURL = fileURL ?? Self.defaultFileURL
         self.now = now
     }
@@ -58,6 +79,16 @@ actor LocalUsageCache {
         return r
     }
 
+    func geminiEntries(modifiedSince: Date) -> [LocalUsageReader.Entry] {
+        ensureLoaded()
+        let fmt = LocalUsageReader.localDayFormatter()
+        let r = collect(root: geminiRoot ?? LocalUsageReader.geminiTmpDir, since: modifiedSince, cache: &geminiCache) {
+            LocalUsageReader.parseGeminiFile($0, fmt: fmt)
+        }
+        saveIfNeeded()
+        return r
+    }
+
     private func collect(root: URL, since: Date, cache: inout [String: Blob],
                          parse: (URL) -> [LocalUsageReader.Entry]) -> [LocalUsageReader.Entry] {
         let fm = FileManager.default
@@ -67,7 +98,8 @@ actor LocalUsageCache {
             options: [.skipsHiddenFiles]) else { return [] }
         var result: [LocalUsageReader.Entry] = []
         for case let url as URL in en {
-            guard url.pathExtension == "jsonl" else { continue }
+            // .jsonl(Claude/Codex/Gemini 신규) + .json(Gemini 레거시 세션)
+            guard url.pathExtension == "jsonl" || url.pathExtension == "json" else { continue }
             guard let v = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
                   let mtime = v.contentModificationDate, mtime >= since else { continue }
             let size = v.fileSize ?? 0
@@ -95,6 +127,7 @@ actor LocalUsageCache {
         guard let snap = try? JSONDecoder().decode(Snapshot.self, from: data) else { return }
         claudeCache = snap.claude
         codexCache = snap.codex
+        geminiCache = snap.gemini
     }
 
     /// 어떤 조회 윈도우(오늘/주/월)에도 들지 않는 오래된 파일 blob 을 제거해 캐시 무한 증가를 막는다.
@@ -103,6 +136,7 @@ actor LocalUsageCache {
         let cutoff = now().addingTimeInterval(-40 * 86400)
         claudeCache = claudeCache.filter { $0.value.mtime >= cutoff }
         codexCache = codexCache.filter { $0.value.mtime >= cutoff }
+        geminiCache = geminiCache.filter { $0.value.mtime >= cutoff }
     }
 
     /// 변경이 있으면 디스크에 저장(최소 60초 간격으로 throttle — 잦은 쓰기 방지).
@@ -110,7 +144,7 @@ actor LocalUsageCache {
         guard dirty else { return }
         if let last = lastSave, now().timeIntervalSince(last) < 60 { return }
         prune()
-        let snap = Snapshot(claude: claudeCache, codex: codexCache)
+        let snap = Snapshot(claude: claudeCache, codex: codexCache, gemini: geminiCache)
         if let data = try? JSONEncoder().encode(snap) {
             // JSON 은 zlib 로 크게 압축됨(수 MB → 수백 KB). 실패 시 평문 저장(로드가 양쪽 다 처리).
             let out = (try? (data as NSData).compressed(using: .zlib) as Data) ?? data

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -82,7 +82,8 @@ actor LocalUsageCache {
     func geminiEntries(modifiedSince: Date) -> [LocalUsageReader.Entry] {
         ensureLoaded()
         let fmt = LocalUsageReader.localDayFormatter()
-        let r = collect(root: geminiRoot ?? LocalUsageReader.geminiTmpDir, since: modifiedSince, cache: &geminiCache) {
+        let r = collect(root: geminiRoot ?? LocalUsageReader.geminiTmpDir, since: modifiedSince,
+                        cache: &geminiCache, allowJSON: true) {
             LocalUsageReader.parseGeminiFile($0, fmt: fmt)
         }
         saveIfNeeded()
@@ -90,6 +91,7 @@ actor LocalUsageCache {
     }
 
     private func collect(root: URL, since: Date, cache: inout [String: Blob],
+                         allowJSON: Bool = false,
                          parse: (URL) -> [LocalUsageReader.Entry]) -> [LocalUsageReader.Entry] {
         let fm = FileManager.default
         guard let en = fm.enumerator(
@@ -98,8 +100,9 @@ actor LocalUsageCache {
             options: [.skipsHiddenFiles]) else { return [] }
         var result: [LocalUsageReader.Entry] = []
         for case let url as URL in en {
-            // .jsonl(Claude/Codex/Gemini 신규) + .json(Gemini 레거시 세션)
-            guard url.pathExtension == "jsonl" || url.pathExtension == "json" else { continue }
+            // 기본 .jsonl. .json 은 Gemini 루트에서만(allowJSON) — Claude 루트의 대량
+            // .meta.json 등을 스캔/빈 blob 으로 캐시하지 않도록 스코프 제한.
+            guard url.pathExtension == "jsonl" || (allowJSON && url.pathExtension == "json") else { continue }
             guard let v = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
                   let mtime = v.contentModificationDate, mtime >= since else { continue }
             let size = v.fileSize ?? 0

--- a/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
@@ -32,6 +32,34 @@ struct LocalClaudeProvider: UsageProvider {
     }
 }
 
+/// 로컬 로그 직접 파싱 기반 Gemini CLI provider. (블록 없음 — Codex 와 동일 축약형)
+/// 세션이 ~/.gemini/tmp/<hash>/chats/ 에 있을 때만 데이터가 잡힌다(없으면 스냅샷 미생성 → UI 미표시).
+struct LocalGeminiProvider: UsageProvider {
+    let id = "gemini"
+    let displayName = "Gemini"
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let now = Date()
+        let entries = await LocalUsageCache.shared.geminiEntries(modifiedSince: Calendar.current.startOfDay(for: now))
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey())
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let now = Date()
+        let monthStart = LocalUsageReader.startOfMonth(now)
+        let entries = await LocalUsageCache.shared.geminiEntries(modifiedSince: monthStart)
+        let fmt = LocalUsageReader.localDayFormatter()
+        var r = ProviderEnrichment()
+        let weekStart = LocalUsageReader.startOfWeek(now)
+        r.weekTotal = LocalUsageReader.period(entries: entries, periodKey: fmt.string(from: weekStart),
+                                              fromDay: fmt.string(from: weekStart), toDay: fmt.string(from: now))
+        r.monthTotal = LocalUsageReader.period(entries: entries, periodKey: LocalUsageReader.monthKey(now),
+                                               fromDay: fmt.string(from: monthStart), toDay: fmt.string(from: now))
+        r.periodsOK = true
+        return r
+    }
+}
+
 /// 로컬 로그 직접 파싱 기반 Codex provider. (블록 없음, 주간 = 일별 합산)
 struct LocalCodexProvider: UsageProvider {
     let id = "codex"

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -48,7 +48,7 @@ enum LocalUsageReader {
     // MARK: 스캔 (mtime 윈도우)
 
     /// `root` 하위(재귀)의 `.jsonl` 파일 중 `modifiedSince` 이후 수정된 것.
-    static func jsonlFiles(in root: URL, modifiedSince: Date) -> [URL] {
+    static func jsonlFiles(in root: URL, modifiedSince: Date, allowJSON: Bool = false) -> [URL] {
         let fm = FileManager.default
         guard let en = fm.enumerator(
             at: root,
@@ -56,8 +56,8 @@ enum LocalUsageReader {
             options: [.skipsHiddenFiles]) else { return [] }
         var out: [URL] = []
         for case let url as URL in en {
-            // .jsonl(Claude/Codex/Gemini 신규) + .json(Gemini 레거시 세션)
-            guard url.pathExtension == "jsonl" || url.pathExtension == "json" else { continue }
+            // 기본 .jsonl. .json 은 Gemini 전용(allowJSON) — Claude 루트 .meta.json 스캔 방지.
+            guard url.pathExtension == "jsonl" || (allowJSON && url.pathExtension == "json") else { continue }
             let v = try? url.resourceValues(forKeys: [.contentModificationDateKey])
             if let m = v?.contentModificationDate, m >= modifiedSince { out.append(url) }
         }
@@ -223,7 +223,7 @@ enum LocalUsageReader {
     static func geminiEntries(modifiedSince: Date, root: URL? = nil) -> [Entry] {
         let fmt = localDayFormatter()
         var entries: [Entry] = []
-        for file in jsonlFiles(in: root ?? geminiTmpDir, modifiedSince: modifiedSince) {
+        for file in jsonlFiles(in: root ?? geminiTmpDir, modifiedSince: modifiedSince, allowJSON: true) {
             entries.append(contentsOf: parseGeminiFile(file, fmt: fmt))
         }
         return entries

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -41,6 +41,9 @@ enum LocalUsageReader {
     static var codexSessionsDir: URL {
         FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex/sessions")
     }
+    static var geminiTmpDir: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".gemini/tmp")
+    }
 
     // MARK: 스캔 (mtime 윈도우)
 
@@ -53,7 +56,8 @@ enum LocalUsageReader {
             options: [.skipsHiddenFiles]) else { return [] }
         var out: [URL] = []
         for case let url as URL in en {
-            guard url.pathExtension == "jsonl" else { continue }
+            // .jsonl(Claude/Codex/Gemini 신규) + .json(Gemini 레거시 세션)
+            guard url.pathExtension == "jsonl" || url.pathExtension == "json" else { continue }
             let v = try? url.resourceValues(forKeys: [.contentModificationDateKey])
             if let m = v?.contentModificationDate, m >= modifiedSince { out.append(url) }
         }
@@ -159,6 +163,70 @@ enum LocalUsageReader {
         return Entry(
             id: "codex|\(file)|\(turn)", date: date, localDay: fmt.string(from: date), model: model,
             input: nonCachedInput, output: output, cacheWrite: 0, cacheRead: cached)
+    }
+
+    // MARK: Gemini 파싱
+
+    /// Gemini CLI 세션 파일(~/.gemini/tmp/<hash>/chats/session-*.jsonl 및 레거시 .json) 파싱.
+    /// - 신규 .jsonl: 라인 단위 레코드 — type=="gemini" 메시지의 인라인 tokens, 또는
+    ///   type=="message_update" 의 tokens (같은 id 는 마지막 값이 최종).
+    /// - 레거시 .json: 단일 ConversationRecord { messages: [...] } 의 message.tokens.
+    /// 토큰 매핑(usageMetadata 의미 보존, Entry.total == totalTokenCount):
+    ///   input = (input − cached) + tool(toolUsePrompt, 입력측) / cacheRead = cached
+    ///   output = output + thoughts(출력측 reasoning) / cacheWrite = 0
+    static func parseGeminiFile(_ url: URL, fmt: DateFormatter) -> [Entry] {
+        guard let data = try? Data(contentsOf: url) else { return [] }
+        let file = url.lastPathComponent
+        // 메시지 id → (레코드, 토큰) — message_update 가 나중에 오면 갱신
+        var byID: [String: Entry] = [:]
+        var order: [String] = []
+
+        func absorb(_ obj: [String: Any], fallbackTimestamp: Date?) {
+            guard let tokens = obj["tokens"] as? [String: Any] else { return }
+            let id = (obj["id"] as? String) ?? UUID().uuidString
+            let ts = (obj["timestamp"] as? String).flatMap { ISO8601Parser.date(from: $0) } ?? fallbackTimestamp
+            guard let date = ts else { return }
+            let input = intValue(tokens["input"])
+            let cached = intValue(tokens["cached"])
+            let entry = Entry(
+                id: "gemini|\(file)|\(id)", date: date, localDay: fmt.string(from: date),
+                model: (obj["model"] as? String) ?? "gemini",
+                input: max(0, input - cached) + intValue(tokens["tool"]),
+                output: intValue(tokens["output"]) + intValue(tokens["thoughts"]),
+                cacheWrite: 0, cacheRead: cached)
+            if byID[id] == nil { order.append(id) }
+            byID[id] = entry   // update 레코드가 최종값
+        }
+
+        if url.pathExtension == "jsonl" {
+            guard let text = String(data: data, encoding: .utf8) else { return [] }
+            var lastTimestamp: Date?
+            for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+                guard line.contains("\"tokens\"") || line.contains("\"timestamp\"") else { continue }
+                guard let d = String(line).data(using: .utf8),
+                      let obj = try? JSONSerialization.jsonObject(with: d) as? [String: Any] else { continue }
+                if let ts = (obj["timestamp"] as? String).flatMap({ ISO8601Parser.date(from: $0) }) {
+                    lastTimestamp = ts
+                }
+                absorb(obj, fallbackTimestamp: lastTimestamp)
+            }
+        } else {
+            // 레거시 단일 JSON — messages 배열
+            guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let messages = obj["messages"] as? [[String: Any]] else { return [] }
+            let sessionStart = (obj["startTime"] as? String).flatMap { ISO8601Parser.date(from: $0) }
+            for m in messages { absorb(m, fallbackTimestamp: sessionStart) }
+        }
+        return order.compactMap { byID[$0] }
+    }
+
+    static func geminiEntries(modifiedSince: Date, root: URL? = nil) -> [Entry] {
+        let fmt = localDayFormatter()
+        var entries: [Entry] = []
+        for file in jsonlFiles(in: root ?? geminiTmpDir, modifiedSince: modifiedSince) {
+            entries.append(contentsOf: parseGeminiFile(file, fmt: fmt))
+        }
+        return entries
     }
 
     private static func codexModel(_ line: String) -> String? {

--- a/Sources/PokeTokenBar/Core/ModelPricing.swift
+++ b/Sources/PokeTokenBar/Core/ModelPricing.swift
@@ -26,6 +26,10 @@ enum ModelPricing {
         "claude-haiku-4-5-20251001":  .perMillion(1, 5, 1.25, 0.1),
         "claude-fable-5":             .zero,                          // ccusage 미가격 → $0
         "gpt-5.5":                    .perMillion(5, 30, 0, 0.5),
+        // Gemini — 공식 API 단가(기본 티어, ≤200K 프롬프트). 캐시는 read 단가만(스토리지 시간요금 제외).
+        "gemini-2.5-pro":             .perMillion(1.25, 10, 0, 0.3125),
+        "gemini-2.5-flash":           .perMillion(0.30, 2.5, 0, 0.075),
+        "gemini-2.0-flash":           .perMillion(0.10, 0.4, 0, 0.025),
     ]
 
     /// 모델명 → 단가. 정확 매칭 우선, 없으면 패밀리(opus/sonnet/haiku/gpt) 폴백(버전 드리프트 대비),
@@ -38,6 +42,11 @@ enum ModelPricing {
         if m.contains("haiku")  { return .perMillion(1, 5, 1.25, 0.1) }
         if m.contains("gpt") || m.contains("codex") || m.contains("o4") || m.contains("o3") {
             return .perMillion(5, 30, 0, 0.5)
+        }
+        // Gemini 패밀리 폴백 — pro/flash 만(버전 드리프트 대비). 그 외 gemini 변형은 0(오표시 방지).
+        if m.hasPrefix("gemini") {
+            if m.contains("pro")   { return .perMillion(1.25, 10, 0, 0.3125) }
+            if m.contains("flash") { return .perMillion(0.30, 2.5, 0, 0.075) }
         }
         return .zero
     }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -95,10 +95,6 @@ final class UsageStore {
         return snapshots.reduce(0) { $0 + ($1.today?.date == todayKey ? $1.todayTotalTokens : 0) }
     }
 
-    var hasAnyLimits: Bool {
-        limits != nil || codexLimits?.hasVisibleLimit == true
-    }
-
     /// 사용량 데이터(스냅샷)가 하나라도 있는가 — companion sleep 판정용
     var hasUsageData: Bool { !snapshots.isEmpty }
 

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -123,6 +123,12 @@ final class UsageStore {
         return snapshots.reduce(0) { $0 + ($1.today?.date == todayKey ? ($1.today?.totalCost ?? 0) : 0) }
     }
 
+    /// 프로바이더 탭 선택 해석 — 선호 id 가 연결돼 있으면 그것, 아니면(첫 실행/연결 해제) 첫 번째.
+    func snapshot(preferring id: String?) -> ProviderSnapshot? {
+        if let id, let s = snapshots.first(where: { $0.providerID == id }) { return s }
+        return snapshots.first
+    }
+
     var weekTotalTokens: Int { snapshots.reduce(0) { $0 + ($1.weekTotal?.totalTokens ?? 0) } }
     var weekCostTotal: Double { snapshots.reduce(0) { $0 + ($1.weekTotal?.totalCost ?? 0) } }
     var monthTotalTokens: Int { snapshots.reduce(0) { $0 + ($1.monthTotal?.totalTokens ?? 0) } }
@@ -193,7 +199,7 @@ final class UsageStore {
 
     // MARK: 생명주기
 
-    init(providers: [any UsageProvider] = [LocalClaudeProvider(), LocalCodexProvider()],
+    init(providers: [any UsageProvider] = [LocalClaudeProvider(), LocalCodexProvider(), LocalGeminiProvider()],
          claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),
          autoRefresh: Bool = true,

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -10,6 +10,8 @@ enum PopoverTab { case home, collection }
 final class PopoverNavigation {
     var showSettings = false
     var tab: PopoverTab = .home
+    /// 프로바이더 탭 선택 — reset() 대상이 아님(팝오버를 다시 열어도 보던 서비스 유지).
+    var providerID: String?
 
     func reset() {
         showSettings = false
@@ -82,7 +84,7 @@ struct PopoverView: View {
                 Divider()
                 header
                 Divider()
-                if store.hasAnyLimits {
+                if selectedProviderHasLimits {
                     limitsSection
                     Divider()
                 }
@@ -113,21 +115,51 @@ struct PopoverView: View {
                     .foregroundStyle(.secondary)
             }
 
-            ForEach(store.snapshots) { snapshot in
-                if let today = snapshot.today {
-                    providerRow(snapshot: snapshot, today: today)
-                }
-            }
-
-            // 주간/월간 누적
+            // 주간/월간 누적 (전 서비스 합산 — 오늘 합계와 함께 통합 통계)
             if store.weekTotalTokens > 0 || store.monthTotalTokens > 0 {
                 HStack(spacing: 14) {
                     periodLabel(l.thisWeek, tokens: store.weekTotalTokens, cost: store.weekCostTotal)
                     periodLabel(l.thisMonth, tokens: store.monthTotalTokens, cost: store.monthCostTotal)
                     Spacer()
                 }
-                .padding(.top, 4)
+                .padding(.top, 2)
             }
+
+            // 연결된 서비스가 2개 이상이면 작은 탭으로 서비스별 상세를 넘나든다
+            // (합계는 위에 유지 — 상세·한도만 탭 스코프).
+            if store.snapshots.count > 1 {
+                providerTabBar
+                    .padding(.top, 6)
+            }
+            if let snap = selectedSnapshot, let today = snap.today {
+                providerRow(snapshot: snap, today: today)
+            }
+        }
+    }
+
+    /// 현재 선택된 프로바이더 스냅샷 — 선택이 없거나 연결 해제됐으면 첫 번째로 폴백.
+    private var selectedSnapshot: ProviderSnapshot? {
+        store.snapshot(preferring: nav.providerID)
+    }
+
+    private var providerTabBar: some View {
+        HStack(spacing: 6) {
+            ForEach(store.snapshots) { snap in
+                let isSelected = snap.providerID == selectedSnapshot?.providerID
+                Button {
+                    nav.providerID = snap.providerID
+                } label: {
+                    Text(snap.displayName)
+                        .font(.caption.weight(isSelected ? .semibold : .regular))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(isSelected ? Color.accentColor.opacity(0.18) : Color.secondary.opacity(0.08))
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer()
         }
     }
 
@@ -186,14 +218,22 @@ struct PopoverView: View {
 
     // MARK: 한도 섹션 — 공식 5h/주간 % + 리셋 카운트다운
 
+    /// 선택된 프로바이더에 표시할 공식 한도가 있는가 (Gemini 는 공식 한도 API 없음 → 섹션 생략).
+    private var selectedProviderHasLimits: Bool {
+        switch selectedSnapshot?.providerID {
+        case "claude_code": return store.limits != nil
+        case "codex": return store.codexLimits?.codex.hasVisibleLimit == true
+        default: return false
+        }
+    }
+
     @ViewBuilder
     private var limitsSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(l.limitsOfficial)
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            if let limits = store.limits {
-                limitProviderTitle("Claude Code")
+            if selectedSnapshot?.providerID == "claude_code", let limits = store.limits {
                 limitRow(name: l.fiveHourSession, window: limits.fiveHour)
                 forecastRow
                 limitRow(name: l.weekly, window: limits.sevenDay)
@@ -215,8 +255,8 @@ struct PopoverView: View {
                     }
                 }
             }
-            if let codex = store.codexLimits?.codex, codex.hasVisibleLimit {
-                limitProviderTitle("Codex")
+            if selectedSnapshot?.providerID == "codex",
+               let codex = store.codexLimits?.codex, codex.hasVisibleLimit {
                 codexMetaRow(codex)
                 codexLimitRow(name: l.codexWindow(codex.primary?.windowDurationMins), window: codex.primary)
                 codexLimitRow(name: l.codexWindow(codex.secondary?.windowDurationMins), window: codex.secondary)
@@ -225,12 +265,6 @@ struct PopoverView: View {
         }
     }
 
-    private func limitProviderTitle(_ name: String) -> some View {
-        Text(name)
-            .font(.caption.weight(.semibold))
-            .foregroundStyle(.secondary)
-            .padding(.top, 2)
-    }
 
     @ViewBuilder
     private func limitRow(name: String, window: LimitWindow?) -> some View {

--- a/Tests/PokeTokenBarTests/GeminiUsageTests.swift
+++ b/Tests/PokeTokenBarTests/GeminiUsageTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// Gemini CLI 세션 파싱 — 신규 .jsonl(chatRecordingService) + 레거시 .json, 토큰 매핑·단가.
+final class GeminiUsageTests: XCTestCase {
+    private var root: URL!
+    private var cacheFile: URL!
+
+    override func setUpWithError() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ptb-gemini-\(UUID().uuidString)")
+        root = base.appendingPathComponent("tmp")
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("hash1/chats"), withIntermediateDirectories: true)
+        cacheFile = base.appendingPathComponent("usage-cache.json")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: root.deletingLastPathComponent())
+    }
+
+    private let newJSONL = """
+    {"type":"session_metadata","sessionId":"s1","startTime":"2026-07-03T01:00:00.000Z"}
+    {"type":"user","id":"m1","timestamp":"2026-07-03T01:00:05.000Z","content":[{"text":"hi"}]}
+    {"type":"gemini","id":"m2","timestamp":"2026-07-03T01:00:10.000Z","model":"gemini-2.5-pro","tokens":{"input":1000,"output":50,"cached":600,"thoughts":30,"tool":20,"total":1100}}
+    {"type":"gemini","id":"m3","timestamp":"2026-07-03T01:01:00.000Z","model":"gemini-2.5-flash","tokens":{"input":10,"output":5,"cached":0,"thoughts":0,"tool":0,"total":15}}
+    {"type":"message_update","id":"m3","tokens":{"input":10,"output":8,"cached":0,"thoughts":2,"tool":0,"total":20}}
+    """
+
+    private let legacyJSON = """
+    {"sessionId":"s0","startTime":"2026-07-02T00:00:00.000Z","messages":[
+      {"id":"a1","type":"gemini","timestamp":"2026-07-02T00:10:00.000Z","model":"gemini-2.5-pro","tokens":{"input":100,"output":10,"cached":0,"thoughts":0,"tool":0,"total":110}},
+      {"id":"a2","type":"user","content":[{"text":"x"}]}
+    ]}
+    """
+
+    /// 신규 .jsonl — usageMetadata 의미 보존 매핑 + message_update 가 최종값.
+    func testParseNewJSONLMappingAndUpdate() throws {
+        let url = root.appendingPathComponent("hash1/chats/session-2026-07-03T01-00-abcd1234.jsonl")
+        try newJSONL.write(to: url, atomically: true, encoding: .utf8)
+        let entries = LocalUsageReader.parseGeminiFile(url, fmt: LocalUsageReader.localDayFormatter())
+        XCTAssertEqual(entries.count, 2, "tokens 있는 메시지 2건(user/metadata 제외)")
+
+        let m2 = entries[0]
+        XCTAssertEqual(m2.model, "gemini-2.5-pro")
+        XCTAssertEqual(m2.input, 420, "input = (1000-600 비캐시) + 20 tool")
+        XCTAssertEqual(m2.cacheRead, 600)
+        XCTAssertEqual(m2.output, 80, "output = 50 + 30 thoughts")
+        XCTAssertEqual(m2.cacheWrite, 0)
+        XCTAssertEqual(m2.total, 1100, "Entry.total == totalTokenCount 보존")
+
+        let m3 = entries[1]
+        XCTAssertEqual(m3.output, 10, "message_update(output 8 + thoughts 2)가 최종값")
+        XCTAssertEqual(m3.total, 20)
+    }
+
+    /// 레거시 .json — messages[] 안의 tokens 만 수집.
+    func testParseLegacyJSON() throws {
+        let url = root.appendingPathComponent("hash1/chats/checkpoint-old.json")
+        try legacyJSON.write(to: url, atomically: true, encoding: .utf8)
+        let entries = LocalUsageReader.parseGeminiFile(url, fmt: LocalUsageReader.localDayFormatter())
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].input, 100)
+        XCTAssertEqual(entries[0].output, 10)
+        XCTAssertEqual(entries[0].total, 110)
+    }
+
+    /// 캐시 경로 — .jsonl 과 .json 둘 다 수집되고 (path,mtime,size) 재사용도 동작.
+    func testCacheCollectsBothExtensions() async throws {
+        try newJSONL.write(to: root.appendingPathComponent("hash1/chats/session-a.jsonl"),
+                           atomically: true, encoding: .utf8)
+        try legacyJSON.write(to: root.appendingPathComponent("hash1/chats/checkpoint-b.json"),
+                             atomically: true, encoding: .utf8)
+        let cache = LocalUsageCache(geminiRoot: root, fileURL: cacheFile)
+        let entries = await cache.geminiEntries(modifiedSince: Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(entries.count, 3, "jsonl 2건 + json 1건")
+        XCTAssertEqual(entries.map(\.total).reduce(0, +), 1100 + 20 + 110)
+        // 스냅샷에 gemini 캐시가 영속되는지(라운드트립)
+        let again = await LocalUsageCache(geminiRoot: root, fileURL: cacheFile)
+            .geminiEntries(modifiedSince: Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(again.count, 3)
+    }
+
+    /// tokens 없는 파일(프롬프트 로그 등)은 조용히 0건.
+    func testFileWithoutTokensYieldsNothing() throws {
+        let url = root.appendingPathComponent("hash1/logs.json")
+        try #"{"entries":[{"sessionId":"x","type":"user","message":"hello"}]}"#
+            .write(to: url, atomically: true, encoding: .utf8)
+        let entries = LocalUsageReader.parseGeminiFile(url, fmt: LocalUsageReader.localDayFormatter())
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    /// Gemini 단가 — 정확 매칭 + pro/flash 패밀리 폴백 + 미지 변형은 0.
+    func testGeminiPricing() {
+        XCTAssertEqual(ModelPricing.rate(for: "gemini-2.5-pro"), .perMillion(1.25, 10, 0, 0.3125))
+        XCTAssertEqual(ModelPricing.rate(for: "gemini-2.5-flash"), .perMillion(0.30, 2.5, 0, 0.075))
+        XCTAssertEqual(ModelPricing.rate(for: "gemini-3.1-pro-preview"), .perMillion(1.25, 10, 0, 0.3125))
+        XCTAssertEqual(ModelPricing.rate(for: "gemini-3-flash-lite"), .perMillion(0.30, 2.5, 0, 0.075))
+        XCTAssertEqual(ModelPricing.rate(for: "gemini-nano-banana"), .zero, "미지 변형은 오표시 방지 위해 0")
+        // 실제 비용 산술 (m2 케이스): 420 in + 80 out + 600 cacheR @2.5-pro
+        let c = ModelPricing.cost(model: "gemini-2.5-pro", input: 420, output: 80, cacheWrite: 0, cacheRead: 600)
+        XCTAssertEqual(c, 420 * 1.25e-6 + 80 * 10e-6 + 600 * 0.3125e-6, accuracy: 1e-12)
+    }
+}

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -182,7 +182,7 @@ final class UsageStoreTests: XCTestCase {
         store.critThreshold = 95
         await store.refresh(scheduleEmptyRetry: false)
         XCTAssertTrue(store.isLimitWarning)
-        XCTAssertTrue(store.hasAnyLimits)
+        XCTAssertNotNil(store.limits, "한도가 로드돼야 한다")
     }
 
     func testNoLimitWarningWhenUnderCritical() async {

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -242,6 +242,18 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertFalse(store.isStale)
     }
 
+    // MARK: 프로바이더 탭 선택 해석
+
+    func testSnapshotPreferringSelection() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(1_000))
+        let gemini = FakeUsageProvider(id: "gemini", displayName: "Gemini", daily: todayDaily(2_000))
+        let store = makeStore(providers: [claude, gemini])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.snapshot(preferring: "gemini")?.providerID, "gemini")
+        XCTAssertEqual(store.snapshot(preferring: nil)?.providerID, "claude_code", "선호 없음 → 첫 번째")
+        XCTAssertEqual(store.snapshot(preferring: "cursor")?.providerID, "claude_code", "미연결 id → 첫 번째 폴백")
+    }
+
     // MARK: 주/월 누적 유지 (팝오버 깜빡임 회귀 방지)
 
     /// phase1 재빌드가 이전 스냅샷의 주/월 누적을 이어받지 않으면, 다음 enrichment 가


### PR DESCRIPTION
## Phase 2 — Gemini CLI 지원 + 프로바이더 탭 UI

> 머지 후 **배포 없음** (지시). README 홈 스크린샷(GIF)은 탭 UI 반영 전 상태 — 다음 릴리스 때 재캡처 예정.

### 1. Gemini CLI 지원 (세 번째 프로바이더)

| 항목 | 내용 |
|---|---|
| 소스 | `~/.gemini/tmp/<hash>/chats/session-*.jsonl`(신규) + 레거시 `.json` — gemini-cli `chatRecordingService` 공식 포맷 |
| 레코드 | `gemini` 메시지의 인라인 `tokens {input, output, cached, thoughts, tool, total}` + `message_update`(같은 id 최종값) |
| 토큰 매핑 | usageMetadata 의미 보존: `input=(input−cached)+tool` · `cacheRead=cached` · `output=output+thoughts` — **Entry.total == totalTokenCount** 를 픽스처로 고정 |
| 단가 | gemini-2.5-pro `$1.25/$10` · 2.5-flash `$0.30/$2.50` · 2.0-flash(공식 기본 티어) + pro/flash 패밀리 폴백, 미지 변형은 $0(오표시 방지) |
| 표시 | 세션 데이터가 있을 때만 스냅샷 생성 → 미사용 머신(현재 이 머신 포함)에선 UI 변화 없음 |

캐시 스냅샷은 gemini 키 **하위호환 디코딩**(구버전 캐시 무손상), `.json` 확장자 수집 추가.

### 2. 프로바이더 탭 UI (codexbar 레퍼런스)

- **오늘 합계 + 주간/월간은 전 서비스 합산 그대로** (요청 사항).
- 연결 서비스 **2개 이상일 때만** 합계 아래 작은 **캡슐 탭** 등장 — 상세(in/out/cache 분해)와 공식 한도 섹션이 선택 프로바이더로 전환. 상단 Home/Collection 세그먼트와 모양·위치로 구분.
- 선택은 재오픈에도 유지(`PopoverNavigation.providerID`, reset 대상 아님). 미연결 id 는 첫 번째 폴백.
- Gemini 는 공식 한도 API 부재 → 한도 섹션 자동 생략.

실렌더 캡처(가짜 3-프로바이더) 검증 완료: 합계 265.8M 통합 표기 + `[Claude Code] [Codex] [Gemini]` 캡슐 탭 + 선택 상세만 표시.

### 검증

- 신규 테스트 8종: Gemini 파서(신규 jsonl+update / 레거시 json / 토큰무시 파일 / 매핑 산술) · 캐시 양확장자+라운드트립 · 단가(정확+폴백+미지0) · 탭 선택 폴백 3케이스
- 게이트 **137 테스트, 81.02% ≥ 75%** · E2E **7/7** (신규 빌드)
- README EN/KO/JA 동기 반영(소개·How it works·요구사항·데이터소스 표)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
