### PR TITLE
fix: 잠긴 키체인일 때 자동 폴링이 암호 다이얼로그 띄우던 결함 제거

### DIFF
--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -58,6 +58,18 @@ private actor OAuthAccessTokenCache {
             return cachedCredential.accessToken
         }
 
+        // 자동(무프롬프트) 경로에서 login 키체인이 잠겨 있으면 키체인 접근을 일절 하지 않는다.
+        // no-UI 플래그(kSecUseAuthenticationUIFail/LAContext)는 '인증' 프롬프트만 억제할 뿐
+        // 잠긴 키체인의 '암호 입력' 다이얼로그는 못 막는다 → 잠긴 아침마다 사용자에게 팝업이 뜨는
+        // 결함의 원인. 잠겨 있으면 파일 크리덴셜만 시도하고(키체인 무관), 없으면 조용히 실패한다.
+        if !allowKeychainPrompt, Self.isDefaultKeychainLocked() {
+            if let credential = try Self.readClaudeCredentialsFile() {
+                cachedCredential = credential   // 잠긴 키체인에는 캐시 write 안 함(그 write 도 프롬프트 유발)
+                return credential.accessToken
+            }
+            throw LimitsError.keychainInteractionNotAllowed
+        }
+
         if let credential = try Self.readPokeTokenBarCache() {
             cachedCredential = credential
             return credential.accessToken
@@ -102,6 +114,17 @@ private actor OAuthAccessTokenCache {
             AppLog.write("silent claude keychain read failed: \(error)")
             return nil
         }
+    }
+
+    /// login(기본) 키체인 잠금 여부. GetStatus 는 프롬프트 없이 상태만 읽는다(안전).
+    /// SecKeychain* 는 deprecated 지만 파일 기반 login 키체인의 잠금 상태를 무프롬프트로 조회하는
+    /// 유일한 API — 대체재 없음. 조회 실패 시 '잠기지 않음'으로 간주(기존 경로 유지, 보수적).
+    private nonisolated static func isDefaultKeychainLocked() -> Bool {
+        var keychain: SecKeychain?
+        guard SecKeychainCopyDefault(&keychain) == errSecSuccess, let keychain else { return false }
+        var status = SecKeychainStatus()
+        guard SecKeychainGetStatus(keychain, &status) == errSecSuccess else { return false }
+        return (status & SecKeychainStatus(kSecUnlockStateStatus)) == 0   // unlock 비트 꺼짐 = 잠김
     }
 
     func invalidate(removePersistentCache: Bool = false) {
@@ -172,6 +195,10 @@ private actor OAuthAccessTokenCache {
     }
 
     private nonisolated static func deletePokeTokenBarCache() {
+        // 잠긴 키체인에서 삭제(SecItemDelete)도 암호 다이얼로그를 유발한다. 401 무효화 경로가
+        // 프롬프트 여부와 무관하게 호출하므로, 잠겨 있으면 디스크 삭제는 생략한다(메모리 캐시는
+        // invalidate 가 이미 비움 — 만료 항목은 다음 unlocked 읽기에서 정리됨).
+        if isDefaultKeychainLocked() { return }
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: OAuthCredentialData.tokenMacCacheService,


### PR DESCRIPTION
## 문제 (전 사용자 대상 결함)

login 키체인이 **잠긴 상태**에서 앱의 2분 자동 폴링이 Claude 자격증명을 읽으려 하면
**"'로그인' 키체인 암호를 입력하십시오" 다이얼로그가 반복적으로** 떴다. 사용자가
스크린샷 제보 — 암호칸이 있는 걸로 "인증 프롬프트"가 아니라 "키체인 잠금해제"임이 확인됨.

키체인이 잠기는 상황은 흔함: 회사 맥 MDM/보안정책, **키체인 암호와 로그인 암호 desync**
(비번 변경 후 로그인 시 자동 잠금해제 안 됨), 잠자기 잠금 정책 등. → 다운로드한 모든
사용자에게 발생 가능.

### 왜 기존 no-UI 억제로 못 막았나
자동 경로는 `LAContext.interactionNotAllowed` + `kSecUseAuthenticationUIFail` 로 프롬프트를
억제하지만, 이 플래그들은 **'인증'(Touch ID/ACL 확인) UI 만** 막는다. **'키체인 잠금해제
암호' 다이얼로그는 macOS 설계상 이 플래그로 억제되지 않는다.**

## 수정

- `SecKeychainGetStatus`(프롬프트 없이 상태만 조회)로 기본 키체인 **잠금 여부를 사전 확인**.
- **자동(allowKeychainPrompt=false) 경로 + 잠김** → 키체인 접근을 일절 하지 않음.
  키체인과 무관한 파일 크리덴셜만 시도, 없으면 조용히 실패(한도 섹션만 숨김).
  **토큰/비용 집계·포켓몬 성장은 로컬 로그라 전혀 영향 없음.**
- 잠긴 키체인에는 캐시 write / delete(401 무효화)도 하지 않음 — 둘 다 프롬프트 유발원.
- **수동 갱신 버튼은 그대로** — 사용자가 명시적으로 누르면 프롬프트/잠금해제 정상(의도된 동작).

`SecKeychain*` 는 deprecated(macOS 10.10)지만 파일 기반 login 키체인 잠금을 **무프롬프트로
조회하는 유일한 API** — 대체재 없음, 주석에 명시. (deprecation 경고 2건 발생, 기능 무해)

## 검증

| 항목 | 결과 |
|---|---|
| 잠금 판정 로직 | 임시 키체인으로 unlocked→locked→unlocked 정확 검출 확인 |
| unlocked happy-path | 한도 자동 갱신·캐시 write **회귀 없음**(빌드+실행 로그 확인) |
| 전체 게이트 | 137 테스트, 로직 코어 **81.02% ≥ 75%** |

## 사용자 안내(병행)
근본 회피책 2가지도 있음 — ① 설정의 "Keychain 접근 끄기"(한도만 끔, 즉효) ② 키체인 접근 앱에서
login 키체인 암호를 로그인 암호와 재일치(자동 잠금해제 복구). 이 PR 은 그와 별개로, **아무 설정도
안 한 사용자에게 애초에 프롬프트가 안 뜨게** 만드는 앱 차원의 근본 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
