### PR TITLE
feat: Claude 세션 만료(401) UX 보강 — 안내 배너 + 원탭 재시도

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -248,6 +248,19 @@ struct L {
           "Claude の上限取得が一時的に制限されています (429)。少し待って自動的に再試行します。")
     }
 
+    // MARK: Claude 세션 만료(401) 안내
+    var claudeAuthExpiredTitle: String {
+        t("Claude 세션 만료 — 한도가 갱신 안 돼요",
+          "Claude session expired — limits can't refresh",
+          "Claude セッション期限切れ — 上限を更新できません")
+    }
+    var claudeAuthExpiredHint: String {
+        t("표시된 값은 만료 전 기준이에요. 다시 시도하거나, Claude Code 를 한 번 실행하면 자동 갱신됩니다.",
+          "Values shown are from before expiry. Retry, or run Claude Code once to refresh automatically.",
+          "表示値は期限切れ前のものです。再試行するか、Claude Code を一度実行すると自動更新されます。")
+    }
+    var retry: String { t("다시 시도", "Retry", "再試行") }
+
     // MARK: 업데이트 알림
     func updateAvailable(_ version: String, current: String) -> String {
         t("🆕 v\(version) 사용 가능 (현재 \(current))",

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -19,6 +19,9 @@ final class UsageStore {
     private(set) var codexLimitsUpdatedAt: Date?
     private(set) var limitsUpdatedAt: Date?
     private(set) var limitsAvailable = true
+    /// Claude 한도 조회가 401/403(세션 만료)로 실패한 상태 — UI 에서 명확한 안내+재시도 노출용.
+    /// 성공 시 해제. 자동 폴링은 무프롬프트라 만료 토큰을 스스로 못 고치므로 사용자 액션 유도가 필요.
+    private(set) var limitsAuthExpired = false
     private(set) var lastUpdated: Date?
     private(set) var isRefreshing = false
     private(set) var isRefreshingLimitToken = false
@@ -406,6 +409,7 @@ final class UsageStore {
         if disableKeychainAccess {
             limits = nil
             limitsAvailable = false
+            limitsAuthExpired = false   // 조회 자체를 안 하므로 "세션 만료" 안내는 무의미 → 해제
             AppLog.write("claude limits skipped: keychain access disabled")
         } else if let until = claudeLimitsBackoffUntil, Date() < until {
             // 429 백오프 중 — 폴링을 쉬어 rate limit 악화 방지 (버그 리포트 실측: 매분 429 재시도)
@@ -415,11 +419,13 @@ final class UsageStore {
                 limits = try await limitsProvider.fetch(allowKeychainPrompt: false)
                 limitsAvailable = true
                 limitsUpdatedAt = Date()
+                limitsAuthExpired = false
                 resetLimitsBackoff()
                 AppLog.write("limits refreshed fiveHour=\(limits?.fiveHour?.utilization?.description ?? "nil") sevenDay=\(limits?.sevenDay?.utilization?.description ?? "nil")")
             } catch {
                 // 비공식 endpoint 실패 → 섹션 숨김, 토큰 표시는 무영향
                 if limits == nil { limitsAvailable = false }
+                updateAuthExpired(from: error)
                 applyLimitsBackoffIfRateLimited(error)
                 AppLog.write("limits unavailable: \(error)")
             }
@@ -457,6 +463,7 @@ final class UsageStore {
             limits = try await limitsProvider.fetch(allowKeychainPrompt: true)
             limitsAvailable = true
             limitsUpdatedAt = Date()
+            limitsAuthExpired = false
             limitTokenRefreshError = nil
             resetLimitsBackoff()
             AppLog.write("limits refreshed by user action fiveHour=\(limits?.fiveHour?.utilization?.description ?? "nil") sevenDay=\(limits?.sevenDay?.utilization?.description ?? "nil")")
@@ -464,8 +471,17 @@ final class UsageStore {
         } catch {
             limitTokenRefreshError = Self.friendlyLimitError(error, L(localizationLanguage))
             if limits == nil { limitsAvailable = false }
+            updateAuthExpired(from: error)
             applyLimitsBackoffIfRateLimited(error)
             AppLog.write("limits user refresh failed: \(error)")
+        }
+    }
+
+    /// 401/403(세션 만료)면 auth-expired 플래그를 세운다. 다른 오류(네트워크·키체인 잠금 등)는
+    /// 만료가 아니므로 건드리지 않는다 — 오탐으로 "세션 만료" 안내를 띄우지 않기 위함.
+    private func updateAuthExpired(from error: any Error) {
+        if case LimitsError.httpStatus(let status) = error, status == 401 || status == 403 {
+            limitsAuthExpired = true
         }
     }
 

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -221,7 +221,7 @@ struct PopoverView: View {
     /// 선택된 프로바이더에 표시할 공식 한도가 있는가 (Gemini 는 공식 한도 API 없음 → 섹션 생략).
     private var selectedProviderHasLimits: Bool {
         switch selectedSnapshot?.providerID {
-        case "claude_code": return store.limits != nil
+        case "claude_code": return store.limits != nil || store.limitsAuthExpired
         case "codex": return store.codexLimits?.hasVisibleLimit == true
         default: return false
         }
@@ -233,37 +233,45 @@ struct PopoverView: View {
             Text(l.limitsOfficial)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            if selectedSnapshot?.providerID == "claude_code", store.limitsAuthExpired {
+                claudeAuthExpiredNotice
+            }
             if selectedSnapshot?.providerID == "claude_code", let limits = store.limits {
-                if store.claudeLimitsStale {
+                // 세션 만료 안내가 이미 있으면 stale 배지는 생략(중복 신호 방지)
+                if store.claudeLimitsStale, !store.limitsAuthExpired {
                     staleBadge(updatedAt: store.limitsUpdatedAt)
                 }
-                limitRow(name: l.fiveHourSession, window: limits.fiveHour)
-                forecastRow
-                limitRow(name: l.weekly, window: limits.sevenDay)
-                limitRow(name: l.weeklyOpus, window: limits.sevenDayOpus)
-                limitRow(name: l.weeklySonnet, window: limits.sevenDaySonnet)
-                // 신형 limits[] — 모델별 주간(weekly_scoped) 등 레거시 필드 밖 윈도우
-                ForEach(Array(limits.scopedLimitEntries.enumerated()), id: \.offset) { _, entry in
-                    limitRow(
-                        name: l.claudeLimitEntry(kind: entry.kind, model: entry.scope?.model?.displayName),
-                        window: LimitWindow(utilization: entry.percent, resetsAt: entry.resetsAt))
-                }
-                // 전 프로바이더가 블록을 갖게 됨 — "Claude 현재 5h 블록" 행은 명시 조회
-                if let block = store.snapshots.first(where: { $0.providerID == "claude_code" })?.activeBlock,
-                   let end = block.endDate {
-                    HStack {
-                        Text(l.claudeCurrentBlock)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(TokenFormatter.compact(block.totalTokens))
-                            .font(.caption)
-                            .monospacedDigit()
-                        Spacer()
-                        (Text("\(l.reset) ") + Text(end, style: .relative))
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
+                // 세션 만료 시 표시값은 만료 전 기준 → 흐리게 처리해 "현재 값 아님"을 시각적으로 전달
+                VStack(alignment: .leading, spacing: 8) {
+                    limitRow(name: l.fiveHourSession, window: limits.fiveHour)
+                    forecastRow
+                    limitRow(name: l.weekly, window: limits.sevenDay)
+                    limitRow(name: l.weeklyOpus, window: limits.sevenDayOpus)
+                    limitRow(name: l.weeklySonnet, window: limits.sevenDaySonnet)
+                    // 신형 limits[] — 모델별 주간(weekly_scoped) 등 레거시 필드 밖 윈도우
+                    ForEach(Array(limits.scopedLimitEntries.enumerated()), id: \.offset) { _, entry in
+                        limitRow(
+                            name: l.claudeLimitEntry(kind: entry.kind, model: entry.scope?.model?.displayName),
+                            window: LimitWindow(utilization: entry.percent, resetsAt: entry.resetsAt))
+                    }
+                    // 전 프로바이더가 블록을 갖게 됨 — "Claude 현재 5h 블록" 행은 명시 조회
+                    if let block = store.snapshots.first(where: { $0.providerID == "claude_code" })?.activeBlock,
+                       let end = block.endDate {
+                        HStack {
+                            Text(l.claudeCurrentBlock)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(TokenFormatter.compact(block.totalTokens))
+                                .font(.caption)
+                                .monospacedDigit()
+                            Spacer()
+                            (Text("\(l.reset) ") + Text(end, style: .relative))
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
                     }
                 }
+                .opacity(store.limitsAuthExpired ? 0.5 : 1)
             }
             if selectedSnapshot?.providerID == "codex",
                let codexStatus = store.codexLimits, codexStatus.hasVisibleLimit {
@@ -334,6 +342,36 @@ struct PopoverView: View {
                 }
             }
         }
+    }
+
+    /// Claude 세션 만료(401) 안내 — 자동 폴링은 만료 토큰을 스스로 못 고치므로,
+    /// "왜 어제 값에 멈췄는지 + 원탭 재시도 + Claude Code 실행 시 자동 갱신" 을 눈에 띄게 노출.
+    @ViewBuilder
+    private var claudeAuthExpiredNotice: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text(l.claudeAuthExpiredTitle)
+                    .font(.caption).fontWeight(.semibold)
+                Spacer()
+                Button {
+                    Task { await store.refreshLimitTokenFromKeychain() }
+                } label: {
+                    if store.isRefreshingLimitToken {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text(l.retry)
+                    }
+                }
+                .controlSize(.small)
+                .disabled(store.isRefreshingLimitToken)
+            }
+            Text(l.claudeAuthExpiredHint)
+                .font(.caption2).foregroundStyle(.secondary)
+        }
+        .padding(8)
+        .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
     }
 
     /// 한도 스냅샷 갱신 지연 배지 — Claude/Codex 공용 (마지막 성공 시각 상대 표시).

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -36,6 +36,20 @@ private struct FakeClaudeLimits: ClaudeLimitsProviding {
     }
 }
 
+/// 호출마다 다른 결과 — 첫 N회는 지정 오류, 이후 성공(또는 실패) 반환. auth-expired 회복 테스트용.
+private final class SequenceClaudeLimits: ClaudeLimitsProviding, @unchecked Sendable {
+    nonisolated(unsafe) var errors: [any Error]
+    nonisolated(unsafe) var success: LimitStatus?
+    nonisolated(unsafe) var call = 0
+    init(errors: [any Error], success: LimitStatus? = nil) { self.errors = errors; self.success = success }
+    func fetch(allowKeychainPrompt: Bool) async throws -> LimitStatus {
+        defer { call += 1 }
+        if call < errors.count { throw errors[call] }
+        if let success { return success }
+        throw LimitsError.keychainInteractionNotAllowed
+    }
+}
+
 private struct FakeCodexLimits: CodexLimitsProviding {
     var status: CodexRateLimitStatus?
     func fetch() async throws -> CodexRateLimitStatus? { status }
@@ -290,6 +304,31 @@ final class UsageStoreTests: XCTestCase {
     }
 
     // MARK: stale
+
+    // MARK: 세션 만료(401) UX
+
+    func testLimitsAuthExpiredSetOn401AndClearedOnSuccess() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        let seq = SequenceClaudeLimits(errors: [LimitsError.httpStatus(401)],
+                                       success: claudeLimits(fiveHourUtil: 12, resetsAt: "2099-01-01T00:00:00Z"))
+        let store = UsageStore(providers: [claude], claudeLimitsProvider: seq,
+                               codexLimitsProvider: FakeCodexLimits(status: nil),
+                               autoRefresh: false, defaults: testDefaults)
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(store.limitsAuthExpired, "401 → 세션 만료 안내 상태")
+        await store.refresh(scheduleEmptyRetry: false)   // 이번엔 성공
+        XCTAssertFalse(store.limitsAuthExpired, "성공 시 해제")
+    }
+
+    func testLimitsAuthExpiredNotSetOnNon401() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        let store = UsageStore(providers: [claude],
+                               claudeLimitsProvider: SequenceClaudeLimits(errors: [LimitsError.httpStatus(500)]),
+                               codexLimitsProvider: FakeCodexLimits(status: nil),
+                               autoRefresh: false, defaults: testDefaults)
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertFalse(store.limitsAuthExpired, "500 은 세션 만료 아님 — 오탐 방지")
+    }
 
     func testIsStaleBeforeFirstRefreshThenFreshAfter() async {
         let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))


### PR DESCRIPTION
## 요약
사용자 리포트: "자고 일어나니 한도가 초기화 안 됐고, 갑자기 401." 밤새 Claude OAuth 토큰이
만료되면 아침 자동 폴링(무프롬프트)이 401 로 실패하는데, `limits` 는 어제 값이라 nil 이 아니어서
그대로 표시 → "한도 미초기화"로 오인. 401 을 명확히 감지·안내하는 UX 로 보강.

## 근본 배경
- 자동 폴링은 무프롬프트(잠긴 키체인에 다이얼로그 안 띄우기 — PR #40 정책)라 만료 토큰을
  스스로 못 고친다. 앱은 Claude Code 의 토큰을 읽을 뿐 자체 refresh 안 함 → Claude Code 가
  갱신(재실행)하거나 사용자가 재인증해야 회복.

## 변경 (UI)
| 상황 | Before | After |
|---|---|---|
| 401 후 한도 섹션 | 어제 값 그대로(현재처럼), 15분 뒤 작은 "갱신 지연" 배지 | 상단에 주황 안내 **"Claude 세션 만료 — 한도가 갱신 안 돼요"** + 힌트 + **"다시 시도"** 버튼, 한도 행은 흐리게(opacity 0.5) |
| 다시 시도 | (고급에 묻힌 캐시 갱신 버튼뿐) | 안내에 바로 노출 — 재인증(keychain prompt) 후 성공 시 안내 사라지고 최신 한도 표시 |
| 힌트 | 없음 | "표시값은 만료 전 기준. 다시 시도하거나 Claude Code 를 한 번 실행하면 자동 갱신" |

## 오탐 방지
- `limitsAuthExpired` 는 **401/403 에만** 설정 — 네트워크 오류·키체인 잠금·429 는 "세션 만료" 안내를 띄우지 않음. 성공·keychain 끄기 시 해제.

## 테스트 / 확인
- [x] swift test 158개 통과 (신규: 401→안내 set·성공→clear, 500→미설정)
- [x] 리뷰어 결함 없음 (401/403 한정·3경로 clear·재시도 무한루프 없음)
- [x] 안내 화면 렌더로 시각 확인 (주황 배너 + 다시시도 + 흐린 한도 행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
