### PR TITLE
docs: make PR before/after images optional for UI changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,10 +15,11 @@
 ## UI changes
 
 <!--
-REQUIRED when this PR changes anything under `Sources/PokeTokenBar/UI/`:
-attach **before/after** images (screenshots or GIFs) so reviewers can compare
-the old and new UI side by side. Remove this section only if there are no UI
-changes.
+When this PR changes anything under `Sources/PokeTokenBar/UI/`, describe the
+before/after below. Images (screenshots or GIFs) are welcome but optional — a
+clear text description is fine. The canonical app screenshots in `assets/` are
+regenerated at release, so they don't need updating per PR. Remove this section
+only if there are no UI changes.
 -->
 
 | Before | After |
@@ -29,6 +30,6 @@ changes.
 
 - [ ] `swift build` and `swift test` pass locally
 - [ ] PR title and description are written in English
-- [ ] **UI changes include before/after images** in the section above
+- [ ] UI changes are described above (before/after — images optional)
 - [ ] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
 - [ ] Tests were added or updated for this change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,10 @@ Because the repository squash-merges, the PR title becomes the commit subject on
 - Use [Conventional Commits](https://www.conventionalcommits.org/) style:
   `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, etc.
 - Fill out the pull request template.
-- **UI changes** (anything under `Sources/PokeTokenBar/UI/`) must include
-  before/after screenshots in the PR, and regenerate affected screenshots in
-  `assets/` when relevant.
+- **UI changes** (anything under `Sources/PokeTokenBar/UI/`) should describe the
+  before/after in the PR. Screenshots or GIFs are welcome but optional — a clear
+  text description is fine. The canonical `assets/` screenshots are regenerated
+  at release, not per PR.
 
 ## Code conventions
 


### PR DESCRIPTION
## Summary

Make before/after **images optional** for UI-change PRs. A clear text description of the before/after is now sufficient; screenshots or GIFs are welcome but not required. The canonical app screenshots in `assets/` are regenerated at release, so per-PR images are redundant.

This removes a workflow friction: images can't be attached to a PR body from the CLI (only via GitHub's web upload), so requiring them per PR forced a manual step on every UI change. UI changes are still documented in text, and CI + tests remain the gates.

## Type of change

- [x] Documentation

## Checklist

- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
