### PR TITLE
feat: 컬렉션 희귀도 필터 — 상단 캡슐 탭으로 단일 희귀도만 보기(재탭 해제)

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -187,6 +187,7 @@ struct L {
     var rarityUncommon: String { t("고급", "Uncommon", "アンコモン") }
     var rarityRare: String { t("희귀", "Rare", "レア") }
     var rarityLegendary: String { t("전설", "Legendary", "伝説") }
+    var dexFilterHint: String { t("탭하면 이 희귀도만 보기 · 다시 탭하면 전체", "Tap to show only this rarity · tap again to clear", "タップでこの希少度のみ表示・再タップで全体") }
     func rarityLabel(_ r: Rarity) -> String {
         switch r {
         case .common:    return rarityCommon

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -240,15 +240,18 @@ struct RarityTally: View {
     let label: String
     let count: Int
     let color: Color
+    var isSelected: Bool = false      // 이 희귀도로 필터 활성 → solid 채움
     var body: some View {
         HStack(spacing: 3) {
-            Circle().fill(color).frame(width: 6, height: 6)
+            Circle().fill(isSelected ? .white : color).frame(width: 6, height: 6)
             Text(label).font(.system(size: 9, weight: .medium))
             Text("\(count)").font(.system(size: 9, weight: .bold))
         }
+        .foregroundStyle(isSelected ? .white : .primary)
         .padding(.horizontal, 6).padding(.vertical, 2)
-        .background(color.opacity(0.12))
+        .background(isSelected ? color : color.opacity(0.12))
         .clipShape(Capsule())
+        .overlay(Capsule().strokeBorder(color.opacity(0.35), lineWidth: isSelected ? 0 : 0.5))
         .opacity(count == 0 ? 0.4 : 1)
     }
 }
@@ -256,6 +259,8 @@ struct RarityTally: View {
 /// 도감 요약 헤더 — 총 개수 + 희귀도별 개수 캡슐.
 struct DexSummaryHeader: View {
     let store: CompanionStore
+    let selected: Rarity?                  // nil = 필터 없음(전체)
+    let onSelect: (Rarity) -> Void         // 캡슐 탭 → 토글
     private let order: [Rarity] = [.legendary, .rare, .uncommon, .common]
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
@@ -266,7 +271,15 @@ struct DexSummaryHeader: View {
             }
             HStack(spacing: 4) {
                 ForEach(order, id: \.self) { r in
-                    RarityTally(label: store.l.rarityLabel(r), count: store.dexCount(r), color: rarityColor(r))
+                    let count = store.dexCount(r)
+                    Button { onSelect(r) } label: {
+                        RarityTally(
+                            label: store.l.rarityLabel(r), count: count, color: rarityColor(r),
+                            isSelected: selected == r)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(count == 0)          // 0마리 희귀도는 필터 불가
+                    .help(store.l.dexFilterHint)
                 }
             }
         }
@@ -276,6 +289,14 @@ struct DexSummaryHeader: View {
 /// 도감 — 잡은 라인(초기→최종 전부) 목록.
 struct CollectionView: View {
     let store: CompanionStore
+    @State private var selectedRarity: Rarity?
+
+    /// 선택된 희귀도만 노출(없으면 전체). 상단 캡슐 토글로 설정.
+    private var visibleEntries: [DexEntry] {
+        guard let r = selectedRarity else { return store.dexEntriesSorted }
+        return store.dexEntriesSorted.filter { $0.rarity == r }
+    }
+
     var body: some View {
         if store.dexEntries.isEmpty {
             emptyState
@@ -284,8 +305,12 @@ struct CollectionView: View {
             // 크기가 줄어드는 문제가 있어 height 로 고정한다.
             ScrollView {
                 VStack(alignment: .leading, spacing: 8) {
-                    DexSummaryHeader(store: store)
-                    ForEach(store.dexEntriesSorted) { entry in
+                    DexSummaryHeader(store: store, selected: selectedRarity) { r in
+                        withAnimation(.easeInOut(duration: 0.15)) {
+                            selectedRarity = (selectedRarity == r) ? nil : r
+                        }
+                    }
+                    ForEach(visibleEntries) { entry in
                         VStack(alignment: .leading, spacing: 3) {
                             HStack {
                                 Text(store.l.rarityLabel(entry.rarity).uppercased())


### PR DESCRIPTION
## 요약
도감(컬렉션) 상단 **희귀도 캡슐을 탭 가능한 필터 칩**으로 만들었습니다. 흔한 필터칩 토글 플로우 그대로 — 탭하면 그 희귀도만, 다시 탭하면 해제.

## 동작 (Before → After)
| | Before | After |
|---|---|---|
| 상단 희귀도 캡슐 | 개수 표시 전용(비상호작용) | **탭 → 그 희귀도만 필터**, 재탭 → 해제 |
| 선택 표시 | 없음 | 선택 칩 solid 채움 + 흰 텍스트/점, 나머지는 기존 tint 유지 |
| 0마리 희귀도 | 흐리게 표시 | 흐리게 + `.disabled`(필터 불가 → 빈 목록 방지) |
| 헤더 개수 | 전체 카운트 | 전체 카운트(필터와 무관하게 항상 전체) |

## 케이스 분기
- **필터 없음(기본)**: `selectedRarity == nil` → 전체(`dexEntriesSorted`) 노출
- **희귀도 A 탭**: `selectedRarity = A` → A 라인만
- **A 다시 탭**: `selectedRarity = nil` → 전체 복귀 (`(sel == r) ? nil : r`)
- **A 활성 중 B 탭**: `selectedRarity = B` → 단일 선택 전환
- **0마리 희귀도 탭**: `.disabled` 로 무반응

## 구현 범위
- `CollectionView`: 로컬 `@State selectedRarity` + `visibleEntries`(필터) 추가. 집계·정렬(`dexEntriesSorted`)·엔트리 렌더는 불변.
- `DexSummaryHeader`: 캡슐을 `Button`(`.buttonStyle(.plain)`)으로 감싸고 `selected`/`onSelect` 주입, `.help` 툴팁.
- `RarityTally`: `isSelected` 스타일(solid fill + 흰 텍스트/점) 추가.
- `Localization`: `dexFilterHint` 3개 언어(ko/en/ja) 추가.

## 검증
- `swift build` 통과, `swift test` **161개 통과**(모델/스토어 회귀 없음 — 순수 뷰-로컬 추가).
- 팝오버 라이브 캡처 불가(Keychain/NSPopover) → 컬렉션 헤더+목록을 HTML 렌더로 3상태 자가검토: 필터 없음 / 희귀 선택(파랑 solid, 목록 희귀만) / 일반 선택(회색 solid 흰글자 가독성 = 최약 대비 케이스도 판독 OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
