### PR TITLE
chore(release): UI 변경 시 스크린샷 stale 자동 경고

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,11 @@
 "2.1.1 배포", "release", "다음 버전 내줘" — 한 줄 명령을 시키지 말고 아래를 직접 수행한다.
 
 1. **문서 일관성 검토**: `./scripts/release.sh --check-only` 실행. 경고(README/랜딩/cask 의
-   stale 버전·제거된 의존성 등)가 있으면 **먼저 문서를 갱신**한다 — README.md/ko/ja, gh-pages
-   랜딩 `index.html`(3개 언어 i18n 사전 정합 유지), homebrew-tap cask caveat. (`RELEASE.md` 체크리스트)
+   stale 버전·제거된 의존성, **UI 변경 시 스크린샷 stale** 등)가 있으면 **먼저 문서를 갱신**한다 —
+   README.md/ko/ja, gh-pages 랜딩 `index.html`(3개 언어 i18n 사전 정합 유지), homebrew-tap cask caveat.
+   **UI(`Sources/PokeTokenBar/UI/`)를 바꿨으면 `assets/` 스크린샷을 재생성**한다 — 언어별 이미지
+   (`settings.png`/`-ko`/`-ja` 등) 각 README 참조. 팝오버 라이브 캡처가 막히면(Keychain 프롬프트·
+   NSPopover 창 미노출) 실제 UI 를 HTML 로 렌더해 반영. (`RELEASE.md` 체크리스트)
 2. **버전 결정** (2026-07-03 확정 규칙): 사용자가 말한 **단어가 곧 세그먼트 지정 명령**이다 —
    릴리스에 기능이 포함돼 있어도 변경 내용으로 재해석하지 않는다.
    - "**패치**(해줘)" → x.y.**Z+1** / "**마이너**" → x.**Y+1**.0 / "**메이저**" → **X+1**.0.0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,6 +32,20 @@ doc_check() {
       echo "  ⚠ README 에 '$pat' 잔존 — 제거된 항목인지 확인."; warn=1
     fi
   done
+  # UI 변경 → 스크린샷 staleness (실제 diff 상태 검증 — 수동 체크리스트가 통과의례로 묻히지 않게).
+  # 직전 릴리스 태그 이후 UI 소스가 바뀌었는데 assets 스크린샷이 안 바뀌었으면 README 이미지 stale 가능.
+  local last_tag ui_changed shot_changed
+  last_tag=$(git describe --tags --match "v*" --abbrev=0 2>/dev/null || echo "")
+  if [[ -n "$last_tag" ]]; then
+    ui_changed=$(git diff --name-only "$last_tag"..HEAD -- 'Sources/PokeTokenBar/UI/' 2>/dev/null)
+    shot_changed=$(git diff --name-only "$last_tag"..HEAD -- 'assets/settings*' 'assets/screenshot*' 'assets/menubar*' 'assets/shiny*' 2>/dev/null)
+    if [[ -n "$ui_changed" && -z "$shot_changed" ]]; then
+      echo "  ⚠ UI 소스가 $last_tag 이후 변경됐으나 스크린샷(assets/) 갱신 없음 — README 이미지 stale 가능:"
+      echo "$ui_changed" | sed 's/^/       /'
+      echo "     → 변경된 화면이면 assets 스크린샷 재생성 (README.md/ko/ja 각 언어)."
+      warn=1
+    fi
+  fi
   cat <<'CHECK'
   ─ 수동 체크리스트 (내용 변경 시 갱신) ─────────────────────────────
    [ ] README.md / .ko / .ja : 기능 목록·요구사항·데이터소스·스크린샷


### PR DESCRIPTION
## 요약
v2.3.5 배포 시 설정 UI 를 그룹형으로 바꾸고도 README 스크린샷을 안 갱신한 채 배포한 실패의
재발 방지. release.sh 문서검토가 "스크린샷"을 수동 체크리스트로만 안내해 통과의례로 묻히던 것을
실제 diff 상태 검증으로 승격.

## 변경
- `scripts/release.sh` `doc_check()`: 직전 릴리스 태그 이후 `Sources/PokeTokenBar/UI/` 변경 O +
  `assets/{settings,screenshot,menubar,shiny}*` 변경 X 이면 ⚠ 경고(배포는 막지 않고 안내). 스코프 한정
  으로 오탐 최소화.
- `CLAUDE.md` 릴리스 절차: UI 변경 시 언어별 스크린샷 재생성 명시 + 라이브 캡처 막힐 때 HTML 렌더 폴백.

## 검증
- `bash -n` 구문 OK, `--check-only` 오탐 없음(현재 UI 변경 없음)
- 실증: `v2.3.4..HEAD` 에 UI 변경(PopoverView/SettingsView) 존재 → v2.3.5 배포 시점(스크린샷 미갱신)엔 경고가 배포를 잡았을 것
- 리뷰어 결함 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
