### PR TITLE
feat: 메뉴바 라이브 피드백 — 기동 dim 제거 + 2줄 적응형 폰트

### DIFF
--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -109,10 +109,10 @@ final class UsageStore {
     /// 사용량 데이터(스냅샷)가 하나라도 있는가 — companion sleep 판정용
     var hasUsageData: Bool { !snapshots.isEmpty }
 
-    /// 메뉴바 표시 줄 — 사용량(토큰·비용)을 1줄, 한도를 1줄로 나눠 세로 스택(둘 다 있으면 2줄).
-    /// 한도는 **오늘 실제 사용한 프로바이더만** 노출한다(오늘 미사용 프로바이더가 뜨지 않게 —
-    /// snapshots 의 오늘 토큰>0 으로 게이트). 한도 소스는 프로바이더 고유(Claude=OAuth·Codex=프로세스)라
-    /// providerID 로 명시 분기(확장 규약 §"프로바이더 고유 동작"에 해당).
+    /// 메뉴바 표시 줄 — 사용량(토큰·비용)을 윗줄에 나란히, 한도를 아랫줄로. **최대 2줄**(3줄은
+    /// 가독성 저하로 사용자가 반려). 한도는 **오늘 실제 사용한 프로바이더만** 노출한다(오늘 미사용
+    /// 프로바이더가 뜨지 않게 — snapshots 의 오늘 토큰>0 으로 게이트). 한도 소스는 프로바이더
+    /// 고유(Claude=OAuth·Codex=프로세스)라 providerID 로 명시 분기(확장 규약 §"프로바이더 고유 동작").
     var menuLines: [String] {
         guard lastUpdated != nil else { return ["—"] }
         var usage: [String] = []
@@ -129,8 +129,8 @@ final class UsageStore {
             }
         }
         var lines: [String] = []
-        if !usage.isEmpty { lines.append(usage.joined(separator: " · ")) }
-        if !limitParts.isEmpty { lines.append(limitParts.joined(separator: " · ")) }
+        if !usage.isEmpty { lines.append(usage.joined(separator: " · ")) }            // 윗줄: 토큰·비용 나란히
+        if !limitParts.isEmpty { lines.append(limitParts.joined(separator: " · ")) }  // 아랫줄: 한도
         return lines   // 빈 배열이면 아이콘만
     }
 

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -79,27 +79,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func applyState() {
         guard let button = statusItem.button else { return }
         Self.applyMenuText(store.menuLines, to: button)
-        button.appearsDisabled = store.isStale
+        // 최초 로딩 중(데이터 없음)엔 흐리게 하지 않는다 — 한 번이라도 로드된 뒤 오래된(stale)
+        // 경우에만 dim. (기동 직후 '비활성처럼 회색'으로 보이던 것 방지 — stale 은 '오래됨' 표시지
+        // '로딩 중' 표시가 아니므로.)
+        button.appearsDisabled = store.isStale && store.lastUpdated != nil
 
         updateCompanion()
         ensureMenuAnimation()
         syncMenuAnimation()   // 가시성 상태 주기적 재평가(occlusion 이 잘못 멈춰도 자가 복구)
     }
 
-    /// 메뉴바 버튼 텍스트 반영 — 1줄이면 기본 title(13pt), 2줄 이상이면 세로 스택
-    /// (작은 폰트 + 타이트 줄높이)으로 attributedTitle. 색을 지정하지 않아 메뉴바 명암(라이트/다크)·
-    /// 비활성(appearsDisabled) 상태에 자동 적응한다.
+    /// 메뉴바 버튼 텍스트 반영 — 1줄이면 기본 title(13pt), 2줄 이상이면 세로 스택.
+    /// 줄 수에 맞춰 폰트를 자동 축소해 N줄이 메뉴바 높이에 클리핑 없이 들어오게 한다. 색을 지정하지
+    /// 않아 메뉴바 명암(라이트/다크)·비활성(appearsDisabled) 상태에 자동 적응한다.
     private static func applyMenuText(_ lines: [String], to button: NSStatusBarButton) {
         if lines.count >= 2 {
+            // 줄당 높이 = 메뉴바 두께 / (줄 수 × 1.2[폰트 자연 줄높이 배수]). 7~11pt 로 클램프.
+            // (노치맥 메뉴바는 더 두꺼워 큰 폰트, 일반은 작게 → 2줄이든 3줄이든 안 잘리게.)
+            let thickness = NSStatusBar.system.thickness
+            let fontSize = min(11, max(7, (thickness / (CGFloat(lines.count) * 1.2)).rounded(.down)))
             let para = NSMutableParagraphStyle()
             para.alignment = .center
-            // 두 줄이 메뉴바 높이(~22pt)에 들어오게 줄간격만 압축. maximumLineHeight 하드캡은
-            // 글리프를 잘라낼 수 있어 쓰지 않고 lineHeightMultiple 로만 좁힌다.
-            para.lineHeightMultiple = 0.85
+            para.lineHeightMultiple = 0.9
             button.attributedTitle = NSAttributedString(
                 string: lines.joined(separator: "\n"),
                 attributes: [
-                    .font: NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .regular),
+                    .font: NSFont.monospacedDigitSystemFont(ofSize: fontSize, weight: .regular),
                     .paragraphStyle: para,
                 ])
         } else {

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -203,8 +203,23 @@ final class UsageStoreTests: XCTestCase {
         store.showCostInMenu = false
         store.showLimitInMenu = true
         await store.refresh(scheduleEmptyRetry: false)
-        XCTAssertEqual(store.menuLines.count, 2)              // 사용량 줄 + 한도 줄
+        XCTAssertEqual(store.menuLines.count, 2)              // 토큰 줄 + 한도 줄
         XCTAssertTrue(store.menuLines[1].contains("Claude"))  // 둘째 줄 = 한도
+    }
+
+    /// 토큰·비용·한도 다 켜면 → 토큰·비용은 윗줄에 나란히, 한도는 아랫줄. 최대 2줄(3줄은 가독성 반려).
+    func testMenuLinesTokenCostTogetherLimitBelow() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code",
+                                       daily: todayDaily(1_200_000, cost: 3.45))
+        let store = makeStore(providers: [claude],
+                              claude: claudeLimits(fiveHourUtil: 40, resetsAt: "2099-01-01T00:00:00Z"))
+        store.showTokensInMenu = true
+        store.showCostInMenu = true
+        store.showLimitInMenu = true
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.menuLines.count, 2)               // 사용량(토큰·비용) 윗줄 + 한도 아랫줄
+        XCTAssertTrue(store.menuLines[0].contains(" · "))      // 윗줄에 토큰·비용 나란히
+        XCTAssertTrue(store.menuLines[1].contains("Claude"))   // 아랫줄 = 한도
     }
 
     // MARK: 집계


### PR DESCRIPTION
실기기 테스트 반영: ① 기동 직후 회색 dim 제거(로드 후 stale 만) ② 2줄 스택 폰트를 메뉴바 두께 기반 적응형(7~11pt). menuLines 2줄 구조는 #62 유지. 169 테스트 통과, 리뷰 결함 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)