### PR TITLE
fix: QA 검증팀 발견 결함 9건 (SIGPIPE 크래시·응답 유실·자정 소실·이중부화·bucket 렌더 등)

### DIFF
--- a/Sources/PokeTokenBar/Core/BinaryLocator.swift
+++ b/Sources/PokeTokenBar/Core/BinaryLocator.swift
@@ -7,23 +7,27 @@ import Foundation
 /// 바이너리별로 1회 캐시(셸 호출 비용 회피).
 enum BinaryLocator {
     private static let lock = NSLock()
-    private nonisolated(unsafe) static var cache: [String: String?] = [:]
+    private struct Cached { let path: String?; let at: Date }
+    private nonisolated(unsafe) static var cache: [String: Cached] = [:]
+    /// 미탐지(nil) 캐시 재해석 주기 — 상주 앱이 실행 중 codex 설치 시 반영. 성공 캐시는 영구(경로 소멸 시만 재해석).
+    private static let notFoundTTL: TimeInterval = 600
 
     /// `binary` 의 절대경로(없으면 nil). 스레드 세이프, 1회 해석 후 캐시.
     /// `staticPaths`: 셸 해석 전에 먼저 확인할 알려진 설치 경로.
     static func resolve(_ binary: String, staticPaths: [String]) -> String? {
         lock.lock(); defer { lock.unlock() }
         if let hit = cache[binary] {
-            // stale 캐시 방어 — 해석 후 앱 삭제/교체(Codex.app 업데이트 등)로 경로가 사라졌으면 재해석.
-            // (버그 리포트 실측: 존재하지 않는 /Applications/Codex.app/... 를 계속 실행 시도)
-            if let path = hit, !FileManager.default.isExecutableFile(atPath: path) {
+            if let path = hit.path {
+                // stale 방어 — 해석 후 앱 삭제/교체(Codex.app 업데이트 등)로 경로 소멸 시 재해석.
+                if FileManager.default.isExecutableFile(atPath: path) { return path }
                 AppLog.write("\(binary) cached path gone, re-resolving: \(path)")
-            } else {
-                return hit
+            } else if Date().timeIntervalSince(hit.at) < notFoundTTL {
+                return nil   // 최근 미탐지 — TTL 내엔 셸 resolve 비용 회피
             }
+            // else: 미탐지 캐시가 TTL 지남 → 재해석(그새 설치됐을 수 있음)
         }
         let result = locate(binary, staticPaths: staticPaths)
-        cache[binary] = result
+        cache[binary] = Cached(path: result, at: Date())
         AppLog.write(result.map { "\(binary) resolved: \($0)" } ?? "\(binary) NOT found on PATH")
         return result
     }

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -185,6 +185,9 @@ final class CompanionStore {
                 let newName = line.localizedName(next.speciesID, state.language)
                 justEvolvedTo = newName
                 fireCelebration(.evolve)
+                // 짧은 levelUp 창 — 진화 순간 "…(으)로 진화했어요" 문구 노출(hatch/graduate 와 동일 패턴).
+                // 이게 없으면 computeState 가 .levelUp 을 안 내 statusEvolved 가 도달 불가(dead code)였다.
+                eventUntil = clock().addingTimeInterval(4)
                 notifyCompanionEvent(l.notifEvolveTitle, l.notifEvolveBody(newName))
             }
         }
@@ -238,8 +241,12 @@ final class CompanionStore {
         // 프리패치가 "종 롤 중"(pending 미확정)일 때만 대기 — 이중 rng 소비 방지.
         // pending 확정 후의 예열(라인/스프라이트)과는 동시 진행해도 안전하다.
         guard state.pendingHatchID != nil || !prefetchInFlight else { return }
-        // 샘플링(네트워크) 동안 중복 진입 차단 — hatch() 자체 가드와 별개.
+        // isHatching 을 롤~부화 전체에 defer 로 잠근다. 과거엔 chooseBase 후 isHatching 을 잠깐
+        // 내렸다가(hatch 자체 가드 통과용) hatch 를 호출해, 그 await 창에서 다른 update 틱이
+        // 두 번째 종을 롤하는 경합이 있었다. hatchCore 는 isHatching 을 재검사하지 않으므로
+        // 여기서 소유한 락 하나로 롤·부화가 원자적으로 보호된다.
         isHatching = true
+        defer { isHatching = false }
         // 프리패칭된 종이 있으면 그대로 사용(라인·스프라이트 예열됨 → 딜레이 ~0), 없으면 지금 롤.
         let base: Int?
         if let pending = state.pendingHatchID {
@@ -247,10 +254,9 @@ final class CompanionStore {
         } else {
             base = await chooseBase()
         }
-        isHatching = false
         guard let base else { return }   // 네트워크 불안정 → 알 유지, 다음 update 틱에 재시도
         state.pendingHatchID = nil
-        await hatch(baseID: base)
+        await hatchCore(baseID: base)
     }
 
     // MARK: 알 프리패칭
@@ -288,6 +294,11 @@ final class CompanionStore {
         guard !isHatching else { return }
         isHatching = true
         defer { isHatching = false }
+        await hatchCore(baseID: baseID)
+    }
+
+    /// 실제 부화 로직 — isHatching 락은 호출자(hatch / hatchIfNeeded)가 소유·해제한다.
+    private func hatchCore(baseID: Int) async {
         guard let line = try? await provider.line(baseSpeciesID: baseID) else {
             AppLog.write("hatch: line fetch failed for base \(baseID) — egg kept, retry next tick")
             return
@@ -391,6 +402,6 @@ final class CompanionStore {
     }
     private func save() {
         guard let data = try? JSONEncoder().encode(state) else { return }
-        try? data.write(to: fileURL)
+        try? data.write(to: fileURL, options: .atomic)   // 부분 쓰기 손상 방지(펫 상태)
     }
 }

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -151,7 +151,7 @@ actor LocalUsageCache {
         if let data = try? JSONEncoder().encode(snap) {
             // JSON 은 zlib 로 크게 압축됨(수 MB → 수백 KB). 실패 시 평문 저장(로드가 양쪽 다 처리).
             let out = (try? (data as NSData).compressed(using: .zlib) as Data) ?? data
-            try? out.write(to: fileURL)
+            try? out.write(to: fileURL, options: .atomic)
             dirty = false
             lastSave = now()
         }

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -85,7 +85,7 @@ actor PokeAPIClient: PokeProviding {
             let entries = try await fetchBaseIndex()
             baseIndexCache = entries
             if let data = try? JSONEncoder().encode(BaseIndexSnapshot(fetchedAt: Date(), entries: entries)) {
-                try? data.write(to: Self.baseIndexFile)
+                try? data.write(to: Self.baseIndexFile, options: .atomic)
             }
             return entries
         } catch {
@@ -136,7 +136,7 @@ actor PokeAPIClient: PokeProviding {
         bases.sort { $0.id < $1.id }
         baseIndexCache = bases
         if let data = try? JSONEncoder().encode(BaseIndexSnapshot(fetchedAt: Date(), entries: bases)) {
-            try? data.write(to: Self.baseIndexFile)
+            try? data.write(to: Self.baseIndexFile, options: .atomic)
         }
         AppLog.write("base index: REST build done — \(bases.count) bases persisted (offline-capable now)")
     }

--- a/Sources/PokeTokenBar/Core/ProcessRunner.swift
+++ b/Sources/PokeTokenBar/Core/ProcessRunner.swift
@@ -73,7 +73,10 @@ enum ProcessRunner {
         }
 
         let payload = inputLines.joined(separator: "\n") + "\n"
-        stdinPipe.fileHandleForWriting.write(Data(payload.utf8))
+        // 자식이 stdin 을 읽기 전에 조기 종료하면 broken pipe. non-throwing write 는 SIGPIPE 로
+        // 앱 전체를 죽인다 → throwing API + try? 로 EPIPE 를 삼킨다(앱 기동 시 SIG_IGN 도 설치).
+        // write 가 실패해도 아래 폴링이 종료/타임아웃으로 처리하므로 무해.
+        try? stdinPipe.fileHandleForWriting.write(contentsOf: Data(payload.utf8))
 
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
@@ -85,6 +88,13 @@ enum ProcessRunner {
                 break
             }
             try await Task.sleep(nanoseconds: 200_000_000)
+        }
+
+        // 프로세스 종료 직전 flush 분이 마지막 in-loop read 보다 늦게 도착할 수 있어
+        // 최종 1회 재read (정상 종료 시 유효 응답이 파일에 있는데 놓치던 레이스 방지).
+        if let response = try Self.jsonRPCResultData(
+            in: (try? Data(contentsOf: outURL)) ?? Data(), responseID: responseID) {
+            return response
         }
 
         if process.isRunning {

--- a/Sources/PokeTokenBar/Core/SupportMail.swift
+++ b/Sources/PokeTokenBar/Core/SupportMail.swift
@@ -15,6 +15,12 @@ enum SupportMail {
             URLQueryItem(name: "subject", value: subject),
             URLQueryItem(name: "body", value: body),
         ]
-        return components.url
+        // URLComponents 는 query 의 '+' 를 percent-encode 하지 않아, 다수 메일 클라이언트가 공백으로
+        // 디코드한다(제목/본문의 'C++'·경로 등 왜곡). query 부분의 '+' 만 %2B 로 치환.
+        guard let raw = components.url?.absoluteString else { return nil }
+        guard let q = raw.firstIndex(of: "?") else { return URL(string: raw) }
+        let head = raw[...q]
+        let query = raw[raw.index(after: q)...].replacingOccurrences(of: "+", with: "%2B")
+        return URL(string: head + query)
     }
 }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -396,7 +396,22 @@ final class UsageStore {
                 group.addTask { (provider.id, await provider.fetchEnrichment()) }
             }
             for await (id, enrichment) in group {
-                guard let index = snapshots.firstIndex(where: { $0.providerID == id }) else { continue }
+                guard let index = snapshots.firstIndex(where: { $0.providerID == id }) else {
+                    // phase1 이 스냅샷을 안 만든 프로바이더(오늘 토큰 0)라도, 활성 5h 블록·주/월 누적이
+                    // 있으면 캐리어 스냅샷을 생성(today=nil). 없으면 자정~첫토큰 창에서 burn/forecast/
+                    // 주월이 매일 소실된다(어제 늦은밤 코딩이 5h 윈도우에 남은 경우).
+                    let hasEnrichment = (enrichment.blocksOK && enrichment.activeBlock != nil)
+                        || (enrichment.periodsOK && (enrichment.weekTotal != nil || enrichment.monthTotal != nil))
+                    if hasEnrichment, let provider = providers.first(where: { $0.id == id }) {
+                        snapshots.append(ProviderSnapshot(
+                            providerID: id, displayName: provider.displayName, today: nil,
+                            activeBlock: enrichment.blocksOK ? enrichment.activeBlock : nil,
+                            weekTotal: enrichment.periodsOK ? enrichment.weekTotal : nil,
+                            monthTotal: enrichment.periodsOK ? enrichment.monthTotal : nil,
+                            fetchedAt: Date()))
+                    }
+                    continue
+                }
                 if enrichment.blocksOK { snapshots[index].activeBlock = enrichment.activeBlock }
                 if enrichment.periodsOK {
                     snapshots[index].weekTotal = enrichment.weekTotal
@@ -648,7 +663,7 @@ final class UsageStore {
             "lastError": lastErrorDescription ?? "",
         ]
         if let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]) {
-            try? data.write(to: dir.appendingPathComponent("last-snapshot.json"))
+            try? data.write(to: dir.appendingPathComponent("last-snapshot.json"), options: .atomic)
         }
     }
 }

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -31,6 +31,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var displayAwake = true     // 디스플레이 켜짐 여부 (꺼지면 메뉴 애니메이션 정지 — 배터리)
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // 서브프로세스(codex app-server 등) 파이프가 조기 종료로 끊겨도 SIGPIPE 로 앱이 죽지 않게
+        // 무시한다. ProcessRunner 의 throwing write 와 함께 broken-pipe 크래시를 막는 이중 방어.
+        signal(SIGPIPE, SIG_IGN)
         NSApp.setActivationPolicy(.accessory)
         Self.migrateLegacyStorageIfNeeded()   // TokenMac → PokeTokenBar 리네임: 기존 companion/캐시 보존
         store = UsageStore()

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -277,7 +277,9 @@ struct PopoverView: View {
                let codexStatus = store.codexLimits, codexStatus.hasVisibleLimit {
                 let buckets = codexStatus.visibleSnapshots
                 codexMetaRow(codexStatus)
-                ForEach(buckets, id: \.limitId) { bucket in
+                // id 는 offset — limitId 가 nil 인 bucket 이 2개 이상이면 \.limitId 는 충돌(행 누락)한다.
+                // snapshots 순서는 결정적(sorted)이라 offset 안정. (scopedLimitEntries 와 동일 방식)
+                ForEach(Array(buckets.enumerated()), id: \.offset) { _, bucket in
                     // bucket 이 여럿일 때만 구분 라벨 (단일 bucket 사용자는 기존 UI 그대로)
                     if buckets.count > 1 {
                         Text(bucket.bucketDisplayName)

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -337,6 +337,15 @@ final class SupportMailTests: XCTestCase {
                        "문제 내용:\n(설명)\n---\n앱 버전: v2.3.3")
     }
 
+    func testMailtoEncodesPlusSign() throws {
+        let url = try XCTUnwrap(SupportMail.mailtoURL(subject: "C++ crash", body: "path a+b\n2+2"))
+        let s = url.absoluteString
+        XCTAssertFalse(s.contains("+"), "query 의 '+' 는 %2B 로 인코딩돼야 함(메일 클라이언트 공백 오독 방지): \(s)")
+        let comps = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(comps.queryItems?.first { $0.name == "subject" }?.value, "C++ crash")
+        XCTAssertEqual(comps.queryItems?.first { $0.name == "body" }?.value, "path a+b\n2+2")
+    }
+
     func testMailBodyContainsDiagnostics() {
         let body = L(.ko).reportMailBody(version: "2.3.3", os: "Version 14.5 (Build 23F79)")
         XCTAssertTrue(body.contains("v2.3.3"))

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -256,6 +256,25 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(store.burnTier, .fast)
     }
 
+    /// 자정 직후 — 오늘 토큰 0이지만 활성 5h 블록·주월 누적이 있으면 캐리어 스냅샷 생성.
+    /// (없으면 매일 자정~첫토큰 창에서 burn/forecast/주월이 소실되던 버그 회귀 방지)
+    func testMidnightCarrierSnapshotFromEnrichmentOnly() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: nil)
+        claude.enrichment = ProviderEnrichment(
+            activeBlock: block(tokensPerMinute: 200_000), blocksOK: true,
+            weekTotal: PeriodUsage(period: "w", totalTokens: 90_000_000, totalCost: 0),
+            monthTotal: PeriodUsage(period: "m", totalTokens: 300_000_000, totalCost: 0),
+            periodsOK: true)
+        let store = makeStore(providers: [claude])
+        await store.refresh(scheduleEmptyRetry: false)
+
+        let snap = store.snapshot(preferring: "claude_code")
+        XCTAssertEqual(snap?.providerID, "claude_code", "캐리어 스냅샷 미생성")
+        XCTAssertNil(snap?.today, "오늘 데이터는 없어야(today=nil)")
+        XCTAssertEqual(store.weekTotalTokens, 90_000_000)
+        XCTAssertEqual(store.burnTier, .fast, "자정 직후에도 활성 블록으로 burn 반영(idle 아님)")
+    }
+
     /// 여러 프로바이더의 burn 은 합산된다 (60k + 60k = 120k → fast).
     func testBurnTierCombinesProviders() async {
         let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))


### PR DESCRIPTION
## 요약
앱 전 영역을 6개 도메인 병렬 검증(agent team)으로 엣지케이스 전수 검사 → 실제 결함 9건 수정.
HIGH 5 + MED 4. 오탐/정보성(Codex prefill=ccusage 패리티 설계, claimedTodayTokens=방어됨)은 제외.

## HIGH
| # | 결함 | 파일 |
|---|---|---|
| 1 | 자식 프로세스 조기종료 시 stdin write → **SIGPIPE 로 앱 전체 크래시** | ProcessRunner + PokeTokenBarApp(SIG_IGN) |
| 2 | 프로세스 종료 시 최종 재read 없이 break → **유효 응답 유실** 레이스 | ProcessRunner |
| 3 | 자정 직후 오늘 0이면 스냅샷 미생성 → **활성 블록·주월·burn 매일 소실**(companion idle 오표시) | UsageStore phase2 캐리어 스냅샷 |
| 4 | hatchIfNeeded isHatching 수동 리셋 → await 창 **이중 부화 롤**(rng 이중소비) | CompanionStore(hatchCore 분리+defer 락) |
| 5 | Codex 다중 bucket ForEach(id:\.limitId) nil 2개 시 **행 렌더 붕괴**(②⑤ 동시 확인) | PopoverView(id:\.offset) |

## MED
| # | 결함 | 수정 |
|---|---|---|
| 6 | BinaryLocator 미탐지 캐시 미재해석 — 실행 후 codex 설치 시 재시작 전까지 못 찾음 | nil 캐시 600s TTL |
| 7 | mailto query '+' → 메일 클라이언트 공백 오독 | %2B 인코딩 |
| 8 | 상태 파일 원자적 쓰기 부재(부분쓰기 손상) | companion-state·usage-cache·base-index·last-snapshot .atomic |
| 9 | 진화 status 문구 도달 불가(dead code) | 진화 시 eventUntil 로 노출 |

## 검증
- [x] swift test 160개 통과 (신규 회귀: 자정 캐리어 스냅샷, mailto + 인코딩)
- [x] 리뷰어 결함 없음 (9건 수정의 회귀 전수 확인)
- [x] .app 빌드+실행 — 크래시 없음, 로그 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)
