### PR TITLE
fix: Codex 다중 bucket 한도 전부 표시 + Claude 신형 limits[] 파싱

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -34,12 +34,29 @@ struct L {
     var reset: String { t("리셋", "Reset", "リセット") }
     var limitReached: String { t("한도 도달", "Limit reached", "上限到達") }
     var personalSpendLimit: String { t("개인 사용 한도", "Personal spend limit", "個人利用上限") }
+    var staleLimits: String { t("갱신 지연", "Stale", "更新遅延") }
     func plan(_ p: String) -> String { t("플랜 \(p)", "Plan \(p)", "プラン \(p)") }
     func forecastReach(_ time: String) -> String {
         t("현재 속도면 \(time) 한도 도달", "At current rate, limit hit at \(time)", "現在のペースで \(time) に上限到達")
     }
     var forecastNoReach: String {
         t("현재 속도로는 리셋 전 한도 도달 없음", "Won't hit limit before reset at current rate", "現在のペースではリセット前に上限到達なし")
+    }
+
+    /// Claude oauth/usage 신형 limits[] 엔트리 이름 — kind + 모델 스코프 기반.
+    func claudeLimitEntry(kind: String?, model: String?) -> String {
+        switch kind {
+        case "session": return fiveHourSession
+        case "weekly_all": return weekly
+        case "weekly_scoped":
+            // 모델명이 없으면 레거시 "주간" 행과 이름이 겹치므로 scoped 임을 구분 표기
+            guard let model else { return t("주간 (모델별)", "Weekly (scoped)", "週間（モデル別）") }
+            return t("주간 \(model)", "Weekly \(model)", "週間 \(model)")
+        default:
+            let base = kind ?? "limit"
+            let name = model.map { " \($0)" } ?? ""
+            return base.replacingOccurrences(of: "_", with: " ") + name
+        }
     }
 
     /// Codex 한도 윈도우 이름 (windowDurationMins 기반). 알림·팝오버 공통.

--- a/Sources/PokeTokenBar/Core/Models.swift
+++ b/Sources/PokeTokenBar/Core/Models.swift
@@ -196,12 +196,55 @@ struct LimitStatus: Decodable, Sendable {
     var sevenDay: LimitWindow?
     var sevenDayOpus: LimitWindow?
     var sevenDaySonnet: LimitWindow?
+    var limits: [OAuthLimitEntry]?
 
     private enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
         case sevenDay = "seven_day"
         case sevenDayOpus = "seven_day_opus"
         case sevenDaySonnet = "seven_day_sonnet"
+        case limits
+    }
+
+    /// 레거시 필드가 못 담는 윈도우 — session(=five_hour)·weekly_all(=seven_day)은 레거시 행이
+    /// 이미 표시하므로 제외하고, weekly_scoped(모델별 주간) 등 나머지만 추가 노출.
+    /// 레거시 필드가 전부 비면(신형 응답만 오는 경우) limits 전체를 표시 대상으로 폴백.
+    var scopedLimitEntries: [OAuthLimitEntry] {
+        let entries = limits ?? []
+        if fiveHour == nil && sevenDay == nil { return entries }
+        return entries.filter { $0.kind != "session" && $0.kind != "weekly_all" }
+    }
+}
+
+/// oauth/usage 신형 `limits[]` 엔트리 — 레거시 five_hour/seven_day 를 일반화한 목록.
+/// 구 seven_day_opus/seven_day_sonnet 는 null 로 바뀌었고, 모델별 주간 한도는
+/// kind=weekly_scoped + scope.model.displayName 으로 여기에만 온다.
+struct OAuthLimitEntry: Decodable, Sendable {
+    var kind: String?
+    var group: String?
+    var percent: Double?
+    var severity: String?
+    var resetsAt: String?
+    var scope: Scope?
+    var isActive: Bool?
+
+    struct Scope: Decodable, Sendable {
+        var model: Model?
+        struct Model: Decodable, Sendable {
+            var displayName: String?
+            private enum CodingKeys: String, CodingKey { case displayName = "display_name" }
+        }
+    }
+
+    var resetDate: Date? {
+        guard let resetsAt else { return nil }
+        return ISO8601Parser.date(from: resetsAt)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, group, percent, severity, scope
+        case resetsAt = "resets_at"
+        case isActive = "is_active"
     }
 }
 
@@ -257,17 +300,44 @@ struct CodexRateLimitSnapshot: Decodable, Sendable {
     var hasVisibleLimit: Bool {
         primary != nil || secondary != nil || individualLimit != nil
     }
+
+    /// bucket 표시명 — limitName/limitId 기반 ("codex" → "Codex", "codex_other" → "Codex other").
+    var bucketDisplayName: String {
+        let raw = limitName ?? limitId ?? "codex"
+        let spaced = raw.replacingOccurrences(of: "_", with: " ")
+        return spaced.prefix(1).uppercased() + spaced.dropFirst()
+    }
 }
 
 struct CodexRateLimitStatus: Decodable, Sendable {
     var rateLimits: CodexRateLimitSnapshot
     var rateLimitsByLimitId: [String: CodexRateLimitSnapshot]?
 
-    var codex: CodexRateLimitSnapshot {
-        rateLimitsByLimitId?["codex"] ?? rateLimits
+    /// 전체 bucket 목록 — codex TUI `app_server_rate_limit_snapshots` 미러링.
+    /// 서버 top-level(rateLimits)은 "codex" bucket 우선이라 codex_other 등 나머지 bucket은
+    /// rateLimitsByLimitId 에만 있다. top-level + byLimitId 나머지를 limitId 기준 dedup 후 합성.
+    var snapshots: [CodexRateLimitSnapshot] {
+        var result = [rateLimits]
+        guard let byLimitId = rateLimitsByLimitId else { return result }
+        // 서버는 limitId 없는 스냅샷을 "codex" 키로 넣는다(account_processor.rs) —
+        // top-level 과 같은 키/ID 는 중복이므로 제외. 정렬은 dict 순서 비결정성 제거용.
+        let primaryKey = rateLimits.limitId ?? "codex"
+        for (limitId, snapshot) in byLimitId.sorted(by: { $0.key < $1.key }) {
+            if limitId == primaryKey { continue }
+            if let id = snapshot.limitId, id == rateLimits.limitId { continue }
+            result.append(snapshot)
+        }
+        return result
     }
 
-    var hasVisibleLimit: Bool { codex.hasVisibleLimit }
+    var visibleSnapshots: [CodexRateLimitSnapshot] { snapshots.filter(\.hasVisibleLimit) }
+
+    var hasVisibleLimit: Bool { !visibleSnapshots.isEmpty }
+
+    /// 메뉴바 표기·경고 판정용 — 전체 bucket 중 최대 5h(primary) 사용률.
+    var maxPrimaryUsedPercent: Int? {
+        visibleSnapshots.compactMap { $0.primary?.usedPercent }.max()
+    }
 }
 
 // MARK: - Provider snapshot

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -16,6 +16,7 @@ final class UsageStore {
     private(set) var snapshots: [ProviderSnapshot] = []
     private(set) var limits: LimitStatus?
     private(set) var codexLimits: CodexRateLimitStatus?
+    private(set) var codexLimitsUpdatedAt: Date?
     private(set) var limitsAvailable = true
     private(set) var lastUpdated: Date?
     private(set) var isRefreshing = false
@@ -107,7 +108,7 @@ final class UsageStore {
             if let utilization = limits?.fiveHour?.utilization {
                 parts.append("Claude \(TokenFormatter.percent(utilization))")
             }
-            if let usedPercent = codexLimits?.codex.primary?.usedPercent {
+            if let usedPercent = codexLimits?.maxPrimaryUsedPercent {
                 parts.append("Codex \(TokenFormatter.percent(Double(usedPercent)))")
             }
         }
@@ -169,12 +170,14 @@ final class UsageStore {
     /// 메뉴바 경고 상태 — 임계 초과 또는 리셋 전 한도 도달 예측
     var isLimitWarning: Bool {
         if let utilization = limits?.fiveHour?.utilization, utilization >= critThreshold { return true }
-        if let utilization = codexLimits?.codex.primary?.usedPercent,
-           Double(utilization) >= critThreshold { return true }
-        if let utilization = codexLimits?.codex.secondary?.usedPercent,
-           Double(utilization) >= critThreshold { return true }
-        if let utilization = codexLimits?.codex.individualLimit?.usedPercent,
-           Double(utilization) >= critThreshold { return true }
+        for bucket in codexLimits?.visibleSnapshots ?? [] {
+            if let utilization = bucket.primary?.usedPercent,
+               Double(utilization) >= critThreshold { return true }
+            if let utilization = bucket.secondary?.usedPercent,
+               Double(utilization) >= critThreshold { return true }
+            if let utilization = bucket.individualLimit?.usedPercent,
+               Double(utilization) >= critThreshold { return true }
+        }
         if let forecast = fiveHourForecast, forecast.beforeReset { return true }
         return false
     }
@@ -460,14 +463,25 @@ final class UsageStore {
     private func refreshCodexLimits() async {
         do {
             codexLimits = try await codexLimitsProvider.fetch()
-            if let codex = codexLimits?.codex {
-                AppLog.write("codex limits refreshed primary=\(codex.primary?.usedPercent.description ?? "nil") secondary=\(codex.secondary?.usedPercent.description ?? "nil") plan=\(codex.planType ?? "nil")")
+            if let status = codexLimits {
+                codexLimitsUpdatedAt = Date()
+                let buckets = status.snapshots.map { bucket in
+                    "\(bucket.limitId ?? "codex"): primary=\(bucket.primary?.usedPercent.description ?? "nil") secondary=\(bucket.secondary?.usedPercent.description ?? "nil")"
+                }.joined(separator: " | ")
+                AppLog.write("codex limits refreshed [\(buckets)] plan=\(status.rateLimits.planType ?? "nil")")
             } else {
                 AppLog.write("codex limits skipped: codex binary not found")
             }
         } catch {
             AppLog.write("codex limits unavailable: \(error)")
         }
+    }
+
+    /// codex 한도 스냅샷 staleness — 갱신 실패가 이어지면 이전 값이 남는다는 사실을 UI에 노출.
+    /// 임계 15분은 codex TUI `RATE_LIMIT_STALE_THRESHOLD_MINUTES` 와 동일.
+    var codexLimitsStale: Bool {
+        guard codexLimits != nil, let codexLimitsUpdatedAt else { return false }
+        return Date().timeIntervalSince(codexLimitsUpdatedAt) > 15 * 60
     }
 
     // MARK: 한도 알림 (ClaudeBar 임계값 패턴)
@@ -500,20 +514,21 @@ final class UsageStore {
                     limits.sevenDay?.resetsAt ?? "none"))
             }
         }
-        if let codex = codexLimits?.codex {
-            if let primary = codex.primary {
+        for bucket in codexLimits?.visibleSnapshots ?? [] {
+            let bucketName = bucket.bucketDisplayName   // "Codex" / "Codex other" 등
+            if let primary = bucket.primary {
                 windows.append((
-                    "Codex \(l.codexWindow(primary.windowDurationMins))",
+                    "\(bucketName) \(l.codexWindow(primary.windowDurationMins))",
                     Double(primary.usedPercent),
                     primary.resetsAt.map(String.init) ?? "none"))
             }
-            if let secondary = codex.secondary {
+            if let secondary = bucket.secondary {
                 windows.append((
-                    "Codex \(l.codexWindow(secondary.windowDurationMins))",
+                    "\(bucketName) \(l.codexWindow(secondary.windowDurationMins))",
                     Double(secondary.usedPercent),
                     secondary.resetsAt.map(String.init) ?? "none"))
             }
-            if let individual = codex.individualLimit {
+            if let individual = bucket.individualLimit {
                 windows.append((
                     l.codexPersonalLimit,
                     Double(individual.usedPercent),

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -222,7 +222,7 @@ struct PopoverView: View {
     private var selectedProviderHasLimits: Bool {
         switch selectedSnapshot?.providerID {
         case "claude_code": return store.limits != nil
-        case "codex": return store.codexLimits?.codex.hasVisibleLimit == true
+        case "codex": return store.codexLimits?.hasVisibleLimit == true
         default: return false
         }
     }
@@ -239,6 +239,12 @@ struct PopoverView: View {
                 limitRow(name: l.weekly, window: limits.sevenDay)
                 limitRow(name: l.weeklyOpus, window: limits.sevenDayOpus)
                 limitRow(name: l.weeklySonnet, window: limits.sevenDaySonnet)
+                // 신형 limits[] — 모델별 주간(weekly_scoped) 등 레거시 필드 밖 윈도우
+                ForEach(Array(limits.scopedLimitEntries.enumerated()), id: \.offset) { _, entry in
+                    limitRow(
+                        name: l.claudeLimitEntry(kind: entry.kind, model: entry.scope?.model?.displayName),
+                        window: LimitWindow(utilization: entry.percent, resetsAt: entry.resetsAt))
+                }
                 if let block = store.snapshots.first(where: { $0.activeBlock != nil })?.activeBlock,
                    let end = block.endDate {
                     HStack {
@@ -256,11 +262,21 @@ struct PopoverView: View {
                 }
             }
             if selectedSnapshot?.providerID == "codex",
-               let codex = store.codexLimits?.codex, codex.hasVisibleLimit {
-                codexMetaRow(codex)
-                codexLimitRow(name: l.codexWindow(codex.primary?.windowDurationMins), window: codex.primary)
-                codexLimitRow(name: l.codexWindow(codex.secondary?.windowDurationMins), window: codex.secondary)
-                codexSpendLimitRow(codex.individualLimit)
+               let codexStatus = store.codexLimits, codexStatus.hasVisibleLimit {
+                let buckets = codexStatus.visibleSnapshots
+                codexMetaRow(codexStatus)
+                ForEach(buckets, id: \.limitId) { bucket in
+                    // bucket 이 여럿일 때만 구분 라벨 (단일 bucket 사용자는 기존 UI 그대로)
+                    if buckets.count > 1 {
+                        Text(bucket.bucketDisplayName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 2)
+                    }
+                    codexLimitRow(name: l.codexWindow(bucket.primary?.windowDurationMins), window: bucket.primary)
+                    codexLimitRow(name: l.codexWindow(bucket.secondary?.windowDurationMins), window: bucket.secondary)
+                    codexSpendLimitRow(bucket.individualLimit)
+                }
             }
         }
     }
@@ -292,18 +308,27 @@ struct PopoverView: View {
     }
 
     @ViewBuilder
-    private func codexMetaRow(_ snapshot: CodexRateLimitSnapshot) -> some View {
-        if snapshot.planType != nil || snapshot.rateLimitReachedType != nil {
+    private func codexMetaRow(_ status: CodexRateLimitStatus) -> some View {
+        // plan 은 계정 속성 — bucket 필터와 무관하게 top-level 에서 읽는다 (로그와 동일 소스)
+        let planType = status.rateLimits.planType ?? status.visibleSnapshots.first?.planType
+        let reached = status.visibleSnapshots.contains { $0.rateLimitReachedType != nil }
+        if planType != nil || reached || store.codexLimitsStale {
             HStack(spacing: 8) {
-                if let plan = snapshot.planType {
+                if let plan = planType {
                     Text(l.plan(plan))
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
-                if snapshot.rateLimitReachedType != nil {
+                if reached {
                     Text(l.limitReached)
                         .font(.caption)
                         .foregroundStyle(.red)
+                }
+                // 갱신 실패가 15분+ 이어지면 이전 스냅샷임을 노출 (codex TUI stale 임계와 동일)
+                if store.codexLimitsStale, let updated = store.codexLimitsUpdatedAt {
+                    (Text(l.staleLimits) + Text(" · ") + Text(updated, style: .relative))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
                 }
             }
         }

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -175,6 +175,45 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(status.sevenDay?.utilization, 16.0)
     }
 
+    /// oauth/usage 신형 limits[] — 레거시 필드가 커버하는 session/weekly_all 은 제외,
+    /// weekly_scoped(모델별 주간)만 추가 노출 대상. (2026-07 실측 스키마 기반)
+    func testLimitStatusScopedEntries() throws {
+        let json = """
+        {"five_hour":{"utilization":32.0,"resets_at":"2026-07-10T04:10:00.497904+00:00"},
+        "seven_day":{"utilization":7.0,"resets_at":"2026-07-12T03:00:00.497928+00:00"},
+        "seven_day_opus":null,"seven_day_sonnet":null,
+        "limits":[
+        {"kind":"session","group":"session","percent":32,"severity":"normal","resets_at":"2026-07-10T04:10:00.497904+00:00","scope":null,"is_active":true},
+        {"kind":"weekly_all","group":"weekly","percent":7,"severity":"normal","resets_at":"2026-07-12T03:00:00.497928+00:00","scope":null,"is_active":false},
+        {"kind":"weekly_scoped","group":"weekly","percent":41,"severity":"normal","resets_at":"2026-07-12T03:00:00.498239+00:00","scope":{"model":{"id":null,"display_name":"Fable"},"surface":null},"is_active":false}
+        ]}
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(LimitStatus.self, from: json)
+
+        XCTAssertEqual(status.limits?.count, 3)
+        XCTAssertEqual(status.scopedLimitEntries.count, 1)
+        let scoped = try XCTUnwrap(status.scopedLimitEntries.first)
+        XCTAssertEqual(scoped.kind, "weekly_scoped")
+        XCTAssertEqual(scoped.percent, 41)
+        XCTAssertEqual(scoped.scope?.model?.displayName, "Fable")
+        XCTAssertNotNil(scoped.resetDate)
+    }
+
+    /// 레거시 필드가 전부 비면 limits[] 전체가 표시 대상 (신형 응답 전환 대비 폴백).
+    func testLimitStatusLegacyEmptyFallsBackToAllEntries() throws {
+        let json = """
+        {"five_hour":null,"seven_day":null,
+        "limits":[
+        {"kind":"session","group":"session","percent":10,"severity":"normal","resets_at":"2026-07-10T04:10:00+00:00","scope":null,"is_active":true},
+        {"kind":"weekly_all","group":"weekly","percent":5,"severity":"normal","resets_at":"2026-07-12T03:00:00+00:00","scope":null,"is_active":false}
+        ]}
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(LimitStatus.self, from: json)
+        XCTAssertEqual(status.scopedLimitEntries.count, 2)
+    }
+
     func testCodexRateLimitStatus() throws {
         let json = """
         {"rateLimits":{"limitId":"codex","limitName":null,
@@ -191,12 +230,62 @@ final class ModelDecodingTests: XCTestCase {
 
         let status = try JSONDecoder().decode(CodexRateLimitStatus.self, from: json)
 
-        XCTAssertEqual(status.codex.primary?.usedPercent, 86)
-        XCTAssertEqual(status.codex.primary?.displayName, "5시간 세션")
-        XCTAssertEqual(status.codex.secondary?.displayName, "주간")
-        XCTAssertEqual(status.codex.planType, "team")
+        // 단일 bucket — top-level 과 byLimitId["codex"] 가 같은 스냅샷이므로 1개로 dedup
+        XCTAssertEqual(status.snapshots.count, 1)
+        let codex = try XCTUnwrap(status.visibleSnapshots.first)
+        XCTAssertEqual(codex.primary?.usedPercent, 86)
+        XCTAssertEqual(codex.primary?.displayName, "5시간 세션")
+        XCTAssertEqual(codex.secondary?.displayName, "주간")
+        XCTAssertEqual(codex.planType, "team")
         XCTAssertTrue(status.hasVisibleLimit)
-        XCTAssertNotNil(status.codex.primary?.resetDate)
+        XCTAssertNotNil(codex.primary?.resetDate)
+        XCTAssertEqual(status.maxPrimaryUsedPercent, 86)
+    }
+
+    /// 다중 bucket 계정 (codex + codex_other) — 리포트된 버그 시나리오:
+    /// "codex" bucket 은 미사용(0%), 실사용은 codex_other(주간 93%). 두 bucket 모두 노출돼야 한다.
+    func testCodexRateLimitStatusMultiBucket() throws {
+        let json = """
+        {"rateLimits":{"limitId":"codex","limitName":null,
+        "primary":{"usedPercent":0,"windowDurationMins":300,"resetsAt":1781694161},
+        "secondary":{"usedPercent":0,"windowDurationMins":10080,"resetsAt":1781855658},
+        "credits":null,"individualLimit":null,"planType":"plus","rateLimitReachedType":null},
+        "rateLimitsByLimitId":{
+        "codex":{"limitId":"codex","limitName":null,
+        "primary":{"usedPercent":0,"windowDurationMins":300,"resetsAt":1781694161},
+        "secondary":{"usedPercent":0,"windowDurationMins":10080,"resetsAt":1781855658},
+        "credits":null,"individualLimit":null,"planType":"plus","rateLimitReachedType":null},
+        "codex_other":{"limitId":"codex_other","limitName":"codex_other",
+        "primary":{"usedPercent":41,"windowDurationMins":300,"resetsAt":1781694161},
+        "secondary":{"usedPercent":93,"windowDurationMins":10080,"resetsAt":1781855658},
+        "credits":null,"individualLimit":null,"planType":"plus","rateLimitReachedType":null}}}
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(CodexRateLimitStatus.self, from: json)
+
+        XCTAssertEqual(status.snapshots.count, 2)
+        XCTAssertEqual(status.snapshots[0].limitId, "codex")          // top-level 우선
+        XCTAssertEqual(status.snapshots[1].limitId, "codex_other")
+        XCTAssertEqual(status.snapshots[1].secondary?.usedPercent, 93)
+        XCTAssertEqual(status.maxPrimaryUsedPercent, 41)              // 메뉴바 = bucket 최대값
+        XCTAssertEqual(status.snapshots[1].bucketDisplayName, "Codex other")
+        XCTAssertEqual(status.snapshots[0].bucketDisplayName, "Codex")
+    }
+
+    /// limitId 없는 구형 응답 — byLimitId["codex"] 가 top-level 과 동일 내용이면 중복 노출 금지.
+    func testCodexRateLimitStatusLegacyNilLimitIdDedup() throws {
+        let json = """
+        {"rateLimits":{"limitId":null,"limitName":null,
+        "primary":{"usedPercent":30,"windowDurationMins":300,"resetsAt":1},
+        "secondary":null,"credits":null,"individualLimit":null,"planType":null,"rateLimitReachedType":null},
+        "rateLimitsByLimitId":{"codex":{"limitId":null,"limitName":null,
+        "primary":{"usedPercent":30,"windowDurationMins":300,"resetsAt":1},
+        "secondary":null,"credits":null,"individualLimit":null,"planType":null,"rateLimitReachedType":null}}}
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(CodexRateLimitStatus.self, from: json)
+        XCTAssertEqual(status.snapshots.count, 1)
+        XCTAssertEqual(status.maxPrimaryUsedPercent, 30)
     }
 }
 


### PR DESCRIPTION
## 요약
사용자 버그 리포트 대응: 공식 사용량 페이지는 주간 93%인데 앱은 0%로 표시되던 문제.
원인은 Codex 한도가 bucket 목록(`codex` + `codex_other` 등)으로 분리됐는데 앱이
`rateLimitsByLimitId["codex"]` 하나만 읽던 것. 같은 계열 누락으로 Claude 쪽도
`seven_day_opus/seven_day_sonnet`이 null로 바뀌며 모델별 주간 행이 사라진 상태여서
신형 `limits[]` 파싱을 함께 추가했다.

## 변경 사항
- `CodexRateLimitStatus.snapshots`: top-level + `rateLimitsByLimitId` 나머지 bucket을
  limitId 기준 dedup 후 합성 (codex app-server의 bucket 키 규칙과 동일). 경고·알림·메뉴바 전 bucket 순회
- Codex 한도 fetch 성공 시각 추적(`codexLimitsUpdatedAt`) — 실패 지속 15분 초과 시 stale 표시
- Claude `oauth/usage` 신형 `limits[]`(`OAuthLimitEntry`) 디코딩 — `weekly_scoped`(모델별 주간) 행 표시,
  레거시 필드 전부 null이면 `limits[]` 전체 폴백
- 테스트 5케이스 추가 (다중 bucket·구형 nil limitId dedup·weekly_scoped 추출·레거시 폴백), 전체 144개 통과

## UI 변경 (팝오버·메뉴바·알림)

| 화면 | Before | After |
|---|---|---|
| 팝오버 Codex 한도 (bucket 1개 계정) | 5h/주간/개인지출 행 | **변화 없음** (동일 UI) |
| 팝오버 Codex 한도 (bucket 2개+ 계정) | "codex" bucket만 표시 — 실사용 bucket이 다르면 0% 오표시 | bucket별 구분 라벨("Codex" / "Codex other") 아래 각 5h/주간/개인지출 행 |
| 팝오버 Codex 메타 행 | 플랜·한도도달 | + 갱신 실패 15분 초과 시 주황색 "갱신 지연 · n분 전" (플랜은 top-level 소스로 통일) |
| 메뉴바 "Codex n%" | "codex" bucket의 5h % | 전체 bucket 중 최대 5h % (5h 기준은 Claude 표기와 동일하게 유지) |
| 한도 임계 알림 | "codex" bucket만 검사 | 전 bucket 검사, 알림명에 bucket 라벨 포함 |
| 팝오버 Claude 한도 | 5h/주간/주간 Opus/주간 Sonnet (후자 2개는 응답 null화로 표시 안 됨) | + `limits[]`의 모델별 주간 행 (예: "주간 Fable"). 모델명 없으면 "주간 (모델별)" 폴백. 레거시 행은 하위호환 유지 |

폴백 동작: bucket이 하나뿐이면 구분 라벨 생략(기존과 동일), `limits[]` 부재 시 레거시 필드만으로 기존과 동일 렌더링.

## 테스트 / 확인 사항
- [x] `swift test` 144개 통과 (신규 5케이스 포함)
- [x] 코드 리뷰 2라운드 — 발견 4건 반영(dedup 키 기반 교체·planType 소스 통일·ForEach id·이름 충돌 폴백) 후 재검토 결함 없음
- [ ] 다중 bucket 계정 실물 확인 — 리포트 사용자에게 수정 빌드 검증 요청 (로컬 재현 불가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
