### PR TITLE
feat: 설정창 그룹형 재구성 + 알 부화 불가 수정(REST 폴백·자가치유 인덱스)

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -288,7 +288,10 @@ final class CompanionStore {
         guard !isHatching else { return }
         isHatching = true
         defer { isHatching = false }
-        guard let line = try? await provider.line(baseSpeciesID: baseID) else { return }
+        guard let line = try? await provider.line(baseSpeciesID: baseID) else {
+            AppLog.write("hatch: line fetch failed for base \(baseID) — egg kept, retry next tick")
+            return
+        }
         currentLine = line
         // 부화 임계 초과분은 부화체 성장에 이월(낭비 없음).
         let overflow = max(0, state.eggUsage - PokemonBalance.eggHatchThreshold)
@@ -299,6 +302,7 @@ final class CompanionStore {
         state.active = MonState(baseID: line.baseID, pathIDs: [line.baseID], stageIndex: 0,
                                 usedAtStage: 0, rarity: line.rarity, totalForms: line.totalForms,
                                 isShiny: isShiny, nature: nature)
+        AppLog.write("hatch: hatched base=\(line.baseID) rarity=\(line.rarity) shiny=\(isShiny) forms=\(line.totalForms)")
         let name = line.localizedName(line.baseID, state.language)
         notifyCompanionEvent(isShiny ? l.notifShinyHatchTitle : l.notifHatchTitle,
                              isShiny ? l.notifShinyHatchBody(name) : l.notifHatchBody(name))
@@ -328,18 +332,43 @@ final class CompanionStore {
     ///   ③ 누적 가중치에서 정확히 1롤 — 루프/재롤 없음, 시간 상한 확정적
     /// 인덱스 취득 실패(오프라인 + 캐시 없음) 시 nil → 알 유지, 다음 갱신 틱 재시도.
     private func chooseBase() async -> Int? {
-        guard let index = try? await provider.baseSpeciesIndex(), !index.isEmpty else { return nil }
-        let weights = index.map { e in
-            state.collectedFinals.contains(where: { $0.hasPrefix("\(e.id):") })
-                ? max(1, e.captureRate / 2) : max(1, e.captureRate)
+        if let index = try? await provider.baseSpeciesIndex(), !index.isEmpty {
+            let weights = index.map { e in
+                state.collectedFinals.contains(where: { $0.hasPrefix("\(e.id):") })
+                    ? max(1, e.captureRate / 2) : max(1, e.captureRate)
+            }
+            let total = weights.reduce(0, +)
+            var r = Int(rng.next() % UInt64(total))
+            for (i, w) in weights.enumerated() {
+                r -= w
+                if r < 0 { return index[i].id }
+            }
+            return index.last?.id   // 도달 불가(방어)
         }
-        let total = weights.reduce(0, +)
-        var r = Int(rng.next() % UInt64(total))
-        for (i, w) in weights.enumerated() {
-            r -= w
-            if r < 0 { return index[i].id }
+        // GraphQL base 인덱스 엔드포인트 장애 → REST 폴백. 부화가 한 엔드포인트에 묶이지 않게.
+        AppLog.write("hatch: base index unavailable — REST fallback")
+        return await chooseBaseViaREST()
+    }
+
+    /// REST 폴백 — 1~649 중 무작위 id 를 뽑아 base 인지 pokemon-species 로 확인(rejection sampling).
+    /// GraphQL 인덱스가 죽어도 부화가 되게 한다. 가중치(capture_rate)는 생략 — 희귀도는 부화 후
+    /// line() 이 실제 capture_rate 로 계산하므로 결과 개체의 등급은 정확하다. 인덱스 복구 시 가중 선택 재개.
+    private func chooseBaseViaREST() async -> Int? {
+        for attempt in 1...16 {
+            let id = Int(rng.next() % 649) + 1
+            do {
+                if let bs = try await provider.baseSpecies(id: id) {
+                    AppLog.write("hatch: REST fallback picked base \(id) (cap \(bs.captureRate), \(attempt) tries)")
+                    return id
+                }
+                // nil = base 아님(진화 중간체) → 다음 시도
+            } catch {
+                AppLog.write("hatch: REST fallback network error — retry next tick: \(error)")
+                return nil   // REST 도 불가 → 알 유지, 다음 update 틱 재시도
+            }
         }
-        return index.last?.id   // 도달 불가(방어)
+        AppLog.write("hatch: REST fallback exhausted 16 tries")
+        return nil
     }
 
     private func computeState(burnTier: BurnTier, limitWarning: Bool, hasUsageData: Bool, today: Int) -> CompanionStateKind {

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -76,6 +76,12 @@ struct L {
     var refreshNow: String { t("지금 새로고침", "Refresh now", "今すぐ更新") }
     var updated: String { t("갱신", "Updated", "更新") }
     var settings: String { t("설정", "Settings", "設定") }
+    var back: String { t("뒤로", "Back", "戻る") }
+    var generalSectionTitle: String { t("일반", "General", "一般") }
+    var menuBarSectionTitle: String { t("메뉴바에 표시", "Show in menu bar", "メニューバーに表示") }
+    var advancedSectionTitle: String { t("고급", "Advanced", "詳細") }
+    var advancedDisclosureLabel: String { t("고급 설정 · 진단", "Advanced · diagnostics", "詳細設定・診断") }
+    var aboutSupportSectionTitle: String { t("정보 & 지원", "About & Support", "情報とサポート") }
     var quit: String { t("종료", "Quit", "終了") }
 
     // MARK: 설정

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -11,6 +11,9 @@ protocol PokeProviding: Sendable {
     func line(baseSpeciesID: Int) async throws -> EvoLine
     /// 1~5세대 base 전체 인덱스 (GraphQL 1쿼리, 디스크 캐시).
     func baseSpeciesIndex() async throws -> [BaseSpecies]
+    /// 단일 종이 base(진화 시작점)면 BaseSpecies, 아니면 nil.
+    /// GraphQL 인덱스 엔드포인트 장애 시 REST(pokemon-species)로 부화 후보를 뽑는 폴백용.
+    func baseSpecies(id: Int) async throws -> BaseSpecies?
 }
 
 /// PokéAPI 클라이언트 — 종/진화체인을 런타임 fetch + 파싱. 포켓몬 데이터는 레포에 번들하지 않는다.
@@ -52,6 +55,8 @@ actor PokeAPIClient: PokeProviding {
     // MARK: base 인덱스 (부화 후보)
 
     private var baseIndexCache: [BaseSpecies]?
+    private var restBuildInFlight = false
+    private var restBuildTried = false   // 세션당 1회 (GraphQL 다운 시 REST 인덱스 구축 트리거)
     private static let baseIndexFile: URL = {
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("PokeTokenBar")
@@ -88,8 +93,52 @@ actor PokeAPIClient: PokeProviding {
                 baseIndexCache = disk.entries
                 return disk.entries
             }
+            // GraphQL 다운 + 캐시 없음 → REST 로 인덱스를 백그라운드 구축(세션 1회).
+            // 이번 부화는 per-hatch REST 폴백(chooseBaseViaREST)이 즉시 처리하고,
+            // 구축이 끝나면 디스크 캐시로 남아 이후 선택이 가중·수집반영·오프라인가능으로 복귀한다.
+            if !restBuildTried {
+                restBuildTried = true
+                Task { await self.buildBaseIndexViaREST() }
+            }
+            AppLog.write("base index (GraphQL) failed, no cache — REST build triggered; per-hatch fallback handles now: \(error)")
             throw error
         }
+    }
+
+    /// GraphQL base 인덱스 엔드포인트 장애 시 REST(pokemon-species/{id})로 base 인덱스를 직접 구축·영속.
+    /// 한 번 성공하면 base-index.json(30일)으로 남아 이후 선택은 네트워크 없이 가중·수집반영으로 동작 →
+    /// 부화가 특정 엔드포인트 생존에 영구히 묶이지 않게 하는 자가치유 캐시. PokéAPI 배려로 소규모 동시성.
+    func buildBaseIndexViaREST() async {
+        guard baseIndexCache == nil, !restBuildInFlight else { return }
+        restBuildInFlight = true
+        defer { restBuildInFlight = false }
+        AppLog.write("base index: building via REST (GraphQL unavailable)…")
+        var bases: [BaseSpecies] = []
+        let batchSize = 6
+        var start = 1
+        let maxID = 649   // Gen-V 애니메이션 스프라이트 상한 (fetchBaseIndex GraphQL 쿼리와 동일 범위)
+        while start <= maxID {
+            let end = min(start + batchSize - 1, maxID)
+            let found = await withTaskGroup(of: BaseSpecies?.self) { group -> [BaseSpecies] in
+                for id in start...end { group.addTask { try? await self.baseSpecies(id: id) } }
+                var acc: [BaseSpecies] = []
+                for await r in group { if let r { acc.append(r) } }
+                return acc
+            }
+            bases.append(contentsOf: found)
+            start += batchSize
+        }
+        // 대부분 실패(네트워크 불안정)면 빈약한 인덱스를 영속하지 않고 다음 세션 재시도.
+        guard bases.count >= 150 else {
+            AppLog.write("base index: REST build incomplete (\(bases.count)) — not cached, will retry next session")
+            return
+        }
+        bases.sort { $0.id < $1.id }
+        baseIndexCache = bases
+        if let data = try? JSONEncoder().encode(BaseIndexSnapshot(fetchedAt: Date(), entries: bases)) {
+            try? data.write(to: Self.baseIndexFile)
+        }
+        AppLog.write("base index: REST build done — \(bases.count) bases persisted (offline-capable now)")
     }
 
     private func fetchBaseIndex() async throws -> [BaseSpecies] {
@@ -114,6 +163,14 @@ actor PokeAPIClient: PokeProviding {
         let dto: SpeciesDTO = try await get(base.appendingPathComponent("pokemon-species/\(id)"))
         speciesCache[id] = dto
         return dto
+    }
+
+    /// REST 폴백 — 단일 종 상세(pokemon-species/{id})로 base 여부·capture_rate 판정.
+    /// GraphQL base 인덱스가 죽어도 REST(pokeapi.co/api/v2)는 별개 엔드포인트라 동작한다.
+    func baseSpecies(id: Int) async throws -> BaseSpecies? {
+        let dto = try await species(id)
+        guard dto.evolves_from_species == nil else { return nil }   // 진화 중간체는 부화 후보 아님
+        return BaseSpecies(id: id, captureRate: dto.capture_rate)
     }
 
     private func get<T: Decodable>(_ url: URL) async throws -> T {

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -9,6 +9,7 @@ struct SettingsView: View {
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var launchAtLoginError: String?
     @State private var reportError: String?
+    @State private var advancedExpanded = false
 
     private var l: L { companion.l }
 
@@ -20,6 +21,298 @@ struct SettingsView: View {
     private static var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
     }
+
+    // MARK: 레이아웃 — 헤더 고정 / 본문 스크롤 / 푸터 고정
+
+    var body: some View {
+        @Bindable var store = store
+        VStack(spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    generalGroup(store)
+                    menuBarGroup(store)
+                    notificationsGroup(store)
+                    advancedGroup(store)
+                    aboutSupportGroup
+                }
+                .padding(16)
+            }
+            Divider()
+            footer
+        }
+        .frame(height: 460)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Button(action: onClose) {
+                HStack(spacing: 2) {
+                    Image(systemName: "chevron.backward")
+                    Text(l.back)
+                }
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.accentColor)
+            .keyboardShortcut(.cancelAction)
+            Spacer()
+            Text(l.settings).font(.headline)
+            Spacer()
+            // 좌측 뒤로 버튼과 시각적 균형 (제목 중앙 정렬 유지)
+            Text(l.back).opacity(0).accessibilityHidden(true)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 5) {
+            Text("v\(Self.appVersion)")
+            Text("·")
+            footerLink("GitHub", "https://github.com/chattymin/PokeTokenBar")
+            Text("·")
+            footerLink("Web", "https://chattymin.github.io/PokeTokenBar/")
+            Text("·")
+            // 개발자 후원 — 기능 잠금·너지 없는 푸터 링크
+            footerLink("♥ Sponsor", "https://github.com/sponsors/chattymin")
+            Spacer()
+        }
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: 그룹 섹션
+
+    @ViewBuilder
+    private func generalGroup(_ store: UsageStore) -> some View {
+        @Bindable var store = store
+        settingsSection(l.generalSectionTitle) {
+            groupRow {
+                Text(l.language)
+                Spacer()
+                Picker("", selection: Binding(
+                    get: { companion.language },
+                    set: { companion.setLanguage($0); store.localizationLanguage = $0 })) {
+                    ForEach(AppLanguage.allCases, id: \.self) { Text($0.label).tag($0) }
+                }
+                .labelsHidden().pickerStyle(.menu).fixedSize()
+            }
+            Divider()
+            groupRow {
+                Text(l.refreshInterval)
+                Spacer()
+                Picker("", selection: $store.refreshInterval) {
+                    ForEach(UsageStore.intervalPresets, id: \.value) { Text(l.intervalLabel($0.value)).tag($0.value) }
+                }
+                .labelsHidden().pickerStyle(.menu).fixedSize()
+            }
+            Divider()
+            groupRow {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(l.launchAtLogin)
+                    if !isBundledApp {
+                        Text(l.bundledOnly).font(.caption2).foregroundStyle(.tertiary)
+                    }
+                    if let launchAtLoginError {
+                        Text(launchAtLoginError).font(.caption2).foregroundStyle(.red)
+                    }
+                }
+                Spacer()
+                Toggle("", isOn: $launchAtLogin)
+                    .labelsHidden().toggleStyle(.switch).controlSize(.small)
+                    .disabled(!isBundledApp)
+                    .onChange(of: launchAtLogin) { _, newValue in
+                        do {
+                            if newValue { try SMAppService.mainApp.register() }
+                            else { try SMAppService.mainApp.unregister() }
+                            launchAtLoginError = nil
+                        } catch {
+                            launchAtLoginError = "\(error.localizedDescription)"
+                            launchAtLogin = SMAppService.mainApp.status == .enabled
+                        }
+                    }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func menuBarGroup(_ store: UsageStore) -> some View {
+        @Bindable var store = store
+        VStack(alignment: .leading, spacing: 6) {
+            settingsSection(l.menuBarSectionTitle) {
+                toggleRow(l.todayTokensShort, $store.showTokensInMenu)
+                Divider()
+                toggleRow(l.todayCost, $store.showCostInMenu)
+                Divider()
+                toggleRow(l.limitPercent, $store.showLimitInMenu)
+            }
+            Text(l.allOffHint).font(.caption2).foregroundStyle(.tertiary).padding(.leading, 4)
+        }
+    }
+
+    @ViewBuilder
+    private func notificationsGroup(_ store: UsageStore) -> some View {
+        @Bindable var store = store
+        settingsSection(l.notificationsSection) {
+            toggleRow(l.limitNotificationsLabel, $store.limitNotifications)
+            if store.limitNotifications {
+                Divider()
+                groupRow {
+                    Text(l.warning).font(.callout)
+                    Slider(value: $store.warnThreshold, in: 50...95, step: 5)
+                    Text(TokenFormatter.percent(store.warnThreshold))
+                        .font(.caption).monospacedDigit().frame(width: 38, alignment: .trailing)
+                }
+                Divider()
+                groupRow {
+                    Text(l.critical).font(.callout)
+                    Slider(value: $store.critThreshold, in: 80...100, step: 5)
+                    Text(TokenFormatter.percent(store.critThreshold))
+                        .font(.caption).monospacedDigit().frame(width: 38, alignment: .trailing)
+                }
+            }
+            Divider()
+            toggleRow(l.companionNotificationsLabel, $store.companionNotifications)
+        }
+    }
+
+    @ViewBuilder
+    private func advancedGroup(_ store: UsageStore) -> some View {
+        @Bindable var store = store
+        settingsSection(l.advancedSectionTitle) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) { advancedExpanded.toggle() }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.forward")
+                        .font(.caption).foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(advancedExpanded ? 90 : 0))
+                    Text(l.advancedDisclosureLabel)
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 12).padding(.vertical, 9)
+
+            if advancedExpanded {
+                Divider()
+                groupRow {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(l.disableKeychain)
+                        Text(l.disableKeychainHint).font(.caption2).foregroundStyle(.tertiary)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $store.disableKeychainAccess)
+                        .labelsHidden().toggleStyle(.switch).controlSize(.small)
+                }
+                Divider()
+                groupRow {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(l.refreshLimitToken)
+                        Text(l.onlyOnPress).font(.caption2).foregroundStyle(.tertiary)
+                    }
+                    Spacer()
+                    Button {
+                        Task { await store.refreshLimitTokenFromKeychain() }
+                    } label: {
+                        if store.isRefreshingLimitToken {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Text(l.refreshLimitToken)
+                        }
+                    }
+                    .disabled(store.disableKeychainAccess || store.isRefreshingLimitToken)
+                }
+                if let limitTokenRefreshError = store.limitTokenRefreshError {
+                    Text(limitTokenRefreshError)
+                        .font(.caption2).foregroundStyle(.orange).lineLimit(2)
+                        .padding(.horizontal, 12).padding(.bottom, 6)
+                }
+                Divider()
+                Text(l.aggregationNote)
+                    .font(.caption2).foregroundStyle(.tertiary)
+                    .padding(.horizontal, 12).padding(.vertical, 8)
+            }
+        }
+    }
+
+    private var aboutSupportGroup: some View {
+        settingsSection(l.aboutSupportSectionTitle) {
+            groupRow {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(l.reportProblem)
+                    Text(l.reportAttachHint).font(.caption2).foregroundStyle(.tertiary)
+                }
+                Spacer()
+                Button(l.reportProblem) { reportProblem() }
+            }
+            Divider()
+            // 로그 파일 보기 — 문제 제보 시 바로 첨부할 수 있게 같은 그룹에 둔다(고급 접기 밖).
+            groupRow {
+                Text(l.showLogFile)
+                Spacer()
+                Button("Finder") {
+                    NSWorkspace.shared.activateFileViewerSelecting([AppLog.logFileURL])
+                }
+            }
+            if let reportError {
+                Text(reportError)
+                    .font(.caption2).foregroundStyle(.orange).textSelection(.enabled)
+                    .padding(.horizontal, 12).padding(.bottom, 6)
+            }
+        }
+    }
+
+    // MARK: 공용 빌더
+
+    /// 섹션 = 소문자 회색 타이틀 + 라운드 카드 (macOS inset grouped 룩).
+    @ViewBuilder
+    private func settingsSection<Content: View>(
+        _ title: String, @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption).fontWeight(.semibold).foregroundStyle(.secondary)
+                .textCase(.uppercase).padding(.leading, 4)
+            VStack(spacing: 0) { content() }
+                .background(Color(nsColor: .controlBackgroundColor),
+                           in: RoundedRectangle(cornerRadius: 8))
+                .overlay(RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.6), lineWidth: 1))
+        }
+    }
+
+    /// 카드 내부 한 줄 — 좌 라벨 / 우 컨트롤.
+    private func groupRow<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        HStack(spacing: 10) { content() }
+            .padding(.horizontal, 12).padding(.vertical, 8)
+            .frame(minHeight: 38)
+    }
+
+    private func toggleRow(_ label: String, _ isOn: Binding<Bool>) -> some View {
+        groupRow {
+            Text(label)
+            Spacer()
+            Toggle("", isOn: isOn).labelsHidden().toggleStyle(.switch).controlSize(.small)
+        }
+    }
+
+    /// 푸터 링크 — 버전 표기와 동일한 크기·색을 상속하고 밑줄로만 구분.
+    private func footerLink(_ title: String, _ urlString: String) -> some View {
+        Button {
+            if let url = URL(string: urlString) { NSWorkspace.shared.open(url) }
+        } label: {
+            Text(title).underline()
+        }
+        .buttonStyle(.plain)
+        .help(urlString)
+    }
+
+    // MARK: 동작
 
     /// 문제점 알리기 — 진단 정보(버전·macOS)가 채워진 리포트 메일을 기본 메일 앱으로 연다.
     /// 메일 앱이 없거나 열기에 실패하면 수신 주소를 안내(복사 가능)한다.
@@ -34,173 +327,5 @@ struct SettingsView: View {
             return
         }
         reportError = nil
-    }
-
-    /// 푸터 링크 — 버전 표기와 동일한 크기·색을 상속하고 밑줄로만 구분(부모 HStack 스타일 사용).
-    private func footerLink(_ title: String, _ urlString: String) -> some View {
-        Button {
-            if let url = URL(string: urlString) { NSWorkspace.shared.open(url) }
-        } label: {
-            Text(title).underline()
-        }
-        .buttonStyle(.plain)
-        .help(urlString)
-    }
-
-    var body: some View {
-        @Bindable var store = store
-        VStack(alignment: .leading, spacing: 14) {
-            Text(l.settings)
-                .font(.headline)
-
-            Picker(l.language, selection: Binding(
-                get: { companion.language },
-                set: { companion.setLanguage($0); store.localizationLanguage = $0 })) {
-                ForEach(AppLanguage.allCases, id: \.self) { lang in
-                    Text(lang.label).tag(lang)
-                }
-            }
-            .pickerStyle(.menu)
-
-            Picker(l.refreshInterval, selection: $store.refreshInterval) {
-                ForEach(UsageStore.intervalPresets, id: \.value) { preset in
-                    Text(l.intervalLabel(preset.value)).tag(preset.value)
-                }
-            }
-            .pickerStyle(.menu)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(l.menuBarItems)
-                    .font(.callout)
-                Toggle(l.todayTokensShort, isOn: $store.showTokensInMenu)
-                Toggle(l.todayCost, isOn: $store.showCostInMenu)
-                Toggle(l.limitPercent, isOn: $store.showLimitInMenu)
-                Text(l.allOffHint)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                Toggle(l.disableKeychain, isOn: $store.disableKeychainAccess)
-                Text(l.disableKeychainHint)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                HStack(spacing: 8) {
-                    Button {
-                        Task { await store.refreshLimitTokenFromKeychain() }
-                    } label: {
-                        if store.isRefreshingLimitToken {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else {
-                            Text(l.refreshLimitToken)
-                        }
-                    }
-                    .disabled(store.disableKeychainAccess || store.isRefreshingLimitToken)
-                    Text(l.onlyOnPress)
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
-                if let limitTokenRefreshError = store.limitTokenRefreshError {
-                    Text(limitTokenRefreshError)
-                        .font(.caption2)
-                        .foregroundStyle(.orange)
-                        .lineLimit(2)
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                Toggle(l.launchAtLogin, isOn: $launchAtLogin)
-                    .disabled(!isBundledApp)
-                    .onChange(of: launchAtLogin) { _, newValue in
-                        do {
-                            if newValue {
-                                try SMAppService.mainApp.register()
-                            } else {
-                                try SMAppService.mainApp.unregister()
-                            }
-                            launchAtLoginError = nil
-                        } catch {
-                            launchAtLoginError = "\(error.localizedDescription)"
-                            launchAtLogin = SMAppService.mainApp.status == .enabled
-                        }
-                    }
-                if !isBundledApp {
-                    Text(l.bundledOnly)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-                if let launchAtLoginError {
-                    Text(launchAtLoginError)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(l.notificationsSection).font(.callout)
-                Toggle(l.limitNotificationsLabel, isOn: $store.limitNotifications)
-                if store.limitNotifications {
-                    // 한도 알림 켜진 경우에만 임계값 슬라이더 노출
-                    HStack {
-                        Text(l.warning)
-                        Slider(value: $store.warnThreshold, in: 50...95, step: 5)
-                        Text(TokenFormatter.percent(store.warnThreshold))
-                            .monospacedDigit().frame(width: 40, alignment: .trailing)
-                    }
-                    .font(.caption).padding(.leading, 12)
-                    HStack {
-                        Text(l.critical)
-                        Slider(value: $store.critThreshold, in: 80...100, step: 5)
-                        Text(TokenFormatter.percent(store.critThreshold))
-                            .monospacedDigit().frame(width: 40, alignment: .trailing)
-                    }
-                    .font(.caption).padding(.leading, 12)
-                }
-                Toggle(l.companionNotificationsLabel, isOn: $store.companionNotifications)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 8) {
-                    Button(l.reportProblem) { reportProblem() }
-                    Button(l.showLogFile) {
-                        NSWorkspace.shared.activateFileViewerSelecting([AppLog.logFileURL])
-                    }
-                }
-                Text(l.reportAttachHint)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                if let reportError {
-                    Text(reportError)
-                        .font(.caption2)
-                        .foregroundStyle(.orange)
-                        .textSelection(.enabled)   // 폴백 주소를 복사할 수 있게
-                }
-            }
-
-            Text(l.aggregationNote)
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-
-            HStack {
-                HStack(spacing: 5) {
-                    // 버전과 같은 크기·색, 밑줄로만 링크임을 표시
-                    Text("v\(Self.appVersion)")
-                    Text("·")
-                    footerLink("GitHub", "https://github.com/chattymin/PokeTokenBar")
-                    Text("·")
-                    footerLink("Web", "https://chattymin.github.io/PokeTokenBar/")
-                    Text("·")
-                    // 개발자 후원 — 기능 잠금·너지 없는 푸터 링크 (GitHub/Web 과 동급 톤 유지)
-                    footerLink("♥ Sponsor", "https://github.com/sponsors/chattymin")
-                }
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-                Spacer()
-                Button(l.close) { onClose() }
-                    .keyboardShortcut(.defaultAction)
-            }
-        }
-        .padding(16)
     }
 }

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -59,7 +59,21 @@ struct StubProvider: PokeProviding {
     func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: value.baseID, captureRate: 255)] }
 }
 
+// 테스트 스텁 공통 — base 판정을 주입 인덱스에서 파생. REST 폴백 경로는 실클라이언트만 override.
+extension PokeProviding {
+    func baseSpecies(id: Int) async throws -> BaseSpecies? {
+        try await baseSpeciesIndex().first { $0.id == id }
+    }
+}
+
 private enum PokeStubError: Error { case boom }
+
+/// GraphQL base 인덱스 장애 시뮬 — baseSpeciesIndex 는 throw(엔드포인트 다운), REST 폴백(baseSpecies)은 성공.
+private struct FallbackOnlyProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine { makeLine(base: baseSpeciesID, tree: node(baseSpeciesID)) }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { throw PokeStubError.boom }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { BaseSpecies(id: id, captureRate: 100) }
+}
 
 /// 샘플러 테스트용 — 주입한 base 인덱스 + 요청 id 그대로의 무진화 라인 반환.
 final class IndexProvider: PokeProviding, @unchecked Sendable {
@@ -145,6 +159,18 @@ final class CompanionStoreTests: XCTestCase {
         use(s, PokemonBalance.eggHatchThreshold + 500_000)   // 임계 초과 0.5M
         await s.hatchIfNeeded()
         XCTAssertEqual(s.state.active?.usedAtStage, 500_000)   // 초과분 이월
+    }
+
+    /// GraphQL base 인덱스 엔드포인트가 죽어도 REST 폴백으로 부화한다 (2026-07 실장애 회귀 방지).
+    func testEggHatchesViaRESTFallbackWhenIndexDown() async {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
+        let s = CompanionStore(provider: FallbackOnlyProvider(),
+                               clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 7))
+        base(s)
+        use(s, PokemonBalance.eggHatchThreshold)
+        await s.hatchIfNeeded()
+        XCTAssertNotNil(s.state.active, "인덱스 장애 시 REST 폴백으로 부화해야 함")
+        XCTAssertEqual(s.state.eggUsage, 0)
     }
 
     func testNewEggAfterGraduationReincubates() async {


### PR DESCRIPTION
## 요약
설정창 규격화 + 알 부화 불가(실사용 버그) 수정을 묶은 배치. 라이브 검증 완료.

## 1. 설정창 그룹형 재구성

평평한 단일 열(11개 항목, 매일 쓰는 것과 고급이 같은 비중) → 목적별 그룹 카드로 규격화.

| 영역 | Before | After |
|---|---|---|
| 구조 | 단일 VStack 11개 나열, 섹션 헤더 2개 | 일반 / 메뉴바에 표시 / 알림 / 고급(접기) / 정보&지원 5개 그룹 |
| 헤더·푸터 | 푸터(버전·링크)가 본문 끝 → 스크롤에 가려짐 | 헤더(뒤로+제목)·푸터(버전·GitHub·Web·♥ Sponsor) 스크롤 밖 고정, 본문만 스크롤 |
| 고급 항목 | Keychain 끄기·캐시 갱신·집계 기준 상시 노출 | DisclosureGroup 으로 접어 기본 화면 정돈 |
| 로그 파일 보기 | 고급(접힘) 안 | "정보&지원"의 "문제점 알리기" 옆 — 제보 시 바로 첨부 |

동작·바인딩 100% 보존(언어·간격·메뉴바·알림 임계·자동시작·Keychain·문제제보), 섹션 라벨 ko/en/ja.

## 2. 알 부화 불가 수정 (근본원인 + 자가치유)

**근본원인(로그 실측):** 부화 후보 종 인덱스가 `graphql.pokeapi.co` 단일 엔드포인트에만 의존 →
HTTP 521 지속 다운 + `base-index.json` 캐시 부재 → 종 선택 실패 → 임계(5M)를 7배 넘겨도 부화 불가.
스프라이트·진화라인은 REST(정상)라 다른 건 다 돼 진단이 가려졌고, 부화 경로 로깅이 0이라 원인이 숨음.

**수정:**
- `PokeProviding.baseSpecies(id:)` — REST(`pokemon-species/{id}`)로 base 여부·capture_rate 판정
- `chooseBase`: GraphQL 인덱스 실패 시 REST rejection sampling 폴백 → **즉시 부화 복구**
- `buildBaseIndexViaREST()`: REST 로 인덱스를 구축해 `base-index.json` 영속(세션 1회, 소규모 동시성) →
  이후 선택이 **가중·수집반영·오프라인가능** 주 경로로 복귀. 부화가 단일 엔드포인트에 영구히 묶이지 않게
- 부화 경로 전반 로깅(재발 시 즉시 진단 가능)

**주의(오해 방지):** 수집한 종이 많아져도 "못 고르는" 구조가 아님 — 수집 종은 제외가 아니라 가중치 절반(최소 1 보장). 원인은 수집량이 아니라 엔드포인트 장애였음.

## 테스트 / 확인
- [x] swift test 156개 통과 (신규: 인덱스 장애 시 REST 폴백 부화 회귀 테스트)
- [x] 리뷰 전건 결함 없음 (설정 바인딩 보존 / 폴백 correctness / actor 동시성)
- [x] 라이브 검증: 막혀 있던 알 부화(base=453), REST build 329종 영속(GraphQL과 동일 인덱스), 설정 화면 정상 실행
- [ ] 실기기 설정 화면 시각 확인 — brew 업그레이드 후

🤖 Generated with [Claude Code](https://claude.com/claude-code)
