### PR TITLE
feat: 크래시/OOM 자동 재실행 — KeepAlive LaunchAgent

### DIFF
--- a/Sources/PokeTokenBar/Core/LoginItem.swift
+++ b/Sources/PokeTokenBar/Core/LoginItem.swift
@@ -1,0 +1,41 @@
+import ServiceManagement
+
+/// 로그인 시 실행 + **크래시/비정상 종료 시 자동 재실행**(launchd KeepAlive).
+///
+/// 배경: `SMAppService.mainApp`(로그인아이템)은 **크래시 시 시스템이 재실행하지 않는다**(Apple 명시).
+/// 그래서 KeepAlive 를 가진 LaunchAgent 로 대체한다 — launchd 가 워치독으로 동작해 앱이 비정상
+/// 종료(크래시·OOM SIGKILL 등 exit≠0)되면 자동 재실행하고, **정상 종료(exit 0: 사용자 종료·업데이트)
+/// 시엔 재실행하지 않는다**(`KeepAlive.SuccessfulExit=false`). ThrottleInterval 10s 로 폭주 방지.
+///
+/// plist 는 앱 번들 `Contents/Library/LaunchAgents/<plistName>` 에 있어야 한다(build-app.sh 가 생성).
+/// 크래시-재실행은 launchd 가 프로세스를 소유해야 가능하므로, 로그인 실행도 이 에이전트가 담당한다
+/// (= 로그인 실행과 크래시-재실행이 한 토글로 묶임 — 메뉴바 앱엔 자연스러운 결합).
+@MainActor
+enum LoginItem {
+    static let plistName = "io.github.chattymin.poketokenbar.login.plist"
+    static let label = "io.github.chattymin.poketokenbar.login"
+    private static var agent: SMAppService { SMAppService.agent(plistName: plistName) }
+
+    /// 현재 "로그인 시 실행(+크래시 자동 재실행)" 활성 여부.
+    static var isEnabled: Bool { agent.status == .enabled }
+
+    /// 토글 — 켜면 에이전트 등록(로그인 실행+KeepAlive), 끄면 해제. 실패 시 throw(호출부가 표면화).
+    static func setEnabled(_ on: Bool) throws {
+        if on { try agent.register() } else { try agent.unregister() }
+    }
+
+    /// 구버전(`SMAppService.mainApp` 로그인아이템) → KeepAlive 에이전트로 **1회 이관**.
+    /// 안전: mainApp 이 켜져 있을 때만 이관하고, **에이전트 등록이 성공한 뒤에만 mainApp 을 해제**한다
+    /// (등록 실패 시 mainApp 을 유지 → 구동작 보존, "로그인 실행"을 잃지 않는다). 멱등(반복 호출 무해).
+    static func migrateFromLegacyLoginItemIfNeeded() {
+        let legacy = SMAppService.mainApp
+        guard legacy.status == .enabled else { return }   // 구 로그인아이템 미사용 → 이관 불필요
+        do {
+            if agent.status != .enabled { try agent.register() }   // 에이전트 먼저 등록
+            try legacy.unregister()                                 // 성공 후에만 구 항목 해제
+            AppLog.write("login item migrated: mainApp → KeepAlive agent")
+        } catch {
+            AppLog.write("login item migration failed (mainApp 유지): \(error)")
+        }
+    }
+}

--- a/Sources/PokeTokenBar/Core/UpdateChecker.swift
+++ b/Sources/PokeTokenBar/Core/UpdateChecker.swift
@@ -126,7 +126,11 @@ final class UpdateChecker {
         brew_pid=$!
         for i in $(seq 1 300); do kill -0 "$brew_pid" 2>/dev/null || break; sleep 1; done
         kill "$brew_pid" 2>/dev/null
-        for i in $(seq 1 15); do open "$2" && break; sleep 1; done
+        for i in $(seq 1 15); do
+          launchctl kickstart -k "gui/$(id -u)/io.github.chattymin.poketokenbar.login" 2>/dev/null && break
+          open "$2" 2>/dev/null && break
+          sleep 1
+        done
         """
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/bin/sh")

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -36,6 +36,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         signal(SIGPIPE, SIG_IGN)
         NSApp.setActivationPolicy(.accessory)
         Self.migrateLegacyStorageIfNeeded()   // TokenMac → PokeTokenBar 리네임: 기존 companion/캐시 보존
+        LoginItem.migrateFromLegacyLoginItemIfNeeded()   // 로그인아이템 → KeepAlive 에이전트(크래시 자동 재실행)
         store = UsageStore()
         companion = CompanionStore()
         updater = UpdateChecker()

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -1,4 +1,3 @@
-import ServiceManagement
 import SwiftUI
 
 struct SettingsView: View {
@@ -6,7 +5,7 @@ struct SettingsView: View {
     @Environment(CompanionStore.self) private var companion
     /// 팝오버 내부 화면 전환 방식 — sheet/dismiss 를 쓰지 않는다 (PopoverView 의 NOTE 참조)
     var onClose: () -> Void
-    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+    @State private var launchAtLogin = LoginItem.isEnabled
     @State private var launchAtLoginError: String?
     @State private var reportError: String?
     @State private var advancedExpanded = false
@@ -126,12 +125,11 @@ struct SettingsView: View {
                     .disabled(!isBundledApp)
                     .onChange(of: launchAtLogin) { _, newValue in
                         do {
-                            if newValue { try SMAppService.mainApp.register() }
-                            else { try SMAppService.mainApp.unregister() }
+                            try LoginItem.setEnabled(newValue)   // KeepAlive 에이전트(로그인 실행+크래시 재실행)
                             launchAtLoginError = nil
                         } catch {
                             launchAtLoginError = "\(error.localizedDescription)"
-                            launchAtLogin = SMAppService.mainApp.status == .enabled
+                            launchAtLogin = LoginItem.isEnabled
                         }
                     }
             }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -38,6 +38,32 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
+# 크래시/OOM(exit≠0) 시 자동 재실행 LaunchAgent(KeepAlive) — SMAppService.agent 가 등록해 launchd 가
+# 워치독으로 동작. 정상 종료(exit 0: 사용자 종료·업데이트)엔 재실행 안 함(SuccessfulExit=false).
+# ProgramArguments 는 brew 설치 경로(/Applications) 고정. codesign 전에 생성해 서명 seal 에 포함.
+mkdir -p "$APP/Contents/Library/LaunchAgents"
+cat > "$APP/Contents/Library/LaunchAgents/io.github.chattymin.poketokenbar.login.plist" <<AGENT
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>io.github.chattymin.poketokenbar.login</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Applications/$APP_NAME.app/Contents/MacOS/$APP_NAME</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key><false/>
+    </dict>
+    <key>ThrottleInterval</key><integer>10</integer>
+    <key>LimitLoadToSessionType</key><string>Aqua</string>
+    <key>ProcessType</key><string>Interactive</string>
+</dict>
+</plist>
+AGENT
+
 echo "==> codesign"
 SIGN_IDENTITY="${CODESIGN_IDENTITY:-PokeTokenBar Local}"
 # 안정적 Keychain ACL 을 위해서는 인증서 존재가 아니라 유효한 codesigning identity 가 필요하다.


### PR DESCRIPTION
SMAppService 로그인아이템은 크래시 재실행 안 함 → KeepAlive LaunchAgent 로 대체. launchd 워치독으로 비정상 종료 시 자동 재실행(정상종료·업데이트 시엔 안 함). 실측: kill-9 → 자동 재실행 확인. 170 테스트·리뷰 결함 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)