### PR TITLE
feat: 설정에 문제점 알리기 추가 — mailto 리포트 + 로그 파일 열기

### DIFF
--- a/Sources/PokeTokenBar/Core/AppLog.swift
+++ b/Sources/PokeTokenBar/Core/AppLog.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// ~/Library/Logs/PokeTokenBar.log 단순 append 로거 (디버깅/장애 추적용)
 enum AppLog {
+    /// 로그 파일 경로 — 설정의 "로그 파일 보기"(Finder 표시)에서 사용.
+    static var logFileURL: URL { url }
+
     private static let url: URL = {
         let dir = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("Logs")

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -100,6 +100,57 @@ struct L {
     var aggregationNote: String { t("토큰 집계 기준: totalTokens (input + output + cache, 로컬 날짜)", "Token basis: totalTokens (input + output + cache, local date)", "集計基準: totalTokens (input + output + cache, ローカル日付)") }
     var close: String { t("닫기", "Close", "閉じる") }
 
+    // MARK: 문제점 알리기 (설정 → 메일 리포트)
+    var reportProblem: String { t("문제점 알리기", "Report a problem", "問題を報告") }
+    var showLogFile: String { t("로그 파일 보기", "Show log file", "ログファイルを表示") }
+    var reportAttachHint: String {
+        t("메일에 로그 파일을 첨부해 주시면 원인 파악에 큰 도움이 돼요.",
+          "Attaching the log file to the email helps a lot with diagnosis.",
+          "メールにログファイルを添付していただくと原因の特定に役立ちます。")
+    }
+    func reportMailFallback(_ address: String) -> String {
+        t("메일 앱을 열 수 없어요. \(address) 로 직접 보내주세요.",
+          "Couldn't open a mail app. Please email \(address) directly.",
+          "メールアプリを開けません。\(address) 宛に直接お送りください。")
+    }
+    func reportMailSubject(_ version: String) -> String {
+        t("[PokeTokenBar] 문제 리포트 (v\(version))",
+          "[PokeTokenBar] Problem report (v\(version))",
+          "[PokeTokenBar] 問題レポート (v\(version))")
+    }
+    func reportMailBody(version: String, os: String) -> String {
+        t("""
+        문제 내용:
+        (겪으신 문제를 적어주세요 — 언제, 어떤 화면에서, 어떻게 되었는지)
+
+
+        ---
+        앱 버전: v\(version)
+        macOS: \(os)
+        로그 파일(첨부 권장): ~/Library/Logs/PokeTokenBar.log
+        """,
+        """
+        What happened:
+        (Describe the problem — when, on which screen, and what you saw)
+
+
+        ---
+        App version: v\(version)
+        macOS: \(os)
+        Log file (please attach): ~/Library/Logs/PokeTokenBar.log
+        """,
+        """
+        問題の内容:
+        （いつ・どの画面で・どうなったかをご記入ください）
+
+
+        ---
+        アプリのバージョン: v\(version)
+        macOS: \(os)
+        ログファイル（添付推奨）: ~/Library/Logs/PokeTokenBar.log
+        """)
+    }
+
     /// 새로고침 간격 라벨 (초 단위 값 → 표시). 0 = 수동.
     func intervalLabel(_ seconds: TimeInterval) -> String {
         if seconds == 0 { return t("수동", "Manual", "手動") }

--- a/Sources/PokeTokenBar/Core/SupportMail.swift
+++ b/Sources/PokeTokenBar/Core/SupportMail.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// 설정의 "문제점 알리기" — 기본 메일 클라이언트로 사전 작성된 리포트 메일을 연다.
+/// 앱은 메일을 직접 전송하지 않는다(SMTP/계정 불필요) — mailto URL 조립까지만 담당.
+enum SupportMail {
+    /// 수신 주소 — 개발자 공개 연락처(GitHub 프로필 공개 이메일과 동일).
+    static let address = "parkdongmin123@gmail.com"
+
+    /// mailto URL 조립 — subject/body 는 URLComponents 가 percent-encode (개행·한글 포함).
+    static func mailtoURL(to: String = address, subject: String, body: String) -> URL? {
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = to
+        components.queryItems = [
+            URLQueryItem(name: "subject", value: subject),
+            URLQueryItem(name: "body", value: body),
+        ]
+        return components.url
+    }
+}

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
     var onClose: () -> Void
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var launchAtLoginError: String?
+    @State private var reportError: String?
 
     private var l: L { companion.l }
 
@@ -18,6 +19,21 @@ struct SettingsView: View {
     /// 현재 앱 버전 — 업데이트 적용 여부 확인용으로 설정창 하단에 표기.
     private static var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
+    }
+
+    /// 문제점 알리기 — 진단 정보(버전·macOS)가 채워진 리포트 메일을 기본 메일 앱으로 연다.
+    /// 메일 앱이 없거나 열기에 실패하면 수신 주소를 안내(복사 가능)한다.
+    private func reportProblem() {
+        let subject = l.reportMailSubject(Self.appVersion)
+        let body = l.reportMailBody(
+            version: Self.appVersion,
+            os: ProcessInfo.processInfo.operatingSystemVersionString)
+        guard let url = SupportMail.mailtoURL(subject: subject, body: body),
+              NSWorkspace.shared.open(url) else {
+            reportError = l.reportMailFallback(SupportMail.address)
+            return
+        }
+        reportError = nil
     }
 
     /// 푸터 링크 — 버전 표기와 동일한 크기·색을 상속하고 밑줄로만 구분(부모 HStack 스타일 사용).
@@ -142,6 +158,24 @@ struct SettingsView: View {
                     .font(.caption).padding(.leading, 12)
                 }
                 Toggle(l.companionNotificationsLabel, isOn: $store.companionNotifications)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Button(l.reportProblem) { reportProblem() }
+                    Button(l.showLogFile) {
+                        NSWorkspace.shared.activateFileViewerSelecting([AppLog.logFileURL])
+                    }
+                }
+                Text(l.reportAttachHint)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                if let reportError {
+                    Text(reportError)
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .textSelection(.enabled)   // 폴백 주소를 복사할 수 있게
+                }
             }
 
             Text(l.aggregationNote)

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -289,6 +289,33 @@ final class ModelDecodingTests: XCTestCase {
     }
 }
 
+final class SupportMailTests: XCTestCase {
+    func testMailtoURLEncodesSubjectAndBody() throws {
+        let url = try XCTUnwrap(SupportMail.mailtoURL(
+            subject: "[PokeTokenBar] 문제 리포트 (v2.3.3)",
+            body: "문제 내용:\n(설명)\n---\n앱 버전: v2.3.3"))
+        let s = url.absoluteString
+        XCTAssertTrue(s.hasPrefix("mailto:parkdongmin123@gmail.com?"), s)
+        XCTAssertTrue(s.contains("subject="))
+        XCTAssertTrue(s.contains("body="))
+        // 개행·한글·대괄호가 raw 로 남지 않아야 함 (percent-encode)
+        XCTAssertFalse(s.contains("\n"))
+        XCTAssertFalse(s.contains("문제"))
+        XCTAssertFalse(s.contains("["))
+        // 디코딩 왕복 — 메일 클라이언트가 받을 실제 값 검증
+        let comps = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(comps.queryItems?.first(where: { $0.name == "body" })?.value,
+                       "문제 내용:\n(설명)\n---\n앱 버전: v2.3.3")
+    }
+
+    func testMailBodyContainsDiagnostics() {
+        let body = L(.ko).reportMailBody(version: "2.3.3", os: "Version 14.5 (Build 23F79)")
+        XCTAssertTrue(body.contains("v2.3.3"))
+        XCTAssertTrue(body.contains("Version 14.5"))
+        XCTAssertTrue(body.contains("PokeTokenBar.log"))
+    }
+}
+
 #if os(macOS)
 final class KeychainNoUIQueryTests: XCTestCase {
     func testNoUIQueryAddsAuthenticationContextAndFailPolicy() {


### PR DESCRIPTION
## 요약
설정에 "문제점 알리기" 추가 — 기본 메일 앱으로 진단 정보(앱 버전·macOS 버전·로그 경로)가
미리 채워진 리포트 메일을 연다. 앱은 메일을 직접 전송하지 않는 mailto 방식 (SMTP/계정/서버 불필요).
수신 주소는 GitHub 프로필 공개 이메일과 동일한 `parkdongmin123@gmail.com`.

## 변경 사항
- `Core/SupportMail.swift` 신규 — mailto URL 조립 (`URLComponents` percent-encode: 개행·한글·특수문자)
- `UI/SettingsView.swift` — 지원 섹션(버튼 2개 + 힌트 + 폴백 텍스트), `reportProblem()` 핸들러
- `Core/Localization.swift` — ko/en/ja 문자열 6종 (버튼·힌트·폴백·메일 제목/본문 템플릿)
- `Core/AppLog.swift` — `logFileURL` 노출 (private url 의 computed 접근자)
- 테스트 2건 — mailto 인코딩 왕복 검증, 본문 진단 정보 포함 검증

## UI 변경 (설정 화면)

| 항목 | Before | After |
|---|---|---|
| 지원 섹션 | 없음 | 알림 섹션과 집계 기준 문구 사이에 신설 |
| 문제점 알리기 버튼 | — | 클릭 시 기본 메일 앱에서 새 메일 작성창: 수신자/제목 `[PokeTokenBar] 문제 리포트 (vX.Y.Z)`/본문(문제 설명 안내 + 버전·macOS·로그 경로) 프리필. 표시 언어(ko/en/ja)에 맞는 템플릿 |
| 로그 파일 보기 버튼 | — | `~/Library/Logs/PokeTokenBar.log` 를 Finder 에서 선택 표시 (메일 첨부 유도) |
| 힌트 문구 | — | "메일에 로그 파일을 첨부해 주시면 원인 파악에 큰 도움이 돼요." (caption, tertiary) |
| 폴백 | — | 메일 앱 열기 실패 시 주황색 안내 "메일 앱을 열 수 없어요. parkdongmin123@gmail.com 로 직접 보내주세요." — textSelection 으로 복사 가능 |

폴백 한계(알려진 것): 메일 앱은 있으나 계정 미설정이면 macOS 가 계정 설정 화면을 열어줌 — 앱에서 감지 불가(mailto 방식 공통).

## 테스트 / 확인 사항
- [x] `swift test` 146개 통과 (신규 SupportMailTests 2건 포함)
- [x] 리뷰어 검토 — 결함 없음 판정 (URLComponents 인코딩 실측: `@` path 유지, 개행 %0A, `&`/`=` 값 내 인코딩으로 쿼리 충돌 없음)
- [ ] 실기기 확인 — 설정에서 버튼 클릭 → Mail 작성창 프리필 확인 (머지 후 로컬 빌드로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
