### PR TITLE
feat: disguised Ditto — 1/128 on common ≥2-form hatches, reveals at first evolution

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -227,6 +227,10 @@ enum PokemonNature: String, Codable, Sendable, CaseIterable {
 enum PokemonOdds {
     /// 색이 다른 포켓몬(shiny) 부화 확률 분모 — 1/64 (본가 1/4096 은 데스크톱 앱 규모에선 평생 못 봄).
     static let shinyDenominator: UInt64 = 64
+    /// 메타몽 위장 확률 분모 — common·≥2형태 부화에 한해 1/128 (GO 변장 메타몽 추정 1/50~70보다 귀하게).
+    static let dittoDisguiseDenominator: UInt64 = 128
+    /// 메타몽 종 id — 위장 리빌 전용(일반 부화 풀에서 제외).
+    static let dittoSpeciesID = 132
 }
 
 /// 현재 키우는 포켓몬.
@@ -239,11 +243,15 @@ struct MonState: Codable, Sendable {
     var totalForms: Int
     var isShiny = false             // 부화 시 확정, 진화해도 유지
     var nature: PokemonNature?      // 부화 시 확정 (구버전 저장은 nil)
+    // 메타몽 위장 — nil=일반. 값=정체 메타몽, 이 종으로 위장 중(위장 구간엔 baseID 와 동일, 리빌 후에도 원 위장체 보존).
+    var dittoDisguise: Int?
+    var dittoRevealed = false       // 위장 → 리빌(정체 공개) 전환 여부
     // pathIDs 가 비면(손상된 상태 파일) baseID 로 폴백 — 렌더마다 읽히므로 out-of-bounds 크래시 방지.
     var currentID: Int { pathIDs.isEmpty ? baseID : pathIDs[min(stageIndex, pathIDs.count - 1)] }
 
     init(baseID: Int, pathIDs: [Int], stageIndex: Int, usedAtStage: Int,
-         rarity: Rarity, totalForms: Int, isShiny: Bool = false, nature: PokemonNature? = nil) {
+         rarity: Rarity, totalForms: Int, isShiny: Bool = false, nature: PokemonNature? = nil,
+         dittoDisguise: Int? = nil, dittoRevealed: Bool = false) {
         self.baseID = baseID
         self.pathIDs = pathIDs
         self.stageIndex = stageIndex
@@ -252,6 +260,8 @@ struct MonState: Codable, Sendable {
         self.totalForms = totalForms
         self.isShiny = isShiny
         self.nature = nature
+        self.dittoDisguise = dittoDisguise
+        self.dittoRevealed = dittoRevealed
     }
 
     // 하위호환 디코딩: shiny/nature 는 구버전 저장에 없음 → 기본값.
@@ -269,6 +279,8 @@ struct MonState: Codable, Sendable {
         totalForms = try c.decode(Int.self, forKey: .totalForms)
         isShiny = try c.decodeIfPresent(Bool.self, forKey: .isShiny) ?? false
         nature = try c.decodeIfPresent(PokemonNature.self, forKey: .nature)
+        dittoDisguise = try c.decodeIfPresent(Int.self, forKey: .dittoDisguise)
+        dittoRevealed = try c.decodeIfPresent(Bool.self, forKey: .dittoRevealed) ?? false
     }
 }
 

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -11,12 +11,13 @@ final class CompanionStore {
     private(set) var displayState: CompanionStateKind = .egg
     private(set) var currentLine: EvoLine?
     private(set) var isHatching = false
+    private var isRevealingDitto = false   // 메타몽 리빌 비동기 중복 방지(isHatching 자매)
     private(set) var justEvolvedTo: String?     // 이름(연출/문구)
     private(set) var justGraduated: String?
     private var eventUntil: Date?
 
     /// 부화/진화 연출 트리거 — seq 증가로 UI 가 감지, 팝오버가 닫혀 있었어도 다음 오픈에 1회 재생.
-    enum Celebration: Equatable { case hatch(shiny: Bool), evolve }
+    enum Celebration: Equatable { case hatch(shiny: Bool), evolve, dittoReveal(shiny: Bool) }
     private(set) var celebration: Celebration?
     private(set) var celebrationSeq = 0
     private func fireCelebration(_ c: Celebration) { celebration = c; celebrationSeq += 1 }
@@ -79,7 +80,11 @@ final class CompanionStore {
 
     var hasActive: Bool { state.active != nil }
     var rarity: Rarity? { state.active?.rarity }
-    var currentIsShiny: Bool { state.active?.isShiny ?? false }
+    var currentIsShiny: Bool {
+        guard let a = state.active else { return false }
+        if a.dittoDisguise != nil && !a.dittoRevealed { return false }   // 위장 중엔 이로치 숨김(리빌 때 공개)
+        return a.isShiny
+    }
     var currentNature: PokemonNature? { state.active?.nature }
 
     // 알 인큐베이션 (active 없을 때)
@@ -208,6 +213,12 @@ final class CompanionStore {
         if state.active != nil, currentLine == nil, !isHatching {
             Task { await loadCurrentLine() }
         }
+        // 위장 메타몽이 첫 진화 임계 도달 → 리빌(재시작 등 applyUsage 킥을 못 탄 경우 백업 트리거)
+        if let a = state.active, a.dittoDisguise != nil, !a.dittoRevealed, currentLine != nil,
+           !isHatching, !isRevealingDitto,
+           a.usedAtStage >= PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0) {
+            Task { await revealDitto() }
+        }
         displayState = computeState(burnTier: burnTier, limitWarning: limitWarning,
                                     hasUsageData: hasUsageData, today: todayTokens)
         save()
@@ -230,6 +241,12 @@ final class CompanionStore {
             if node.children.isEmpty {
                 graduate(); break
             } else {
+                // 메타몽 위장: 진화 못 하는 메타몽 → 첫 진화 순간 진화 대신 정체를 드러낸다(리빌).
+                // 라인 로드가 필요해 여기선 진화만 멈추고(임계 이상 유지) 리빌은 비동기 revealDitto 가 처리.
+                if a.dittoDisguise != nil, !a.dittoRevealed {
+                    if !isRevealingDitto { Task { await revealDitto() } }
+                    break
+                }
                 let next = pickNextChild(node, baseID: a.baseID)
                 state.active!.pathIDs = Array(a.pathIDs.prefix(a.stageIndex + 1)) + [next.speciesID]
                 state.active!.stageIndex += 1
@@ -489,6 +506,16 @@ final class CompanionStore {
         await hatchCore(baseID: baseID)
     }
 
+    // MARK: 메타몽 위장/리빌
+
+    /// .app 번들 실행 여부 — 알림/프리패치와 동일 게이트. 위장 롤을 실앱에서만 발동(테스트/개발실행 제외).
+    static var isAppBundle: Bool { Bundle.main.bundleIdentifier != nil && Bundle.main.bundlePath.hasSuffix(".app") }
+
+    /// 메타몽 위장 롤 판정(순수) — common·≥2형태만, 미리 뽑은 roll 값으로 1/128. (부수효과 없이 xctest)
+    nonisolated static func dittoDisguiseHit(rarity: Rarity, totalForms: Int, roll: UInt64) -> Bool {
+        rarity == .common && totalForms >= 2 && roll % PokemonOdds.dittoDisguiseDenominator == 0
+    }
+
     /// 실제 부화 로직 — isHatching 락은 호출자(hatch / hatchIfNeeded)가 소유·해제한다.
     private func hatchCore(baseID: Int) async {
         guard let line = try? await provider.line(baseSpeciesID: baseID) else {
@@ -502,21 +529,64 @@ final class CompanionStore {
         // 개체 롤 — shiny(1/64)·성격(25종)은 부화 순간 확정, 진화해도 유지.
         let isShiny = rng.next() % PokemonOdds.shinyDenominator == 0
         let nature = PokemonNature.allCases[Int(rng.next() % UInt64(PokemonNature.allCases.count))]
+        // 메타몽 위장 롤 — common·≥2형태에 한해 1/128. .app 게이트(&& 단락 → 비앱에선 rng 미소비로
+        // 기존 테스트 RNG 시퀀스 무영향). 위장/리빌 로직은 상태 기반으로 별도 테스트한다.
+        var dittoDisguise: Int?
+        if Self.isAppBundle, Self.dittoDisguiseHit(rarity: line.rarity, totalForms: line.totalForms, roll: rng.next()) {
+            dittoDisguise = line.baseID
+        }
+        // 위장 중엔 이로치를 숨긴다 — 부화 알림·연출도 일반체로(정체는 리빌 때 공개).
+        let showShiny = isShiny && dittoDisguise == nil
         state.active = MonState(baseID: line.baseID, pathIDs: [line.baseID], stageIndex: 0,
                                 usedAtStage: 0, rarity: line.rarity, totalForms: line.totalForms,
-                                isShiny: isShiny, nature: nature)
-        AppLog.write("hatch: hatched base=\(line.baseID) rarity=\(line.rarity) shiny=\(isShiny) forms=\(line.totalForms)")
+                                isShiny: isShiny, nature: nature, dittoDisguise: dittoDisguise)
+        AppLog.write("hatch: base=\(line.baseID) rarity=\(line.rarity) shiny=\(isShiny) forms=\(line.totalForms) ditto=\(dittoDisguise != nil)")
         let name = line.localizedName(line.baseID, state.language)
-        notifyCompanionEvent(isShiny ? l.notifShinyHatchTitle : l.notifHatchTitle,
-                             isShiny ? l.notifShinyHatchBody(name) : l.notifHatchBody(name))
+        notifyCompanionEvent(showShiny ? l.notifShinyHatchTitle : l.notifHatchTitle,
+                             showShiny ? l.notifShinyHatchBody(name) : l.notifHatchBody(name))
         justEvolvedTo = nil        // 새 부화는 "성장" 문구(진화 아님) — 직전 진화명이 남아 표시되지 않게
         displayState = .levelUp
         eventUntil = clock().addingTimeInterval(4)
-        if overflow > 0 { applyUsage(overflow) }   // 이월분 즉시 반영(필요 시 진화까지)
+        if overflow > 0 { applyUsage(overflow) }   // 이월분 즉시 반영(필요 시 진화/리빌까지)
         // 연출은 이월 진화 뒤에 발화 — 이월 evolve 가 shiny 부화 버스트를 덮지 않도록
         // 마지막 이벤트를 hatch 로 유지한다. 이월로 즉시 졸업한 극단 케이스면 생략(이미 도감행).
-        if state.active != nil { fireCelebration(.hatch(shiny: isShiny)) }
+        if state.active != nil { fireCelebration(.hatch(shiny: showShiny)) }
         save()
+    }
+
+    /// 위장 → 리빌: 진화 못 하는 메타몽이 "첫 진화 임계"에서 진화 대신 정체를 드러내는 순간.
+    /// Ditto 라인 로드 후 상태 변환(rare·단일형태·초과분 이월, isShiny/nature 유지) + 연출·알림.
+    private func revealDitto() async {
+        guard let a = state.active, a.dittoDisguise != nil, !a.dittoRevealed, !isRevealingDitto else { return }
+        let firstEvoThr = PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0)
+        guard a.usedAtStage >= firstEvoThr else { return }   // 임계 미달 방어
+        isRevealingDitto = true
+        defer { isRevealingDitto = false }
+        guard let dittoLine = try? await provider.line(baseSpeciesID: PokemonOdds.dittoSpeciesID) else {
+            AppLog.write("ditto reveal: line fetch failed — retry next tick"); return
+        }
+        guard var m = state.active, m.dittoDisguise != nil, !m.dittoRevealed else { return }   // await 사이 변화 방어
+        let disguiseName = currentLine?.localizedName(m.baseID, state.language) ?? "#\(m.baseID)"
+        let carryOver = max(0, m.usedAtStage - firstEvoThr)   // 위장체 첫 진화 초과분 → 메타몽 성장 이월
+        // 메타몽으로 전환 — rarity/forms 는 로드한 라인에서, isShiny/nature/dittoDisguise 는 유지.
+        m.baseID = dittoLine.baseID
+        m.pathIDs = [dittoLine.baseID]
+        m.stageIndex = 0
+        m.rarity = dittoLine.rarity
+        m.totalForms = dittoLine.totalForms
+        m.usedAtStage = carryOver
+        m.dittoRevealed = true
+        let shiny = m.isShiny
+        state.active = m
+        currentLine = dittoLine
+        AppLog.write("ditto reveal: disguise=\(m.dittoDisguise ?? -1) → ditto rarity=\(dittoLine.rarity) shiny=\(shiny)")
+        fireCelebration(.dittoReveal(shiny: shiny))
+        displayState = .levelUp
+        eventUntil = clock().addingTimeInterval(5)
+        notifyCompanionEvent(shiny ? l.notifShinyDittoRevealTitle : l.notifDittoRevealTitle,
+                             shiny ? l.notifShinyDittoRevealBody(disguiseName) : l.notifDittoRevealBody(disguiseName))
+        save()
+        applyUsage(0)   // 이월분으로 메타몽 졸업 재평가(rare 3B라 보통 즉시 졸업 아님)
     }
 
     private func loadCurrentLine() async {

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -233,6 +233,11 @@ struct L {
           "ローカルの Claude・Codex・Gemini の使用量で育ちます。約5Mトークンでタマゴが孵化します。") }
     var notifEvolveTitle: String { t("✨ 진화!", "✨ Evolved!", "✨ 進化！") }
     func notifEvolveBody(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！") }
+    // 메타몽 위장 리빌 — 진화 못 하는 메타몽이 첫 진화 순간 정체를 드러낸다.
+    var notifDittoRevealTitle: String { t("🎭 어라? 메타몽!", "🎭 Huh? It's Ditto!", "🎭 あれ？メタモン！") }
+    func notifDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 사실은 메타몽이었어요!", "You thought it was \(disguise) — it was Ditto all along!", "\(disguise) だと思ってた… 実はメタモンでした！") }
+    var notifShinyDittoRevealTitle: String { t("🎭✨ 어라? 이로치 메타몽!", "🎭✨ Huh? A shiny Ditto!", "🎭✨ あれ？色違いメタモン！") }
+    func notifShinyDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 이로치 메타몽이었어요! (1/64)", "You thought it was \(disguise) — it was a shiny Ditto! (1 in 64)", "\(disguise) だと思ってた… 色違いのメタモンでした！(1/64)") }
     var notifGraduateTitle: String { t("🎓 졸업!", "🎓 Graduated!", "🎓 卒業！") }
     func notifGraduateBody(_ name: String) -> String { t("\(name) — 도감에 보존! 새 알이 도착했어요.", "\(name) — saved to your Pokédex! A new egg has arrived.", "\(name) — 図鑑に保存！新しいタマゴが届きました。") }
 

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -146,7 +146,8 @@ actor PokeAPIClient: PokeProviding {
         req.httpMethod = "POST"
         req.timeoutInterval = 15
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        let query = "{ pokemonspecies(where: {evolves_from_species_id: {_is_null: true}, id: {_lte: 649}}, order_by: {id: asc}) { id capture_rate } }"
+        // 메타몽(#132)은 위장 리빌 전용 → 일반 부화 풀에서 제외(_neq).
+        let query = "{ pokemonspecies(where: {evolves_from_species_id: {_is_null: true}, id: {_lte: 649, _neq: \(PokemonOdds.dittoSpeciesID)}}, order_by: {id: asc}) { id capture_rate } }"
         req.httpBody = try JSONSerialization.data(withJSONObject: ["query": query])
         let (data, resp) = try await URLSession.shared.data(for: req)
         guard (resp as? HTTPURLResponse)?.statusCode == 200 else { throw URLError(.badServerResponse) }
@@ -166,6 +167,7 @@ actor PokeAPIClient: PokeProviding {
     /// REST 폴백 — 단일 종 상세(pokemon-species/{id})로 base 여부·capture_rate 판정.
     /// GraphQL base 인덱스가 죽어도 REST(pokeapi.co/api/v2)는 별개 엔드포인트라 동작한다.
     func baseSpecies(id: Int) async throws -> BaseSpecies? {
+        guard id != PokemonOdds.dittoSpeciesID else { return nil }   // 메타몽은 위장 리빌 전용 — 일반 부화 제외
         let dto = try await species(id)
         guard dto.evolves_from_species == nil else { return nil }   // 진화 중간체는 부화 후보 아님
         return BaseSpecies(id: id, captureRate: dto.capture_rate)

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -156,6 +156,7 @@ struct CompanionHeader: View {
     @State private var flashOpacity: Double = 0
     @State private var celebScale: CGFloat = 1
     @State private var shinyBurst = false
+    @State private var dittoBurst = false   // 메타몽 리빌 🎭 버스트
     @State private var seenSeq = -1     // 재생 완료한 celebrationSeq (팝오버 재오픈 시 1회 재생 보장)
     @State private var eggWiggle = false
     // 사탕 "+XP" 순간 표시 (진화 없이 부분 진행일 때도 피드백)
@@ -185,6 +186,13 @@ struct CompanionHeader: View {
                             Text("✨").font(.system(size: 22))
                                 .transition(.scale.combined(with: .opacity))
                                 .offset(x: 6, y: -6)
+                        }
+                    }
+                    .overlay(alignment: .top) {
+                        if dittoBurst {
+                            Text("🎭").font(.system(size: 26))
+                                .transition(.scale.combined(with: .opacity))
+                                .offset(y: -12)
                         }
                     }
                     .overlay(alignment: .top) {
@@ -281,6 +289,17 @@ struct CompanionHeader: View {
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 2_600_000_000)
                 withAnimation(.easeOut(duration: 0.5)) { shinyBurst = false }
+            }
+        }
+        // 메타몽 리빌 — 위장체→메타몽 스프라이트 교체를 플래시가 덮고, 🎭 버스트(이로치면 ✨ 동반).
+        if case .dittoReveal(let shiny) = c {
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.5).delay(0.25)) { dittoBurst = true }
+            if shiny {
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.5).delay(0.45)) { shinyBurst = true }
+            }
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 2_600_000_000)
+                withAnimation(.easeOut(duration: 0.5)) { dittoBurst = false; shinyBurst = false }
             }
         }
     }

--- a/Tests/PokeTokenBarTests/DittoTests.swift
+++ b/Tests/PokeTokenBarTests/DittoTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import PokeTokenBar
+
+// MARK: 메타몽 위장/리빌
+
+private func dNode(_ id: Int, _ children: [EvoNode] = []) -> EvoNode { EvoNode(speciesID: id, children: children) }
+private func dLine(base: Int, tree: EvoNode, rarity: Rarity) -> EvoLine {
+    func ids(_ n: EvoNode) -> [Int] { [n.speciesID] + n.children.flatMap(ids) }
+    var names: [Int: [String: String]] = [:]
+    for id in ids(tree) { names[id] = ["en": "P\(id)", "ko": "포\(id)", "ja": "ポ\(id)"] }
+    return EvoLine(baseID: base, tree: tree, rarity: rarity, names: names)
+}
+private let disguiseLine = dLine(base: 1, tree: dNode(1, [dNode(2, [dNode(3)])]), rarity: .common) // 커먼 3형태: 첫 진화 125M
+private let dittoLine = dLine(base: 132, tree: dNode(132), rarity: .rare)                           // 메타몽: rare 단일형태
+private let dNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+/// base 1=위장체 라인, 132=메타몽 라인 반환(리빌 시 필요). StubProvider 는 단일 라인이라 부적합.
+private struct DittoTestProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine {
+        baseSpeciesID == PokemonOdds.dittoSpeciesID ? dittoLine : disguiseLine
+    }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: 1, captureRate: 255)] }
+}
+
+// MARK: 위장 롤 판정(순수) — 부화 롤은 .app 게이트라 실앱에서만 발동, 판정 로직은 순수 함수로 검증
+
+final class DittoDisguiseRollTests: XCTestCase {
+    func testHitCommonMultiFormOnMultipleOfDenominator() {
+        XCTAssertTrue(CompanionStore.dittoDisguiseHit(rarity: .common, totalForms: 2, roll: 0))
+        XCTAssertTrue(CompanionStore.dittoDisguiseHit(rarity: .common, totalForms: 3, roll: 128))
+        XCTAssertTrue(CompanionStore.dittoDisguiseHit(rarity: .common, totalForms: 3, roll: 256))
+    }
+    func testMissWhenRollNotMultipleOfDenominator() {
+        XCTAssertFalse(CompanionStore.dittoDisguiseHit(rarity: .common, totalForms: 3, roll: 1))
+        XCTAssertFalse(CompanionStore.dittoDisguiseHit(rarity: .common, totalForms: 3, roll: 127))
+        XCTAssertFalse(CompanionStore.dittoDisguiseHit(rarity: .common, totalForms: 3, roll: 129))
+    }
+    /// 단일형태 제외 — 진화를 못 하면 리빌 트리거(첫 진화 순간)가 없다.
+    func testExcludesSingleForm() {
+        XCTAssertFalse(CompanionStore.dittoDisguiseHit(rarity: .common, totalForms: 1, roll: 0))
+    }
+    /// common 만 — uncommon/rare/legendary 위장 불가.
+    func testExcludesNonCommon() {
+        XCTAssertFalse(CompanionStore.dittoDisguiseHit(rarity: .uncommon, totalForms: 3, roll: 0))
+        XCTAssertFalse(CompanionStore.dittoDisguiseHit(rarity: .rare, totalForms: 3, roll: 0))
+        XCTAssertFalse(CompanionStore.dittoDisguiseHit(rarity: .legendary, totalForms: 3, roll: 0))
+    }
+    func testDenominatorIs128() {
+        XCTAssertEqual(PokemonOdds.dittoDisguiseDenominator, 128)
+    }
+}
+
+// MARK: 위장 → 리빌 상태 전환
+
+@MainActor
+final class DittoRevealTests: XCTestCase {
+    /// 활성 = 커먼 3형태 위장 메타몽(정체). currentLine 은 nil(재시작류) → update 로 로드해 리빌 트리거.
+    private func seedDisguise(usedAtStage: Int = 0, shiny: Bool = false, revealed: Bool = false) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("ditto-\(UUID().uuidString).json")
+        let active = "{\"baseID\":1,\"pathIDs\":[1],\"stageIndex\":0,\"usedAtStage\":\(usedAtStage),"
+            + "\"rarity\":\"common\",\"totalForms\":3,\"isShiny\":\(shiny),"
+            + "\"dittoDisguise\":1,\"dittoRevealed\":\(revealed)}"
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":1000000000,\"spentTokens\":0,"
+            + "\"lastDate\":\"d1\",\"active\":\(active),\"dex\":[],\"collectedFinals\":[]}"
+        try? json.data(using: .utf8)!.write(to: url)
+        return CompanionStore(provider: DittoTestProvider(), clock: { dNow }, fileURL: url, rng: SeededRNG(seed: 7))
+    }
+
+    /// update → loadCurrentLine → applyUsage(0) → (임계 초과 시) revealDitto 비동기 체인을 드레인.
+    private func drainReveal(_ s: CompanionStore) async {
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        for _ in 0..<200 where !(s.state.active?.dittoRevealed ?? false) { await Task.yield() }
+    }
+
+    /// 위장 중엔 이로치가 표시상 숨겨진다(내부 isShiny 는 유지 — 리빌 때 공개).
+    func testShinyHiddenDuringDisguise() {
+        let s = seedDisguise(shiny: true)
+        XCTAssertTrue(s.state.active?.isShiny ?? false, "내부적으론 이로치")
+        XCTAssertFalse(s.currentIsShiny, "위장 중엔 표시상 숨김")
+    }
+
+    /// [트리거 브랜치] 첫 진화 임계에서 진화 대신 메타몽으로 리빌 — 진화 자체를 밟지 않는다.
+    func testRevealAtFirstEvolution() async {
+        let s = seedDisguise()
+        s.applyUsage(300_000_000)   // 라인 미로딩 중 적립(첫 진화 125M 초과) — 진화/리빌 보류
+        XCTAssertEqual(s.state.active?.usedAtStage, 300_000_000)
+        XCTAssertEqual(s.currentSpeciesID, 1, "아직 위장체 표시")
+        XCTAssertFalse(s.state.active?.dittoRevealed ?? true)
+        await drainReveal(s)
+        XCTAssertTrue(s.state.active?.dittoRevealed ?? false, "첫 진화 임계에서 리빌돼야 한다")
+        XCTAssertEqual(s.state.active?.baseID, PokemonOdds.dittoSpeciesID, "메타몽으로 전환")
+        XCTAssertEqual(s.currentSpeciesID, PokemonOdds.dittoSpeciesID)
+        XCTAssertNotEqual(s.currentSpeciesID, 2, "위장체는 진화하지 않는다")
+        XCTAssertEqual(s.state.active?.rarity, .rare, "메타몽 rare")
+        XCTAssertEqual(s.state.active?.totalForms, 1, "메타몽 단일형태")
+        XCTAssertEqual(s.state.active?.stageIndex, 0)
+        XCTAssertEqual(s.state.active?.usedAtStage, 300_000_000 - 125_000_000, "첫 진화 초과분 이월")
+        XCTAssertNotNil(s.state.active?.dittoDisguise, "위장 마커 보존")
+        XCTAssertEqual(s.celebration, .dittoReveal(shiny: false), "리빌 연출 발화")
+    }
+
+    /// 리빌 후 이로치가 공개된다(위장 중 숨겼던 것) + 이로치 리빌 연출.
+    func testShinyUnmaskedAfterReveal() async {
+        let s = seedDisguise(shiny: true)
+        s.applyUsage(300_000_000)
+        XCTAssertFalse(s.currentIsShiny, "리빌 전 숨김")
+        await drainReveal(s)
+        XCTAssertTrue(s.state.active?.dittoRevealed ?? false)
+        XCTAssertTrue(s.currentIsShiny, "리빌 후 이로치 공개")
+        XCTAssertEqual(s.celebration, .dittoReveal(shiny: true), "이로치 리빌 연출")
+    }
+
+    /// 임계 미달이면 리빌하지 않는다(위장 유지).
+    func testNoRevealBelowThreshold() async {
+        let s = seedDisguise()
+        s.applyUsage(100_000_000)   // 첫 진화 125M 미달
+        await drainReveal(s)        // (드레인해도 리빌 조건 미충족)
+        XCTAssertFalse(s.state.active?.dittoRevealed ?? true, "임계 미달 → 위장 유지")
+        XCTAssertEqual(s.currentSpeciesID, 1, "여전히 위장체")
+    }
+
+    /// 구버전 저장(ditto 필드 없음) → nil/false, 일반 포켓몬으로 동작(이로치는 그대로 표시).
+    func testBackwardCompatDecodeNoDittoFields() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("ditto-bc-\(UUID().uuidString).json")
+        let active = "{\"baseID\":1,\"pathIDs\":[1],\"stageIndex\":0,\"usedAtStage\":0,"
+            + "\"rarity\":\"common\",\"totalForms\":3,\"isShiny\":true}"   // ditto 필드 없음
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":0,\"spentTokens\":0,"
+            + "\"lastDate\":\"d1\",\"active\":\(active),\"dex\":[],\"collectedFinals\":[]}"
+        try? json.data(using: .utf8)!.write(to: url)
+        let s = CompanionStore(provider: DittoTestProvider(), clock: { dNow }, fileURL: url, rng: SeededRNG(seed: 7))
+        XCTAssertNil(s.state.active?.dittoDisguise)
+        XCTAssertFalse(s.state.active?.dittoRevealed ?? true)
+        XCTAssertTrue(s.currentIsShiny, "위장 아님 → 이로치 그대로 표시")
+    }
+
+    /// 메타몽(#132)은 REST 폴백 부화 후보에서 제외(위장 리빌 전용) — 가드는 네트워크 전 조기 반환.
+    func testDittoExcludedFromRestFallback() async throws {
+        let result = try await PokeAPIClient().baseSpecies(id: PokemonOdds.dittoSpeciesID)
+        XCTAssertNil(result, "메타몽은 일반 부화 후보 아님")
+    }
+}


### PR DESCRIPTION
## Summary

A hatched companion that is **common-tier with ≥2 evolution forms** now has a **1/128** chance of secretly being a **disguised Ditto**. It grows normally as the disguise; at its **first evolution threshold** it **reveals as Ditto instead of evolving** (Ditto can't evolve, so the disguise breaks). Shiny is hidden during the disguise and unmasked at the reveal — a double surprise.

**Behavior by case:**

| Hatch | Disguise roll | Behavior |
|---|---|---|
| common, ≥2 forms | miss (127/128) | normal Pokémon, evolves normally |
| common, ≥2 forms | hit (1/128) | grows as the disguise → **reveals as Ditto at first evolution** |
| uncommon / rare / legendary, or single-form | — | never disguised (no roll) |

**Reveal transition:** `currentID` → 132, rarity → rare, `totalForms` → 1, the first-evolution overshoot is carried over, shiny is unmasked. The Pokédex entry is a plain Ditto (✨ if shiny). Ditto is removed from the normal hatch pool, so it only ever appears via a reveal.

**Design notes:**
- The hatch-time roll is gated behind the `.app` bundle check (same pattern as notifications / sprite prefetch). The `&&` short-circuits so `rng.next()` is not consumed in test/non-app runs, keeping existing hatch-test RNG sequences unchanged. The reveal/display logic is not gated and is tested via seeded state.
- Reveal is async because it must load the Ditto line; `applyUsage` (sync) only blocks the disguise from evolving and kicks `revealDitto`, guarded by `isRevealingDitto`.

## Type of change

- [x] New feature (companion mechanic)

## Checklist

- [x] `swift build` and `swift test` pass locally (266 tests, 0 failures)
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
