### PR TITLE
feat: Claude 요금제(구독 플랜) 팝오버 표시

### DIFF
--- a/Sources/PokeTokenBar/Core/Models.swift
+++ b/Sources/PokeTokenBar/Core/Models.swift
@@ -197,6 +197,10 @@ struct LimitStatus: Decodable, Sendable {
     var sevenDayOpus: LimitWindow?
     var sevenDaySonnet: LimitWindow?
     var limits: [OAuthLimitEntry]?
+    /// 계정 구독 정보 — HTTP usage 응답이 아니라 OAuth 자격증명(Keychain)에서 주입한다.
+    /// CodingKeys 에 없어 디코드 시 무시되고, OAuthLimitsProvider.fetch 가 채운다.
+    var subscriptionType: String?
+    var rateLimitTier: String?
 
     private enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
@@ -204,6 +208,29 @@ struct LimitStatus: Decodable, Sendable {
         case sevenDayOpus = "seven_day_opus"
         case sevenDaySonnet = "seven_day_sonnet"
         case limits
+    }
+
+    /// subscriptionType(max/pro/free) + rateLimitTier 배수를 합친 표시 문자열.
+    /// 예: subscriptionType="max", rateLimitTier="default_claude_max_20x" → "Max 20x".
+    /// 배수는 등급과 무관하게 tier 에 배수 토큰이 있을 때만 붙는다(Max 전용 분기 아님).
+    /// tier 에 배수 토큰이 없으면 등급명만("Pro"/"Free"), 구독 정보가 없으면 nil.
+    var planDisplay: String? {
+        guard let subscriptionType, !subscriptionType.isEmpty else { return nil }
+        let base = subscriptionType.prefix(1).uppercased() + subscriptionType.dropFirst()
+        if let tier = rateLimitTier, let multiplier = Self.tierMultiplier(from: tier) {
+            return "\(base) \(multiplier)"
+        }
+        return base
+    }
+
+    /// rateLimitTier 끝의 배수 토큰("20x"/"5x") 추출 — "_" 로 나눠 숫자+x 형태를 찾는다.
+    /// 배수가 없는 등급("default_claude_pro")은 nil → 등급명만 표시.
+    private static func tierMultiplier(from tier: String) -> String? {
+        for part in tier.split(separator: "_") where part.hasSuffix("x") {
+            let digits = part.dropLast()
+            if !digits.isEmpty, digits.allSatisfy(\.isNumber) { return String(part) }
+        }
+        return nil
     }
 
     /// 레거시 필드가 못 담는 윈도우 — session(=five_hour)·weekly_all(=seven_day)은 레거시 행이

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -24,18 +24,24 @@ struct OAuthLimitsProvider: ClaudeLimitsProviding, Sendable {
 
     func fetch(allowKeychainPrompt: Bool = false) async throws -> LimitStatus {
         let token = try await accessTokenCache.accessToken(allowKeychainPrompt: allowKeychainPrompt)
+        var status: LimitStatus
         do {
-            return try await fetchStatus(accessToken: token)
+            status = try await fetchStatus(accessToken: token)
         } catch let error as LimitsError {
-            guard case .httpStatus(let status) = error, status == 401 || status == 403 else {
+            guard case .httpStatus(let httpStatus) = error, httpStatus == 401 || httpStatus == 403 else {
                 throw error
             }
             await accessTokenCache.invalidate(removePersistentCache: true)
             let refreshed = try await accessTokenCache.accessToken(
                 allowKeychainPrompt: allowKeychainPrompt, bypassCache: true)
             guard refreshed != token else { throw error }
-            return try await fetchStatus(accessToken: refreshed)
+            status = try await fetchStatus(accessToken: refreshed)
         }
+        // 플랜은 usage 응답이 아니라 방금 읽은 자격증명(캐시)에 담겨 있다 — 추가 Keychain 접근 없음.
+        let plan = await accessTokenCache.planInfo()
+        status.subscriptionType = plan.subscriptionType
+        status.rateLimitTier = plan.rateLimitTier
+        return status
     }
 
     private func fetchStatus(accessToken: String) async throws -> LimitStatus {
@@ -134,6 +140,12 @@ private actor OAuthAccessTokenCache {
         return (status & SecKeychainStatus(kSecUnlockStateStatus)) == 0   // unlock 비트 꺼짐 = 잠김
     }
 
+    /// 마지막으로 사용한 자격증명의 플랜 정보. accessToken() 이 모든 경로에서 cachedCredential 을
+    /// 반환 토큰과 일치시키므로, fetch 가 토큰 취득 직후 호출하면 동일 자격증명 기준이다.
+    func planInfo() -> (subscriptionType: String?, rateLimitTier: String?) {
+        (cachedCredential?.subscriptionType, cachedCredential?.rateLimitTier)
+    }
+
     func invalidate(removePersistentCache: Bool = false) {
         // 앱 자체 키체인 캐시는 코드서명이 바뀔 때마다(재빌드·실사용자 매 업그레이드) 항목 ACL 이
         // 안 맞아 write/삭제 시 접근 허용 프롬프트를 유발했다(no-UI 로도 억제 안 됨) → 제거.
@@ -193,6 +205,9 @@ enum OAuthCredentialData {
         let accessToken: String
         let expiresAt: Date?
         let data: Data
+        /// 구독 등급(max/pro/free)과 rate limit 티어(default_claude_max_20x 등) — 플랜 표시용.
+        let subscriptionType: String?
+        let rateLimitTier: String?
 
         var isExpired: Bool {
             guard let expiresAt else { return false }
@@ -208,7 +223,12 @@ enum OAuthCredentialData {
         else {
             return nil
         }
-        return Credential(accessToken: token, expiresAt: expiresAt(from: oauth["expiresAt"]), data: data)
+        return Credential(
+            accessToken: token,
+            expiresAt: expiresAt(from: oauth["expiresAt"]),
+            data: data,
+            subscriptionType: oauth["subscriptionType"] as? String,
+            rateLimitTier: oauth["rateLimitTier"] as? String)
     }
 
     private static func expiresAt(from raw: Any?) -> Date? {

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -273,6 +273,12 @@ struct PopoverView: View {
                 claudeAuthExpiredNotice
             }
             if selectedSnapshot?.providerID == "claude_code", let limits = store.limits {
+                // 플랜(계정 속성) — Codex codexMetaRow 와 동일 스타일. 구독 정보 있을 때만 노출.
+                if let plan = limits.planDisplay {
+                    Text(l.plan(plan))
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
                 // 세션 만료 안내가 이미 있으면 stale 배지는 생략(중복 신호 방지)
                 if store.claudeLimitsStale, !store.limitsAuthExpired {
                     staleBadge(updatedAt: store.limitsUpdatedAt)

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -214,6 +214,56 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(status.scopedLimitEntries.count, 2)
     }
 
+    /// 플랜 표시 문자열 — subscriptionType + rateLimitTier 조립. Max 는 배수까지 세분화.
+    /// 조합표 전수: {max×20x, max×5x, pro×배수없음, free×nil, 구독없음}.
+    func testPlanDisplay() throws {
+        var status = try JSONDecoder().decode(LimitStatus.self, from: Data("{}".utf8))
+
+        status.subscriptionType = "max"
+        status.rateLimitTier = "default_claude_max_20x"
+        XCTAssertEqual(status.planDisplay, "Max 20x")
+
+        status.rateLimitTier = "default_claude_max_5x"
+        XCTAssertEqual(status.planDisplay, "Max 5x")
+
+        // 배수 토큰이 없는 등급 → 등급명만
+        status.subscriptionType = "pro"
+        status.rateLimitTier = "default_claude_pro"
+        XCTAssertEqual(status.planDisplay, "Pro")
+
+        // 티어가 nil 이어도 등급명은 표시
+        status.subscriptionType = "free"
+        status.rateLimitTier = nil
+        XCTAssertEqual(status.planDisplay, "Free")
+
+        // 구독 정보가 없으면 플랜 행 자체를 숨긴다
+        status.subscriptionType = nil
+        XCTAssertNil(status.planDisplay)
+
+        // 빈 문자열도 표시 안 함
+        status.subscriptionType = ""
+        XCTAssertNil(status.planDisplay)
+    }
+
+    /// 자격증명 파싱이 subscriptionType/rateLimitTier 를 추출하는지 — 실 keychain JSON 형태 기반.
+    func testCredentialParsesPlanFields() throws {
+        let json = Data("""
+        {"claudeAiOauth":{"accessToken":"tok","expiresAt":9999999999999,
+        "subscriptionType":"max","rateLimitTier":"default_claude_max_20x"}}
+        """.utf8)
+        let credential = try XCTUnwrap(OAuthCredentialData.credential(from: json))
+        XCTAssertEqual(credential.subscriptionType, "max")
+        XCTAssertEqual(credential.rateLimitTier, "default_claude_max_20x")
+
+        // 플랜 필드가 없는 구형 자격증명도 파싱은 성공(플랜만 nil)
+        let legacy = Data("""
+        {"claudeAiOauth":{"accessToken":"tok","expiresAt":9999999999999}}
+        """.utf8)
+        let legacyCredential = try XCTUnwrap(OAuthCredentialData.credential(from: legacy))
+        XCTAssertNil(legacyCredential.subscriptionType)
+        XCTAssertNil(legacyCredential.rateLimitTier)
+    }
+
     func testCodexRateLimitStatus() throws {
         let json = """
         {"rateLimits":{"limitId":"codex","limitName":null,


### PR DESCRIPTION
## 변경
Claude Code 구독 플랜을 팝오버 한도 섹션에 표시. Codex 플랜 표시(`codexMetaRow`)와 동일 스타일로 통일.

### 표시 규칙 (조합표)
| subscriptionType × rateLimitTier | 표시 |
|---|---|
| `max` × `default_claude_max_20x` | **Max 20x** |
| `max` × `default_claude_max_5x` | Max 5x |
| `pro` × `default_claude_pro` (배수 토큰 없음) | Pro |
| `free` × nil | Free |
| 구독 정보 없음 / 빈 문자열 | 행 숨김 |

배수는 등급과 무관하게 tier 에 `<숫자>x` 토큰이 있을 때만 붙는다(Max 전용 분기 아님).

### 데이터 경로 (추가 Keychain 접근 0)
- `OAuthCredentialData.credential(from:)` — `claudeAiOauth.subscriptionType`/`rateLimitTier` 파싱.
- `OAuthAccessTokenCache.planInfo()` — access token 취득 시 이미 캐시된 자격증명 재사용.
- `OAuthLimitsProvider.fetch()` — HTTP usage 응답(`LimitStatus`)에 플랜 주입.
- `LimitStatus.planDisplay` — 순수 함수(등급명 + 배수 조립).
- `PopoverView` — `limits.planDisplay != nil` 일 때만 렌더(메뉴바 아님, 팝오버 전용).

### 확장 규약 준수
- 게이트는 `subscriptionType == nil` — 리터럴 `== "claude_code"` 분기 아님.
- 플랜은 팝오버 상세 전용, 메뉴바 미변경.

### 테스트
- `testPlanDisplay` — 조합표 전수(max/pro/free/nil/빈문자열).
- `testCredentialParsesPlanFields` — 파싱 + 플랜 없는 구형 자격증명 폴백.
- 전체 232개 통과.

### 참고
- Gemini 는 로컬 로그에 구독 정보가 없어 미적용.
- UI 변경 → 다음 릴리스 시 `assets/` 팝오버 스크린샷 재생성 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)