### PR TITLE
docs: README 재미 우선 리포지셔닝 — 컴패니언 훅 먼저, 트래커는 근거로 (ko/en/ja)

### DIFF
--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -29,9 +29,7 @@ actor PokeAPIClient: PokeProviding {
         if let cached = lineCache[baseSpeciesID] { return cached }
         let baseSpecies = try await species(baseSpeciesID)
         // PokéAPI 응답의 URL — 비정상/빈 값이면 force-unwrap 대신 throw(앱은 알 상태 유지).
-        // 서버 제어 문자열이므로 https + pokeapi.co 로 고정(응답 변조 시 임의 호스트 fetch 방지).
-        guard let chainURL = URL(string: baseSpecies.evolution_chain.url),
-              chainURL.scheme == "https", chainURL.host == "pokeapi.co" else {
+        guard let chainURL = Self.validatedChainURL(baseSpecies.evolution_chain.url) else {
             throw URLError(.badURL)
         }
         let chainDTO: ChainDTO = try await get(chainURL)
@@ -190,6 +188,13 @@ actor PokeAPIClient: PokeProviding {
         // ".../pokemon-species/{id}/"
         let parts = speciesURL.split(separator: "/").filter { !$0.isEmpty }
         return Int(parts.last ?? "0") ?? 0
+    }
+
+    /// PokéAPI evolution_chain URL 검증(SSRF 가드) — 서버 제어 문자열이므로 https + pokeapi.co 로 고정해
+    /// 응답 변조 시 임의 호스트 fetch 를 막는다. 부적합하면 nil(호출부가 throw → 앱은 알 상태 유지).
+    static func validatedChainURL(_ raw: String) -> URL? {
+        guard let url = URL(string: raw), url.scheme == "https", url.host == "pokeapi.co" else { return nil }
+        return url
     }
 }
 

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -324,6 +324,28 @@ final class CompanionStoreTests: XCTestCase {
         s.setLanguage(.en); XCTAssertEqual(s.displayName, "P1")
         s.setLanguage(.ja); XCTAssertEqual(s.displayName, "ポ1")
     }
+
+    /// [문서화] 비대칭 깊이 분기 — totalForms=tree.depth(최장 경로)라 짧은 분기를 뽑으면 실제 경로가
+    /// totalForms 보다 짧다. 실 Gen1-5 라인은 분기 깊이가 대칭(뷰티플라이·이브이 등)이라 발생하지 않는다
+    /// (CompanionModel depth 주석 "분기는 보통 같은 깊이" 가정). 크래시·무한루프 없이 최종체에서 졸업하고
+    /// 실제 경로가 보존됨을 잠근다.
+    func testAsymmetricBranchGraduatesSafely() async {
+        let line = makeLine(base: 1, tree: node(1, [node(2), node(3, [node(4)])]))   // depth=3, 분기 {2, 3→4}
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-asym-\(UUID().uuidString).json")
+        let s = CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 7))
+        await s.hatch(baseID: 1)
+        XCTAssertEqual(s.state.active?.totalForms, 3, "totalForms = 최장 경로 깊이")
+        var guardCount = 0
+        while s.state.active != nil, guardCount < 12 {
+            guardCount += 1
+            let stage = s.state.active!.stageIndex
+            s.applyUsage(PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: stage))
+        }
+        XCTAssertNil(s.state.active, "어느 분기든 최종체에서 졸업(크래시·무한루프 없음)")
+        XCTAssertEqual(s.dexEntries.count, 1)
+        let chain = s.dexEntries[0].chainOrder
+        XCTAssertTrue(chain == [1, 2] || chain == [1, 3, 4], "실제 진화 경로 보존: \(chain)")
+    }
 }
 
 // MARK: 도감 정렬 / 요약
@@ -703,5 +725,19 @@ final class CompanionIdentityTests: XCTestCase {
             XCTAssertEqual(Set(names).count, 25, "\(lang) 중복/누락")
             XCTAssertFalse(names.contains(where: \.isEmpty))
         }
+    }
+}
+
+// MARK: PokéAPI SSRF 가드 (evolution_chain URL 검증 — 응답 변조 시 임의 호스트 fetch 방지)
+
+final class PokeAPIGuardTests: XCTestCase {
+    func testValidatedChainURLAcceptsPokeapiHttps() {
+        XCTAssertNotNil(PokeAPIClient.validatedChainURL("https://pokeapi.co/api/v2/evolution-chain/1/"))
+    }
+    func testValidatedChainURLRejectsUntrusted() {
+        XCTAssertNil(PokeAPIClient.validatedChainURL("https://evil.example.com/x"), "임의 호스트 거부(SSRF)")
+        XCTAssertNil(PokeAPIClient.validatedChainURL("https://pokeapi.co.evil.com/x"), "유사 호스트 거부")
+        XCTAssertNil(PokeAPIClient.validatedChainURL("http://pokeapi.co/x"), "http 거부(https 고정)")
+        XCTAssertNil(PokeAPIClient.validatedChainURL(""), "빈 문자열 거부")
     }
 }

--- a/Tests/PokeTokenBarTests/RareCandyTests.swift
+++ b/Tests/PokeTokenBarTests/RareCandyTests.swift
@@ -18,6 +18,13 @@ private func w(_ key: String, _ kind: WindowClass, _ util: Double, name: String 
     CandyWindow(key: key, name: name, kind: kind, utilization: util)
 }
 
+/// line() 이 throw 하는 provider — 라인 미로딩(오프라인/재시작 직후) 상태 재현용.
+private struct RCLineThrows: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine { throw URLError(.notConnectedToInternet) }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [] }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { nil }
+}
+
 // MARK: 순수 판정 (evaluateCandyGrants — 부수효과 분리)
 
 @MainActor
@@ -277,6 +284,22 @@ final class RareCandyStoreTests: XCTestCase {
         XCTAssertEqual(s.rareCandyCount, 0)
         XCTAssertFalse(s.canUseRareCandy)
         XCTAssertEqual(s.useRareCandy(), .unavailable)
+    }
+
+    /// [회귀 가드] 활성 포켓몬이 있어도 라인 미로딩(재시작 직후·오프라인)이면 사용 불가 —
+    /// 진화 없이 XP만 적립되는 것 방지. 재고가 있어도 소모되지 않는다.
+    func testCannotUseWhileLineUnloaded() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rc-unloaded-\(UUID().uuidString).json")
+        // 활성 포켓몬 + 사탕 1 + 시드완료 상태를 저장 → RCLineThrows 로 로드하면 currentLine 이 nil.
+        let json = #"{"installBaselineSet":true,"lastDate":"d1","active":{"baseID":1,"pathIDs":[1],"stageIndex":0,"usedAtStage":0,"rarity":"common","totalForms":3},"inventory":{"rareCandy":1},"candyFeatureSeeded":true,"dex":[],"collectedFinals":[]}"#
+        try? json.data(using: .utf8)!.write(to: url)
+        let s = CompanionStore(provider: RCLineThrows(), clock: { rcNow }, fileURL: url, rng: SeededRNG(seed: 1))
+        XCTAssertNotNil(s.state.active, "활성 포켓몬 로드")
+        XCTAssertNil(s.currentLine, "라인 미로딩(throws)")
+        XCTAssertEqual(s.rareCandyCount, 1)
+        XCTAssertFalse(s.canUseRareCandy)
+        XCTAssertEqual(s.useRareCandy(), .unavailable)
+        XCTAssertEqual(s.rareCandyCount, 1, "라인 미로딩 시 사탕 소모 안 됨")
     }
 
     /// 사용 시 "+XP" 피드백 seq 가 증가(진화 없이 부분 진행이어도).
@@ -541,6 +564,46 @@ final class RareCandyGrantIntegrationTests: XCTestCase {
         let codexNames = Dictionary(uniqueKeysWithValues: codexStore.candyEligibleWindows.map { ($0.key, $0.name) })
         XCTAssertEqual(codexNames["codex.codex.primary"], "Codex 5시간 세션")
         XCTAssertEqual(codexNames["codex.codex.secondary"], "Codex 주간")
+    }
+
+    /// utilization nil(five_hour 존재하나 값 없음) 창은 지급 대상 제외 — 옵셔널 tautology 방지
+    /// (CompanionState "값이 있나"는 의미값으로 검사 — CLAUDE.md 회귀 부류).
+    func testEligibleWindowsSkipNilUtilization() async {
+        let claude = try! JSONDecoder().decode(LimitStatus.self, from: Data(#"{"five_hour":{}}"#.utf8))
+        let store = usage(claude: claude)
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertNil(store.limits?.fiveHour?.utilization, "five_hour 는 있으나 utilization 은 nil")
+        XCTAssertTrue(store.candyEligibleWindows.isEmpty, "utilization nil → 지급 창 아님")
+    }
+
+    /// 사탕 임계(100)와 알림 임계(crit 95)는 분리 — 97%는 경고는 켜지되 사탕은 지급 0.
+    /// (두 임계가 리팩터에서 조용히 수렴하지 않도록 잠금.)
+    func testCandyThresholdSeparateFromAlertThreshold() async {
+        let c = companion()
+        c.grantCandies(from: [], limitsReady: true)   // 시드(현재 100% 없음)
+        let store = usage(claude: rcClaude(fiveHour: 97))
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(store.isLimitWarning, "97% ≥ crit 95 → 한도 경고 켜짐")
+        c.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        XCTAssertEqual(c.rareCandyCount, 0, "97% < 사탕 임계 100 → 지급 없음")
+    }
+
+    /// [문서화된 한계 잠금] 첫 시드에 한 프로바이더만 로드되면 그 프로바이더만 시드된다.
+    /// 이후 늦게 등장한 프로바이더가 이미 100%면 소급 지급된다(정상 경로는 둘 다 await 후라 원자적).
+    /// 이 동작을 잠가, 향후 "수정"이 의식적 선택이 되게 한다.
+    func testStaggeredProviderSeedRetroactiveGrant() async {
+        let c = companion()
+        let claudeStore = usage(claude: rcClaude(fiveHour: 50))   // 시드 시점 Claude 는 100 아님
+        await claudeStore.refresh(scheduleEmptyRetry: false)
+        c.grantCandies(from: claudeStore.candyEligibleWindows, limitsReady: claudeStore.limitsReady)  // 시드(Claude만)
+        XCTAssertTrue(c.state.candyFeatureSeeded)
+        XCTAssertEqual(c.rareCandyCount, 0)
+        // 이후: Codex 가 이미 100% 인 채 처음 등장 → 시드 안 돼 소급 지급
+        let codexStore = usage(codex: rcCodex(primary: 100),
+                               providers: [RCFakeProvider(id: "codex", displayName: "Codex", daily: rcDaily(1_000))])
+        await codexStore.refresh(scheduleEmptyRetry: false)
+        c.grantCandies(from: codexStore.candyEligibleWindows, limitsReady: codexStore.limitsReady)
+        XCTAssertEqual(c.rareCandyCount, 1, "문서화된 한계: 늦게 등장한 100% 창은 소급 지급됨")
     }
 }
 


### PR DESCRIPTION
## 무엇을
홍보 착수를 앞두고 README 상단(above-the-fold) 포지셔닝을 "유틸리티 우선" → "컴패니언(재미) 우선"으로 재배치. 기능 설명 섹션은 모두 보존.

## 변경
- **인트로 문단**: 첫 절을 "이미 태우고 있는 토큰을 자라나는 포켓몬 컴패니언으로"로 전환. 정확한 사용량 트래커(오늘 사용량·비용·공식 5h/주간 한도)는 그 아래 근거 문장으로 유지.
- **"왜" 섹션**: 첫 항목을 `열어보는 게 즐거운 사용량 트래커`로 승격. 사용량 한눈에·공식 한도 추적은 후순위로.
- **보존**: How it works / Tour / Also in the box / Install / Data sources / Privacy / License 그대로.
- **3개 언어**(en/ko/ja) 동일 적용.

## 미변경
- 스크린샷/에셋 변경 없음(UI 무변경). 기능·데이터 소스·면책 문구 동일.