### PR TITLE
feat: Mint — shop item that re-rolls a Pokémon's nature at random

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -85,17 +85,27 @@ enum PokemonBalance {
 /// 인벤토리 아이템 종류 — 확장 대비 enum(현재 이상한 사탕 1종). rawValue 로 CompanionState.inventory 에 저장.
 enum ItemKind: String, Codable, Sendable, CaseIterable {
     case rareCandy
+    case mint
 
     /// PokéAPI 아이템 스프라이트 파일명(.../sprites/items/{name}.png). nil = 스프라이트 없음(이모지 폴백만).
     var spriteName: String? {
         switch self {
         case .rareCandy: return "rare-candy"
+        case .mint: return nil   // PokéAPI 에 민트 스프라이트 없음(8세대 아이템) → 이모지 폴백
         }
     }
     /// 스프라이트 로딩 전/미제공/실패 시 폴백 이모지.
     var fallbackEmoji: String {
         switch self {
         case .rareCandy: return "🍬"
+        case .mint: return "🌿"
+        }
+    }
+    /// 상점 판매가(재화 = 사용한 토큰). nil = 상점 미판매.
+    var shopPrice: Int? {
+        switch self {
+        case .rareCandy: return RareCandy.price
+        case .mint: return Mint.price
         }
     }
 }
@@ -112,6 +122,14 @@ enum RareCandy {
     /// 공짜 추가성장(150M 써서 250M 성장)이 된다. 500M 로 두면 그 값 모으는 500M 패시브 성장 + 사탕
     /// 100M = 실질 보너스 +20% 로 억제된다. 무료 획득(한도 100% 보상)이 항상 이득이도록 값어치보다 비싸게.
     static let price = 500_000_000
+}
+
+/// 민트 밸런스 상수.
+enum Mint {
+    /// 상점 구매가. 성격 변경은 순수 코스메틱(성장·능력치 무관)이라 밸런스 근거가 없어 "느낌" 값 —
+    /// 사탕(500M)의 1/5로 싸게 둬서 성격을 마음에 들 때까지 굴려보는 가벼운 재미. 성장을 안 줘서
+    /// 이중계산 이슈도 없음(가격 = 순수 소비).
+    static let price = 100_000_000
 }
 
 /// 사탕 지급 대상 한도 창의 분류 — session=1개·weekly=weeklyGrant.

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -30,6 +30,11 @@ final class CompanionStore {
     /// 홈으로 재진입할 때(CompanionHeader 재마운트) @State 가 초기화돼 같은 값이 다시 떠오른다(회귀).
     func consumeCandyFeedback() { candyFeedbackAmount = 0 }
 
+    /// 민트 사용 시 "성격이 X로" 순간 표시 — 사탕 피드백과 동일 1회성 패턴(seq + consume).
+    private(set) var mintFeedbackSeq = 0
+    private(set) var mintFeedbackNature: PokemonNature?
+    func consumeMintFeedback() { mintFeedbackNature = nil }
+
     private let provider: any PokeProviding
     private let clock: () -> Date
     private let fileURL: URL
@@ -307,25 +312,58 @@ final class CompanionStore {
         return .progressed
     }
 
+    // MARK: 민트 (성격 랜덤 재설정)
+
+    /// 민트 사용 가능 — 활성 포켓몬 + 재고>0. 성격은 MonState 에만 있어 진화 라인 로딩과 무관하다
+    /// (사탕과 달리 currentLine 조건 없음 — 재시작 직후·오프라인에도 사용 가능).
+    var canUseMint: Bool { hasActive && itemCount(.mint) > 0 }
+
+    /// 민트 1개 사용 — 현재 포켓몬 성격을 '현재와 다른' 무작위 성격으로 교체(반드시 바뀐다). 성장·shiny·
+    /// 종·usedAtStage·통계 전부 무관(순수 코스메틱). 사용 불가면 nil(무소모). 바뀐 성격을 반환(피드백용).
+    @discardableResult
+    func useMint() -> PokemonNature? {
+        guard canUseMint, state.active != nil else { return nil }
+        let cur = state.active!.nature
+        let pool = PokemonNature.allCases.filter { $0 != cur }   // cur=nil(구버전 개체)이면 25종 전체
+        let new = pool[Int(rng.next() % UInt64(pool.count))]
+        state.active!.nature = new
+        state.inventory[ItemKind.mint.rawValue] = itemCount(.mint) - 1
+        mintFeedbackNature = new
+        mintFeedbackSeq += 1
+        save()
+        return new
+    }
+
     // MARK: 상점 (재화 = 사용한 토큰)
 
     /// 상점에서 쓸 수 있는 토큰(재화) = 실사용 누적 − 상점 지출 누적. 성장 미터(usedSinceInstall)는
     /// 여기선 읽기만 — 구매는 spentTokens 만 올려 잔액을 깎는다(진화 진행·오늘/주/월 통계 무영향).
     var availableTokens: Int { max(0, state.usedSinceInstall - state.spentTokens) }
 
-    /// 이상한 사탕 구매 가능 — 잔액이 가격 이상. 활성/알 무관(재고는 미리 쌓아둘 수 있음, 사용만 부화 후).
-    var canBuyRareCandy: Bool { availableTokens >= RareCandy.price }
+    /// 상점 판매 아이템 — shopPrice 있는 것만(ItemKind.allCases 순서).
+    var purchasableItems: [ItemKind] { ItemKind.allCases.filter { $0.shopPrice != nil } }
 
-    /// 이상한 사탕 1개 구매 — 지갑에서 price 차감, 인벤토리 +1. usedSinceInstall(성장·통계)·진화 진행엔
-    /// 무영향(지출 원장만 증가). 잔액 부족이면 no-op(false) — 뷰가 이미 버튼을 비활성화하지만 이중 가드.
+    /// 구매 가능 — 잔액이 그 아이템 가격 이상(상점 미판매면 false). 활성/알 무관(재고는 미리 쌓아둘 수 있음).
+    func canBuy(_ kind: ItemKind) -> Bool {
+        guard let price = kind.shopPrice else { return false }
+        return availableTokens >= price
+    }
+
+    /// 아이템 1개 구매 — 지갑에서 price 차감, 인벤토리 +1. usedSinceInstall(성장·통계)·진화 진행엔
+    /// 무영향(지출 원장만 증가). 잔액 부족/미판매면 no-op(false).
     @discardableResult
-    func buyRareCandy() -> Bool {
-        guard canBuyRareCandy else { return false }
-        state.spentTokens += RareCandy.price
-        state.inventory[ItemKind.rareCandy.rawValue, default: 0] += 1
+    func buy(_ kind: ItemKind) -> Bool {
+        guard let price = kind.shopPrice, availableTokens >= price else { return false }
+        state.spentTokens += price
+        state.inventory[kind.rawValue, default: 0] += 1
         save()
         return true
     }
+
+    // 사탕 전용 래퍼 — 기존 호출부/테스트 호환.
+    var canBuyRareCandy: Bool { canBuy(.rareCandy) }
+    @discardableResult
+    func buyRareCandy() -> Bool { buy(.rareCandy) }
 
     /// 지급 판정(순수·엣지 트리거) — 한도 창이 100% 를 새로 넘어선 순간에만 지급.
     /// - 100% 미만 → 맵에서 제거(재무장). resets_at 등 휘발 필드는 key 에 없다(안정 식별자만).

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -311,6 +311,7 @@ struct L {
     func itemName(_ kind: ItemKind) -> String {
         switch kind {
         case .rareCandy: return t("이상한 사탕", "Rare Candy", "ふしぎなアメ")
+        case .mint:      return t("민트", "Mint", "ミント")
         }
     }
     func itemDescription(_ kind: ItemKind) -> String {
@@ -320,8 +321,14 @@ struct L {
             return t("현재 포켓몬의 경험치를 \(xp) 상승시킨다.",
                      "Raises your Pokémon's EXP by \(xp).",
                      "ポケモンの経験値を\(xp)上げる。")
+        case .mint:
+            return t("현재 포켓몬의 성격을 랜덤으로 바꾼다.",
+                     "Randomly changes your Pokémon's nature.",
+                     "ポケモンのせいかくをランダムに変える。")
         }
     }
+    /// 가방 사용 컨트롤의 효과 힌트 — 민트("성격 랜덤 변경", 사탕의 "+XP" 자리).
+    var mintEffectHint: String { t("성격 랜덤 변경", "Random nature", "せいかくランダム変更") }
 
     // MARK: 상점 (재화 = 사용한 토큰)
     var shop: String { t("상점", "Shop", "ショップ") }

--- a/Sources/PokeTokenBar/UI/BagView.swift
+++ b/Sources/PokeTokenBar/UI/BagView.swift
@@ -67,9 +67,30 @@ private struct ItemCard: View {
         .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 
+    /// 이 아이템을 지금 쓸 수 있나 (kind 별 — 사탕은 라인 로딩 필요, 민트는 활성 포켓몬만).
+    private var canUse: Bool {
+        switch kind {
+        case .rareCandy: return store.canUseRareCandy
+        case .mint:      return store.canUseMint
+        }
+    }
+    /// 사용 컨트롤 효과 힌트 ("+XP" / "성격 랜덤 변경").
+    private func effectHint(_ l: L) -> String {
+        switch kind {
+        case .rareCandy: return "+\(TokenFormatter.compact(RareCandy.xp)) XP"
+        case .mint:      return l.mintEffectHint
+        }
+    }
+    private func performUse() {
+        switch kind {
+        case .rareCandy: _ = store.useRareCandy()
+        case .mint:      _ = store.useMint()
+        }
+    }
+
     @ViewBuilder
     private func useControls(_ l: L) -> some View {
-        if store.canUseRareCandy {
+        if canUse {
             if confirming {
                 HStack(spacing: 8) {
                     Text(l.useOnCurrent(store.displayName))
@@ -82,7 +103,7 @@ private struct ItemCard: View {
                 }
             } else {
                 HStack {
-                    Text("+\(TokenFormatter.compact(RareCandy.xp)) XP")
+                    Text(effectHint(l))
                         .font(.caption2).foregroundStyle(.tertiary).monospacedDigit()
                     Spacer()
                     Button(l.useItem) { confirming = true }
@@ -90,16 +111,16 @@ private struct ItemCard: View {
                 }
             }
         } else {
-            // 알(부화 전)/활성 없음/라인 미로딩 — 비활성 + 사유
+            // 알(부화 전)/활성 없음/(사탕만)라인 미로딩 — 비활성 + 사유
             Text(store.isEgg ? l.useAfterHatch : l.useNeedsPokemon)
                 .font(.caption2).foregroundStyle(.tertiary)
         }
     }
 
-    /// 사용 → 항상 Home 탭으로 전환(진화/졸업 연출·"+XP" 는 Home 의 CompanionHeader 에서 재생).
+    /// 사용 → 항상 Home 탭으로 전환(진화/졸업 연출·"+XP"·성격 변경 토스트는 Home 의 CompanionHeader 에서 재생).
     private func useNow() {
         confirming = false
-        _ = store.useRareCandy()
+        performUse()
         nav.tab = .home
     }
 }

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -162,6 +162,9 @@ struct CompanionHeader: View {
     @State private var seenCandySeq = -1
     @State private var candyXPShown = false
     @State private var candyXPAmount = 0     // 표시 순간 캡처(consume 후에도 텍스트 유지)
+    // 민트 사용 시 "반짝" 스파클 (성격 변경 피드백 — 텍스트 없이 짧은 이펙트)
+    @State private var seenMintSeq = -1
+    @State private var mintSparkle = false
 
     /// 부화 임박(90%+) — 알이 흔들리고 문구가 바뀐다.
     private var eggImminent: Bool { store.isEgg && store.eggProgress >= 0.9 }
@@ -192,6 +195,16 @@ struct CompanionHeader: View {
                                 .background(.regularMaterial, in: Capsule())
                                 .transition(.move(edge: .bottom).combined(with: .opacity))
                                 .offset(y: -16)
+                        }
+                    }
+                    .overlay {
+                        if mintSparkle {
+                            ZStack {
+                                Text("✨").font(.system(size: 22)).offset(x: -11, y: -9)
+                                Text("✨").font(.system(size: 15)).offset(x: 13, y: 5)
+                                Text("✨").font(.system(size: 12)).offset(x: 1, y: 13)
+                            }
+                            .transition(.scale.combined(with: .opacity))
                         }
                     }
                 VStack(alignment: .leading, spacing: 4) {
@@ -245,10 +258,12 @@ struct CompanionHeader: View {
         .onAppear {
             playCelebrationIfNeeded()
             showCandyXPIfNeeded()
+            showMintIfNeeded()
             syncEggWiggle()
         }
         .onChange(of: store.celebrationSeq) { playCelebrationIfNeeded() }
         .onChange(of: store.candyFeedbackSeq) { showCandyXPIfNeeded() }
+        .onChange(of: store.mintFeedbackSeq) { showMintIfNeeded() }
         .onChange(of: eggImminent) { syncEggWiggle() }
     }
 
@@ -281,6 +296,18 @@ struct CompanionHeader: View {
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 1_300_000_000)
             withAnimation(.easeOut(duration: 0.4)) { candyXPShown = false }
+        }
+    }
+
+    /// 민트 사용 "반짝" 스파클 1회 재생 — 사탕과 동일 1회성 계약(consume 로 재마운트 재생 방지). 텍스트 없음.
+    private func showMintIfNeeded() {
+        guard store.mintFeedbackNature != nil, store.mintFeedbackSeq != seenMintSeq else { return }
+        seenMintSeq = store.mintFeedbackSeq
+        store.consumeMintFeedback()
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.5)) { mintSparkle = true }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 900_000_000)
+            withAnimation(.easeOut(duration: 0.4)) { mintSparkle = false }
         }
     }
 

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// 상점 — 사용한 토큰(재화 = usedSinceInstall − spentTokens)으로 아이템 구매. v1: 이상한 사탕.
+/// 상점 — 사용한 토큰(재화 = usedSinceInstall − spentTokens)으로 아이템 구매(이상한 사탕·민트).
 /// 인라인 확인(버튼 morph) — .sheet/.alert 금지(BagView 주석과 동일: transient 팝오버가 닫힐 때
 /// 고아 시트가 이후 클릭을 먹통내는 결함 회피).
 struct ShopView: View {
@@ -12,7 +12,9 @@ struct ShopView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 10) {
                 walletHeader(l)
-                ShopItemCard(store: store, kind: .rareCandy, price: RareCandy.price)
+                ForEach(store.purchasableItems, id: \.self) { kind in
+                    ShopItemCard(store: store, kind: kind)
+                }
             }
         }
         .frame(height: 520)
@@ -34,14 +36,14 @@ struct ShopView: View {
     }
 }
 
-/// 상점 아이템 1장 — 아이콘·이름·설명·보유수 + 가격/구매(인라인 확인).
-/// v1 은 이상한 사탕만 판매하므로 구매 동작을 store.buyRareCandy 로 직접 호출한다. 스톤 추가(v1.5) 시
-/// store 에 kind 별 buy(kind)/canBuy(kind) 를 두어 일반화한다.
+/// 상점 아이템 1장 — 아이콘·이름·설명(사탕 XP / 민트 "성격 랜덤 변경")·보유수 + 가격/구매(인라인 확인).
+/// kind 별 store.canBuy(kind)/buy(kind) 로 일반화 — 판매 목록은 store.purchasableItems.
 private struct ShopItemCard: View {
     let store: CompanionStore
     let kind: ItemKind
-    let price: Int
     @State private var confirming = false
+
+    private var price: Int { kind.shopPrice ?? 0 }
 
     var body: some View {
         let l = store.l
@@ -87,7 +89,7 @@ private struct ShopItemCard: View {
                 Text("\(l.shopPriceLabel) \(TokenFormatter.compact(price))")
                     .font(.caption2).foregroundStyle(.tertiary).monospacedDigit()
                 Spacer()
-                if store.canBuyRareCandy {
+                if store.canBuy(kind) {
                     Button(l.buy) { confirming = true }
                         .buttonStyle(.bordered).controlSize(.small)
                 } else {
@@ -100,6 +102,6 @@ private struct ShopItemCard: View {
 
     private func buyNow() {
         confirming = false
-        _ = store.buyRareCandy()
+        _ = store.buy(kind)
     }
 }

--- a/Tests/PokeTokenBarTests/MintTests.swift
+++ b/Tests/PokeTokenBarTests/MintTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import PokeTokenBar
+
+// MARK: 민트 (성격 랜덤 재설정) + 상점 구매
+
+/// 라인 로딩이 필요 없는 테스트용 provider — 민트는 currentLine 과 무관(성격은 MonState 에만 있음).
+private struct MintNoProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine { throw URLError(.notConnectedToInternet) }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [] }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { nil }
+}
+
+@MainActor
+final class MintTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// 활성 포켓몬 + 민트 재고를 지정한 상태 파일 로드 (라인 미로딩이어도 민트는 사용 가능).
+    /// nature=nil 이면 성격 미지정(구버전 개체) 재현.
+    private func store(nature: String? = "adamant", mint: Int = 1, used: Int = 1_000_000_000,
+                       spent: Int = 0, usedAtStage: Int = 50_000_000, shiny: Bool = false,
+                       seed: UInt64 = 7) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mint-\(UUID().uuidString).json")
+        let natureField = nature.map { ",\"nature\":\"\($0)\"" } ?? ""
+        let active = "{\"baseID\":1,\"pathIDs\":[1],\"stageIndex\":0,\"usedAtStage\":\(usedAtStage),"
+            + "\"rarity\":\"common\",\"totalForms\":3,\"isShiny\":\(shiny)\(natureField)}"
+        let inv = mint > 0 ? ",\"inventory\":{\"mint\":\(mint)}" : ""
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":\(used),\"spentTokens\":\(spent),"
+            + "\"lastDate\":\"d\",\"active\":\(active),\"dex\":[],\"collectedFinals\":[]\(inv)}"
+        try? json.data(using: .utf8)!.write(to: url)
+        return CompanionStore(provider: MintNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: seed))
+    }
+
+    // MARK: 사용
+
+    func testUseMintChangesNatureToDifferent() {
+        let s = store(nature: "adamant", mint: 1)
+        XCTAssertEqual(s.state.active?.nature, .adamant)
+        let new = s.useMint()
+        XCTAssertNotNil(new)
+        XCTAssertNotEqual(new, .adamant, "현재와 다른 성격으로 바뀌어야 함")
+        XCTAssertEqual(s.state.active?.nature, new)
+        XCTAssertEqual(s.itemCount(.mint), 0, "재고 1 소모")
+    }
+
+    /// 여러 번 써도 매번 '직전 성격과 다른' 값으로만 바뀐다(현재 제외 롤).
+    func testMintNeverRepeatsCurrentAcrossUses() {
+        let s = store(nature: "adamant", mint: 6)
+        for _ in 0..<6 {
+            let before = s.state.active?.nature
+            let new = s.useMint()
+            XCTAssertNotNil(new)
+            XCTAssertNotEqual(new, before, "매 사용은 직전 성격과 달라야 함")
+        }
+    }
+
+    /// 성격 nil(구버전 개체) → 유효한 성격이 설정된다.
+    func testUseMintFromNilNatureSetsValid() {
+        let s = store(nature: nil, mint: 1)
+        XCTAssertNil(s.state.active?.nature)
+        let new = s.useMint()
+        XCTAssertNotNil(new)
+        XCTAssertEqual(s.state.active?.nature, new)
+    }
+
+    /// 성장·종·shiny·usedAtStage·통계 전부 불변(순수 코스메틱).
+    func testUseMintDoesNotAffectGrowthOrIdentity() {
+        let s = store(nature: "adamant", mint: 1, used: 1_000_000_000, usedAtStage: 50_000_000, shiny: true)
+        let beforeStage = s.state.active?.stageIndex
+        let beforeUsed = s.state.usedSinceInstall
+        let beforeSpecies = s.currentSpeciesID
+        _ = s.useMint()
+        XCTAssertEqual(s.state.active?.usedAtStage, 50_000_000, "진화 진행 불변")
+        XCTAssertEqual(s.state.active?.stageIndex, beforeStage)
+        XCTAssertEqual(s.currentSpeciesID, beforeSpecies)
+        XCTAssertTrue(s.currentIsShiny, "shiny 불변")
+        XCTAssertEqual(s.state.usedSinceInstall, beforeUsed, "실사용 통계 불변")
+    }
+
+    // MARK: 게이트
+
+    func testCannotUseMintOnEgg() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mint-egg-\(UUID().uuidString).json")
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":1,\"lastDate\":\"d\","
+            + "\"dex\":[],\"collectedFinals\":[],\"inventory\":{\"mint\":2}}"
+        try? json.data(using: .utf8)!.write(to: url)
+        let s = CompanionStore(provider: MintNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: 1))
+        XCTAssertTrue(s.isEgg)
+        XCTAssertFalse(s.canUseMint)
+        XCTAssertNil(s.useMint())
+        XCTAssertEqual(s.itemCount(.mint), 2, "알 상태에선 소모 안 됨")
+    }
+
+    func testCannotUseMintWithoutStock() {
+        let s = store(nature: "adamant", mint: 0)
+        XCTAssertFalse(s.canUseMint)
+        XCTAssertNil(s.useMint())
+    }
+
+    // MARK: 피드백
+
+    func testMintFeedbackSetAndConsumed() {
+        let s = store(nature: "adamant", mint: 1)
+        let before = s.mintFeedbackSeq
+        let new = s.useMint()
+        XCTAssertEqual(s.mintFeedbackNature, new)
+        XCTAssertEqual(s.mintFeedbackSeq, before + 1)
+        s.consumeMintFeedback()
+        XCTAssertNil(s.mintFeedbackNature)
+    }
+
+    // MARK: 영속
+
+    func testUseMintPersistsAcrossRestart() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mint-persist-\(UUID().uuidString).json")
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":1,\"lastDate\":\"d\","
+            + "\"active\":{\"baseID\":1,\"pathIDs\":[1],\"stageIndex\":0,\"usedAtStage\":0,\"rarity\":\"common\",\"totalForms\":3,\"nature\":\"adamant\"},"
+            + "\"inventory\":{\"mint\":2},\"dex\":[],\"collectedFinals\":[]}"
+        try? json.data(using: .utf8)!.write(to: url)
+        let s1 = CompanionStore(provider: MintNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: 3))
+        let new = s1.useMint()
+        XCTAssertNotNil(new)
+
+        let s2 = CompanionStore(provider: MintNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: 3))
+        XCTAssertEqual(s2.state.active?.nature, new, "바뀐 성격 영속")
+        XCTAssertEqual(s2.itemCount(.mint), 1, "재고 감소 영속")
+    }
+
+    // MARK: 상점 구매
+
+    func testMintShopPriceAndPurchasable() {
+        XCTAssertEqual(ItemKind.mint.shopPrice, Mint.price)
+        XCTAssertEqual(ItemKind.mint.shopPrice, 100_000_000)
+        let s = store(mint: 0)
+        XCTAssertTrue(s.purchasableItems.contains(.rareCandy))
+        XCTAssertTrue(s.purchasableItems.contains(.mint))
+    }
+
+    func testBuyMintDebitsWalletAndCredits() {
+        let s = store(mint: 0, used: 300_000_000)
+        XCTAssertTrue(s.canBuy(.mint))
+        XCTAssertTrue(s.buy(.mint))
+        XCTAssertEqual(s.itemCount(.mint), 1)
+        XCTAssertEqual(s.state.spentTokens, Mint.price)
+        XCTAssertEqual(s.availableTokens, 300_000_000 - Mint.price)
+    }
+
+    func testCannotBuyMintBelowPrice() {
+        let s = store(mint: 0, used: Mint.price - 1)
+        XCTAssertFalse(s.canBuy(.mint))
+        XCTAssertFalse(s.buy(.mint))
+        XCTAssertEqual(s.itemCount(.mint), 0)
+    }
+}


### PR DESCRIPTION
## Summary

Add **Mint**, a shop item that re-rolls the active Pokémon's **nature** to a random one — always different from the current (rolls from the other 24; from all 25 if the nature was unset). Nature is cosmetic, so Mint has **zero effect** on growth, evolution, species, shininess, or usage stats.

Priced at **100M** (1/5 of Rare Candy). Since it grants no growth, there's no double-count concern — the price is pure spend.

The shop's buy path is generalized to `ItemKind.shopPrice` + `buy(_:)`/`canBuy(_:)`, with the existing Rare Candy helpers folded in as thin wrappers.

## Type of change

- [x] New feature

## UI changes

- **Shop**: new Mint card (leaf emoji) at 100M with the description "Randomly changes your Pokémon's nature." Rare Candy and Mint both appear.
- **Bag**: the Mint card is usable when a Pokémon is active (no line-load requirement, unlike candy). Using it switches to Home.
- **Home**: on use, a brief sparkle plays over the sprite and the nature label updates — no text toast.

## Checklist

- [x] `swift build` and `swift test` pass locally (255 tests, 0 failures)
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed
- [x] Tests were added or updated for this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
