### PR TITLE
feat: 프로바이더 상태(인시던트) 배지 — API 장애를 앱 고장으로 오인 방지

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -35,6 +35,18 @@ struct L {
     var limitReached: String { t("한도 도달", "Limit reached", "上限到達") }
     var personalSpendLimit: String { t("개인 사용 한도", "Personal spend limit", "個人利用上限") }
     var staleLimits: String { t("갱신 지연", "Stale", "更新遅延") }
+
+    /// 프로바이더 상태 페이지 인시던트 지표 → 현지화 라벨(표시 전용).
+    func providerStatusLabel(_ indicator: ProviderStatusIndicator) -> String {
+        switch indicator {
+        case .operational: return t("정상", "Operational", "正常")
+        case .minor:       return t("일부 장애", "Minor issues", "一部障害")
+        case .major:       return t("장애", "Major outage", "障害")
+        case .critical:    return t("심각한 장애", "Critical outage", "重大障害")
+        case .maintenance: return t("점검 중", "Maintenance", "メンテナンス")
+        case .unknown:     return t("상태 불명", "Status unknown", "状態不明")
+        }
+    }
     func plan(_ p: String) -> String { t("플랜 \(p)", "Plan \(p)", "プラン \(p)") }
     func forecastReach(_ time: String) -> String {
         t("현재 속도면 \(time) 한도 도달", "At current rate, limit hit at \(time)", "現在のペースで \(time) に上限到達")
@@ -101,6 +113,8 @@ struct L {
     var notificationsSection: String { t("알림", "Notifications", "通知") }
     var limitNotificationsLabel: String { t("한도 알림", "Limit alerts", "上限通知") }
     var companionNotificationsLabel: String { t("Companion 이벤트 (부화·진화·졸업)", "Companion events (hatch / evolve / graduate)", "コンパニオンイベント（孵化・進化・卒業）") }
+    var statusChecksLabel: String { t("프로바이더 상태 확인", "Provider status checks", "プロバイダー状態チェック") }
+    var statusChecksHint: String { t("Claude·OpenAI 장애를 팝오버에 표시 (알림 아님)", "Show Claude / OpenAI incidents in the popover (not a notification)", "Claude・OpenAIの障害をポップオーバーに表示（通知ではない）") }
     var warning: String { t("경고", "Warning", "警告") }
     var critical: String { t("임박", "Critical", "切迫") }
     var aggregationNote: String { t("토큰 집계 기준: totalTokens (input + output + cache, 로컬 날짜)", "Token basis: totalTokens (input + output + cache, local date)", "集計基準: totalTokens (input + output + cache, ローカル日付)") }

--- a/Sources/PokeTokenBar/Core/ProviderStatusChecker.swift
+++ b/Sources/PokeTokenBar/Core/ProviderStatusChecker.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// 프로바이더 상태 페이지(statuspage.io)의 인시던트 지표.
+/// 목적: Claude/OpenAI API 장애 시 stale·0·에러 표시를 "앱 고장"으로 오인하지 않도록 **표시 전용** 신호.
+/// (알림으로 만들지 않는다 — 한도/버burn 알림과 충돌·스팸 방지.)
+enum ProviderStatusIndicator: String, Sendable {
+    // 케이스명을 `operational` 로 둔다(rawValue 는 statuspage 문자열 "none"). `none` 으로 두면
+    // 옵셔널 비교 시 `Optional.none`(nil)과 충돌하는 Swift footgun 이 생긴다.
+    case operational = "none"
+    case minor, major, critical, maintenance, unknown
+
+    /// 인시던트가 있는가(정상=operational 만 false). 아이콘/행 노출 게이트.
+    var hasIssue: Bool { self != .operational }
+
+    /// statuspage.io `status.indicator` 문자열 → 지표(미지 값은 unknown).
+    init(statuspage raw: String) {
+        self = ProviderStatusIndicator(rawValue: raw) ?? .unknown
+    }
+}
+
+/// 한 프로바이더의 상태 스냅샷. `description` 은 statuspage 원문(영문, 예: "Partially Degraded Service").
+struct ProviderStatus: Sendable, Equatable {
+    var indicator: ProviderStatusIndicator
+    var description: String
+}
+
+/// providerID → 상태. 조회 실패한 프로바이더는 결과에서 **생략**한다(호출부가 이전 상태를 유지).
+protocol ProviderStatusProviding: Sendable {
+    func fetch() async -> [String: ProviderStatus]
+}
+
+/// statuspage.io summary(`.../api/v2/status.json`)를 조회하는 기본 구현.
+/// PokeTokenBar 가 추적하는 provider 중 statuspage.io 를 쓰는 Claude·OpenAI(Codex) 만.
+/// Gemini(Google Workspace 피드)는 파서가 무거워 제외(추후).
+struct StatuspageStatusProvider: ProviderStatusProviding {
+    /// providerID ↔ statuspage summary URL. Codex 는 OpenAI 상태 페이지를 공유한다.
+    static let endpoints: [(id: String, url: URL)] = [
+        ("claude_code", URL(string: "https://status.anthropic.com/api/v2/status.json")!),
+        ("codex", URL(string: "https://status.openai.com/api/v2/status.json")!),
+    ]
+
+    func fetch() async -> [String: ProviderStatus] {
+        var out: [String: ProviderStatus] = [:]
+        await withTaskGroup(of: (String, ProviderStatus?).self) { group in
+            for (id, url) in Self.endpoints {
+                group.addTask { (id, await Self.fetchOne(url)) }
+            }
+            for await (id, status) in group where status != nil {
+                out[id] = status
+            }
+        }
+        return out
+    }
+
+    private static func fetchOne(_ url: URL) async -> ProviderStatus? {
+        var request = URLRequest(url: url, timeoutInterval: 10)
+        request.setValue("PokeTokenBar", forHTTPHeaderField: "User-Agent")
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+        return parse(data)
+    }
+
+    /// statuspage.io status.json 파싱(순수 — 테스트 가능). `{ "status": { "indicator", "description" } }`.
+    static func parse(_ data: Data) -> ProviderStatus? {
+        guard let decoded = try? JSONDecoder().decode(StatuspageResponse.self, from: data) else { return nil }
+        return ProviderStatus(indicator: ProviderStatusIndicator(statuspage: decoded.status.indicator),
+                              description: decoded.status.description ?? "")
+    }
+
+    private struct StatuspageResponse: Decodable {
+        struct Status: Decodable { let indicator: String; let description: String? }
+        let status: Status
+    }
+}

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -22,6 +22,8 @@ final class UsageStore {
     /// Claude 한도 조회가 401/403(세션 만료)로 실패한 상태 — UI 에서 명확한 안내+재시도 노출용.
     /// 성공 시 해제. 자동 폴링은 무프롬프트라 만료 토큰을 스스로 못 고치므로 사용자 액션 유도가 필요.
     private(set) var limitsAuthExpired = false
+    /// providerID → 프로바이더 상태 페이지 인시던트 지표(표시 전용). 조회 실패 시 이전 값 유지.
+    private(set) var statuses: [String: ProviderStatus] = [:]
     private(set) var lastUpdated: Date?
     private(set) var isRefreshing = false
     private(set) var isRefreshingLimitToken = false
@@ -60,6 +62,10 @@ final class UsageStore {
     var companionNotifications: Bool {
         didSet { defaults.set(companionNotifications, forKey: "companionNotifications") }
     }
+    /// 프로바이더 상태(인시던트) 조회 — 기본 켬. 표시 전용(알림 아님). Claude/OpenAI statuspage.io.
+    var statusChecksEnabled: Bool {
+        didSet { defaults.set(statusChecksEnabled, forKey: "statusChecksEnabled") }
+    }
     var disableKeychainAccess: Bool {
         didSet {
             defaults.set(disableKeychainAccess, forKey: "disableKeychainAccess")   // 저장 누락이던 기존 버그 — 재시작 후 풀렸음
@@ -87,6 +93,7 @@ final class UsageStore {
     var registeredProviderIDs: [String] { providers.map(\.id) }
     private let limitsProvider: any ClaudeLimitsProviding
     private let codexLimitsProvider: any CodexLimitsProviding
+    private let statusProvider: any ProviderStatusProviding
     /// 설정 저장소 — 테스트는 suite 를 주입해 실제 사용자 설정을 오염시키지 않는다.
     private let defaults: UserDefaults
     private var timer: Timer?
@@ -251,11 +258,13 @@ final class UsageStore {
     init(providers: [any UsageProvider] = [LocalClaudeProvider(), LocalCodexProvider(), LocalGeminiProvider()],
          claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),
+         statusProvider: any ProviderStatusProviding = StatuspageStatusProvider(),
          autoRefresh: Bool = true,
          defaults: UserDefaults = .standard) {
         self.providers = providers
         self.limitsProvider = claudeLimitsProvider
         self.codexLimitsProvider = codexLimitsProvider
+        self.statusProvider = statusProvider
         self.defaults = defaults
         let d = defaults
         refreshInterval = d.object(forKey: "refreshInterval") as? TimeInterval ?? 120
@@ -266,6 +275,7 @@ final class UsageStore {
         showLimitInMenu = d.object(forKey: "showLimitInMenu") as? Bool ?? false
         limitNotifications = d.object(forKey: "limitNotifications") as? Bool ?? true
         companionNotifications = d.object(forKey: "companionNotifications") as? Bool ?? true
+        statusChecksEnabled = d.object(forKey: "statusChecksEnabled") as? Bool ?? true
         disableKeychainAccess = d.object(forKey: "disableKeychainAccess") as? Bool ?? false
 
         reschedule()
@@ -481,6 +491,7 @@ final class UsageStore {
             }
         }
         await refreshCodexLimits()
+        await refreshProviderStatuses()
 
         checkLimitNotifications()
         writeParitySnapshot()
@@ -589,6 +600,33 @@ final class UsageStore {
         } catch {
             AppLog.write("codex limits unavailable: \(error)")
         }
+    }
+
+    /// 프로바이더 상태 페이지(인시던트) 조회 — 표시 전용, 기존 refresh 루프에 편승(별도 타이머 없음).
+    /// 조회 실패한 provider 는 결과에서 빠지므로 이전 값 유지(keep-previous — flaky 엔드포인트가 앱을
+    /// 흔들지 않게). 껐으면 저장된 상태를 비워 UI 에서 사라지게 한다.
+    /// 트레이드오프: keep-previous 는 상한이 없어, 엔드포인트가 영구 폐기되면 마지막 값이 세션 내내
+    /// 남는다. statuses 키는 항상 endpoints(claude_code·codex) 뿐이고 배너는 라이브 스냅샷과 co-gate
+    /// 되므로 실질 영향은 없다(2개 안정 엔드포인트). 엔드포인트가 늘면 fetchedAt+만료를 재검토.
+    private func refreshProviderStatuses() async {
+        guard statusChecksEnabled else {
+            if !statuses.isEmpty { statuses = [:] }
+            return
+        }
+        let fresh = await statusProvider.fetch()
+        for (id, status) in fresh { statuses[id] = status }
+        if !fresh.isEmpty {
+            AppLog.write("provider status: "
+                + fresh.map { "\($0.key)=\($0.value.indicator.rawValue)" }.sorted().joined(separator: " "))
+        }
+    }
+
+    /// 표시용 프로바이더 상태 — 조회 꺼짐이면 nil. 인시던트 없음(operational)도 반환하므로 호출부가
+    /// hasIssue 로 게이트. (꺼짐 가드는 refreshProviderStatuses 의 statuses 비움과 중복이지만, 다음
+    /// refresh 전에도 토글이 즉시 반영되게 여기서도 막는다.)
+    func providerStatus(for providerID: String) -> ProviderStatus? {
+        guard statusChecksEnabled else { return nil }
+        return statuses[providerID]
     }
 
     /// codex 한도 스냅샷 staleness — 갱신 실패가 이어지면 이전 값이 남는다는 사실을 UI에 노출.

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -84,6 +84,7 @@ struct PopoverView: View {
                 Divider()
                 header
                 Divider()
+                providerStatusBanner   // 인시던트 있을 때만 — 한도 가용 여부와 무관(API 다운=한도 nil 케이스에도)
                 if selectedProviderHasLimits {
                     limitsSection
                     Divider()
@@ -224,6 +225,38 @@ struct PopoverView: View {
         case "claude_code": return store.limits != nil || store.limitsAuthExpired
         case "codex": return store.codexLimits?.hasVisibleLimit == true
         default: return false
+        }
+    }
+
+    /// 선택 프로바이더의 상태 페이지 인시던트(있을 때만) — Claude/OpenAI API 장애를 앱 고장으로
+    /// 오인하지 않게. 표시 전용(알림 아님). 인시던트 없거나 상태조회 꺼짐이면 아무것도 안 그림.
+    /// 범위(v1): 선택된 provider 탭 한정. 오늘 안 쓴 provider 는 탭/스냅샷이 없어 배너도 안 뜬다 —
+    /// 오인이 실제로 생기는 케이스(오늘 써서 이상 수치를 보는데 한도는 nil)는 로컬 사용 스냅샷이 있어
+    /// 탭이 존재하므로 커버된다. 전 provider 전역 인시던트 행은 추후.
+    @ViewBuilder
+    private var providerStatusBanner: some View {
+        if let id = selectedSnapshot?.providerID,
+           let status = store.providerStatus(for: id), status.indicator.hasIssue {
+            HStack(spacing: 6) {
+                Circle().fill(statusColor(status.indicator)).frame(width: 7, height: 7)
+                Text(l.providerStatusLabel(status.indicator))
+                    .font(.caption).fontWeight(.medium)
+                if !status.description.isEmpty {
+                    Text(status.description)
+                        .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+                Spacer()
+            }
+        }
+    }
+
+    private func statusColor(_ indicator: ProviderStatusIndicator) -> Color {
+        switch indicator {
+        case .operational:         return .green
+        case .minor, .maintenance: return .yellow
+        case .major:               return .orange
+        case .critical:            return .red
+        case .unknown:             return .gray
         }
     }
 

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -174,6 +174,16 @@ struct SettingsView: View {
             }
             Divider()
             toggleRow(l.companionNotificationsLabel, $store.companionNotifications)
+            Divider()
+            groupRow {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(l.statusChecksLabel)
+                    Text(l.statusChecksHint).font(.caption2).foregroundStyle(.tertiary)
+                }
+                Spacer()
+                Toggle("", isOn: $store.statusChecksEnabled)
+                    .labelsHidden().toggleStyle(.switch).controlSize(.small)
+            }
         }
     }
 

--- a/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
@@ -86,9 +86,11 @@ final class LocalUsageReaderTests: XCTestCase {
     // MARK: 기간 집계 + 활성 블록
 
     func testPeriodAndActiveBlock() {
-        let now = Date()
-        let recent = now.addingTimeInterval(-30 * 60)   // 30분 전
-        let old = now.addingTimeInterval(-10 * 3600)    // 10시간 전(블록 밖)
+        // 로컬 정오로 고정 — Date() 로 두면 자정 직후 실행 시 now-30분이 전날로 넘어가
+        // period(today,today) 범위 밖이 돼 flaky 했다(시각-의존 결함, 자정±30분에만 실패).
+        let now = Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: Date()) ?? Date()
+        let recent = now.addingTimeInterval(-30 * 60)   // 30분 전(같은 날)
+        let old = now.addingTimeInterval(-10 * 3600)    // 10시간 전(블록 밖, 같은 날)
         let fmt = LocalUsageReader.localDayFormatter()
         func entry(_ date: Date, _ tok: Int) -> LocalUsageReader.Entry {
             LocalUsageReader.Entry(id: UUID().uuidString, date: date, localDay: fmt.string(from: date),

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -55,6 +55,12 @@ private struct FakeCodexLimits: CodexLimitsProviding {
     func fetch() async throws -> CodexRateLimitStatus? { status }
 }
 
+private final class FakeStatusProvider: ProviderStatusProviding, @unchecked Sendable {
+    nonisolated(unsafe) var result: [String: ProviderStatus]
+    init(_ result: [String: ProviderStatus] = [:]) { self.result = result }
+    func fetch() async -> [String: ProviderStatus] { result }
+}
+
 // MARK: 픽스처 헬퍼
 
 private func todayDaily(_ tokens: Int, cost: Double = 0) -> DailyUsage {
@@ -113,6 +119,55 @@ final class UsageStoreTests: XCTestCase {
                    codexLimitsProvider: FakeCodexLimits(status: codex),
                    autoRefresh: false,
                    defaults: testDefaults)
+    }
+
+    private func makeStatusStore(_ stub: FakeStatusProvider) -> UsageStore {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(1_000))
+        return UsageStore(providers: [claude], claudeLimitsProvider: FakeClaudeLimits(status: nil),
+                          codexLimitsProvider: FakeCodexLimits(status: nil), statusProvider: stub,
+                          autoRefresh: false, defaults: testDefaults)
+    }
+
+    // MARK: 프로바이더 상태(인시던트) 표시
+
+    /// statuspage.io status.json 파싱(순수) — indicator/description 매핑 + 미지값 unknown + malformed nil.
+    func testProviderStatusParse() {
+        let s = StatuspageStatusProvider.parse(Data(#"{"page":{"name":"Claude"},"status":{"indicator":"minor","description":"Partially Degraded Service"}}"#.utf8))
+        XCTAssertEqual(s?.indicator, .minor)
+        XCTAssertEqual(s?.description, "Partially Degraded Service")
+        XCTAssertTrue(s!.indicator.hasIssue)
+        let none = StatuspageStatusProvider.parse(Data(#"{"status":{"indicator":"none","description":"All Systems Operational"}}"#.utf8))
+        XCTAssertEqual(none?.indicator, .operational)
+        XCTAssertFalse(none!.indicator.hasIssue)   // 정상은 배너 안 뜸
+        XCTAssertEqual(StatuspageStatusProvider.parse(Data(#"{"status":{"indicator":"potato"}}"#.utf8))?.indicator, .unknown)
+        XCTAssertNil(StatuspageStatusProvider.parse(Data("not json".utf8)))
+        XCTAssertNil(StatuspageStatusProvider.parse(Data(#"{"nope":true}"#.utf8)))
+    }
+
+    /// 조회 실패(결과에서 빠진 provider)는 이전 값 유지(keep-previous) — flaky 엔드포인트가 앱을 흔들지 않게.
+    func testProviderStatusKeepsPreviousOnFailure() async {
+        let stub = FakeStatusProvider(["claude_code": ProviderStatus(indicator: .minor, description: "deg")])
+        let store = makeStatusStore(stub)
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.providerStatus(for: "claude_code")?.indicator, .minor)
+        stub.result = [:]                                       // 다음 조회 실패
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.providerStatus(for: "claude_code")?.indicator, .minor, "실패 시 이전 값 유지")
+        stub.result = ["claude_code": ProviderStatus(indicator: .operational, description: "ok")]   // 복구
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.providerStatus(for: "claude_code")?.indicator, .operational)
+    }
+
+    /// 상태 조회 꺼짐 → 접근자 nil + refresh 가 저장분도 비워 UI 에서 사라짐.
+    func testProviderStatusDisabledClears() async {
+        let stub = FakeStatusProvider(["claude_code": ProviderStatus(indicator: .major, description: "x")])
+        let store = makeStatusStore(stub)
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.providerStatus(for: "claude_code")?.indicator, .major)
+        store.statusChecksEnabled = false
+        XCTAssertNil(store.providerStatus(for: "claude_code"))   // 꺼짐 → 접근자 nil
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(store.statuses.isEmpty, "꺼진 뒤 refresh 는 저장 상태를 비운다")
     }
 
     // MARK: 한도 알림 — 엣지 트리거(임계값 도달 시 최초 1회만)


### PR DESCRIPTION
## 요약
Claude/OpenAI API 장애를 **앱 고장으로 오인하지 않게** 하는 프로바이더 상태(인시던트) 배지. 상태 페이지(statuspage.io `status.json`)를 조회해 인시던트가 있으면 팝오버에 표시한다. **표시 전용(알림 아님).**

CodexBar 분석(레퍼런스)에서 도출한 T1 권고 — 한도가 nil/에러일 때 "이게 앱 문제인가 provider 문제인가"를 즉시 구분해주는, 1인 사용자에게도 실질 가치 있는 유일한 신규 역량.

## 변경 (UI 포함 — 전부 명시)
- **팝오버 배너 (신규):** 오늘-토큰 헤더 아래에 `● 일부 장애 · Partially Degraded Service` 형태로 표시(색 점 = 심각도, 현지화 라벨 + statuspage 원문). **인시던트 있을 때만** 노출.
  - 배치: 한도섹션 가용 게이트 **밖** — Claude 한도가 nil(=API 다운)일 때에도 배너가 뜨게(그게 오인이 실제 생기는 케이스).
  - `Text(description)` 은 변수 바인딩이라 마크다운/링크 미해석(inert) — 외부 문자열 주입 표면 없음.
- **설정 토글 (신규):** 알림 그룹에 "프로바이더 상태 확인" 토글(기본 켬) + 힌트. ko/en/ja.
- **동작:** 기존 refresh 루프에 편승(별도 타이머 없음). 조회 실패 provider 는 이전 값 유지(keep-previous — flaky 엔드포인트가 앱을 안 흔들게). 껐으면 저장분 비움.

## 범위 / 트레이드오프 (의도된 것)
- **v1: 선택 provider 탭 한정.** 오늘 안 쓴 provider 는 탭/스냅샷이 없어 배너 미노출 — 오인이 실제 생기는 케이스(오늘 써서 이상 수치 봄)는 로컬 사용 스냅샷이 있어 커버됨. 전역 인시던트 행은 추후.
- **keep-previous 무한 보존:** 안정적 2개 엔드포인트 + 라이브 스냅샷 co-gate 라 실질 무해(주석 명시). 엔드포인트 증가 시 만료 재검토.
- Gemini(Google Workspace 피드)는 파서가 무거워 제외(추후).

## 부수 수정 (status 와 무관 — CI 그린 위해 동봉)
- `LocalUsageReaderTests.testPeriodAndActiveBlock` 자정 경계 flaky 결정론화: `now = Date()` → 로컬 정오 고정. `now-30분`이 전날로 넘어가 `period(today,today)` 범위 밖이던 시각-의존 결함(자정±30분에만 실패).

## 테스트 / 확인
- [x] 신규 3건: `testProviderStatusParse`(valid/unknown/malformed/none), `testProviderStatusKeepsPreviousOnFailure`(set→실패유지→복구), `testProviderStatusDisabledClears`.
- [x] 전체 180 테스트 0 실패(flaky 결정론화 포함).
- [x] 오프스크린 배너 렌더 확인 — Claude 상태가 실제 "minor"라 실데이터 검증.
- [x] 독립 리뷰어 APPROVE(BLOCKER/HIGH 0; MEDIUM 2는 범위 판단 → 주석 명시).
- [ ] **다음 릴리스 시:** `assets/settings*.png` 스크린샷 재생성(새 토글 반영) — release.sh 문서검토가 경고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
