### PR TITLE
refactor: drop redundant "N forms · complete" label from dex entries

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -192,7 +192,6 @@ struct L {
     }
     var dexEmptyTitle: String { t("아직 잡은 포켓몬이 없어요!", "No Pokémon caught yet!", "まだ捕まえたポケモンがいません！") }
     var dexEmptyHint: String { t("토큰을 써서 첫 포켓몬을 부화시켜 보세요.", "Spend tokens to hatch your first Pokémon.", "トークンを使って最初のポケモンを孵化させましょう。") }
-    func formsComplete(_ n: Int) -> String { t("\(n)단계 · 완성", "\(n) forms · complete", "\(n)段階・完成") }
 
     // MARK: 도감 요약 헤더
     var dexTitle: String { t("도감", "Pokédex", "図鑑") }

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -431,9 +431,10 @@ private struct DexEntryRow: View {
                     .clipShape(Capsule())
                 if entry.isShiny { Text("✨").font(.system(size: 10)) }
                 Spacer()
-                let nature = entry.nature.map { "\($0.name(store.language)) · " } ?? ""
-                Text(nature + store.l.formsComplete(entry.chainOrder.count))
-                    .font(.system(size: 9)).foregroundStyle(.secondary)
+                if let nature = entry.nature {
+                    Text(nature.name(store.language))
+                        .font(.system(size: 9)).foregroundStyle(.secondary)
+                }
             }
             EvoLineView(nodes: entry.chainOrder.map { ($0, "done") }, thumb: 56,
                         shiny: entry.isShiny, names: names)


### PR DESCRIPTION
## Summary

Remove the redundant **"N forms · complete"** label from the top-right of each Collection (dex) entry.

Every dex entry is a graduated final form, so "complete" was always true, and the stage count is already visible from the evolution-line sprites in the same row. The per-entry nature tag (e.g. Adamant) is kept — it's individual info. The now-unused `formsComplete` localization string is removed too.

## Type of change

- [x] Refactor / cleanup

## UI changes

Collection dex entry, top-right corner:
- Before: `[nature] · N forms · complete` (e.g. "Adamant · 3 forms · complete")
- After: `[nature]` only (e.g. "Adamant"); empty if the entry has no nature.

## Checklist

- [x] `swift build` and `swift test` pass locally (244 tests, 0 failures)
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed
- [ ] Tests were added or updated for this change — N/A (UI-only label removal, no logic to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
