### PR TITLE
fix: mise/asdf shim 경유 codex 실행 실패 수정 (PATH 보강 + stale 캐시 + stderr 로그)

### DIFF
--- a/Sources/PokeTokenBar/Core/BinaryLocator.swift
+++ b/Sources/PokeTokenBar/Core/BinaryLocator.swift
@@ -13,11 +13,45 @@ enum BinaryLocator {
     /// `staticPaths`: 셸 해석 전에 먼저 확인할 알려진 설치 경로.
     static func resolve(_ binary: String, staticPaths: [String]) -> String? {
         lock.lock(); defer { lock.unlock() }
-        if let hit = cache[binary] { return hit }
+        if let hit = cache[binary] {
+            // stale 캐시 방어 — 해석 후 앱 삭제/교체(Codex.app 업데이트 등)로 경로가 사라졌으면 재해석.
+            // (버그 리포트 실측: 존재하지 않는 /Applications/Codex.app/... 를 계속 실행 시도)
+            if let path = hit, !FileManager.default.isExecutableFile(atPath: path) {
+                AppLog.write("\(binary) cached path gone, re-resolving: \(path)")
+            } else {
+                return hit
+            }
+        }
         let result = locate(binary, staticPaths: staticPaths)
         cache[binary] = result
         AppLog.write(result.map { "\(binary) resolved: \($0)" } ?? "\(binary) NOT found on PATH")
         return result
+    }
+
+    /// 자식 프로세스용 PATH 보강 — GUI 앱의 최소 PATH 로는 mise/asdf shim 이 내부에서
+    /// 버전매니저 본체(mise 등)를 못 찾아 exit 1 로 죽는다(버그 리포트 실측).
+    /// 해석된 바이너리의 디렉토리 + 버전매니저/Homebrew 공통 경로를 기존 PATH 앞에 붙인다.
+    static func augmentedEnvironment(binaryPath: String,
+                                     base: [String: String] = ProcessInfo.processInfo.environment) -> [String: String] {
+        let home = NSHomeDirectory()
+        var paths = [
+            URL(fileURLWithPath: binaryPath).deletingLastPathComponent().path,
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "\(home)/.local/bin",
+            "\(home)/.local/share/mise/shims",
+            "\(home)/.asdf/shims",
+            "\(home)/.volta/bin",
+            "\(home)/.bun/bin",
+        ]
+        for entry in (base["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin").split(separator: ":") {
+            paths.append(String(entry))
+        }
+        var seen = Set<String>()
+        let merged = paths.filter { seen.insert($0).inserted }.joined(separator: ":")
+        var env = base
+        env["PATH"] = merged
+        return env
     }
 
     /// 설정 변경/재탐지 시 캐시 무효화.

--- a/Sources/PokeTokenBar/Core/ProcessRunner.swift
+++ b/Sources/PokeTokenBar/Core/ProcessRunner.swift
@@ -30,18 +30,30 @@ enum ProcessRunner {
     ) async throws -> Data {
         let outURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("poketokenbar-\(UUID().uuidString).jsonl")
+        let errURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("poketokenbar-\(UUID().uuidString).stderr")
         FileManager.default.createFile(atPath: outURL.path, contents: nil)
-        defer { try? FileManager.default.removeItem(at: outURL) }
+        FileManager.default.createFile(atPath: errURL.path, contents: nil)
+        defer {
+            try? FileManager.default.removeItem(at: outURL)
+            try? FileManager.default.removeItem(at: errURL)
+        }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: binary)
         process.arguments = arguments
         process.qualityOfService = .userInitiated
+        // GUI 앱의 최소 PATH 로는 mise/asdf shim 이 버전매니저 본체를 못 찾아 exit 1
+        // (버그 리포트 실측) — 버전매니저/Homebrew 경로를 보강해 전달.
+        process.environment = BinaryLocator.augmentedEnvironment(binaryPath: binary)
         let stdoutHandle = try FileHandle(forWritingTo: outURL)
         defer { try? stdoutHandle.close() }
+        // stderr 는 버리지 않고 파일로 받아 실패 시 로그에 tail 을 남긴다(원격 진단용).
+        let stderrHandle = try FileHandle(forWritingTo: errURL)
+        defer { try? stderrHandle.close() }
         let stdinPipe = Pipe()
         process.standardOutput = stdoutHandle
-        process.standardError = FileHandle.nullDevice
+        process.standardError = stderrHandle
         process.standardInput = stdinPipe
         var stdinClosed = false
         func closeStdin() {
@@ -82,12 +94,25 @@ enum ProcessRunner {
                     kill(process.processIdentifier, SIGKILL)
                 }
             }
+            logStderrTail(errURL, binary: binary)
             throw RunnerError.timeout(binary)
         }
         if process.terminationStatus != 0 {
+            logStderrTail(errURL, binary: binary)
             throw RunnerError.nonZeroExit(process.terminationStatus, binary)
         }
+        logStderrTail(errURL, binary: binary)
         throw RunnerError.missingResponse(binary)
+    }
+
+    /// 실패 경로에서 stderr 마지막 300자를 로그로 — "exit 1" 만으로는 원인 규명이 불가능했던
+    /// 버그 리포트 재발 방지. 성공 경로에서는 호출하지 않는다(로그 소음 방지).
+    private static func logStderrTail(_ url: URL, binary: String) {
+        guard let data = try? Data(contentsOf: url), !data.isEmpty,
+              let text = String(data: data, encoding: .utf8) else { return }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        AppLog.write("stderr [\(URL(fileURLWithPath: binary).lastPathComponent)]: \(String(trimmed.suffix(300)))")
     }
 
     private static func jsonRPCResultData(in raw: Data, responseID: Int) throws -> Data? {

--- a/Tests/PokeTokenBarTests/BinaryLocatorTests.swift
+++ b/Tests/PokeTokenBarTests/BinaryLocatorTests.swift
@@ -2,6 +2,30 @@ import XCTest
 @testable import PokeTokenBar
 
 final class BinaryLocatorTests: XCTestCase {
+    /// mise shim 이 버전매니저 본체를 찾을 수 있도록 PATH 가 보강되는지 (버그 리포트 시나리오).
+    func testAugmentedEnvironmentPrependsToolPaths() {
+        let home = NSHomeDirectory()
+        let env = BinaryLocator.augmentedEnvironment(
+            binaryPath: "\(home)/.local/share/mise/shims/codex",
+            base: ["PATH": "/usr/bin:/bin", "LANG": "en_US.UTF-8"])
+        let paths = env["PATH"]!.split(separator: ":").map(String.init)
+
+        XCTAssertEqual(paths.first, "\(home)/.local/share/mise/shims")   // 바이너리 디렉토리 최우선
+        XCTAssertTrue(paths.contains("/opt/homebrew/bin"))               // mise 본체 위치 후보
+        XCTAssertTrue(paths.contains("\(home)/.local/bin"))
+        XCTAssertTrue(paths.contains("/usr/bin"))                        // 기존 PATH 보존
+        XCTAssertEqual(paths.filter { $0 == "\(home)/.local/share/mise/shims" }.count, 1)  // dedup
+        XCTAssertEqual(env["LANG"], "en_US.UTF-8")                       // 다른 env 보존
+    }
+
+    func testAugmentedEnvironmentWithoutBasePath() {
+        let env = BinaryLocator.augmentedEnvironment(
+            binaryPath: "/opt/homebrew/bin/codex", base: [:])
+        let paths = env["PATH"]!.split(separator: ":").map(String.init)
+        XCTAssertEqual(paths.first, "/opt/homebrew/bin")
+        XCTAssertTrue(paths.contains("/usr/bin"))   // 기본 PATH 폴백
+    }
+
     func testParsesCleanMarkedPath() {
         XCTAssertEqual(
             BinaryLocator.parseMarkedPath("<<<BIN:/opt/homebrew/bin/ccusage:BIN>>>"),


### PR DESCRIPTION
## 요약
버그 리포트 로그 실측 기반 수정. mise 사용자의 Codex 한도가 한 번도 조회되지 않던 원인:
GUI 앱이 자식 프로세스를 최소 PATH(`/usr/bin:/bin:...`)로 spawn → mise shim이 내부에서 실행할
버전매니저 본체(`/opt/homebrew/bin/mise` 등)를 못 찾아 일관된 exit 1. 토큰 집계(로컬 파일 파싱)는
정상이라 "집계는 되는데 한도만 안 나옴" 증상과 일치.

## 재현 조건 (로그 근거)
1. codex를 mise(shims 모드)로 설치 → 앱이 `~/.local/share/mise/shims/codex`로 해석
2. 앱이 `codex app-server --stdio` spawn (PATH 보강 없음)
3. shim → `mise` 실행 시도 → PATH에 없음 → exit 1 (매 120초 반복)
부차: 해석 후 Codex.app이 삭제/변경되면 존재하지 않는 캐시 경로를 계속 실행 (`NSCocoaErrorDomain Code=4`).

## 변경 사항
- `BinaryLocator.augmentedEnvironment(binaryPath:base:)` 신규 — 바이너리 디렉토리 + 버전매니저/Homebrew
  경로를 기존 PATH 앞에 dedup merge. `ProcessRunner`가 spawn 시 적용
- `BinaryLocator.resolve()` — 캐시된 경로가 executable이 아니면 재해석 (stale 캐시 방어)
- `ProcessRunner` — stderr를 temp 파일로 캡처, 실패 경로(timeout/nonZeroExit/missingResponse)에서
  마지막 300자를 AppLog에 기록. 성공 경로는 미기록(로그 소음 방지)
- 테스트 2건 (PATH 보강·dedup·base env 보존 / PATH 부재 폴백)

## 테스트 / 확인 사항
- [x] swift test 148개 통과
- [x] 리뷰어 검토 — 결함 없음 (dedup·optional 캐시 구분·FileHandle 정리·회귀 무영향 확인)
- [ ] 리포터 실기기 확인 — 다음 릴리스 후 mise 환경에서 한도 표시 여부 + 실패 시 stderr 로그 회수

🤖 Generated with [Claude Code](https://claude.com/claude-code)
