### PR TITLE
fix: 미사용 프로바이더 탭 회귀 — 캐리어 스냅샷을 활성 블록에 한정

### DIFF
--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -397,15 +397,16 @@ final class UsageStore {
             }
             for await (id, enrichment) in group {
                 guard let index = snapshots.firstIndex(where: { $0.providerID == id }) else {
-                    // phase1 이 스냅샷을 안 만든 프로바이더(오늘 토큰 0)라도, 활성 5h 블록·주/월 누적이
-                    // 있으면 캐리어 스냅샷을 생성(today=nil). 없으면 자정~첫토큰 창에서 burn/forecast/
-                    // 주월이 매일 소실된다(어제 늦은밤 코딩이 5h 윈도우에 남은 경우).
-                    let hasEnrichment = (enrichment.blocksOK && enrichment.activeBlock != nil)
-                        || (enrichment.periodsOK && (enrichment.weekTotal != nil || enrichment.monthTotal != nil))
-                    if hasEnrichment, let provider = providers.first(where: { $0.id == id }) {
+                    // 캐리어 스냅샷은 "**실제 활성 5h 블록**이 있을 때만" 만든다(어제 늦은밤 코딩이 5h
+                    // 윈도우에 남아 자정 후 오늘 토큰 0인 경우 — burn/forecast/companion 보존). 주/월
+                    // 누적만으로 만들면, weekTotal 이 옵셔널이 아니라(토큰 0이어도 non-nil) 오늘·최근
+                    // 미사용 프로바이더까지 탭이 떠서 "안 썼는데 왜 뜨지" 회귀가 난다. 블록이 있을 때만
+                    // 그 시점의 주/월도 함께 보존한다.
+                    let hasActiveBlock = enrichment.blocksOK && enrichment.activeBlock != nil
+                    if hasActiveBlock, let provider = providers.first(where: { $0.id == id }) {
                         snapshots.append(ProviderSnapshot(
                             providerID: id, displayName: provider.displayName, today: nil,
-                            activeBlock: enrichment.blocksOK ? enrichment.activeBlock : nil,
+                            activeBlock: enrichment.activeBlock,
                             weekTotal: enrichment.periodsOK ? enrichment.weekTotal : nil,
                             monthTotal: enrichment.periodsOK ? enrichment.monthTotal : nil,
                             fetchedAt: Date()))

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -256,9 +256,9 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(store.burnTier, .fast)
     }
 
-    /// 자정 직후 — 오늘 토큰 0이지만 활성 5h 블록·주월 누적이 있으면 캐리어 스냅샷 생성.
+    /// 자정 직후 — 오늘 토큰 0이지만 **활성 5h 블록**이 있으면 캐리어 스냅샷 생성.
     /// (없으면 매일 자정~첫토큰 창에서 burn/forecast/주월이 소실되던 버그 회귀 방지)
-    func testMidnightCarrierSnapshotFromEnrichmentOnly() async {
+    func testMidnightCarrierSnapshotFromActiveBlock() async {
         let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: nil)
         claude.enrichment = ProviderEnrichment(
             activeBlock: block(tokensPerMinute: 200_000), blocksOK: true,
@@ -273,6 +273,21 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertNil(snap?.today, "오늘 데이터는 없어야(today=nil)")
         XCTAssertEqual(store.weekTotalTokens, 90_000_000)
         XCTAssertEqual(store.burnTier, .fast, "자정 직후에도 활성 블록으로 burn 반영(idle 아님)")
+    }
+
+    /// 오늘·최근 미사용(활성 블록 없음)인데 주/월 기록만 있으면 캐리어를 만들지 않는다 —
+    /// weekTotal 이 항상 non-nil 이라 탭이 뜨던 회귀 방지("안 썼는데 왜 뜨지").
+    func testNoCarrierForWeekMonthOnlyWithoutActiveBlock() async {
+        let codex = FakeUsageProvider(id: "codex", displayName: "Codex", daily: nil)
+        codex.enrichment = ProviderEnrichment(
+            activeBlock: nil, blocksOK: true,   // 최근 5h 사용 없음 → 블록 없음
+            weekTotal: PeriodUsage(period: "w", totalTokens: 50_000_000, totalCost: 0),
+            monthTotal: PeriodUsage(period: "m", totalTokens: 80_000_000, totalCost: 0),
+            periodsOK: true)
+        let store = makeStore(providers: [codex])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertFalse(store.snapshots.contains { $0.providerID == "codex" },
+                       "오늘·최근 미사용 프로바이더는 탭이 뜨면 안 됨")
     }
 
     /// 여러 프로바이더의 burn 은 합산된다 (60k + 60k = 120k → fast).


### PR DESCRIPTION
## 요약
사용자 리포트: "오늘 Gemini·Codex 안 썼는데 왜 앱에 떠 있지?" → #55 의 캐리어 스냅샷 회귀.

`weekTotal` 은 옵셔널이 아니라 **주간 0 토큰이어도 non-nil** 이라, 캐리어 조건의
`주/월 non-nil` 이 사실상 항상 참 → 오늘·최근 미사용 프로바이더까지 탭이 떴다.

## 수정
- phase2 캐리어 조건을 `(활성블록) || (주월 non-nil)` → **`활성 5h 블록이 있을 때만`** 으로 한정.
- 원래 의도(자정 후 어제 밤 코딩이 5h 윈도우에 남은 경우 burn/forecast/주월 보존)는 유지 —
  활성 블록이 있을 때만 캐리어를 만들고 그 시점의 주/월도 함께 보존.
- 트레이드오프(명시): 오늘·최근 미사용 프로바이더의 주/월 합계는 집계에서 제외 —
  이는 원래 동작이자 사용자 기대("안 쓴 건 안 뜬다")와 일치.

## 검증
- [x] swift test 161개 통과 (신규 회귀: 활성블록→캐리어 O / 주월만→캐리어 X)
- [x] 리뷰어 결함 없음
- [x] .app 재빌드+실행 — last-snapshot 에 claude_code 만(codex·gemini 탭 사라짐)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
