### PR TITLE
fix: Claude 한도 429 지수 백오프

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -236,6 +236,11 @@ struct L {
           "Couldn't fetch Claude limits. Please try again shortly.",
           "Claude の上限取得に失敗しました。しばらくして再試行してください。")
     }
+    var limitRefreshRateLimited: String {
+        t("Claude 한도 조회가 일시 제한됐어요 (429). 잠시 쉬었다가 자동으로 재시도합니다.",
+          "Claude limit checks are temporarily rate-limited (429). Backing off and retrying automatically.",
+          "Claude の上限取得が一時的に制限されています (429)。少し待って自動的に再試行します。")
+    }
 
     // MARK: 업데이트 알림
     func updateAvailable(_ version: String, current: String) -> String {

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -7,6 +7,8 @@ enum LimitsError: Error {
     case keychainInteractionNotAllowed
     case credentialFormat
     case httpStatus(Int)
+    /// 429 — 서버가 지정한 Retry-After(초, 없으면 nil). 폴링 백오프 판단에 사용.
+    case rateLimited(retryAfter: TimeInterval?)
 }
 
 /// Claude 한도 조회 추상화 — 실 구현(OAuthLimitsProvider) 또는 테스트 스텁 주입.
@@ -43,9 +45,21 @@ struct OAuthLimitsProvider: ClaudeLimitsProviding, Sendable {
 
         let (data, response) = try await URLSession.shared.data(for: request)
         if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            if http.statusCode == 429 {
+                throw LimitsError.rateLimited(retryAfter: Self.retryAfterSeconds(http))
+            }
             throw LimitsError.httpStatus(http.statusCode)
         }
         return try JSONDecoder().decode(LimitStatus.self, from: data)
+    }
+
+    /// Retry-After 헤더(초 형식만) 파싱 — HTTP-date 형식·비정상 값은 nil(백오프 기본값 사용).
+    /// 서버가 과도한 값을 줘도 1시간으로 캡.
+    static func retryAfterSeconds(_ response: HTTPURLResponse) -> TimeInterval? {
+        guard let raw = response.value(forHTTPHeaderField: "Retry-After"),
+              let seconds = TimeInterval(raw.trimmingCharacters(in: .whitespaces)),
+              seconds > 0 else { return nil }
+        return min(seconds, 3600)
     }
 }
 

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -394,14 +394,19 @@ final class UsageStore {
             limits = nil
             limitsAvailable = false
             AppLog.write("claude limits skipped: keychain access disabled")
+        } else if let until = claudeLimitsBackoffUntil, Date() < until {
+            // 429 백오프 중 — 폴링을 쉬어 rate limit 악화 방지 (버그 리포트 실측: 매분 429 재시도)
+            AppLog.write("claude limits backoff: skipping (\(Int(until.timeIntervalSinceNow))s left)")
         } else {
             do {
                 limits = try await limitsProvider.fetch(allowKeychainPrompt: false)
                 limitsAvailable = true
+                resetLimitsBackoff()
                 AppLog.write("limits refreshed fiveHour=\(limits?.fiveHour?.utilization?.description ?? "nil") sevenDay=\(limits?.sevenDay?.utilization?.description ?? "nil")")
             } catch {
                 // 비공식 endpoint 실패 → 섹션 숨김, 토큰 표시는 무영향
                 if limits == nil { limitsAvailable = false }
+                applyLimitsBackoffIfRateLimited(error)
                 AppLog.write("limits unavailable: \(error)")
             }
         }
@@ -434,16 +439,42 @@ final class UsageStore {
         defer { isRefreshingLimitToken = false }
 
         do {
+            // 명시적 사용자 액션은 백오프를 우회해 1회 시도 — 성공하면 백오프 해제
             limits = try await limitsProvider.fetch(allowKeychainPrompt: true)
             limitsAvailable = true
             limitTokenRefreshError = nil
+            resetLimitsBackoff()
             AppLog.write("limits refreshed by user action fiveHour=\(limits?.fiveHour?.utilization?.description ?? "nil") sevenDay=\(limits?.sevenDay?.utilization?.description ?? "nil")")
             AppLog.write("limits refreshed from keychain by user action")
         } catch {
             limitTokenRefreshError = Self.friendlyLimitError(error, L(localizationLanguage))
             if limits == nil { limitsAvailable = false }
+            applyLimitsBackoffIfRateLimited(error)
             AppLog.write("limits user refresh failed: \(error)")
         }
+    }
+
+    // MARK: Claude 한도 429 백오프
+
+    private var claudeLimitsBackoffUntil: Date?
+    private var claudeLimitsBackoffInterval: TimeInterval = 0
+
+    /// 429 시 지수 백오프: 5분 → 10분 → … → 최대 60분. Retry-After 가 오면 그 값 우선.
+    private func applyLimitsBackoffIfRateLimited(_ error: any Error) {
+        guard case LimitsError.rateLimited(let retryAfter) = error else { return }
+        claudeLimitsBackoffInterval = Self.nextLimitsBackoff(after: claudeLimitsBackoffInterval)
+        let delay = retryAfter ?? claudeLimitsBackoffInterval
+        claudeLimitsBackoffUntil = Date().addingTimeInterval(delay)
+        AppLog.write("claude limits rate-limited: backing off \(Int(delay))s")
+    }
+
+    private func resetLimitsBackoff() {
+        claudeLimitsBackoffUntil = nil
+        claudeLimitsBackoffInterval = 0
+    }
+
+    nonisolated static func nextLimitsBackoff(after current: TimeInterval) -> TimeInterval {
+        current == 0 ? 300 : min(current * 2, 3600)
     }
 
     /// 한도 갱신 실패를 사용자 친화 메시지로 변환. Codex만 쓰는 사용자는 401 이 정상이라,
@@ -451,6 +482,8 @@ final class UsageStore {
     static func friendlyLimitError(_ error: any Error, _ l: L) -> String {
         guard let limitsError = error as? LimitsError else { return l.limitRefreshGeneric }
         switch limitsError {
+        case .rateLimited:
+            return l.limitRefreshRateLimited
         case .httpStatus(let status):
             return l.limitRefreshHTTPError(status)
         case .keychainUnavailable, .credentialFormat:

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -289,6 +289,35 @@ final class ModelDecodingTests: XCTestCase {
     }
 }
 
+final class LimitsBackoffTests: XCTestCase {
+    func testNextBackoffDoublesAndCaps() {
+        XCTAssertEqual(UsageStore.nextLimitsBackoff(after: 0), 300)      // 첫 429 → 5분
+        XCTAssertEqual(UsageStore.nextLimitsBackoff(after: 300), 600)
+        XCTAssertEqual(UsageStore.nextLimitsBackoff(after: 1800), 3600)
+        XCTAssertEqual(UsageStore.nextLimitsBackoff(after: 3600), 3600)  // 60분 캡
+    }
+
+    func testRetryAfterHeaderParsing() throws {
+        func response(_ headers: [String: String]?) -> HTTPURLResponse {
+            HTTPURLResponse(url: URL(string: "https://api.anthropic.com/api/oauth/usage")!,
+                            statusCode: 429, httpVersion: nil, headerFields: headers)!
+        }
+        XCTAssertEqual(OAuthLimitsProvider.retryAfterSeconds(response(["Retry-After": "120"])), 120)
+        XCTAssertEqual(OAuthLimitsProvider.retryAfterSeconds(response(["Retry-After": " 60 "])), 60)
+        XCTAssertEqual(OAuthLimitsProvider.retryAfterSeconds(response(["Retry-After": "999999"])), 3600)  // 캡
+        XCTAssertNil(OAuthLimitsProvider.retryAfterSeconds(response(["Retry-After": "0"])))
+        XCTAssertNil(OAuthLimitsProvider.retryAfterSeconds(response(["Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"])))  // date 형식은 미지원 → 기본 백오프
+        XCTAssertNil(OAuthLimitsProvider.retryAfterSeconds(response(nil)))
+    }
+
+    @MainActor
+    func testFriendlyErrorForRateLimited() {
+        let msg = UsageStore.friendlyLimitError(LimitsError.rateLimited(retryAfter: 60), L(.ko))
+        XCTAssertTrue(msg.contains("429"))
+        XCTAssertFalse(msg.contains("httpStatus"))   // raw 에러 노출 금지
+    }
+}
+
 final class SupportMailTests: XCTestCase {
     func testMailtoURLEncodesSubjectAndBody() throws {
         let url = try XCTUnwrap(SupportMail.mailtoURL(


### PR DESCRIPTION
## 요약
버그 리포트 로그에서 발견된 부차 문제 수정 (#46 과 동일 로그): Claude 한도 조회(비공식
`oauth/usage`)가 429를 15분+ 연속 반환하는 동안 앱이 백오프 없이 매분 재시도 → rate limit
악화 루프. 429 시 지수 백오프를 도입한다.

## 동작 (Before / After)

| 상황 | Before | After |
|---|---|---|
| 429 수신 | 다음 주기(기본 120초)에 그대로 재시도 | 5분 → 10분 → … → 60분 캡 지수 백오프로 폴링 skip. `Retry-After` 헤더(초 형식)가 오면 그 값 우선(3600 캡) |
| 백오프 중 표시 | — | 기존 한도 스냅샷 유지 (섹션 숨김 없음), 로그에 남은 시간 기록 |
| 성공 | — | 백오프 즉시 리셋 |
| 수동 갱신 버튼 | 백오프 개념 없음 | 백오프 우회 1회 시도 — 성공 시 백오프 해제, 429면 백오프 적용 + 친화 메시지("일시 제한됐어요 (429)… 자동으로 재시도합니다", ko/en/ja) |
| 401/403 | 토큰 무효화 후 1회 재시도 | 변화 없음 (rateLimited 는 재시도 가드에 매칭되지 않고 전파) |

## 변경 사항
- `LimitsError.rateLimited(retryAfter:)` 추가, 429 시 `Retry-After` 파싱 (`OAuthLimitsProvider.retryAfterSeconds`)
- `UsageStore`: 백오프 상태 2개(until/interval) + `nextLimitsBackoff` + 적용/리셋 헬퍼
- `friendlyLimitError` rateLimited 케이스, `Localization` 문자열 ko/en/ja
- 테스트 3건: 백오프 수열(5분 시작·60분 캡), Retry-After 파싱 6케이스(공백·캡·0·date형식·부재), 친화 메시지

## 테스트 / 확인 사항
- [x] swift test 151개 통과
- [x] 리뷰어 검토 — 결함 없음 (401 재시도 가드와의 간섭·수동 갱신 상호작용·exhaustive switch 전수 확인)
- [ ] 리포터 실기기 — 다음 릴리스 후 로그에서 backoff 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
