### PR TITLE
feat: token shop — buy Rare Candy with used tokens

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -85,6 +85,19 @@ enum PokemonBalance {
 /// 인벤토리 아이템 종류 — 확장 대비 enum(현재 이상한 사탕 1종). rawValue 로 CompanionState.inventory 에 저장.
 enum ItemKind: String, Codable, Sendable, CaseIterable {
     case rareCandy
+
+    /// PokéAPI 아이템 스프라이트 파일명(.../sprites/items/{name}.png). nil = 스프라이트 없음(이모지 폴백만).
+    var spriteName: String? {
+        switch self {
+        case .rareCandy: return "rare-candy"
+        }
+    }
+    /// 스프라이트 로딩 전/미제공/실패 시 폴백 이모지.
+    var fallbackEmoji: String {
+        switch self {
+        case .rareCandy: return "🍬"
+        }
+    }
 }
 
 /// 이상한 사탕 밸런스 상수.
@@ -94,6 +107,11 @@ enum RareCandy {
     static let xp = 100_000_000
     /// 주간 한도 100% 도달 시 지급 개수(세션급은 1개).
     static let weeklyGrant = 5
+    /// 상점 구매가(재화 = 사용한 토큰: usedSinceInstall − spentTokens). XP 값어치(100M)의 5배.
+    /// 토큰이 "성장 미터 + 상점 지갑"으로 이중 사용되는 구조라, 가격을 XP 와 같게 두면 구매가 사실상
+    /// 공짜 추가성장(150M 써서 250M 성장)이 된다. 500M 로 두면 그 값 모으는 500M 패시브 성장 + 사탕
+    /// 100M = 실질 보너스 +20% 로 억제된다. 무료 획득(한도 100% 보상)이 항상 이득이도록 값어치보다 비싸게.
+    static let price = 500_000_000
 }
 
 /// 사탕 지급 대상 한도 창의 분류 — session=1개·weekly=weeklyGrant.
@@ -286,6 +304,9 @@ struct CompanionState: Codable, Sendable {
     // 토큰: 설치 이후만 측정
     var installBaselineSet = false
     var usedSinceInstall = 0
+    // 상점에서 쓴 토큰 누적(재화 지출 원장). 쓸 수 있는 재화 = usedSinceInstall − spentTokens.
+    // 성장 미터(usedSinceInstall)는 불변 — 구매는 이 값만 올려 잔액을 깎는다(성장 되감김 없음).
+    var spentTokens = 0
     // 현재 알이 생긴 뒤 쓴 토큰(부화 인큐베이션). 누적(usedSinceInstall)과 별개 — 졸업 후 새 알마다 0.
     var eggUsage = 0
     // 알 상태에서 미리 롤해둔 부화 종(프리패칭) — 부화 순간 네트워크 딜레이 제거. 재시작에도 유지.
@@ -313,6 +334,7 @@ struct CompanionState: Codable, Sendable {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         installBaselineSet = try c.decodeIfPresent(Bool.self, forKey: .installBaselineSet) ?? false
         usedSinceInstall = try c.decodeIfPresent(Int.self, forKey: .usedSinceInstall) ?? 0
+        spentTokens = try c.decodeIfPresent(Int.self, forKey: .spentTokens) ?? 0
         eggUsage = try c.decodeIfPresent(Int.self, forKey: .eggUsage) ?? 0
         pendingHatchID = try c.decodeIfPresent(Int.self, forKey: .pendingHatchID)
         claimedTodayTokens = try c.decodeIfPresent(Int.self, forKey: .claimedTodayTokens) ?? 0

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -307,6 +307,26 @@ final class CompanionStore {
         return .progressed
     }
 
+    // MARK: 상점 (재화 = 사용한 토큰)
+
+    /// 상점에서 쓸 수 있는 토큰(재화) = 실사용 누적 − 상점 지출 누적. 성장 미터(usedSinceInstall)는
+    /// 여기선 읽기만 — 구매는 spentTokens 만 올려 잔액을 깎는다(진화 진행·오늘/주/월 통계 무영향).
+    var availableTokens: Int { max(0, state.usedSinceInstall - state.spentTokens) }
+
+    /// 이상한 사탕 구매 가능 — 잔액이 가격 이상. 활성/알 무관(재고는 미리 쌓아둘 수 있음, 사용만 부화 후).
+    var canBuyRareCandy: Bool { availableTokens >= RareCandy.price }
+
+    /// 이상한 사탕 1개 구매 — 지갑에서 price 차감, 인벤토리 +1. usedSinceInstall(성장·통계)·진화 진행엔
+    /// 무영향(지출 원장만 증가). 잔액 부족이면 no-op(false) — 뷰가 이미 버튼을 비활성화하지만 이중 가드.
+    @discardableResult
+    func buyRareCandy() -> Bool {
+        guard canBuyRareCandy else { return false }
+        state.spentTokens += RareCandy.price
+        state.inventory[ItemKind.rareCandy.rawValue, default: 0] += 1
+        save()
+        return true
+    }
+
     /// 지급 판정(순수·엣지 트리거) — 한도 창이 100% 를 새로 넘어선 순간에만 지급.
     /// - 100% 미만 → 맵에서 제거(재무장). resets_at 등 휘발 필드는 key 에 없다(안정 식별자만).
     /// - 이미 지급한 창(tier≥1)은 재지급 안 함. session=1개·weekly=weeklyGrant.

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -324,6 +324,16 @@ struct L {
         }
     }
 
+    // MARK: 상점 (재화 = 사용한 토큰)
+    var shop: String { t("상점", "Shop", "ショップ") }
+    var spendableTokens: String { t("쓸 수 있는 토큰", "Spendable tokens", "使えるトークン") }
+    var shopHint: String { t("사용한 토큰으로 아이템을 살 수 있어요.", "Spend the tokens you've used on items.", "使ったトークンでアイテムを購入できます。") }
+    var buy: String { t("구매", "Buy", "購入") }
+    func buyConfirm(_ name: String) -> String { t("\(name) 구매할까요?", "Buy \(name)?", "\(name) を購入しますか？") }
+    var notEnoughTokens: String { t("토큰이 부족해요", "Not enough tokens", "トークンが足りません") }
+    func ownedCount(_ n: Int) -> String { t("보유 ×\(n)", "Owned ×\(n)", "所持 ×\(n)") }
+    var shopPriceLabel: String { t("가격", "Price", "価格") }
+
     // MARK: 사탕 획득 알림 ("왜 받는지" = 토큰 한도를 다 채운 수고에 대한 보상)
     func notifCandyTitle(item: String, count: Int) -> String {
         t("🍬 \(item) \(count)개를 받았어요!",

--- a/Sources/PokeTokenBar/UI/BagView.swift
+++ b/Sources/PokeTokenBar/UI/BagView.swift
@@ -47,7 +47,7 @@ private struct ItemCard: View {
         let l = store.l
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 10) {
-                Text(icon).font(.system(size: 30))
+                ItemIconView(kind: kind, size: 30)
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 6) {
                         Text(l.itemName(kind)).font(.callout.weight(.semibold))
@@ -101,11 +101,5 @@ private struct ItemCard: View {
         confirming = false
         _ = store.useRareCandy()
         nav.tab = .home
-    }
-
-    private var icon: String {
-        switch kind {
-        case .rareCandy: return "🍬"
-        }
     }
 }

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -9,6 +9,36 @@ func rarityColor(_ r: Rarity?) -> Color {
     }
 }
 
+/// 아이템 아이콘 — 실제 스프라이트(런타임 로드+캐시) 우선, 로딩 전/미제공/실패 시 이모지 폴백.
+struct ItemIconView: View {
+    let kind: ItemKind
+    var size: CGFloat = 30
+    @State private var img: NSImage?
+
+    init(kind: ItemKind, size: CGFloat = 30) {
+        self.kind = kind
+        self.size = size
+        // 캐시에 있으면 즉시(동기) 표시 — 재렌더 플래시 방지.
+        _img = State(initialValue: kind.spriteName.flatMap { SpriteLoader.cachedItemImage(name: $0) })
+    }
+
+    var body: some View {
+        Group {
+            if let img {
+                Image(nsImage: img).resizable().interpolation(.none)
+                    .frame(width: size, height: size)
+            } else {
+                Text(kind.fallbackEmoji).font(.system(size: size))
+                    .frame(width: size, height: size)
+            }
+        }
+        .task(id: kind.spriteName ?? "") {
+            guard img == nil, let name = kind.spriteName else { return }
+            img = await SpriteLoader.itemImage(name: name)
+        }
+    }
+}
+
 /// 스프라이트 1개(런타임 로드 + 캐시). 없으면 알 글리프. bob 으로 가벼운 상하 움직임.
 /// animated=true 면 Gen-V GIF 프레임을 순환(미지원/오프라인이면 정적+bob 으로 폴백).
 struct SpriteView: View {

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-enum PopoverTab { case home, bag, collection }
+enum PopoverTab { case home, shop, bag, collection }
 
 /// 팝오버 내부 내비게이션 상태(현재 탭 / 설정 표시 여부).
 /// NSHostingController 는 팝오버를 닫아도 재사용되어 @State 가 유지되므로, 화면 상태를 이
@@ -72,6 +72,7 @@ struct PopoverView: View {
             updateBanner
             Picker("", selection: $nav.tab) {
                 Text(l.home).tag(PopoverTab.home)
+                Text(l.shop).tag(PopoverTab.shop)
                 Text(l.bag).tag(PopoverTab.bag)
                 Text(l.collection).tag(PopoverTab.collection)
             }
@@ -82,6 +83,8 @@ struct PopoverView: View {
                 CollectionView(store: companion)
             } else if nav.tab == .bag {
                 BagView(store: companion, nav: nav)
+            } else if nav.tab == .shop {
+                ShopView(store: companion)
             } else {
                 CompanionHeader(store: companion)
                 Divider()

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// 상점 — 사용한 토큰(재화 = usedSinceInstall − spentTokens)으로 아이템 구매. v1: 이상한 사탕.
+/// 인라인 확인(버튼 morph) — .sheet/.alert 금지(BagView 주석과 동일: transient 팝오버가 닫힐 때
+/// 고아 시트가 이후 클릭을 먹통내는 결함 회피).
+struct ShopView: View {
+    let store: CompanionStore
+
+    var body: some View {
+        let l = store.l
+        // 고정 높이 — 컬렉션/가방과 동일(팝오버 재오픈 시 fitting size 축소 방지).
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                walletHeader(l)
+                ShopItemCard(store: store, kind: .rareCandy, price: RareCandy.price)
+            }
+        }
+        .frame(height: 520)
+    }
+
+    private func walletHeader(_ l: L) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(l.spendableTokens)
+                .font(.caption).foregroundStyle(.secondary)
+            Text(TokenFormatter.compact(store.availableTokens))
+                .font(.system(size: 24, weight: .bold)).monospacedDigit()
+            Text(l.shopHint)
+                .font(.caption2).foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+/// 상점 아이템 1장 — 아이콘·이름·설명·보유수 + 가격/구매(인라인 확인).
+/// v1 은 이상한 사탕만 판매하므로 구매 동작을 store.buyRareCandy 로 직접 호출한다. 스톤 추가(v1.5) 시
+/// store 에 kind 별 buy(kind)/canBuy(kind) 를 두어 일반화한다.
+private struct ShopItemCard: View {
+    let store: CompanionStore
+    let kind: ItemKind
+    let price: Int
+    @State private var confirming = false
+
+    var body: some View {
+        let l = store.l
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 10) {
+                ItemIconView(kind: kind, size: 30)
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(l.itemName(kind)).font(.callout.weight(.semibold))
+                        let owned = store.itemCount(kind)
+                        if owned > 0 {
+                            Text(l.ownedCount(owned)).font(.caption2.weight(.bold))
+                                .foregroundStyle(.secondary).monospacedDigit()
+                        }
+                    }
+                    Text(l.itemDescription(kind))
+                        .font(.caption).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer()
+            }
+            buyControls(l)
+        }
+        .padding(10)
+        .background(Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    @ViewBuilder
+    private func buyControls(_ l: L) -> some View {
+        if confirming {
+            HStack(spacing: 8) {
+                Text(l.buyConfirm(l.itemName(kind)))
+                    .font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                Spacer()
+                Button(l.buy) { buyNow() }
+                    .buttonStyle(.borderedProminent).controlSize(.small)
+                Button(l.cancel) { confirming = false }
+                    .buttonStyle(.borderless).controlSize(.small)
+            }
+        } else {
+            HStack {
+                Text("\(l.shopPriceLabel) \(TokenFormatter.compact(price))")
+                    .font(.caption2).foregroundStyle(.tertiary).monospacedDigit()
+                Spacer()
+                if store.canBuyRareCandy {
+                    Button(l.buy) { confirming = true }
+                        .buttonStyle(.bordered).controlSize(.small)
+                } else {
+                    Text(l.notEnoughTokens)
+                        .font(.caption2).foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    private func buyNow() {
+        confirming = false
+        _ = store.buyRareCandy()
+    }
+}

--- a/Sources/PokeTokenBar/UI/SpriteLoader.swift
+++ b/Sources/PokeTokenBar/UI/SpriteLoader.swift
@@ -4,6 +4,7 @@ import AppKit
 actor SpriteStore {
     static let shared = SpriteStore()
     private let base = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon"
+    private let itemBase = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/items"
     private var mem: [String: Data] = [:]
     private var memOrder: [String] = []   // LRU 순서(최근 접근이 뒤). 상한 초과 시 앞(오래된 것)부터 evict
     private let memLimit = 24              // in-memory 스프라이트 캐시 상한 — 세션 중 종 변경 누적 무한증가 방지(#H1)
@@ -36,6 +37,21 @@ actor SpriteStore {
               let (d, resp) = try? await URLSession.shared.data(from: url),
               (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
         try? d.write(to: file, options: .atomic)   // torn write 방지 — 크래시/강제종료 시 손상 캐시가 남지 않게
+        remember(key, d)
+        return d
+    }
+
+    /// 아이템 스프라이트(정적 PNG, 이름 기반). 포켓몬과 같은 메모리/디스크 캐시 사용(키 "item-<name>",
+    /// 포켓몬 파일 "<id>-..." 과 안 겹침). 미제공(404)/오프라인이면 nil → 뷰가 이모지로 폴백.
+    func data(itemName: String) async -> Data? {
+        let key = "item-\(itemName)"
+        if let d = mem[key] { touch(key); return d }
+        let file = dir.appendingPathComponent("\(key).png")
+        if let d = try? Data(contentsOf: file) { remember(key, d); return d }
+        guard let url = URL(string: "\(itemBase)/\(itemName).png"),
+              let (d, resp) = try? await URLSession.shared.data(from: url),
+              (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
+        try? d.write(to: file, options: .atomic)
         remember(key, d)
         return d
     }
@@ -88,5 +104,18 @@ enum SpriteLoader {
         // shiny 미제공 → 일반 폴백
         guard shiny else { return nil }
         return await image(speciesID: speciesID, animated: animated, shiny: false)
+    }
+
+    /// 아이템 스프라이트 — 디스크 캐시 동기 조회(없으면 nil). 아이콘 즉시 표시용(재렌더 플래시 방지).
+    static func cachedItemImage(name: String) -> NSImage? {
+        let f = cacheDir.appendingPathComponent("item-\(name).png")
+        if let d = try? Data(contentsOf: f), let img = NSImage(data: d) { return img }
+        return nil
+    }
+
+    /// 아이템 스프라이트 — 런타임 로드(+캐시). 미제공/실패면 nil(뷰가 이모지로 폴백).
+    static func itemImage(name: String) async -> NSImage? {
+        guard let d = await SpriteStore.shared.data(itemName: name), let img = NSImage(data: d) else { return nil }
+        return img
     }
 }

--- a/Tests/PokeTokenBarTests/ShopTests.swift
+++ b/Tests/PokeTokenBarTests/ShopTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import PokeTokenBar
+
+// MARK: 상점 (재화 = usedSinceInstall − spentTokens, 이상한 사탕 구매)
+
+/// 라인 로딩이 필요 없는 상점 테스트용 provider(항상 throw — 지갑/구매는 라인과 무관).
+private struct ShopNoProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine { throw URLError(.notConnectedToInternet) }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [] }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { nil }
+}
+
+@MainActor
+final class ShopTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// usedSinceInstall/spentTokens 를 직접 지정한 상태 파일을 만들어 로드 — 지갑 잔액을 결정적으로
+    /// 세팅(update() 의 delta 적립 경로를 우회). testCannotUseWhileLineUnloaded 와 동일한 JSON 시드 패턴.
+    private func store(used: Int, spent: Int = 0, rareCandy: Int = 0,
+                       file: String = #filePath) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("shop-\(UUID().uuidString).json")
+        let inv = rareCandy > 0 ? ",\"inventory\":{\"rareCandy\":\(rareCandy)}" : ""
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":\(used),\"spentTokens\":\(spent),"
+            + "\"lastDate\":\"d\",\"dex\":[],\"collectedFinals\":[]\(inv)}"
+        try? json.data(using: .utf8)!.write(to: url)
+        return CompanionStore(provider: ShopNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: 1))
+    }
+
+    // MARK: 잔액 계산
+
+    func testAvailableEqualsUsedWhenNothingSpent() {
+        XCTAssertEqual(store(used: 1_000_000_000).availableTokens, 1_000_000_000)
+    }
+
+    func testAvailableSubtractsSpent() {
+        XCTAssertEqual(store(used: 1_000_000_000, spent: 300_000_000).availableTokens, 700_000_000)
+    }
+
+    /// spent > used(비정상 상태 파일)이어도 음수로 새지 않는다(max 가드).
+    func testAvailableNeverNegative() {
+        XCTAssertEqual(store(used: 100_000_000, spent: 500_000_000).availableTokens, 0)
+    }
+
+    /// 하위호환: spentTokens 키 없는 구버전 저장 → 0 으로 로드(잔액 = used).
+    func testDecodesWithoutSpentTokens() throws {
+        let json = #"{"installBaselineSet":true,"usedSinceInstall":900,"lastDate":"d","dex":[]}"#
+        let s = try JSONDecoder().decode(CompanionState.self, from: Data(json.utf8))
+        XCTAssertEqual(s.spentTokens, 0)
+        XCTAssertEqual(s.usedSinceInstall, 900)
+    }
+
+    func testSpentTokensRoundTrip() throws {
+        var st = CompanionState()
+        st.usedSinceInstall = 1000
+        st.spentTokens = 400
+        let round = try JSONDecoder().decode(CompanionState.self, from: JSONEncoder().encode(st))
+        XCTAssertEqual(round.spentTokens, 400)
+    }
+
+    // MARK: 구매 가능 판정 (경계)
+
+    func testCanBuyAtExactPrice() {
+        XCTAssertTrue(store(used: RareCandy.price).canBuyRareCandy)
+    }
+
+    func testCannotBuyOneBelowPrice() {
+        XCTAssertFalse(store(used: RareCandy.price - 1).canBuyRareCandy)
+    }
+
+    // MARK: 구매 (차감 + 적립 + 영속)
+
+    func testBuyDebitsWalletAndCreditsInventory() {
+        let s = store(used: 1_000_000_000)
+        XCTAssertTrue(s.buyRareCandy())
+        XCTAssertEqual(s.rareCandyCount, 1)
+        XCTAssertEqual(s.state.spentTokens, RareCandy.price)
+        XCTAssertEqual(s.availableTokens, 1_000_000_000 - RareCandy.price)
+        XCTAssertEqual(s.state.usedSinceInstall, 1_000_000_000, "성장 미터(usedSinceInstall)는 불변")
+    }
+
+    /// 잔액 부족이면 no-op — 인벤토리·지출 원장 불변, false 반환.
+    func testBuyInsufficientIsNoOp() {
+        let s = store(used: 400_000_000)
+        XCTAssertFalse(s.buyRareCandy())
+        XCTAssertEqual(s.rareCandyCount, 0)
+        XCTAssertEqual(s.state.spentTokens, 0)
+    }
+
+    /// 여러 번 구매하면 잔액이 바닥날 때까지만 성공(가드가 매번 재평가).
+    func testMultipleBuysUntilBroke() {
+        let s = store(used: 1_200_000_000)          // 2개까지 가능(1B), 3번째 실패(잔액 200M)
+        XCTAssertTrue(s.buyRareCandy())
+        XCTAssertTrue(s.buyRareCandy())
+        XCTAssertFalse(s.buyRareCandy())
+        XCTAssertEqual(s.rareCandyCount, 2)
+        XCTAssertEqual(s.state.spentTokens, 2 * RareCandy.price)
+        XCTAssertEqual(s.availableTokens, 200_000_000)
+    }
+
+    /// 구매는 이미 가진 사탕에 합산된다(무료 지급분과 같은 인벤토리).
+    func testBuyAddsToExistingStock() {
+        let s = store(used: 1_000_000_000, rareCandy: 3)
+        XCTAssertTrue(s.buyRareCandy())
+        XCTAssertEqual(s.rareCandyCount, 4)
+        XCTAssertEqual(s.ownedItems.first?.kind, .rareCandy)
+        XCTAssertEqual(s.ownedItems.first?.count, 4)
+    }
+
+    /// [영속] 재시작(같은 파일 재로드) 후 지출·재고가 유지된다.
+    func testBuyPersistsAcrossRestart() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("shop-persist-\(UUID().uuidString).json")
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":1000000000,\"spentTokens\":0,"
+            + "\"lastDate\":\"d\",\"dex\":[],\"collectedFinals\":[]}"
+        try? json.data(using: .utf8)!.write(to: url)
+        let s1 = CompanionStore(provider: ShopNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: 1))
+        XCTAssertTrue(s1.buyRareCandy())
+
+        let s2 = CompanionStore(provider: ShopNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: 1))
+        XCTAssertEqual(s2.rareCandyCount, 1, "재고 영속")
+        XCTAssertEqual(s2.state.spentTokens, RareCandy.price, "지출 영속")
+        XCTAssertEqual(s2.availableTokens, 1_000_000_000 - RareCandy.price)
+    }
+}


### PR DESCRIPTION
## Summary

Add a **Shop** tab where accumulated tokens are spent on items. v1 sells **Rare Candy**.

Currency = `availableTokens = usedSinceInstall − spentTokens`. The growth meter (`usedSinceInstall`) stays monotonic and is untouched by purchases — buying only increments `spentTokens`, so it never affects growth, evolution, or the today/week/month usage stats. Rare Candy costs **500M** (5× its 100M XP value), so the "growth from buying" bonus stays modest; earning candy for free by maxing a usage limit remains the better deal.

This PR also swaps the Rare Candy icon from an emoji to the **real item sprite**, fetched at runtime from PokeAPI (cache key `item-<name>`, never bundled) with an emoji fallback when offline or missing.

## Type of change

- [x] New feature

## UI changes

Before/after is described in text below. Images are not embedded here because attaching an image to a PR body needs GitHub's web upload (not available from the CLI this PR was opened with) — not because capture is blocked. The `assets/` screenshots are regenerated at release.

| Before | After |
| ------ | ----- |
| Tabs = Home / Bag / Collection. Rare Candy shown as a 🍬 emoji in the Bag. | New **Shop** tab (Home / **Shop** / Bag / Collection) with a spendable-token wallet header and a Rare Candy buy card (inline confirm). Rare Candy now renders the real item sprite in both Shop and Bag. |

## Checklist

- [x] `swift build` and `swift test` pass locally (244 tests, 0 failures)
- [x] PR title and description are written in English
- [ ] **UI changes include before/after images** — described in text; PR-body image embedding needs GitHub web upload (not available via CLI). Screenshots regenerated at release.
- [x] No copyrighted assets, secrets, or private tooling references are committed (item sprite is fetched at runtime, never bundled)
- [x] Tests were added or updated for this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
