### PR TITLE
feat: GitHub Sponsors 후원 채널 추가

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: chattymin

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,6 +11,7 @@
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)
 [![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%99%A5-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/chattymin)
 
 [English](README.md) · [한국어](README.ko.md) · **日本語**
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,6 +11,7 @@
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)
 [![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%99%A5-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/chattymin)
 
 [English](README.md) · **한국어** · [日本語](README.ja.md)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)
 [![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%99%A5-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/chattymin)
 
 **English** · [한국어](README.ko.md) · [日本語](README.ja.md)
 

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -190,6 +190,9 @@ struct SettingsView: View {
                     footerLink("GitHub", "https://github.com/chattymin/PokeTokenBar")
                     Text("·")
                     footerLink("Web", "https://chattymin.github.io/PokeTokenBar/")
+                    Text("·")
+                    // 개발자 후원 — 기능 잠금·너지 없는 푸터 링크 (GitHub/Web 과 동급 톤 유지)
+                    footerLink("♥ Sponsor", "https://github.com/sponsors/chattymin")
                 }
                 .font(.caption2)
                 .foregroundStyle(.tertiary)


### PR DESCRIPTION
## 요약
GitHub Sponsors(github.com/sponsors/chattymin, 개설 완료 확인) 후원 채널을 리포·README·앱 설정에 노출.
사전 검토(2026-07-10 사례 분석) 수칙 적용: 후원 문구에서 포켓몬 IP 비언급, 리워드 없음, 기능 잠금·너지 없음.

## 변경 사항
- `.github/FUNDING.yml` — `github: chattymin` (리포 상단 Sponsor 버튼)
- README en/ko/ja — 배지 행 끝에 Sponsor 배지
- `UI/SettingsView.swift` — 푸터 라인에 `♥ Sponsor` 추가 (기존 footerLink 재사용)

## UI 변경 (설정 화면)

| 항목 | Before | After |
|---|---|---|
| 설정 푸터 | `vX.Y.Z · GitHub · Web` | `vX.Y.Z · GitHub · Web · ♥ Sponsor` — 클릭 시 github.com/sponsors/chattymin 브라우저 오픈. 크기·색·밑줄 스타일 기존 링크와 동일 |

## 테스트 / 확인 사항
- [x] swift build + swift test 146개 통과
- [x] 스폰서 공개 페이지 HTTP 200 확인
- [ ] 머지 후 리포 상단 Sponsor 버튼 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
