### PR TITLE
refactor: 플랫폼 종속 제거 — burn tier 전 프로바이더 합산 + stale 대칭 + 경로 단일화

### DIFF
--- a/Sources/PokeTokenBar/Core/BinaryLocator.swift
+++ b/Sources/PokeTokenBar/Core/BinaryLocator.swift
@@ -33,17 +33,8 @@ enum BinaryLocator {
     /// 해석된 바이너리의 디렉토리 + 버전매니저/Homebrew 공통 경로를 기존 PATH 앞에 붙인다.
     static func augmentedEnvironment(binaryPath: String,
                                      base: [String: String] = ProcessInfo.processInfo.environment) -> [String: String] {
-        let home = NSHomeDirectory()
-        var paths = [
-            URL(fileURLWithPath: binaryPath).deletingLastPathComponent().path,
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-            "\(home)/.local/bin",
-            "\(home)/.local/share/mise/shims",
-            "\(home)/.asdf/shims",
-            "\(home)/.volta/bin",
-            "\(home)/.bun/bin",
-        ]
+        var paths = [URL(fileURLWithPath: binaryPath).deletingLastPathComponent().path]
+        paths.append(contentsOf: commonToolDirectories())
         for entry in (base["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin").split(separator: ":") {
             paths.append(String(entry))
         }
@@ -60,20 +51,27 @@ enum BinaryLocator {
         cache.removeAll()
     }
 
-    /// 버전매니저 공통 shim/bin 경로 + 주어진 정적 경로. (절대경로 우선 탐색용)
-    static func commonNodeToolPaths(_ binary: String) -> [String] {
+    /// 버전매니저/패키지매니저 공통 bin·shim 디렉토리 — 탐색(commonNodeToolPaths)과
+    /// 자식 프로세스 PATH 보강(augmentedEnvironment)이 공유하는 단일 소스.
+    /// 새 버전매니저 지원 시 여기 한 곳만 추가하면 두 경로 모두에 반영된다.
+    static func commonToolDirectories() -> [String] {
         let home = NSHomeDirectory()
         return [
-            "/opt/homebrew/bin/\(binary)",                 // Homebrew (Apple Silicon)
-            "/usr/local/bin/\(binary)",                    // Homebrew (Intel) / npm prefix
-            "\(home)/.local/share/mise/shims/\(binary)",   // mise (shims 모드)
-            "\(home)/.asdf/shims/\(binary)",               // asdf
-            "\(home)/.volta/bin/\(binary)",                // Volta
-            "\(home)/.bun/bin/\(binary)",                  // Bun
-            "\(home)/.npm-global/bin/\(binary)",           // npm prefix=~/.npm-global
-            "\(home)/.local/bin/\(binary)",
-            "/usr/bin/\(binary)",
+            "/opt/homebrew/bin",                 // Homebrew (Apple Silicon)
+            "/usr/local/bin",                    // Homebrew (Intel) / npm prefix
+            "\(home)/.local/share/mise/shims",   // mise (shims 모드)
+            "\(home)/.asdf/shims",               // asdf
+            "\(home)/.volta/bin",                // Volta
+            "\(home)/.bun/bin",                  // Bun
+            "\(home)/.npm-global/bin",           // npm prefix=~/.npm-global
+            "\(home)/.local/bin",
+            "/usr/bin",
         ]
+    }
+
+    /// 버전매니저 공통 shim/bin 경로 + 주어진 정적 경로. (절대경로 우선 탐색용)
+    static func commonNodeToolPaths(_ binary: String) -> [String] {
+        commonToolDirectories().map { "\($0)/\(binary)" }
     }
 
     private static func locate(_ binary: String, staticPaths: [String]) -> String? {

--- a/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
@@ -32,7 +32,7 @@ struct LocalClaudeProvider: UsageProvider {
     }
 }
 
-/// 로컬 로그 직접 파싱 기반 Gemini CLI provider. (블록 없음 — Codex 와 동일 축약형)
+/// 로컬 로그 직접 파싱 기반 Gemini CLI provider.
 /// 세션이 ~/.gemini/tmp/<hash>/chats/ 에 있을 때만 데이터가 잡힌다(없으면 스냅샷 미생성 → UI 미표시).
 struct LocalGeminiProvider: UsageProvider {
     let id = "gemini"
@@ -50,6 +50,9 @@ struct LocalGeminiProvider: UsageProvider {
         let entries = await LocalUsageCache.shared.geminiEntries(modifiedSince: monthStart)
         let fmt = LocalUsageReader.localDayFormatter()
         var r = ProviderEnrichment()
+        // 블록(burn rate) 계산은 프로바이더 공통 — companion 리듬이 전 프로바이더를 따르게.
+        r.activeBlock = LocalUsageReader.activeBlock(entries: entries, now: now)
+        r.blocksOK = true
         let weekStart = LocalUsageReader.startOfWeek(now)
         r.weekTotal = LocalUsageReader.period(entries: entries, periodKey: fmt.string(from: weekStart),
                                               fromDay: fmt.string(from: weekStart), toDay: fmt.string(from: now))
@@ -60,7 +63,7 @@ struct LocalGeminiProvider: UsageProvider {
     }
 }
 
-/// 로컬 로그 직접 파싱 기반 Codex provider. (블록 없음, 주간 = 일별 합산)
+/// 로컬 로그 직접 파싱 기반 Codex provider. (주간 = 일별 합산)
 struct LocalCodexProvider: UsageProvider {
     let id = "codex"
     let displayName = "Codex"
@@ -81,6 +84,9 @@ struct LocalCodexProvider: UsageProvider {
         let entries = await LocalUsageCache.shared.codexEntries(modifiedSince: monthStart)
         let fmt = LocalUsageReader.localDayFormatter()
         var r = ProviderEnrichment()
+        // 블록(burn rate) 계산은 프로바이더 공통 — companion 리듬이 전 프로바이더를 따르게.
+        r.activeBlock = LocalUsageReader.activeBlock(entries: entries, now: now)
+        r.blocksOK = true
         let weekStart = LocalUsageReader.startOfWeek(now)
         let week = LocalUsageReader.period(entries: entries, periodKey: fmt.string(from: weekStart),
                                            fromDay: fmt.string(from: weekStart), toDay: fmt.string(from: now))

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -17,6 +17,7 @@ final class UsageStore {
     private(set) var limits: LimitStatus?
     private(set) var codexLimits: CodexRateLimitStatus?
     private(set) var codexLimitsUpdatedAt: Date?
+    private(set) var limitsUpdatedAt: Date?
     private(set) var limitsAvailable = true
     private(set) var lastUpdated: Date?
     private(set) var isRefreshing = false
@@ -131,8 +132,15 @@ final class UsageStore {
     var monthTotalTokens: Int { snapshots.reduce(0) { $0 + ($1.monthTotal?.totalTokens ?? 0) } }
     var monthCostTotal: Double { snapshots.reduce(0) { $0 + ($1.monthTotal?.totalCost ?? 0) } }
 
+    /// Claude 의 활성 5h 블록 — 5h forecast·"현재 블록" 행은 Claude 공식 한도와 짝이므로
+    /// providerID 로 명시 조회한다 (전 프로바이더가 블록을 갖게 된 후 first-with-block 은 오매칭).
     private var claudeActiveBlock: BlockUsage? {
-        snapshots.first { $0.activeBlock != nil }?.activeBlock
+        snapshots.first { $0.providerID == "claude_code" }?.activeBlock
+    }
+
+    /// 전 프로바이더 활성 블록의 합산 burn (tokens/min) — companion 리듬 판정용.
+    private var combinedBurnPerMinute: Double {
+        snapshots.compactMap { $0.activeBlock?.tokensPerMinute }.reduce(0, +)
     }
 
     // MARK: 한도 소진 예측
@@ -183,8 +191,10 @@ final class UsageStore {
     }
 
     /// burn rate 티어 — companion 표시 상태(idle/working/focus) 판정에 사용.
+    /// 전 프로바이더 합산 — Codex/Gemini 전용 사용자도 코딩 리듬이 반영된다.
     var burnTier: BurnTier {
-        guard let burn = claudeActiveBlock?.tokensPerMinute, burn > 1_000 else { return .idle }
+        let burn = combinedBurnPerMinute
+        guard burn > 1_000 else { return .idle }
         if burn < 100_000 { return .normal }
         if burn < 400_000 { return .fast }
         return .blazing
@@ -401,6 +411,7 @@ final class UsageStore {
             do {
                 limits = try await limitsProvider.fetch(allowKeychainPrompt: false)
                 limitsAvailable = true
+                limitsUpdatedAt = Date()
                 resetLimitsBackoff()
                 AppLog.write("limits refreshed fiveHour=\(limits?.fiveHour?.utilization?.description ?? "nil") sevenDay=\(limits?.sevenDay?.utilization?.description ?? "nil")")
             } catch {
@@ -442,6 +453,7 @@ final class UsageStore {
             // 명시적 사용자 액션은 백오프를 우회해 1회 시도 — 성공하면 백오프 해제
             limits = try await limitsProvider.fetch(allowKeychainPrompt: true)
             limitsAvailable = true
+            limitsUpdatedAt = Date()
             limitTokenRefreshError = nil
             resetLimitsBackoff()
             AppLog.write("limits refreshed by user action fiveHour=\(limits?.fiveHour?.utilization?.description ?? "nil") sevenDay=\(limits?.sevenDay?.utilization?.description ?? "nil")")
@@ -515,6 +527,13 @@ final class UsageStore {
     var codexLimitsStale: Bool {
         guard codexLimits != nil, let codexLimitsUpdatedAt else { return false }
         return Date().timeIntervalSince(codexLimitsUpdatedAt) > 15 * 60
+    }
+
+    /// Claude 한도 staleness — Codex 와 동일 임계(15분). 429 백오프(최대 60분)로 폴링이
+    /// 쉬는 동안 이전 스냅샷이 남는다는 사실을 노출한다 (프로바이더 간 표시 대칭).
+    var claudeLimitsStale: Bool {
+        guard limits != nil, let limitsUpdatedAt else { return false }
+        return Date().timeIntervalSince(limitsUpdatedAt) > 15 * 60
     }
 
     // MARK: 한도 알림 (ClaudeBar 임계값 패턴)

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -234,6 +234,9 @@ struct PopoverView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             if selectedSnapshot?.providerID == "claude_code", let limits = store.limits {
+                if store.claudeLimitsStale {
+                    staleBadge(updatedAt: store.limitsUpdatedAt)
+                }
                 limitRow(name: l.fiveHourSession, window: limits.fiveHour)
                 forecastRow
                 limitRow(name: l.weekly, window: limits.sevenDay)
@@ -245,7 +248,8 @@ struct PopoverView: View {
                         name: l.claudeLimitEntry(kind: entry.kind, model: entry.scope?.model?.displayName),
                         window: LimitWindow(utilization: entry.percent, resetsAt: entry.resetsAt))
                 }
-                if let block = store.snapshots.first(where: { $0.activeBlock != nil })?.activeBlock,
+                // 전 프로바이더가 블록을 갖게 됨 — "Claude 현재 5h 블록" 행은 명시 조회
+                if let block = store.snapshots.first(where: { $0.providerID == "claude_code" })?.activeBlock,
                    let end = block.endDate {
                     HStack {
                         Text(l.claudeCurrentBlock)
@@ -325,12 +329,20 @@ struct PopoverView: View {
                         .foregroundStyle(.red)
                 }
                 // 갱신 실패가 15분+ 이어지면 이전 스냅샷임을 노출 (codex TUI stale 임계와 동일)
-                if store.codexLimitsStale, let updated = store.codexLimitsUpdatedAt {
-                    (Text(l.staleLimits) + Text(" · ") + Text(updated, style: .relative))
-                        .font(.caption)
-                        .foregroundStyle(.orange)
+                if store.codexLimitsStale {
+                    staleBadge(updatedAt: store.codexLimitsUpdatedAt)
                 }
             }
+        }
+    }
+
+    /// 한도 스냅샷 갱신 지연 배지 — Claude/Codex 공용 (마지막 성공 시각 상대 표시).
+    @ViewBuilder
+    private func staleBadge(updatedAt: Date?) -> some View {
+        if let updatedAt {
+            (Text(l.staleLimits) + Text(" · ") + Text(updatedAt, style: .relative))
+                .font(.caption)
+                .foregroundStyle(.orange)
         }
     }
 

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -232,6 +232,29 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(blazing, .blazing)
     }
 
+    /// Codex 전용 사용자도 burn tier 가 반영되는지 (프로바이더 종속 제거 회귀 방지).
+    func testBurnTierFromNonClaudeProvider() async {
+        let codex = FakeUsageProvider(id: "codex", displayName: "Codex", daily: todayDaily(10_000_000))
+        codex.enrichment = ProviderEnrichment(activeBlock: block(tokensPerMinute: 200_000), blocksOK: true,
+                                              weekTotal: nil, monthTotal: nil, periodsOK: false)
+        let store = makeStore(providers: [codex])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.burnTier, .fast)
+    }
+
+    /// 여러 프로바이더의 burn 은 합산된다 (60k + 60k = 120k → fast).
+    func testBurnTierCombinesProviders() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        claude.enrichment = ProviderEnrichment(activeBlock: block(tokensPerMinute: 60_000), blocksOK: true,
+                                               weekTotal: nil, monthTotal: nil, periodsOK: false)
+        let codex = FakeUsageProvider(id: "codex", displayName: "Codex", daily: todayDaily(10_000_000))
+        codex.enrichment = ProviderEnrichment(activeBlock: block(tokensPerMinute: 60_000), blocksOK: true,
+                                              weekTotal: nil, monthTotal: nil, periodsOK: false)
+        let store = makeStore(providers: [claude, codex])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.burnTier, .fast)
+    }
+
     // MARK: stale
 
     func testIsStaleBeforeFirstRefreshThenFreshAfter() async {


### PR DESCRIPTION
## 요약
플랫폼 종속성 전수 감사 결과 적용. "특정 툴/프로바이더에만 있는 동작"을 일반화해
새 버전매니저·새 AI CLI 추가 시 수정 지점을 줄이고, 프로바이더 간 기능 비대칭을 해소.

## 감사 판정 요약

| 항목 | 판정 | 처리 |
|---|---|---|
| 버전매니저 경로 목록이 탐색·PATH 보강 두 곳에 중복 | 필요 | ✅ `commonToolDirectories()` 단일 소스 (mise/asdf/volta/bun/npm — 신규는 한 곳만 추가) |
| activeBlock(burn rate)이 Claude provider 전용 | 필요 | ✅ Codex/Gemini 도 계산 — **Codex/Gemini 전용 사용자의 companion 이 항상 idle 이던 문제 해소** |
| burnTier 가 first-with-block 휴리스틱 | 필요 | ✅ 전 프로바이더 tokens/min 합산 (Claude 단독 사용자는 기존과 동일 값) |
| 5h forecast·"현재 블록" 행의 블록 조회 | 필요(동반) | ✅ providerID `claude_code` 명시 조회 — Claude 공식 한도와 짝인 기능이 타 프로바이더 블록을 잡지 않게 |
| Claude 한도 stale 표시 부재 (Codex 만 있음) | 필요 | ✅ 15분 임계 동일 적용 + `staleBadge` 공용 헬퍼 — 429 백오프(최대 60분) 동안 이전 스냅샷임을 노출 |
| PopoverView providerID 리터럴 분기 추상화 | 과잉설계 | 보류 (3개 프로바이더 한정 UI 분기, 추상화 이득 낮음) |
| 프로바이더 한도 조회 프로토콜 통합 | 과잉설계 | 보류 (Claude=HTTP·Codex=프로세스로 구조 상이 — 4번째 한도 소스 등장 시 재검토) |
| Gemini 공식 한도 표시 | 불가능 | 공식 한도 API 부재 |

## UI 변경

| 항목 | Before | After |
|---|---|---|
| companion 상태 (Codex/Gemini 전용 사용자) | 항상 idle (Claude 블록만 관측) | 사용량에 따라 working/focus/blazing |
| companion 상태 (다중 프로바이더) | Claude burn 만 반영 | 전 프로바이더 합산 burn |
| Claude 한도 섹션 | stale 표시 없음 | 갱신 15분+ 지연 시 주황 "갱신 지연 · n분 전" (Codex 와 동일) |
| Claude 한도·블록 행 (Claude 단독 사용자) | — | **변화 없음** |

## 테스트 / 확인 사항
- [x] swift test 153개 통과 (신규: codex 전용 burn tier / 다중 프로바이더 합산)
- [x] 리뷰어 검토 — 결함 없음 (Claude 동작 불변·PATH 순서 #46 의도 유지·stale 오탐 경로 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
