### PR TITLE
feat: 컬렉션 필터 선택 강조를 링+체크마크로 개선 (대비·다크모드 가독)

### DIFF
--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -235,23 +235,31 @@ struct CompanionHeader: View {
     }
 }
 
-/// 희귀도 1종 요약 캡슐 — 색 점 + 라벨 + 개수. 0이면 흐리게.
+/// 희귀도 1종 캡슐 — 색 점 + 라벨 + 개수. 선택 시 원색 링 + 체크마크로 강조.
+/// (solid 채움 대신 링+체크 — green/orange 위 흰 텍스트 대비 문제 회피 + 라이트/다크 양쪽 가독.
+///  텍스트는 .primary 라 모드 자동 적응, 색 정체성은 점·링·체크로 유지 → 엔트리 배지와 안 어긋남.)
+/// 0이면 흐리게(필터 불가).
 struct RarityTally: View {
     let label: String
     let count: Int
     let color: Color
-    var isSelected: Bool = false      // 이 희귀도로 필터 활성 → solid 채움
+    var isSelected: Bool = false      // 이 희귀도로 필터 활성 → 원색 링 + 체크
     var body: some View {
         HStack(spacing: 3) {
-            Circle().fill(isSelected ? .white : color).frame(width: 6, height: 6)
-            Text(label).font(.system(size: 9, weight: .medium))
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label).font(.system(size: 9, weight: isSelected ? .semibold : .medium))
             Text("\(count)").font(.system(size: 9, weight: .bold))
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 7, weight: .bold)).foregroundStyle(color)
+            }
         }
-        .foregroundStyle(isSelected ? .white : .primary)
+        .foregroundStyle(.primary)
         .padding(.horizontal, 6).padding(.vertical, 2)
-        .background(isSelected ? color : color.opacity(0.12))
+        .background(color.opacity(isSelected ? 0.22 : 0.12))
         .clipShape(Capsule())
-        .overlay(Capsule().strokeBorder(color.opacity(0.35), lineWidth: isSelected ? 0 : 0.5))
+        .overlay(Capsule().strokeBorder(isSelected ? color : color.opacity(0.35),
+                                        lineWidth: isSelected ? 1.5 : 0.5))
         .opacity(count == 0 ? 0.4 : 1)
     }
 }


### PR DESCRIPTION
## 요약
#59 의 컬렉션 희귀도 필터에서 **선택 강조 방식**을 개선했다. 기존 solid 원색 채움 + 흰 텍스트는 green(고급)/orange(전설) 위에서 대비가 약했다(리뷰 #2/#3). 원색 링 + 체크마크 방식으로 바꿔 전 희귀도·라이트/다크 모두 또렷하게.

## Before → After
| | Before (#59) | After |
|---|---|---|
| 선택 강조 | solid 원색 채움 + **흰 텍스트/점** | **원색 링(1.5px) + 강한 tint(.22) + 체크마크 ✓** |
| green/orange 가독 | 흰 9pt 텍스트 WCAG AA 미달 | `.primary` 텍스트 → 4색 모두 또렷 |
| 다크모드 | 흰 텍스트라 밝은 원색서 약함 | `.primary` 자동 적응(다크=흰), 원색은 링/점/체크에만 |
| 배지 정합 | 칩=배지 동일 solid | 색 정체성만 공유(점·링·체크), 컨트롤은 컨트롤답게 구분 |

## 근거
- 리뷰(oh-my-claudecode:code-reviewer)가 MEDIUM 으로 지목한 "흰-텍스트-on-원색 대비"를, **칩만 색을 바꾸면 엔트리 배지와 어긋나는** 딜레마를 링+체크로 우회 — 원색은 링·점·체크에만 쓰고 텍스트는 `.primary` 라 배지와 색 충돌 없음.
- 체크마크는 Material 필터칩의 정통 "선택" 어포던스라 사용자가 기대한 "유명한 플로우"와 일치.

## 검증
- `swift build` + `swift test` **161개 통과**(필터 로직·집계 불변, `RarityTally` 표현만 변경).
- HTML 렌더로 **라이트+다크 × 최약 케이스(green/orange 선택)** 시각 확인 — 4색 전부 가독, 선택 명확.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
