### PR TITLE
fix: 메뉴바 항목 각각 세로 줄 + 스프라이트 캐시 LRU 상한(H1)

### DIFF
--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -109,28 +109,26 @@ final class UsageStore {
     /// 사용량 데이터(스냅샷)가 하나라도 있는가 — companion sleep 판정용
     var hasUsageData: Bool { !snapshots.isEmpty }
 
-    /// 메뉴바 표시 줄 — 사용량(토큰·비용)을 윗줄에 나란히, 한도를 아랫줄로. **최대 2줄**(3줄은
-    /// 가독성 저하로 사용자가 반려). 한도는 **오늘 실제 사용한 프로바이더만** 노출한다(오늘 미사용
-    /// 프로바이더가 뜨지 않게 — snapshots 의 오늘 토큰>0 으로 게이트). 한도 소스는 프로바이더
-    /// 고유(Claude=OAuth·Codex=프로세스)라 providerID 로 명시 분기(확장 규약 §"프로바이더 고유 동작").
+    /// 메뉴바 표시 줄 — 켜진 항목을 **각각 세로로** 쌓는다: 토큰 / 비용 / 한도(각 1줄).
+    /// 토큰·비용을 가로로 합치지 않는다(사용자 요청: 토큰 위·비용 아래). 3개 다 켜면 3줄.
+    /// 한도는 **오늘 실제 사용한 프로바이더만** 노출(snapshots 의 오늘 토큰>0 게이트), 한 줄에 나란히.
+    /// 한도 소스는 프로바이더 고유(Claude=OAuth·Codex=프로세스)라 providerID 로 명시 분기(확장 규약).
     var menuLines: [String] {
         guard lastUpdated != nil else { return ["—"] }
-        var usage: [String] = []
-        if showTokensInMenu { usage.append(TokenFormatter.compact(todayTotalTokens)) }
-        if showCostInMenu { usage.append(TokenFormatter.costCompact(todayCostTotal)) }
-        var limitParts: [String] = []
+        var lines: [String] = []
+        if showTokensInMenu { lines.append(TokenFormatter.compact(todayTotalTokens)) }
+        if showCostInMenu { lines.append(TokenFormatter.costCompact(todayCostTotal)) }
         if showLimitInMenu {
             let usedToday = Set(snapshots.filter { $0.todayTotalTokens > 0 }.map(\.providerID))
+            var limitParts: [String] = []
             if usedToday.contains("claude_code"), let utilization = limits?.fiveHour?.utilization {
                 limitParts.append("Claude \(TokenFormatter.percent(utilization))")
             }
             if usedToday.contains("codex"), let usedPercent = codexLimits?.maxPrimaryUsedPercent {
                 limitParts.append("Codex \(TokenFormatter.percent(Double(usedPercent)))")
             }
+            if !limitParts.isEmpty { lines.append(limitParts.joined(separator: " · ")) }   // 한도 1줄(프로바이더 나란히)
         }
-        var lines: [String] = []
-        if !usage.isEmpty { lines.append(usage.joined(separator: " · ")) }            // 윗줄: 토큰·비용 나란히
-        if !limitParts.isEmpty { lines.append(limitParts.joined(separator: " · ")) }  // 아랫줄: 한도
         return lines   // 빈 배열이면 아이콘만
     }
 

--- a/Sources/PokeTokenBar/UI/SpriteLoader.swift
+++ b/Sources/PokeTokenBar/UI/SpriteLoader.swift
@@ -5,6 +5,8 @@ actor SpriteStore {
     static let shared = SpriteStore()
     private let base = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon"
     private var mem: [String: Data] = [:]
+    private var memOrder: [String] = []   // LRU 순서(최근 접근이 뒤). 상한 초과 시 앞(오래된 것)부터 evict
+    private let memLimit = 24              // in-memory 스프라이트 캐시 상한 — 세션 중 종 변경 누적 무한증가 방지(#H1)
     private let dir: URL = {
         let d = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("PokeTokenBar/sprites")
@@ -19,10 +21,10 @@ actor SpriteStore {
 
     func data(speciesID: Int, animated: Bool, shiny: Bool = false) async -> Data? {
         let key = Self.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny)
-        if let d = mem[key] { return d }
+        if let d = mem[key] { touch(key); return d }
         let ext = animated ? "gif" : "png"
         let file = dir.appendingPathComponent("\(key).\(ext)")
-        if let d = try? Data(contentsOf: file) { mem[key] = d; return d }
+        if let d = try? Data(contentsOf: file) { remember(key, d); return d }
         let urlStr: String
         switch (animated, shiny) {
         case (true, false):  urlStr = "\(base)/versions/generation-v/black-white/animated/\(speciesID).gif"
@@ -34,8 +36,23 @@ actor SpriteStore {
               let (d, resp) = try? await URLSession.shared.data(from: url),
               (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
         try? d.write(to: file)
-        mem[key] = d
+        remember(key, d)
         return d
+    }
+
+    /// in-memory 캐시에 넣고 LRU 상한 유지(#H1) — 세션 중 종이 여러 번 바뀌어도 무한 성장 방지.
+    private func remember(_ key: String, _ data: Data) {
+        mem[key] = data
+        touch(key)
+        while memOrder.count > memLimit {
+            let old = memOrder.removeFirst()
+            mem.removeValue(forKey: old)
+        }
+    }
+    /// 접근/삽입 키를 최근(뒤)으로 이동 — 활성 종이 evict 되지 않게 하는 LRU.
+    private func touch(_ key: String) {
+        if let i = memOrder.firstIndex(of: key) { memOrder.remove(at: i) }
+        memOrder.append(key)
     }
 }
 

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -207,8 +207,23 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertTrue(store.menuLines[1].contains("Claude"))  // 둘째 줄 = 한도
     }
 
-    /// 토큰·비용·한도 다 켜면 → 토큰·비용은 윗줄에 나란히, 한도는 아랫줄. 최대 2줄(3줄은 가독성 반려).
-    func testMenuLinesTokenCostTogetherLimitBelow() async {
+    /// 회귀(#사용자리포트): 토큰·비용만 켜면 가로("488M · $376")로 붙어 나오던 것 →
+    /// 각각 세로 2줄(토큰 위, 비용 아래). 가로로 합치지 않는다.
+    func testMenuLinesTokenAndCostStackVertically() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code",
+                                       daily: todayDaily(1_200_000, cost: 3.45))
+        let store = makeStore(providers: [claude])
+        store.showTokensInMenu = true
+        store.showCostInMenu = true
+        store.showLimitInMenu = false
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.menuLines.count, 2)               // 토큰 / 비용 = 2줄 (가로 아님)
+        XCTAssertFalse(store.menuLines[0].contains(" · "))     // 윗줄 = 토큰만(합치지 않음)
+        XCTAssertTrue(store.menuLines[1].contains("$"))        // 아랫줄 = 비용
+    }
+
+    /// 3개 다 켜면 → 각각 세로 3줄(토큰 / 비용 / 한도).
+    func testMenuLinesAllThreeStackPerItem() async {
         let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code",
                                        daily: todayDaily(1_200_000, cost: 3.45))
         let store = makeStore(providers: [claude],
@@ -217,9 +232,8 @@ final class UsageStoreTests: XCTestCase {
         store.showCostInMenu = true
         store.showLimitInMenu = true
         await store.refresh(scheduleEmptyRetry: false)
-        XCTAssertEqual(store.menuLines.count, 2)               // 사용량(토큰·비용) 윗줄 + 한도 아랫줄
-        XCTAssertTrue(store.menuLines[0].contains(" · "))      // 윗줄에 토큰·비용 나란히
-        XCTAssertTrue(store.menuLines[1].contains("Claude"))   // 아랫줄 = 한도
+        XCTAssertEqual(store.menuLines.count, 3)               // 토큰 / 비용 / 한도
+        XCTAssertTrue(store.menuLines[2].contains("Claude"))   // 마지막 줄 = 한도
     }
 
     // MARK: 집계


### PR DESCRIPTION
① 메뉴바: 토큰·비용을 가로로 합치던 것 → 각 항목 개별 세로 줄(토큰+비용=2줄 세로). 오프스크린 실측 확인. ② H1: SpriteStore.mem LRU 상한(24)으로 무한성장 방지(OOM 완화). 170 테스트·리뷰 결함 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)