### PR TITLE
feat: 이상한 사탕 & 인벤토리 — 한도 채우면 지급, 가방에서 사용해 성장

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -82,6 +82,38 @@ enum PokemonBalance {
     }
 }
 
+/// 인벤토리 아이템 종류 — 확장 대비 enum(현재 이상한 사탕 1종). rawValue 로 CompanionState.inventory 에 저장.
+enum ItemKind: String, Codable, Sendable, CaseIterable {
+    case rareCandy
+}
+
+/// 이상한 사탕 밸런스 상수.
+enum RareCandy {
+    /// 사용 시 현재 포켓몬에 주입하는 XP(토큰 환산). 최소 진화 임계(커먼 1형태 125M)보다 작아
+    /// 사탕 1개는 최대 1단계만 올린다(연쇄·졸업 폭주 없음). applyUsage 로 주입 → 이월/진화/졸업 자동.
+    static let xp = 100_000_000
+    /// 주간 한도 100% 도달 시 지급 개수(세션급은 1개).
+    static let weeklyGrant = 5
+}
+
+/// 사탕 지급 대상 한도 창의 분류 — session=1개·weekly=weeklyGrant.
+enum WindowClass: Sendable { case session, weekly }
+
+/// 사탕 지급 판정 입력 — 프로바이더 무관 한도 창 1개. (UsageStore.candyEligibleWindows 가 생성)
+struct CandyWindow: Sendable {
+    let key: String          // 안정 식별자(tier 추적) — resets_at 등 휘발 필드 금지
+    let name: String         // 표시용(알림 "왜 받는지")
+    let kind: WindowClass    // session=1개 · weekly=5개
+    let utilization: Double  // 0~100+
+}
+
+/// 사탕 지급 1건(순수 판정 결과) — 부수효과(인벤토리·알림)와 분리해 테스트 가능하게.
+struct CandyGrant: Equatable, Sendable {
+    let windowKey: String
+    let windowName: String   // 알림 "왜 받는지"
+    let count: Int
+}
+
 /// PokéAPI evolution-chain 을 파싱한 트리. 분기(evolves_to 다수)를 children 으로.
 struct EvoNode: Codable, Sendable {
     let speciesID: Int
@@ -267,6 +299,12 @@ struct CompanionState: Codable, Sendable {
     // 소유한 (base,final) 쌍 — 분기 다양성용
     var collectedFinals: Set<String> = []
     var language: AppLanguage = .systemDefault   // 신규 설치 = 시스템 로케일
+    // 인벤토리 (ItemKind.rawValue → 개수)
+    var inventory: [String: Int] = [:]
+    // 사탕 지급 엣지 상태(창 key → 지급한 tier). ★영속 — notifiedTier(인메모리)와 달리 재시작 무한지급 방지.
+    var candyGrantTier: [String: Int] = [:]
+    // 사탕 지급 첫 실행 시드 완료 — 업데이트 직후 이미 100%였던 창의 소급 지급 차단.
+    var candyFeatureSeeded = false
 
     init() {}
 
@@ -283,6 +321,9 @@ struct CompanionState: Codable, Sendable {
         dex = try c.decodeIfPresent([DexEntry].self, forKey: .dex) ?? []
         collectedFinals = try c.decodeIfPresent(Set<String>.self, forKey: .collectedFinals) ?? []
         language = try c.decodeIfPresent(AppLanguage.self, forKey: .language) ?? .systemDefault
+        inventory = try c.decodeIfPresent([String: Int].self, forKey: .inventory) ?? [:]
+        candyGrantTier = try c.decodeIfPresent([String: Int].self, forKey: .candyGrantTier) ?? [:]
+        candyFeatureSeeded = try c.decodeIfPresent(Bool.self, forKey: .candyFeatureSeeded) ?? false
     }
 }
 

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -23,6 +23,13 @@ final class CompanionStore {
     /// 연출 재생 후 UI 가 호출(1회성 보장).
     func consumeCelebration() { celebration = nil }
 
+    /// 사탕 사용 시 "+XP" 순간 표시 — 진화 없이 부분 진행일 때도 피드백. seq 증가로 CompanionHeader 감지.
+    private(set) var candyFeedbackSeq = 0
+    private(set) var candyFeedbackAmount = 0
+    /// "+XP" 표시 1회성 보장 — CompanionHeader 가 재생 후 호출한다. 소비하지 않으면 다른 탭에 갔다
+    /// 홈으로 재진입할 때(CompanionHeader 재마운트) @State 가 초기화돼 같은 값이 다시 떠오른다(회귀).
+    func consumeCandyFeedback() { candyFeedbackAmount = 0 }
+
     private let provider: any PokeProviding
     private let clock: () -> Date
     private let fileURL: URL
@@ -41,8 +48,19 @@ final class CompanionStore {
     }
 
     static func defaultURL() -> URL {
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("PokeTokenBar")
+        // 상태 파일 위치. 기본은 Application Support/PokeTokenBar. `PTB_STATE_DIR` 환경변수가 있으면
+        // 그 디렉토리를 쓴다 — 개발/QA 격리용(실제 companion 상태를 건드리지 않고 데모 상태로 실행).
+        // 프로덕션은 이 변수가 없어 무영향.
+        // 공백만 있는 값은 무시(URL(fileURLWithPath:)가 CWD 상대경로로 해석되는 것 방지).
+        let override = (ProcessInfo.processInfo.environment["PTB_STATE_DIR"] ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let dir: URL
+        if !override.isEmpty {
+            dir = URL(fileURLWithPath: override, isDirectory: true)
+        } else {
+            dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("PokeTokenBar")
+        }
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir.appendingPathComponent("companion-state.json")
     }
@@ -251,6 +269,89 @@ final class CompanionStore {
         state.eggUsage = 0   // 새 알은 처음부터 인큐베이션
         // "알을 받는 순간" 즉시 프리패칭 시작 — 다음 부화의 종·라인·스프라이트 예열.
         Task { await self.ensureEggPrefetch() }
+    }
+
+    // MARK: 인벤토리 / 이상한 사탕
+
+    var rareCandyCount: Int { itemCount(.rareCandy) }
+    func itemCount(_ kind: ItemKind) -> Int { state.inventory[kind.rawValue] ?? 0 }
+
+    /// 소유 아이템(개수>0) — 가방 목록. 정렬은 ItemKind.allCases 순서.
+    var ownedItems: [(kind: ItemKind, count: Int)] {
+        ItemKind.allCases.compactMap { k in
+            let c = itemCount(k)
+            return c > 0 ? (k, c) : nil
+        }
+    }
+
+    /// 이상한 사탕 사용 가능 — 활성 포켓몬 + 라인 로딩 완료 + 재고>0.
+    /// 라인 미로딩(재시작 직후·오프라인)이면 비활성 — 사탕이 진화 없이 적립만 되는 것 방지.
+    var canUseRareCandy: Bool { hasActive && currentLine != nil && rareCandyCount > 0 }
+
+    /// 사탕 사용 결과 — UI 피드백 분기용.
+    enum CandyUseResult: Equatable { case evolved, graduated, progressed, unavailable }
+
+    /// 이상한 사탕 1개 사용 — 현재 포켓몬에 +RareCandy.xp. applyUsage 재사용으로 이월·진화·졸업·연출 자동.
+    /// 사탕 XP 는 usedAtStage(진화 진행)에만 반영 — usedSinceInstall/오늘 토큰(실사용 통계)엔 안 잡힌다.
+    @discardableResult
+    func useRareCandy() -> CandyUseResult {
+        guard canUseRareCandy else { return .unavailable }
+        state.inventory[ItemKind.rareCandy.rawValue] = rareCandyCount - 1
+        let beforeStage = state.active?.stageIndex ?? 0
+        // 진화 안 될 때(부분 진행)도 즉시 "+XP" 피드백 — CompanionHeader 가 연출과 별개로 표시.
+        candyFeedbackAmount = RareCandy.xp
+        candyFeedbackSeq += 1
+        applyUsage(RareCandy.xp)   // 내부에서 save() 수행(인벤토리 감소 포함 영속)
+        if state.active == nil { return .graduated }
+        if state.active!.stageIndex > beforeStage { return .evolved }
+        return .progressed
+    }
+
+    /// 지급 판정(순수·엣지 트리거) — 한도 창이 100% 를 새로 넘어선 순간에만 지급.
+    /// - 100% 미만 → 맵에서 제거(재무장). resets_at 등 휘발 필드는 key 에 없다(안정 식별자만).
+    /// - 이미 지급한 창(tier≥1)은 재지급 안 함. session=1개·weekly=weeklyGrant.
+    /// - 부수효과(인벤토리·알림)와 분리해 xctest 가능. (evaluateLimitAlerts 자매)
+    static func evaluateCandyGrants(
+        windows: [CandyWindow], grantTier: inout [String: Int]
+    ) -> [CandyGrant] {
+        var grants: [CandyGrant] = []
+        for w in windows {
+            guard w.utilization >= 100 else { grantTier[w.key] = nil; continue }
+            let previous = grantTier[w.key] ?? 0
+            guard previous < 1 else { continue }
+            grantTier[w.key] = 1
+            let count = w.kind == .weekly ? RareCandy.weeklyGrant : 1
+            grants.append(CandyGrant(windowKey: w.key, windowName: w.name, count: count))
+        }
+        return grants
+    }
+
+    /// 한도 창 상태로부터 사탕 지급(엣지·영속). AppDelegate 가 매 refresh 완료 시(한도 로드 후) 호출.
+    /// - 첫 실행: 현재 100% 창을 지급 없이 tier 시드만 → 이후 "새로 넘어서는" 순간부터 지급(소급 차단).
+    /// - limitsReady=false(한도 미로딩)면 시드/지급 모두 대기(다음 refresh 에 재시도).
+    func grantCandies(from windows: [CandyWindow], limitsReady: Bool) {
+        guard limitsReady else { return }
+        if !state.candyFeatureSeeded {
+            // 한계(수용): 첫 refresh 에 한 프로바이더 한도만 로드되면 그 프로바이더 창만 시드된다.
+            // 이후 다른 프로바이더가 이미 100%인 채 로드되면 소급 지급될 수 있으나, 1회·소수 캔디라
+            // 1인 로컬에서 무시(YAGNI). refresh() 는 전 프로바이더 fetch 를 await 후 onRefresh 하므로
+            // 정상 경로(둘 다 성공)에선 원자적 시드다.
+            for w in windows where w.utilization >= 100 { state.candyGrantTier[w.key] = 1 }
+            state.candyFeatureSeeded = true
+            save()
+            return
+        }
+        let before = state.candyGrantTier
+        let grants = Self.evaluateCandyGrants(windows: windows, grantTier: &state.candyGrantTier)
+        for g in grants {
+            state.inventory[ItemKind.rareCandy.rawValue, default: 0] += g.count
+            // 지급 자체는 알림 여부와 무관(상태 변경). 알림은 "왜 받는지"(그 창 한도를 다 채운 수고) 명시.
+            notifyCompanionEvent(l.notifCandyTitle(item: l.itemName(.rareCandy), count: g.count),
+                                 l.notifCandyBody(window: g.windowName))
+        }
+        // 지급이 없어도 재무장(창이 100%→아래로 내려가며 grantTier 에서 제거)은 영속해야 한다 —
+        // 안 하면 재시작 시 stale tier=1 로 다음 100% 도달이 "이미 지급"으로 오판돼 지급 누락(회귀).
+        if !grants.isEmpty || state.candyGrantTier != before { save() }
     }
 
     /// companion 이벤트 시스템 알림(.app + 토글 ON 일 때만). 한도 알림과 독립.

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -295,4 +295,44 @@ struct L {
     var claudeFiveHour: String { t("Claude 5시간 세션", "Claude 5-hour session", "Claude 5時間セッション") }
     var claudeWeekly: String { t("Claude 주간", "Claude weekly", "Claude 週間") }
     var codexPersonalLimit: String { t("Codex 개인 한도", "Codex personal limit", "Codex 個人上限") }
+
+    // MARK: 가방 / 아이템
+    var bag: String { t("가방", "Bag", "バッグ") }
+    var bagEmptyTitle: String { t("아직 가방이 비어있어요!", "Your bag is empty!", "バッグはまだ空っぽです！") }
+    var useItem: String { t("사용하기", "Use", "つかう") }
+    var use: String { t("사용", "Use", "つかう") }
+    var cancel: String { t("취소", "Cancel", "キャンセル") }
+    func useOnCurrent(_ name: String) -> String {
+        t("\(name)에게 사용할까요?", "Use on \(name)?", "\(name) に使いますか？")
+    }
+    var useAfterHatch: String { t("부화 후 사용할 수 있어요", "Usable after hatching", "孵化後に使えます") }
+    var useNeedsPokemon: String { t("사용할 포켓몬이 없어요", "No Pokémon to use it on", "使えるポケモンがいません") }
+
+    /// 아이템 표시명 — species 처럼 공식 현지명.
+    func itemName(_ kind: ItemKind) -> String {
+        switch kind {
+        case .rareCandy: return t("이상한 사탕", "Rare Candy", "ふしぎなアメ")
+        }
+    }
+    func itemDescription(_ kind: ItemKind) -> String {
+        switch kind {
+        case .rareCandy:
+            let xp = TokenFormatter.compact(RareCandy.xp)   // 상수에서 파생(하드코딩 드리프트 방지)
+            return t("현재 포켓몬의 경험치를 \(xp) 상승시킨다.",
+                     "Raises your Pokémon's EXP by \(xp).",
+                     "ポケモンの経験値を\(xp)上げる。")
+        }
+    }
+
+    // MARK: 사탕 획득 알림 ("왜 받는지" = 토큰 한도를 다 채운 수고에 대한 보상)
+    func notifCandyTitle(item: String, count: Int) -> String {
+        t("🍬 \(item) \(count)개를 받았어요!",
+          "🍬 You got \(count)× \(item)!",
+          "🍬 \(item)を\(count)個もらいました！")
+    }
+    func notifCandyBody(window: String) -> String {
+        t("\(window) 토큰 한도를 다 채웠어요. 열심히 쓴 만큼 사탕을 드려요 — 포켓몬에게 써서 진화시켜 보세요!",
+          "You maxed out your \(window) token limit. A treat for the effort — use it to evolve your Pokémon!",
+          "\(window)のトークン上限を使い切りました。がんばったごほうびです — ポケモンに使って進化させよう！")
+    }
 }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -105,6 +105,11 @@ final class UsageStore {
     /// 갱신마다 재알림되던 회귀 원인 제거).
     private var notifiedTier: [String: Int] = [:]
 
+    /// 매 refresh 완료(한도 로드 후) 시 호출 — companion 갱신·사탕 지급을 한도가 신선한 시점에 묶는다.
+    /// observeStore(menuTitle)만으론 showLimitInMenu=false 일 때 한도 변경이 companion 에 전달 안 됨
+    /// (menuTitle 미변경) → 지급은 이 훅으로 확실히 트리거한다. AppDelegate 가 설정.
+    var onRefresh: (@MainActor () -> Void)?
+
     // MARK: 파생값
 
     var todayTotalTokens: Int {
@@ -236,6 +241,50 @@ final class UsageStore {
         if let forecast = fiveHourForecast, forecast.beforeReset { return true }
         return false
     }
+
+    /// 사탕 지급 대상 한도 창 — 세션급(≈5h)=1개, 주간급=5개, 전 프로바이더. Gemini 는 공식 한도
+    /// 신호가 없어 자연히 빠진다(창 목록에 없음). 지급 제외: Opus/Sonnet 주간·scoped·Codex 개인 spend
+    /// limit(헤드라인 창의 하위/중복 → 이중지급 방지). 알림(checkLimitNotifications)보다 좁은 지급 전용.
+    var candyEligibleWindows: [CandyWindow] {
+        let l = L(localizationLanguage)
+        var windows: [CandyWindow] = []
+        if let u = limits?.fiveHour?.utilization {
+            windows.append(CandyWindow(key: "claude.fiveHour", name: l.claudeFiveHour,
+                                       kind: .session, utilization: u))
+        }
+        if let u = limits?.sevenDay?.utilization {
+            windows.append(CandyWindow(key: "claude.sevenDay", name: l.claudeWeekly,
+                                       kind: .weekly, utilization: u))
+        }
+        for bucket in codexLimits?.visibleSnapshots ?? [] {
+            let bucketKey = bucket.limitId ?? bucket.limitName ?? "codex"
+            let bucketName = bucket.bucketDisplayName
+            if let primary = bucket.primary {
+                windows.append(CandyWindow(
+                    key: "codex.\(bucketKey).primary",
+                    name: "\(bucketName) \(l.codexWindow(primary.windowDurationMins))",
+                    kind: Self.windowClass(minutes: primary.windowDurationMins),
+                    utilization: Double(primary.usedPercent)))
+            }
+            if let secondary = bucket.secondary {
+                windows.append(CandyWindow(
+                    key: "codex.\(bucketKey).secondary",
+                    name: "\(bucketName) \(l.codexWindow(secondary.windowDurationMins))",
+                    kind: Self.windowClass(minutes: secondary.windowDurationMins),
+                    utilization: Double(secondary.usedPercent)))
+            }
+        }
+        return windows
+    }
+
+    /// Codex 창 분류 — ≤24h(1440분)=세션, 초과=주간. 미상(nil)은 세션으로 간주(보수적).
+    nonisolated static func windowClass(minutes: Int?) -> WindowClass {
+        if let m = minutes, m > 1440 { return .weekly }
+        return .session
+    }
+
+    /// 한도 데이터가 최소 1개 프로바이더 로드됐는가 — 사탕 첫 실행 시드 게이트(미로딩 중 시드 방지).
+    var limitsReady: Bool { limits != nil || codexLimits != nil }
 
     /// burn rate 티어 — companion 표시 상태(idle/working/focus) 판정에 사용.
     /// 전 프로바이더 합산 — Codex/Gemini 전용 사용자도 코딩 리듬이 반영된다.
@@ -498,6 +547,7 @@ final class UsageStore {
         let summary = snapshots.map { "\($0.providerID):\($0.today?.date ?? "nil")=\($0.todayTotalTokens)" }
             .joined(separator: ", ")
         AppLog.write("refresh done [\(summary)]")
+        onRefresh?()   // 한도 로드 후 companion 갱신·사탕 지급(신선한 한도 시점)
     }
 
     private func handleEmptyUsageRetry(schedule: Bool, hasErrors: Bool) {

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -44,6 +44,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         companion = CompanionStore()
         updater = UpdateChecker()
         store.localizationLanguage = companion.language   // 알림 현지화용 미러 시드
+        store.onRefresh = { [weak self] in self?.onStoreRefreshed() }   // 한도 로드 후 companion·사탕 지급
         Task { await updater.check() }                    // 기동 시 1회 업데이트 확인
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -144,6 +145,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             burnTier: store.burnTier,
             limitWarning: store.isLimitWarning,
             hasUsageData: store.hasUsageData)
+    }
+
+    /// 매 refresh 완료 훅 — companion 갱신 + 사탕 지급(한도가 신선한 시점). 지급을 여기 묶는 이유는
+    /// UsageStore.onRefresh 주석 참조(observeStore 만으론 한도 변경이 companion 에 안 전달되는 케이스).
+    private func onStoreRefreshed() {
+        updateCompanion()
+        companion.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
     }
 
     // MARK: 메뉴바 애니메이션

--- a/Sources/PokeTokenBar/UI/BagView.swift
+++ b/Sources/PokeTokenBar/UI/BagView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+/// 가방(인벤토리) — 소유 아이템 카드 + 사용. 빈 상태는 움직이는 잠만보(컬렉션의 피카츄 패턴).
+struct BagView: View {
+    let store: CompanionStore
+    let nav: PopoverNavigation
+
+    var body: some View {
+        if store.ownedItems.isEmpty {
+            emptyState
+        } else {
+            // 고정 높이 — 컬렉션과 동일(팝오버 재오픈 시 fitting size 축소 방지).
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(store.ownedItems, id: \.kind) { item in
+                        ItemCard(store: store, nav: nav, kind: item.kind, count: item.count)
+                    }
+                }
+            }
+            .frame(height: 520)
+        }
+    }
+
+    /// 빈 가방 — 움직이는 잠만보(143) + 안내(특정 아이템명 미언급, 확장 대비).
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            SpriteView(speciesID: 143, size: 96, animated: true)   // 잠만보(움직임)
+            Text(store.l.bagEmptyTitle)
+                .font(.callout.weight(.semibold))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 28)
+    }
+}
+
+/// 아이템 1장 — 아이콘·이름·개수·설명 + 인라인 확인 사용.
+/// 확인은 인라인(버튼 morph) — .sheet/.alert 금지: transient 팝오버가 닫힐 때 고아 시트가
+/// 이후 클릭을 먹통내는 기존 결함(PopoverView 주석) 회피.
+private struct ItemCard: View {
+    let store: CompanionStore
+    let nav: PopoverNavigation
+    let kind: ItemKind
+    let count: Int
+    @State private var confirming = false
+
+    var body: some View {
+        let l = store.l
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 10) {
+                Text(icon).font(.system(size: 30))
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(l.itemName(kind)).font(.callout.weight(.semibold))
+                        Text("×\(count)").font(.caption.weight(.bold))
+                            .foregroundStyle(.secondary).monospacedDigit()
+                    }
+                    Text(l.itemDescription(kind))
+                        .font(.caption).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer()
+            }
+            useControls(l)
+        }
+        .padding(10)
+        .background(Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    @ViewBuilder
+    private func useControls(_ l: L) -> some View {
+        if store.canUseRareCandy {
+            if confirming {
+                HStack(spacing: 8) {
+                    Text(l.useOnCurrent(store.displayName))
+                        .font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                    Spacer()
+                    Button(l.use) { useNow() }
+                        .buttonStyle(.borderedProminent).controlSize(.small)
+                    Button(l.cancel) { confirming = false }
+                        .buttonStyle(.borderless).controlSize(.small)
+                }
+            } else {
+                HStack {
+                    Text("+\(TokenFormatter.compact(RareCandy.xp)) XP")
+                        .font(.caption2).foregroundStyle(.tertiary).monospacedDigit()
+                    Spacer()
+                    Button(l.useItem) { confirming = true }
+                        .buttonStyle(.bordered).controlSize(.small)
+                }
+            }
+        } else {
+            // 알(부화 전)/활성 없음/라인 미로딩 — 비활성 + 사유
+            Text(store.isEgg ? l.useAfterHatch : l.useNeedsPokemon)
+                .font(.caption2).foregroundStyle(.tertiary)
+        }
+    }
+
+    /// 사용 → 항상 Home 탭으로 전환(진화/졸업 연출·"+XP" 는 Home 의 CompanionHeader 에서 재생).
+    private func useNow() {
+        confirming = false
+        _ = store.useRareCandy()
+        nav.tab = .home
+    }
+
+    private var icon: String {
+        switch kind {
+        case .rareCandy: return "🍬"
+        }
+    }
+}

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -128,6 +128,10 @@ struct CompanionHeader: View {
     @State private var shinyBurst = false
     @State private var seenSeq = -1     // 재생 완료한 celebrationSeq (팝오버 재오픈 시 1회 재생 보장)
     @State private var eggWiggle = false
+    // 사탕 "+XP" 순간 표시 (진화 없이 부분 진행일 때도 피드백)
+    @State private var seenCandySeq = -1
+    @State private var candyXPShown = false
+    @State private var candyXPAmount = 0     // 표시 순간 캡처(consume 후에도 텍스트 유지)
 
     /// 부화 임박(90%+) — 알이 흔들리고 문구가 바뀐다.
     private var eggImminent: Bool { store.isEgg && store.eggProgress >= 0.9 }
@@ -148,6 +152,16 @@ struct CompanionHeader: View {
                             Text("✨").font(.system(size: 22))
                                 .transition(.scale.combined(with: .opacity))
                                 .offset(x: 6, y: -6)
+                        }
+                    }
+                    .overlay(alignment: .top) {
+                        if candyXPShown {
+                            Text("+\(TokenFormatter.compact(candyXPAmount)) XP")
+                                .font(.caption.weight(.bold)).foregroundStyle(.orange)
+                                .padding(.horizontal, 6).padding(.vertical, 2)
+                                .background(.regularMaterial, in: Capsule())
+                                .transition(.move(edge: .bottom).combined(with: .opacity))
+                                .offset(y: -16)
                         }
                     }
                 VStack(alignment: .leading, spacing: 4) {
@@ -200,9 +214,11 @@ struct CompanionHeader: View {
         }
         .onAppear {
             playCelebrationIfNeeded()
+            showCandyXPIfNeeded()
             syncEggWiggle()
         }
         .onChange(of: store.celebrationSeq) { playCelebrationIfNeeded() }
+        .onChange(of: store.candyFeedbackSeq) { showCandyXPIfNeeded() }
         .onChange(of: eggImminent) { syncEggWiggle() }
     }
 
@@ -221,6 +237,20 @@ struct CompanionHeader: View {
                 try? await Task.sleep(nanoseconds: 2_600_000_000)
                 withAnimation(.easeOut(duration: 0.5)) { shinyBurst = false }
             }
+        }
+    }
+
+    /// 사탕 사용 "+XP" 1회 표시. store 를 consume 해 1회성 보장 — 다른 탭 갔다 홈 재진입해
+    /// CompanionHeader 가 재마운트(@State 초기화)돼도 다시 뜨지 않는다(회귀 수정).
+    private func showCandyXPIfNeeded() {
+        guard store.candyFeedbackAmount > 0, store.candyFeedbackSeq != seenCandySeq else { return }
+        seenCandySeq = store.candyFeedbackSeq
+        candyXPAmount = store.candyFeedbackAmount
+        store.consumeCandyFeedback()
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) { candyXPShown = true }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_300_000_000)
+            withAnimation(.easeOut(duration: 0.4)) { candyXPShown = false }
         }
     }
 

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-enum PopoverTab { case home, collection }
+enum PopoverTab { case home, bag, collection }
 
 /// 팝오버 내부 내비게이션 상태(현재 탭 / 설정 표시 여부).
 /// NSHostingController 는 팝오버를 닫아도 재사용되어 @State 가 유지되므로, 화면 상태를 이
@@ -72,6 +72,7 @@ struct PopoverView: View {
             updateBanner
             Picker("", selection: $nav.tab) {
                 Text(l.home).tag(PopoverTab.home)
+                Text(l.bag).tag(PopoverTab.bag)
                 Text(l.collection).tag(PopoverTab.collection)
             }
             .pickerStyle(.segmented)
@@ -79,6 +80,8 @@ struct PopoverView: View {
 
             if nav.tab == .collection {
                 CollectionView(store: companion)
+            } else if nav.tab == .bag {
+                BagView(store: companion, nav: nav)
             } else {
                 CompanionHeader(store: companion)
                 Divider()

--- a/Tests/PokeTokenBarTests/RareCandyTests.swift
+++ b/Tests/PokeTokenBarTests/RareCandyTests.swift
@@ -1,0 +1,578 @@
+import XCTest
+@testable import PokeTokenBar
+
+// MARK: 헬퍼 (CompanionTests 의 private 라인 헬퍼와 독립)
+
+private func rcNode(_ id: Int, _ children: [EvoNode] = []) -> EvoNode { EvoNode(speciesID: id, children: children) }
+private func rcLine(base: Int, tree: EvoNode, rarity: Rarity = .common) -> EvoLine {
+    func ids(_ n: EvoNode) -> [Int] { [n.speciesID] + n.children.flatMap(ids) }
+    var names: [Int: [String: String]] = [:]
+    for id in ids(tree) { names[id] = ["en": "P\(id)", "ko": "포\(id)", "ja": "ポ\(id)"] }
+    return EvoLine(baseID: base, tree: tree, rarity: rarity, names: names)
+}
+private let rcLinear3 = rcLine(base: 1, tree: rcNode(1, [rcNode(2, [rcNode(3)])]))   // 커먼 3형태: 125M/250M/375M
+private let rcNoEvo = rcLine(base: 20, tree: rcNode(20))                              // 커먼 1형태: 750M 단일
+private let rcNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+private func w(_ key: String, _ kind: WindowClass, _ util: Double, name: String = "T") -> CandyWindow {
+    CandyWindow(key: key, name: name, kind: kind, utilization: util)
+}
+
+// MARK: 순수 판정 (evaluateCandyGrants — 부수효과 분리)
+
+@MainActor
+final class CandyGrantEvaluationTests: XCTestCase {
+    func testSessionGrantsOne() {
+        var tier: [String: Int] = [:]
+        let grants = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 100)], grantTier: &tier)
+        XCTAssertEqual(grants.map(\.count), [1])
+        XCTAssertEqual(tier["s"], 1)
+    }
+
+    func testWeeklyGrantsFive() {
+        var tier: [String: Int] = [:]
+        let grants = CompanionStore.evaluateCandyGrants(windows: [w("wk", .weekly, 100)], grantTier: &tier)
+        XCTAssertEqual(grants.map(\.count), [RareCandy.weeklyGrant])
+    }
+
+    func testBelow100NoGrant() {
+        var tier: [String: Int] = [:]
+        let grants = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 99.9)], grantTier: &tier)
+        XCTAssertTrue(grants.isEmpty)
+        XCTAssertNil(tier["s"])
+    }
+
+    /// 같은 tier 유지 중엔 재지급 안 함(80·81·84… 억제의 사탕 버전).
+    func testNoDoubleGrantWhileAt100() {
+        var tier: [String: Int] = [:]
+        _ = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 100)], grantTier: &tier)
+        let again = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 100)], grantTier: &tier)
+        XCTAssertTrue(again.isEmpty, "이미 지급한 창은 재지급 안 함")
+    }
+
+    /// 100% 아래로 내려가면 재무장(맵에서 제거) → 다시 채우면 재지급.
+    func testRearmAfterDropBelow100() {
+        var tier: [String: Int] = [:]
+        _ = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 100)], grantTier: &tier)
+        _ = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 40)], grantTier: &tier)
+        XCTAssertNil(tier["s"], "경고선 아래 → 제거(재무장)")
+        let regrant = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 100)], grantTier: &tier)
+        XCTAssertEqual(regrant.map(\.count), [1], "리셋 후 다시 채우면 재지급")
+    }
+
+    /// 세션+주간+미달 혼합 — 세션 1 + 주간 5, 미달 창은 무시.
+    func testMixedWindows() {
+        var tier: [String: Int] = [:]
+        let grants = CompanionStore.evaluateCandyGrants(windows: [
+            w("claude.fiveHour", .session, 100),
+            w("claude.sevenDay", .weekly, 100),
+            w("codex.codex.primary", .session, 50),
+        ], grantTier: &tier)
+        XCTAssertEqual(grants.reduce(0) { $0 + $1.count }, 1 + RareCandy.weeklyGrant)
+    }
+
+    /// 지급 grant 는 발화 창 이름을 담는다(알림 "왜 받는지").
+    func testGrantCarriesWindowName() {
+        var tier: [String: Int] = [:]
+        let grants = CompanionStore.evaluateCandyGrants(
+            windows: [w("claude.fiveHour", .session, 100, name: "Claude 5시간 세션")], grantTier: &tier)
+        XCTAssertEqual(grants.first?.windowName, "Claude 5시간 세션")
+    }
+
+    /// Codex 창 분류 — ≤24h=세션, 초과=주간, 미상=세션.
+    func testCodexWindowClassification() {
+        XCTAssertEqual(UsageStore.windowClass(minutes: 300), .session)     // 5h
+        XCTAssertEqual(UsageStore.windowClass(minutes: 1440), .session)    // 24h 경계
+        XCTAssertEqual(UsageStore.windowClass(minutes: 10_080), .weekly)   // 7d
+        XCTAssertEqual(UsageStore.windowClass(minutes: nil), .session)
+    }
+}
+
+// MARK: 하위호환 디코딩
+
+final class InventoryDecodeTests: XCTestCase {
+    /// 구버전 저장(인벤토리 키 없음)도 깨지지 않고 기본값으로 로드.
+    func testDecodesWithoutInventoryFields() throws {
+        let json = #"{"installBaselineSet":true,"usedSinceInstall":5,"lastDate":"d","dex":[],"language":"ko"}"#
+        let s = try JSONDecoder().decode(CompanionState.self, from: Data(json.utf8))
+        XCTAssertEqual(s.inventory, [:])
+        XCTAssertEqual(s.candyGrantTier, [:])
+        XCTAssertFalse(s.candyFeatureSeeded)
+    }
+
+    func testInventoryRoundTrip() throws {
+        var st = CompanionState()
+        st.inventory = ["rareCandy": 3]
+        st.candyGrantTier = ["claude.fiveHour": 1]
+        st.candyFeatureSeeded = true
+        let round = try JSONDecoder().decode(CompanionState.self, from: JSONEncoder().encode(st))
+        XCTAssertEqual(round.inventory, ["rareCandy": 3])
+        XCTAssertEqual(round.candyGrantTier, ["claude.fiveHour": 1])
+        XCTAssertTrue(round.candyFeatureSeeded)
+    }
+}
+
+// MARK: 지급 (grantCandies — 시드·영속) + 사용 (useRareCandy)
+
+@MainActor
+final class RareCandyStoreTests: XCTestCase {
+    private func store(_ line: EvoLine, seed: UInt64 = 7) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rc-\(UUID().uuidString).json")
+        return CompanionStore(provider: StubProvider(value: line), clock: { rcNow }, fileURL: url, rng: SeededRNG(seed: seed))
+    }
+
+    /// 시드+지급 헬퍼 — 빈 창으로 시드 완료 후, 유니크 세션 창을 100%로 올려 n개 지급.
+    private func giveCandies(_ s: CompanionStore, _ n: Int) {
+        s.grantCandies(from: [], limitsReady: true)   // 시드(지급 0)
+        for i in 0..<n {
+            s.grantCandies(from: [w("test.session.\(i)", .session, 100)], limitsReady: true)
+        }
+    }
+
+    // MARK: 지급
+
+    /// 첫 실행: 이미 100%인 창은 소급 지급 안 하고 tier 시드만(candyFeatureSeeded=true).
+    func testFirstRunSeedsWithoutGranting() {
+        let s = store(rcLinear3)
+        s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)
+        XCTAssertEqual(s.rareCandyCount, 0, "첫 실행 100% 창은 소급 지급 안 함")
+        XCTAssertTrue(s.state.candyFeatureSeeded)
+        XCTAssertEqual(s.state.candyGrantTier["claude.fiveHour"], 1, "tier 시드됨")
+    }
+
+    /// 시드 후 같은 창이 계속 100%여도 재지급 없음.
+    func testNoGrantForAlreadySeededWindow() {
+        let s = store(rcLinear3)
+        s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)   // 시드
+        s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)   // 재호출
+        XCTAssertEqual(s.rareCandyCount, 0)
+    }
+
+    /// 한도 미로딩(limitsReady=false)이면 시드조차 하지 않는다(다음 refresh 재시도).
+    func testNoSeedWhenLimitsNotReady() {
+        let s = store(rcLinear3)
+        s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: false)
+        XCTAssertFalse(s.state.candyFeatureSeeded)
+        XCTAssertEqual(s.rareCandyCount, 0)
+    }
+
+    /// 시드 후 새 창이 100%를 새로 넘으면 지급 — 세션 1개.
+    func testSessionGrantAfterSeed() {
+        let s = store(rcLinear3)
+        s.grantCandies(from: [], limitsReady: true)   // 시드
+        s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)
+        XCTAssertEqual(s.rareCandyCount, 1)
+    }
+
+    /// 주간 창은 5개.
+    func testWeeklyGrantsFiveCandies() {
+        let s = store(rcLinear3)
+        s.grantCandies(from: [], limitsReady: true)
+        s.grantCandies(from: [w("claude.sevenDay", .weekly, 100)], limitsReady: true)
+        XCTAssertEqual(s.rareCandyCount, RareCandy.weeklyGrant)
+    }
+
+    /// [핵심 회귀] 지급 tier 는 영속 — 재시작(같은 파일 재로드) 후 같은 100% 창이 재지급되지 않는다.
+    /// (notifiedTier 인메모리와 달리 candyGrantTier 는 파일에 저장돼야 함.)
+    func testGrantTierPersistsAcrossRestartNoDoubleGrant() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rc-persist-\(UUID().uuidString).json")
+        let s1 = CompanionStore(provider: StubProvider(value: rcLinear3), clock: { rcNow }, fileURL: url, rng: SeededRNG(seed: 1))
+        s1.grantCandies(from: [], limitsReady: true)                                        // 시드
+        s1.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)     // 지급 1
+        XCTAssertEqual(s1.rareCandyCount, 1)
+
+        // 재시작: 같은 파일 로드
+        let s2 = CompanionStore(provider: StubProvider(value: rcLinear3), clock: { rcNow }, fileURL: url, rng: SeededRNG(seed: 1))
+        XCTAssertEqual(s2.rareCandyCount, 1, "인벤토리 영속")
+        XCTAssertEqual(s2.state.candyGrantTier["claude.fiveHour"], 1, "tier 영속")
+        // 여전히 100%인 같은 창 → 재지급 없어야 함
+        s2.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)
+        XCTAssertEqual(s2.rareCandyCount, 1, "재시작 후 같은 100% 창의 재지급 금지(무한지급 익스플로잇 차단)")
+    }
+
+    /// [회귀] 재무장(100%→아래로)으로 grantTier 에서 제거된 것이 영속돼야 재시작 후 지급 누락이 없다.
+    /// 지급 없이 재무장만 발생한 경우에도 save() 돼야 한다(과거: grants 비면 save 스킵 → stale tier 잔존).
+    func testRearmPersistsAcrossRestart() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rc-rearm-\(UUID().uuidString).json")
+        let s1 = CompanionStore(provider: StubProvider(value: rcLinear3), clock: { rcNow }, fileURL: url, rng: SeededRNG(seed: 1))
+        s1.grantCandies(from: [], limitsReady: true)                                      // 시드
+        s1.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)   // 지급 1 (tier=1)
+        XCTAssertEqual(s1.rareCandyCount, 1)
+        s1.grantCandies(from: [w("claude.fiveHour", .session, 40)], limitsReady: true)    // 재무장(제거) — 지급 0
+        XCTAssertNil(s1.state.candyGrantTier["claude.fiveHour"])
+
+        // 재시작: 재무장이 영속됐어야 함
+        let s2 = CompanionStore(provider: StubProvider(value: rcLinear3), clock: { rcNow }, fileURL: url, rng: SeededRNG(seed: 1))
+        XCTAssertNil(s2.state.candyGrantTier["claude.fiveHour"], "재무장이 영속돼야 함")
+        // 다시 100% → 재지급(누락 없음)
+        s2.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)
+        XCTAssertEqual(s2.rareCandyCount, 2, "재무장 후 재도달은 재지급돼야 함(지급 누락 회귀 방지)")
+    }
+
+    // MARK: 사용
+
+    /// 사탕 XP(100M) < 최소 임계(125M) → 진화 못 시키는 케이스는 부분 진행(.progressed), 통계 불변.
+    func testUseProgressesWithoutEvolution() async {
+        let s = store(rcLinear3)
+        await s.hatch(baseID: 1)
+        giveCandies(s, 1)
+        XCTAssertEqual(s.rareCandyCount, 1)
+        let before = s.state.usedSinceInstall
+        let result = s.useRareCandy()
+        XCTAssertEqual(result, .progressed)
+        XCTAssertEqual(s.state.active?.usedAtStage, RareCandy.xp)
+        XCTAssertEqual(s.state.active?.stageIndex, 0)
+        XCTAssertEqual(s.rareCandyCount, 0, "재고 1 소모")
+        XCTAssertEqual(s.state.usedSinceInstall, before, "사탕 XP 는 실사용 통계에 안 잡힘")
+    }
+
+    /// 잔여가 사탕XP 이하인 단계에서 사용 → 정확히 1단계 진화.
+    func testUseEvolvesWhenCrossingThreshold() async {
+        let s = store(rcLinear3)
+        await s.hatch(baseID: 1)
+        s.applyUsage(50_000_000)   // stage0(125M) 잔여 75M ≤ 100M
+        giveCandies(s, 1)
+        let result = s.useRareCandy()
+        XCTAssertEqual(result, .evolved)
+        XCTAssertEqual(s.currentSpeciesID, 2)
+        XCTAssertEqual(s.state.active?.stageIndex, 1)
+    }
+
+    /// [불변식] 사탕 1개 = 최대 1단계 — 임계 직전(124M)에서 써도 2단계 연쇄 안 됨.
+    func testSingleCandyAdvancesAtMostOneStage() async {
+        let s = store(rcLinear3)
+        await s.hatch(baseID: 1)
+        s.applyUsage(124_000_000)   // stage0 임계 직전
+        giveCandies(s, 1)
+        _ = s.useRareCandy()        // +100M → 224M: stage0(125M) 1회만, stage1(250M) 미달
+        XCTAssertEqual(s.state.active?.stageIndex, 1, "최대 1단계")
+    }
+
+    /// 최종단계에서 잔여가 사탕XP 이하면 졸업 → 도감 + 새 알.
+    func testUseGraduatesFinalStage() async {
+        let s = store(rcNoEvo)
+        await s.hatch(baseID: 20)
+        s.applyUsage(700_000_000)   // 졸업 총량 750M 잔여 50M ≤ 100M
+        giveCandies(s, 1)
+        let result = s.useRareCandy()
+        XCTAssertEqual(result, .graduated)
+        XCTAssertNil(s.state.active)
+        XCTAssertEqual(s.dexEntries.count, 1)
+    }
+
+    /// 알(부화 전)에는 사용 불가 — 재고가 있어도 소모되지 않는다.
+    func testCannotUseOnEgg() {
+        let s = store(rcLinear3)
+        giveCandies(s, 2)
+        XCTAssertTrue(s.isEgg)
+        XCTAssertFalse(s.canUseRareCandy)
+        XCTAssertEqual(s.useRareCandy(), .unavailable)
+        XCTAssertEqual(s.rareCandyCount, 2, "알 상태에선 소모 안 됨")
+    }
+
+    /// 재고 0이면 사용 불가.
+    func testCannotUseWithoutStock() async {
+        let s = store(rcLinear3)
+        await s.hatch(baseID: 1)
+        XCTAssertEqual(s.rareCandyCount, 0)
+        XCTAssertFalse(s.canUseRareCandy)
+        XCTAssertEqual(s.useRareCandy(), .unavailable)
+    }
+
+    /// 사용 시 "+XP" 피드백 seq 가 증가(진화 없이 부분 진행이어도).
+    func testUseBumpsCandyFeedback() async {
+        let s = store(rcLinear3)
+        await s.hatch(baseID: 1)
+        giveCandies(s, 1)
+        let before = s.candyFeedbackSeq
+        _ = s.useRareCandy()
+        XCTAssertEqual(s.candyFeedbackSeq, before + 1)
+        XCTAssertEqual(s.candyFeedbackAmount, RareCandy.xp)
+    }
+
+    /// ownedItems 는 개수>0 아이템만 노출.
+    func testOwnedItemsReflectsStock() async {
+        let s = store(rcLinear3)
+        XCTAssertTrue(s.ownedItems.isEmpty)
+        giveCandies(s, 3)
+        XCTAssertEqual(s.ownedItems.map(\.kind), [.rareCandy])
+        XCTAssertEqual(s.ownedItems.first?.count, 3)
+    }
+
+    /// 데모 시나리오(구구 3형태, usedAtStage 100M, 사탕 3): 진화 → 부분성장 → 진화, 그 뒤 재고 0.
+    func testSequentialCandyUseMatchesDemo() async {
+        let s = store(rcLinear3)
+        await s.hatch(baseID: 1)
+        s.applyUsage(100_000_000)                      // stage0(125M) 도달 전
+        giveCandies(s, 3)
+        XCTAssertEqual(s.useRareCandy(), .evolved)     // 200M ≥125M → stage1, 이월 75M
+        XCTAssertEqual(s.state.active?.stageIndex, 1)
+        XCTAssertEqual(s.useRareCandy(), .progressed)  // 175M <250M → 부분성장
+        XCTAssertEqual(s.state.active?.stageIndex, 1)
+        XCTAssertEqual(s.useRareCandy(), .evolved)     // 275M ≥250M → stage2
+        XCTAssertEqual(s.state.active?.stageIndex, 2)
+        XCTAssertEqual(s.rareCandyCount, 0)
+    }
+
+    /// "+XP" 1회성 store 계약 — 사용 후 amount>0, consume 후 0(재렌더 재생 방지의 핵심).
+    func testConsumeCandyFeedbackResets() async {
+        let s = store(rcLinear3)
+        await s.hatch(baseID: 1)
+        giveCandies(s, 1)
+        _ = s.useRareCandy()
+        XCTAssertEqual(s.candyFeedbackAmount, RareCandy.xp)
+        s.consumeCandyFeedback()
+        XCTAssertEqual(s.candyFeedbackAmount, 0, "consume 후 0 — CompanionHeader 재마운트 시 재생 안 됨")
+    }
+}
+
+// MARK: 지급 통합 (UsageStore 한도 → candyEligibleWindows → grantCandies)
+// "특정 조건(한도 100%)에서 사탕 지급" — 수동으로 열기 힘든 경로를 주입 한도로 결정적 검증.
+
+private struct RCFakeClaude: ClaudeLimitsProviding {
+    var status: LimitStatus?
+    func fetch(allowKeychainPrompt: Bool) async throws -> LimitStatus {
+        guard let status else { throw LimitsError.keychainInteractionNotAllowed }
+        return status
+    }
+}
+private struct RCFakeCodex: CodexLimitsProviding {
+    var status: CodexRateLimitStatus?
+    func fetch() async throws -> CodexRateLimitStatus? { status }
+}
+private final class RCFakeStatus: ProviderStatusProviding, @unchecked Sendable {
+    func fetch() async -> [String: ProviderStatus] { [:] }
+}
+private final class RCFakeProvider: UsageProvider, @unchecked Sendable {
+    let id: String
+    let displayName: String
+    nonisolated(unsafe) var daily: DailyUsage?
+    init(id: String, displayName: String, daily: DailyUsage?) {
+        self.id = id; self.displayName = displayName; self.daily = daily
+    }
+    func fetchDaily() async throws -> DailyUsage? { daily }
+    func fetchEnrichment() async -> ProviderEnrichment { ProviderEnrichment() }
+}
+private func rcDaily(_ tokens: Int) -> DailyUsage {
+    DailyUsage(date: LocalUsageReader.todayKey(), inputTokens: 0, outputTokens: 0,
+               cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: tokens, totalCost: 0)
+}
+private func rcClaude(fiveHour: Double? = nil, sevenDay: Double? = nil,
+                      opus: Double? = nil, sonnet: Double? = nil) -> LimitStatus {
+    var parts: [String] = []
+    if let fiveHour { parts.append("\"five_hour\":{\"utilization\":\(fiveHour)}") }
+    if let sevenDay { parts.append("\"seven_day\":{\"utilization\":\(sevenDay)}") }
+    if let opus { parts.append("\"seven_day_opus\":{\"utilization\":\(opus)}") }
+    if let sonnet { parts.append("\"seven_day_sonnet\":{\"utilization\":\(sonnet)}") }
+    return try! JSONDecoder().decode(LimitStatus.self, from: Data("{\(parts.joined(separator: ","))}".utf8))
+}
+private func rcCodex(primary: Int? = nil, secondary: Int? = nil, individual: Int? = nil) -> CodexRateLimitStatus {
+    func win(_ p: Int, _ mins: Int) -> String { "{\"usedPercent\":\(p),\"windowDurationMins\":\(mins)}" }
+    var parts: [String] = []
+    if let primary { parts.append("\"primary\":\(win(primary, 300))") }
+    if let secondary { parts.append("\"secondary\":\(win(secondary, 10080))") }
+    if let individual {
+        parts.append("\"individualLimit\":{\"limit\":\"$10\",\"remainingPercent\":\(100 - individual),\"resetsAt\":9999999999,\"used\":\"$1\"}")
+    }
+    return try! JSONDecoder().decode(CodexRateLimitStatus.self, from: Data("{\"rateLimits\":{\(parts.joined(separator: ","))}}".utf8))
+}
+
+@MainActor
+final class RareCandyGrantIntegrationTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    override func setUp() {
+        super.setUp()
+        suiteName = "rc-int-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    private func usage(claude: LimitStatus? = nil, codex: CodexRateLimitStatus? = nil,
+                       providers: [any UsageProvider]? = nil) -> UsageStore {
+        UsageStore(
+            providers: providers ?? [RCFakeProvider(id: "claude_code", displayName: "Claude Code", daily: rcDaily(1_000))],
+            claudeLimitsProvider: RCFakeClaude(status: claude),
+            codexLimitsProvider: RCFakeCodex(status: codex),
+            statusProvider: RCFakeStatus(),
+            autoRefresh: false, defaults: defaults)
+    }
+    private func companion() -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rc-int-\(UUID().uuidString).json")
+        return CompanionStore(provider: StubProvider(value: rcLinear3), clock: { rcNow }, fileURL: url, rng: SeededRNG(seed: 7))
+    }
+
+    // MARK: candyEligibleWindows 구성
+
+    func testEligibleWindowsClaudeSessionAndWeekly() async {
+        let store = usage(claude: rcClaude(fiveHour: 100, sevenDay: 100))
+        await store.refresh(scheduleEmptyRetry: false)
+        let byKey = Dictionary(uniqueKeysWithValues: store.candyEligibleWindows.map { ($0.key, $0) })
+        XCTAssertEqual(byKey["claude.fiveHour"]?.kind, .session)
+        XCTAssertEqual(byKey["claude.fiveHour"]?.utilization, 100)
+        XCTAssertEqual(byKey["claude.sevenDay"]?.kind, .weekly)
+        XCTAssertEqual(store.candyEligibleWindows.count, 2)
+    }
+
+    /// Opus/Sonnet 주간은 지급 대상에서 제외(헤드라인 창 중복 방지).
+    func testEligibleWindowsExcludeOpusSonnet() async {
+        let store = usage(claude: rcClaude(fiveHour: 100, opus: 100, sonnet: 100))
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(Set(store.candyEligibleWindows.map(\.key)), ["claude.fiveHour"], "Opus/Sonnet 주간 제외")
+    }
+
+    /// Codex primary=세션, secondary=주간. individual spend limit 은 제외.
+    func testEligibleWindowsCodexClassificationExcludesSpend() async {
+        let store = usage(codex: rcCodex(primary: 100, secondary: 100, individual: 100),
+                          providers: [RCFakeProvider(id: "codex", displayName: "Codex", daily: rcDaily(1_000))])
+        await store.refresh(scheduleEmptyRetry: false)
+        let byKey = Dictionary(uniqueKeysWithValues: store.candyEligibleWindows.map { ($0.key, $0.kind) })
+        XCTAssertEqual(byKey["codex.codex.primary"], .session)
+        XCTAssertEqual(byKey["codex.codex.secondary"], .weekly)
+        XCTAssertFalse(store.candyEligibleWindows.contains { $0.key.contains("individual") }, "spend limit 제외")
+    }
+
+    /// Gemini 는 공식 한도 신호가 없어 창 목록에 안 나온다(제외 설계).
+    func testEligibleWindowsExcludeGemini() async {
+        let store = usage(claude: rcClaude(fiveHour: 100),
+                          providers: [RCFakeProvider(id: "gemini", displayName: "Gemini", daily: rcDaily(9_000)),
+                                      RCFakeProvider(id: "claude_code", displayName: "Claude Code", daily: rcDaily(1_000))])
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertFalse(store.candyEligibleWindows.contains { $0.key.contains("gemini") })
+    }
+
+    func testLimitsReadyReflectsLoad() async {
+        let store = usage(claude: rcClaude(fiveHour: 50))
+        XCTAssertFalse(store.limitsReady, "refresh 전")
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(store.limitsReady, "한도 로드 후")
+    }
+
+    // MARK: 통합 — 한도 100% → 지급
+
+    /// [핵심] 시드된 상태에서 Claude 5h 100% 도달 → 세션 사탕 1개(수동으로 못 여는 경로 검증).
+    func testClaudeSessionLimitGrantsOneCandy() async {
+        let c = companion()
+        c.grantCandies(from: [], limitsReady: true)   // 시드(현재 100% 창 없음)
+        let store = usage(claude: rcClaude(fiveHour: 100))
+        await store.refresh(scheduleEmptyRetry: false)
+        c.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        XCTAssertEqual(c.rareCandyCount, 1)
+    }
+
+    /// 주간 100% → 5개.
+    func testClaudeWeeklyLimitGrantsFive() async {
+        let c = companion()
+        c.grantCandies(from: [], limitsReady: true)
+        let store = usage(claude: rcClaude(sevenDay: 100))
+        await store.refresh(scheduleEmptyRetry: false)
+        c.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        XCTAssertEqual(c.rareCandyCount, RareCandy.weeklyGrant)
+    }
+
+    /// 세션+주간 동시 100% → 1 + 5.
+    func testSessionAndWeeklyTogetherGrantSix() async {
+        let c = companion()
+        c.grantCandies(from: [], limitsReady: true)
+        let store = usage(claude: rcClaude(fiveHour: 100, sevenDay: 100))
+        await store.refresh(scheduleEmptyRetry: false)
+        c.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        XCTAssertEqual(c.rareCandyCount, 1 + RareCandy.weeklyGrant)
+    }
+
+    /// Codex 세션(primary) 100% → 1개(전 프로바이더 지급).
+    func testCodexPrimaryLimitGrantsOne() async {
+        let c = companion()
+        c.grantCandies(from: [], limitsReady: true)
+        let store = usage(codex: rcCodex(primary: 100),
+                          providers: [RCFakeProvider(id: "codex", displayName: "Codex", daily: rcDaily(1_000))])
+        await store.refresh(scheduleEmptyRetry: false)
+        c.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        XCTAssertEqual(c.rareCandyCount, 1)
+    }
+
+    /// 99.9% 는 지급 없음(엄격히 100% 이상).
+    func testJustUnder100NoGrant() async {
+        let c = companion()
+        c.grantCandies(from: [], limitsReady: true)
+        let store = usage(claude: rcClaude(fiveHour: 99.9))
+        await store.refresh(scheduleEmptyRetry: false)
+        c.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        XCTAssertEqual(c.rareCandyCount, 0)
+    }
+
+    /// 첫 실행(미시드) + 이미 100% → 소급 지급 안 함(시드만).
+    func testFirstRunAt100SeedsNoGrant() async {
+        let c = companion()   // candyFeatureSeeded=false
+        let store = usage(claude: rcClaude(fiveHour: 100))
+        await store.refresh(scheduleEmptyRetry: false)
+        c.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        XCTAssertEqual(c.rareCandyCount, 0, "업데이트 직후 이미 100%인 창은 소급 지급 안 함")
+        XCTAssertTrue(c.state.candyFeatureSeeded)
+        c.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        XCTAssertEqual(c.rareCandyCount, 0, "시드된 창은 재호출에도 지급 없음")
+    }
+
+    /// 지급은 엣지 1회 — 같은 100% 창을 여러 refresh 에 반복 평가해도 1개만.
+    func testRepeatedRefreshGrantsOnce() async {
+        let c = companion()
+        c.grantCandies(from: [], limitsReady: true)
+        let store = usage(claude: rcClaude(fiveHour: 100))
+        await store.refresh(scheduleEmptyRetry: false)
+        for _ in 0..<5 { c.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady) }
+        XCTAssertEqual(c.rareCandyCount, 1, "여러 번 호출해도 엣지 1회만")
+    }
+
+    /// 지급 알림 대상 창 이름이 세션/주간 모두 candyEligibleWindows 에 실제로 담기는지(본문 "왜 받는지").
+    /// Claude: "Claude 5시간 세션"/"Claude 주간". Codex: "Codex 5시간 세션"/"Codex 주간".
+    func testEligibleWindowNamesForNotificationBody() async {
+        let claudeStore = usage(claude: rcClaude(fiveHour: 100, sevenDay: 100))
+        await claudeStore.refresh(scheduleEmptyRetry: false)
+        let claudeNames = Dictionary(uniqueKeysWithValues: claudeStore.candyEligibleWindows.map { ($0.key, $0.name) })
+        XCTAssertEqual(claudeNames["claude.fiveHour"], "Claude 5시간 세션")
+        XCTAssertEqual(claudeNames["claude.sevenDay"], "Claude 주간")
+
+        let codexStore = usage(codex: rcCodex(primary: 100, secondary: 100),
+                               providers: [RCFakeProvider(id: "codex", displayName: "Codex", daily: rcDaily(1_000))])
+        await codexStore.refresh(scheduleEmptyRetry: false)
+        let codexNames = Dictionary(uniqueKeysWithValues: codexStore.candyEligibleWindows.map { ($0.key, $0.name) })
+        XCTAssertEqual(codexNames["codex.codex.primary"], "Codex 5시간 세션")
+        XCTAssertEqual(codexNames["codex.codex.secondary"], "Codex 주간")
+    }
+}
+
+// MARK: 알림 문구 치환 (제목 개수 · 본문 창 이름 — Claude/Codex 공통)
+
+final class CandyNotificationCopyTests: XCTestCase {
+    /// 제목에 개수(1개·5개)와 아이템명이 들어간다.
+    func testTitleIncludesCountAndItem() {
+        let l = L(.ko)
+        let one = l.notifCandyTitle(item: l.itemName(.rareCandy), count: 1)
+        let five = l.notifCandyTitle(item: l.itemName(.rareCandy), count: 5)
+        XCTAssertTrue(one.contains("이상한 사탕"))
+        XCTAssertTrue(one.contains("1개"), one)
+        XCTAssertTrue(five.contains("5개"), five)
+    }
+
+    /// 본문은 넘겨받은 창 이름을 그대로 앞에 붙인다 — Claude·Codex 어느 창이든 자연스럽게 뜬다.
+    func testBodyPrefixesWindowNameClaudeAndCodex() {
+        let l = L(.ko)
+        XCTAssertTrue(l.notifCandyBody(window: "Claude 5시간 세션").hasPrefix("Claude 5시간 세션 토큰 한도를 다 채웠"))
+        XCTAssertTrue(l.notifCandyBody(window: "Claude 주간").hasPrefix("Claude 주간 토큰 한도를 다 채웠"))
+        XCTAssertTrue(l.notifCandyBody(window: "Codex 5시간 세션").hasPrefix("Codex 5시간 세션 토큰 한도를 다 채웠"))
+        XCTAssertTrue(l.notifCandyBody(window: "Codex 주간").hasPrefix("Codex 주간 토큰 한도를 다 채웠"))
+    }
+
+    /// 3개 언어 모두 개수 치환 + 비어있지 않음.
+    func testTitleLocalizedAllLanguages() {
+        for lang in AppLanguage.allCases {
+            let l = L(lang)
+            let title = l.notifCandyTitle(item: l.itemName(.rareCandy), count: 3)
+            XCTAssertTrue(title.contains("3"), "\(lang): \(title)")
+            XCTAssertFalse(title.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## 개요
한도(usage limit)를 다 채운 순간을 보상 이벤트로 전환한다. 한도 창이 100%에 도달하면 **이상한 사탕**을 지급하고, 새 **가방** 탭에서 현재 포켓몬에게 사용해 성장(+100M XP)시킨다.

## 지급 (획득)
- 트리거: 사용량 한도 창이 **100% 도달하는 순간(엣지 트리거)**. 알림 crit(95%)과 별개.
- 지급량: **세션급(≈5h) 1개 · 주간급 5개**. 프로바이더 분류:
  - Claude: `five_hour`(세션)·`seven_day`(주간)
  - Codex: `windowDurationMins` ≤24h(세션)·>24h(주간)
  - 제외: Opus/Sonnet 주간·scoped·Codex spend limit(헤드라인 창 하위/중복 → 이중지급 방지)
  - **Gemini는 공식 한도 신호가 없어 자연 제외**(창 목록에 없음). 단 Gemini 토큰은 합산 XP로 펫 성장엔 기여.
- **엣지 + 영속**: `candyGrantTier`(창별 tier)를 `CompanionState`에 저장 → 재시작해도 재지급 안 됨(기존 인메모리 `notifiedTier`와 달리 무한지급 익스플로잇 차단).
- **첫 실행 시드**(`candyFeatureSeeded`): 업데이트 직후 이미 100%였던 창은 소급 지급 안 하고 tier만 시드.
- 재무장: 창이 100% 아래로 내려가면 다음 도달에 재지급.
- 알림(companionNotifications): "🍬 이상한 사탕 N개를 받았어요!" + 본문에 어느 창을 채웠는지 명시(Claude/Codex 창 이름 동적).

## 사용 (효과)
- `useRareCandy()` = `applyUsage(RareCandy.xp = 100M)` — 기존 이월·진화·졸업(→도감+새 알)·연출 로직 재사용.
- 불변식: **100M < 최소 진화 임계(커먼 3형태 stage0 = 125M)** → 사탕 1개 = 최대 1단계(연쇄 없음).
- 사탕 XP는 usedAtStage(진화 진행)에만 반영 — 실사용 통계(usedSinceInstall/오늘 토큰)엔 안 잡힘.

| 대상 | 결과 |
|---|---|
| 활성(비최종) | +100M, 임계 넘으면 1단계 진화 |
| 활성·최종 | +100M, 임계 넘으면 졸업 → 도감 + 새 알 |
| 알(부화 전) | 사용 불가 ("부화 후 사용 가능") |
| 라인 미로딩 | 사용 불가 (오적립 방지) |

## UI
- `PopoverTab.bag` 추가 → **Home │ 가방 │ 도감** 3탭
- `BagView`: 아이템 카드(🍬·이름·×개수·설명) + **인라인 확인**(`.sheet`/`.alert` 금지 — transient 팝오버 고아 시트 회피) + **사용 후 Home 탭 자동 전환**(진화 연출 노출)
- 빈 가방: **움직이는 잠만보(143)** + "아직 가방이 비어있어요!"
- `CompanionHeader` **"+XP" 1회성 피드백**(store consume 패턴 — 탭 재진입 시 재생 안 됨)
- 아이템 설명: "현재 포켓몬의 경험치를 100M 상승시킨다." (`RareCandy.xp` 파생)
- 문구 ko/en/ja

## 데이터 모델
- `ItemKind`(rareCandy) · `RareCandy`(xp=100M, weeklyGrant=5) · `WindowClass` · `CandyWindow`/`CandyGrant`
- `CompanionState` 추가: `inventory`/`candyGrantTier`/`candyFeatureSeeded` — 전부 `decodeIfPresent` 하위호환

## 손댈 지점 (배선)
- `UsageStore.candyEligibleWindows`(전 프로바이더 분류)·`limitsReady`·`onRefresh` 훅
- `AppDelegate.onStoreRefreshed` → `grantCandies`(한도 로드 후 트리거)

## QA seam
- `CompanionStore.defaultURL`에 `PTB_STATE_DIR` 환경변수 override(개발/QA 상태 격리, 프로덕션 무영향)

## 테스트 (43개)
- 순수 판정(엣지/재무장/세션·주간)·첫 실행 시드(소급 차단)·**재시작 영속 회귀**(무한지급/지급누락)·사용 조합(진화/졸업/알/1단계 불변식)·**한도 100%→지급 통합**(Claude 세션+주간, Codex primary/secondary, Opus/Sonnet·spend·Gemini 제외)·알림 문구 치환
- 전체 223개 통과, debug+release 빌드 green

## 검증
- swift build (debug+release), 전체 테스트 green
- dev .app 격리 실행(`PTB_STATE_DIR`)으로 가방·사용·진화·+XP·빈 상태·알림 문구 실렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
