### PR TITLE
chore: 확장 규약 강제 — CLAUDE.md 계약 + 프로바이더 무관 집계 패리티 테스트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,20 @@
 
 릴리스는 외부 공개(비가역)이므로 실행 직전 **적용할 버전과 노트 요약을 한 번 보여준 뒤** 진행한다.
 세부 절차·체크리스트는 `RELEASE.md` 참고.
+
+## 확장 규약 (새 프로바이더/툴 추가 시 — 리뷰에서 위반 확인)
+
+새 AI CLI(사용량 소스)·버전매니저를 더할 때 특정 플랫폼에 종속된 분기를 만들지 않는다.
+아래는 절차이며, 코드 리뷰 시 이 규약 위반을 결함으로 본다.
+
+- **사용량 소스 추가** = `UsageProvider` 프로토콜(`Core/UsageProvider.swift`) 구현체 1개 작성 +
+  `UsageStore.init` 의 기본 `providers:` 배열(`Core/UsageStore.swift`)에 등록. 이 두 곳이 유일한 손댈 지점.
+- **범용 동작은 프로바이더 무관하게 집계**: 오늘/주/월 합계·burn tier·companion 리듬은 전 프로바이더
+  합산이어야 한다(`snapshots` reduce). 한 프로바이더에만 계산을 붙이지 마라(과거 회귀: burn 이 Claude
+  블록만 관측 → Codex/Gemini 전용 사용자 companion 이 항상 idle). 패리티 테스트가 이를 강제한다
+  (`UsageStoreTests` 의 "unknown provider" 계열).
+- **프로바이더 고유 동작만 `providerID` 로 명시 분기**: 공식 한도(Claude=HTTP·Codex=프로세스),
+  5h forecast·"현재 블록" 행처럼 *특정 프로바이더에만 존재하는* 기능만 id 로 조건 분기한다.
+  범용 경로에 `== "claude_code"` 류 리터럴 분기를 추가하는 건 금지.
+- **버전매니저/설치경로 추가** = `BinaryLocator.commonToolDirectories()` 한 곳에만 추가한다
+  (탐색·자식 프로세스 PATH 보강이 이 단일 소스를 공유).

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -79,6 +79,9 @@ final class UsageStore {
     var localizationLanguage: AppLanguage = .systemDefault   // companion.language 로 재시드 전까지의 기본(실행순서 무관 안전)
 
     private let providers: [any UsageProvider]
+
+    /// 등록된 프로바이더 id 목록 — 확장 규약 레지스트리 무결성 테스트용.
+    var registeredProviderIDs: [String] { providers.map(\.id) }
     private let limitsProvider: any ClaudeLimitsProviding
     private let codexLimitsProvider: any CodexLimitsProviding
     /// 설정 저장소 — 테스트는 suite 를 주입해 실제 사용자 설정을 오염시키지 않는다.

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -255,6 +255,40 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(store.burnTier, .fast)
     }
 
+    // MARK: 확장 규약 — 프로바이더 무관 집계 (CLAUDE.md "확장 규약" 강제)
+
+    /// 하드코딩 allow-list 없이 *임의의 미래 프로바이더*(id 가 claude_code/codex/gemini 어느 것도 아님)가
+    /// 범용 집계 경로 전부에 흘러가는지 강제한다. 누군가 오늘/주/월/burn 에 `== "claude_code"` 류
+    /// id 분기를 넣어 특정 프로바이더만 세면 이 테스트가 깨진다.
+    func testUnknownFutureProviderFlowsThroughAllAggregation() async {
+        let future = FakeUsageProvider(
+            id: "future_tool_xyz", displayName: "Future Tool", daily: todayDaily(42_000_000))
+        future.enrichment = ProviderEnrichment(
+            activeBlock: block(tokensPerMinute: 200_000), blocksOK: true,
+            weekTotal: PeriodUsage(period: "w", totalTokens: 90_000_000, totalCost: 0),
+            monthTotal: PeriodUsage(period: "m", totalTokens: 300_000_000, totalCost: 0),
+            periodsOK: true)
+        let store = makeStore(providers: [future])
+        await store.refresh(scheduleEmptyRetry: false)
+
+        XCTAssertEqual(store.todayTotalTokens, 42_000_000, "오늘 합계가 id 로 필터링됨")
+        XCTAssertEqual(store.weekTotalTokens, 90_000_000, "주 합계가 id 로 필터링됨")
+        XCTAssertEqual(store.monthTotalTokens, 300_000_000, "월 합계가 id 로 필터링됨")
+        XCTAssertEqual(store.burnTier, .fast, "burn 이 특정 프로바이더에만 종속됨")
+        // preferring 은 미스 시 .first 폴백이라 id 일치까지 확인해야 유효(theater 방지)
+        XCTAssertEqual(store.snapshot(preferring: "future_tool_xyz")?.providerID, "future_tool_xyz",
+                       "탭에 노출 안 됨")
+    }
+
+    /// 기본 등록 프로바이더 레지스트리 무결성 — 비어 있지 않고 id 가 유일.
+    /// (새 프로바이더를 배열에 등록하는 단일 지점이 살아있는지 최소 보증.)
+    func testDefaultProviderRegistryHasUniqueIds() {
+        let store = UsageStore(autoRefresh: false, defaults: testDefaults)
+        let ids = store.registeredProviderIDs
+        XCTAssertFalse(ids.isEmpty)
+        XCTAssertEqual(Set(ids).count, ids.count, "프로바이더 id 중복")
+    }
+
     // MARK: stale
 
     func testIsStaleBeforeFirstRefreshThenFreshAfter() async {


### PR DESCRIPTION
## 요약
"새 AI CLI/버전매니저 추가 시 플랫폼 종속 분기가 생기지 않는가"를 모델 재량이 아니라
두 메커니즘으로 강제한다. 코드 동작 변경 없음 — 규약(문서) + 접근자 1개 + 테스트 2건.

## 왜
사용량 집계 층은 `UsageProvider` 프로토콜 + 단일 등록 배열로 자기방어되지만, 앞으로의
확장에서 누군가 범용 집계에 `== "claude_code"` 류 id 분기를 넣는 드리프트는 지금 아무것도
막지 못한다. 그 드리프트가 도입되는 순간 잡히게 두 지점을 깐다.

## 변경 사항
- `CLAUDE.md` "확장 규약" 섹션 — 절차형(어디를 손대는가): 사용량 소스 = `UsageProvider` 구현 +
  `UsageStore.init` 배열 등록 두 곳 / 범용 동작은 프로바이더 무관 집계 / 고유 동작만 `providerID`
  분기 / 버전매니저는 `commonToolDirectories()` 한 곳. **리뷰가 위반을 결함으로 본다** 명시
- `UsageStoreTests` — `testUnknownFutureProviderFlowsThroughAllAggregation`: 미등록 id 프로바이더가
  오늘/주/월/burn/탭 집계 전부에 흘러가는지(allow-list 넣으면 실패), `testDefaultProviderRegistryHasUniqueIds`
- `UsageStore.registeredProviderIDs` 접근자 (레지스트리 무결성 테스트용)

## 테스트 / 확인 사항
- [x] swift test 155개 통과 (신규 2건)
- [x] 셀프 리뷰 — 규약 dogfooding: 패리티 테스트가 실제 그물임(집계 id-무관 reduce) 확인, LOW theater assertion 즉시 수정
- [x] 코드 동작 변경 없음 (문서 + 테스트 + 테스트 전용 접근자)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
