### PR TITLE
feat: add update-notifications toggle and manual "check now" in Settings

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -289,6 +289,12 @@ struct L {
     var updateButton: String { t("업데이트", "Update", "更新") }
     var updateLater: String { t("나중에", "Later", "後で") }
     var updating: String { t("업데이트 중…", "Updating…", "更新中…") }
+    var updateSectionTitle: String { t("업데이트", "Updates", "アップデート") }
+    var updateNotificationsLabel: String { t("업데이트 알림", "Update notifications", "アップデート通知") }
+    var checkForUpdatesLabel: String { t("업데이트 확인", "Check for updates", "アップデートを確認") }
+    var checkNowButton: String { t("지금 확인", "Check now", "今すぐ確認") }
+    func updateFound(_ version: String) -> String { t("새 버전 v\(version) 있어요", "Version \(version) is available", "バージョン \(version) が利用可能です") }
+    func upToDate(_ version: String) -> String { t("최신 버전이에요 (v\(version))", "You're on the latest (v\(version))", "最新です (v\(version))") }
 
     // MARK: 알림
     var notifCritical: String { t("한도 임박", "Limit imminent", "上限切迫") }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -62,6 +62,10 @@ final class UsageStore {
     var companionNotifications: Bool {
         didSet { defaults.set(companionNotifications, forKey: "companionNotifications") }
     }
+    /// 새 버전 알림(팝오버 업데이트 배너) 표시 여부 — 기본 켬. 끄면 배너 숨김(수동 확인은 설정에서 가능).
+    var updateNotificationsEnabled: Bool {
+        didSet { defaults.set(updateNotificationsEnabled, forKey: "updateNotificationsEnabled") }
+    }
     /// 프로바이더 상태(인시던트) 조회 — 기본 켬. 표시 전용(알림 아님). Claude/OpenAI statuspage.io.
     var statusChecksEnabled: Bool {
         didSet { defaults.set(statusChecksEnabled, forKey: "statusChecksEnabled") }
@@ -324,6 +328,7 @@ final class UsageStore {
         showLimitInMenu = d.object(forKey: "showLimitInMenu") as? Bool ?? false
         limitNotifications = d.object(forKey: "limitNotifications") as? Bool ?? true
         companionNotifications = d.object(forKey: "companionNotifications") as? Bool ?? true
+        updateNotificationsEnabled = d.object(forKey: "updateNotificationsEnabled") as? Bool ?? true
         statusChecksEnabled = d.object(forKey: "statusChecksEnabled") as? Bool ?? true
         disableKeychainAccess = d.object(forKey: "disableKeychainAccess") as? Bool ?? false
 

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -36,6 +36,7 @@ struct PopoverView: View {
                 SettingsView(onClose: { nav.showSettings = false })
                     .environment(store)
                     .environment(companion)
+                    .environment(updater)
             } else {
                 mainContent
             }
@@ -45,7 +46,7 @@ struct PopoverView: View {
 
     @ViewBuilder
     private var updateBanner: some View {
-        if let update = updater.available {
+        if let update = updater.available, store.updateNotificationsEnabled {
             HStack(spacing: 8) {
                 Text(l.updateAvailable(update.version, current: updater.currentVersion))
                     .font(.caption)

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -3,12 +3,15 @@ import SwiftUI
 struct SettingsView: View {
     @Environment(UsageStore.self) private var store
     @Environment(CompanionStore.self) private var companion
+    @Environment(UpdateChecker.self) private var updater
     /// 팝오버 내부 화면 전환 방식 — sheet/dismiss 를 쓰지 않는다 (PopoverView 의 NOTE 참조)
     var onClose: () -> Void
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var launchAtLoginError: String?
     @State private var reportError: String?
     @State private var advancedExpanded = false
+    @State private var isCheckingUpdate = false
+    @State private var didCheckUpdate = false
 
     private var l: L { companion.l }
 
@@ -33,6 +36,7 @@ struct SettingsView: View {
                     generalGroup(store)
                     menuBarGroup(store)
                     notificationsGroup(store)
+                    updateGroup(store)
                     advancedGroup(store)
                     aboutSupportGroup
                 }
@@ -183,6 +187,48 @@ struct SettingsView: View {
                 Spacer()
                 Toggle("", isOn: $store.statusChecksEnabled)
                     .labelsHidden().toggleStyle(.switch).controlSize(.small)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func updateGroup(_ store: UsageStore) -> some View {
+        @Bindable var store = store
+        settingsSection(l.updateSectionTitle) {
+            toggleRow(l.updateNotificationsLabel, $store.updateNotificationsEnabled)
+            Divider()
+            groupRow {
+                Text(l.checkForUpdatesLabel)
+                Spacer()
+                Button {
+                    isCheckingUpdate = true
+                    Task {
+                        await updater.check(minInterval: 0)   // 수동 확인 — 레이트리밋 우회(강제 조회)
+                        isCheckingUpdate = false
+                        didCheckUpdate = true
+                    }
+                } label: {
+                    if isCheckingUpdate {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text(l.checkNowButton)
+                    }
+                }
+                .disabled(isCheckingUpdate)
+            }
+            // 확인 결과 — 알림을 꺼둔 사용자도 여기서 새 버전을 알고 바로 적용할 수 있게 업데이트 버튼을 함께 노출.
+            if didCheckUpdate, !isCheckingUpdate {
+                Divider()
+                groupRow {
+                    if let version = updater.available?.version {
+                        Text(l.updateFound(version)).font(.caption).foregroundStyle(.orange)
+                        Spacer()
+                        Button(l.updateButton) { updater.applyUpdate() }.controlSize(.small)
+                    } else {
+                        Text(l.upToDate(Self.appVersion)).font(.caption).foregroundStyle(.secondary)
+                        Spacer()
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

The in-popover update banner always showed when a newer release existed, with no way to opt out. This adds a Settings **"Updates"** section:

- **Update notifications** toggle — when off, the update banner is hidden. Persisted (`UsageStore.updateNotificationsEnabled`), defaults to **on** so current behavior is unchanged.
- **Check now** button — force-checks GitHub for the latest release (`check(minInterval: 0)`, bypassing the rate-limit guard), with a spinner while checking.
- **Result row** — shows "You're on the latest (vX.Y.Z)", or "Version X.Y.Z is available" with an **Update** button. The Update button in the result means a user who turned the banner off can still discover and apply an update.

The banner (`PopoverView.updateBanner`) is gated on `updater.available && store.updateNotificationsEnabled` and is reactive — flipping the toggle back on re-shows it.

## Type of change

- [x] New feature (Settings)

## Checklist

- [x] `swift build` and `swift test` pass locally (266 tests, 0 failures)
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
