### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!-- Write the PR title and this description in English (see CONTRIBUTING.md). -->
+
+## Summary
+
+<!-- What does this PR do, and why? Keep it focused. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] Other:
+
+## UI changes
+
+<!--
+REQUIRED when this PR changes anything under `Sources/PokeTokenBar/UI/`:
+attach **before/after** images (screenshots or GIFs) so reviewers can compare
+the old and new UI side by side. Remove this section only if there are no UI
+changes.
+-->
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+## Checklist
+
+- [ ] `swift build` and `swift test` pass locally
+- [ ] PR title and description are written in English
+- [ ] **UI changes include before/after images** in the section above
+- [ ] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
+- [ ] Tests were added or updated for this change


### PR DESCRIPTION
## Summary

Add `.github/PULL_REQUEST_TEMPLATE.md` so new pull requests are pre-filled with a consistent structure.

Key points:
- **Requires before/after images for any UI change** (anything under `Sources/PokeTokenBar/UI/`) — a dedicated Before/After table plus a checklist item.
- Checklist: `swift build`/`swift test` pass, English PR text, no copyrighted assets/secrets/private tooling, tests updated.

## Type of change

- [x] Documentation / repo tooling

## Checklist

- [x] Docs/tooling only — no source changes
- [x] PR text in English