### PR TITLE
fix: read Claude Keychain only on user action, not auto-poll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,18 @@
 - **UI 변경 → 스크린샷 stale** 은 `release.sh` 가 자동 경고(§릴리스 1) — 통과의례화 방지.
 - **앱 소유 keychain 항목 금지.** 앱이 만든 keychain 항목은 코드서명(cdhash)이 바뀔 때마다(로컬 재빌드·
   실사용자 매 업그레이드) 항목 ACL 이 안 맞아 접근 허용 프롬프트를 유발한다 — **no-UI 쿼리로도 이 ACL
-  프롬프트는 억제 안 됨**(#58). 토큰류는 인메모리 캐시 + 원본 소스(Claude 키체인 무UI 읽기·파일) 재취득으로
+  프롬프트는 억제 안 됨**(#58). 토큰류는 인메모리 캐시 + 파일(`~/.claude/.credentials.json`) 재취득으로
   처리하고, 앱 전용 keychain 캐시 항목을 새로 만들지 말 것.
+- **자동 폴링은 Claude 키체인을 절대 읽지 마라(키체인 읽기는 사용자 동작 전용).** no-UI 쿼리
+  (`kSecUseAuthenticationUIFail`/`LAContext`)는 '인증' 프롬프트만 억제할 뿐 **잠긴·미승인 login 키체인의
+  '암호 입력' 다이얼로그는 못 막는다** — 실측: 캐시 만료 폴 도중 `SecItemCopyMatching` 이 13초간 블록하며
+  팝업(토큰 만료 시점마다 하루 몇 회, 아침 등). self-signed 앱은 '항상 허용' 승인도 불안정. → 타이머 경로
+  `fetch(allowKeychainPrompt: false)` 는 캐시+파일만 쓰고 키체인은 건드리지 않는다(`OAuthLimitsProvider`
+  의 `guard allowKeychainPrompt` 가 키체인 읽기 앞에 위치). 키체인 읽기는 명시적 사용자 버튼
+  (설정 갱신·팝오버 `claudeLimitsRefreshRow`, `refreshLimitTokenFromKeychain`)에서만. 캐시 토큰이 살아있는
+  동안은 자동 폴이 그 토큰으로 한도를 계속 갱신하고, 만료되면 stale 표시 후 사용자가 갱신한다. 회귀 가드:
+  `testAutoRefreshUsesNoPromptPathManualUsesPromptPath`. (완전 근절은 Developer ID notarization 으로
+  '항상 허용' 승인을 안정화하는 것뿐 — 신뢰된 서명 신원이라야 ACL 승인이 지속된다. 미도입.)
 - **휘발성 필드를 dedup/identity 키에 쓰지 마라.** 매 fetch/refresh 마다 값이 변하는 필드(예: rolling
   한도 창의 `resets_at`)를 알림 중복방지 키에 넣으면 매번 새 키가 되어 dedup 이 무력화된다 — 주간 한도
   알림이 80·81·84…갱신마다 반복되던 회귀. 임계값 알림은 **엣지 트리거**(직전 tier 보다 높아진 순간만

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -35,6 +35,8 @@ struct L {
     var limitReached: String { t("한도 도달", "Limit reached", "上限到達") }
     var personalSpendLimit: String { t("개인 사용 한도", "Personal spend limit", "個人利用上限") }
     var staleLimits: String { t("갱신 지연", "Stale", "更新遅延") }
+    var refresh: String { t("갱신", "Refresh", "更新") }
+    var limitsTapToLoad: String { t("공식 한도 불러오기", "Load official limits", "公式上限を読み込む") }
 
     /// 프로바이더 상태 페이지 인시던트 지표 → 현지화 라벨(표시 전용).
     func providerStatusLabel(_ indicator: ProviderStatusIndicator) -> String {
@@ -107,7 +109,7 @@ struct L {
     var disableKeychain: String { t("Keychain 접근 끄기", "Disable Keychain access", "Keychainアクセスを無効化") }
     var disableKeychainHint: String { t("켜면 Keychain 접근 허용 팝업이 더 안 뜹니다 — 공식 한도(%)만 숨겨지고 토큰·비용은 그대로", "When on, no more Keychain permission pop-ups — only official limits (%) are hidden; tokens/cost stay", "オンにするとKeychain許可のポップアップが出なくなります — 公式上限(%)のみ非表示、トークン・費用はそのまま") }
     var refreshLimitToken: String { t("한도 토큰 캐시 갱신", "Refresh limit token cache", "上限トークンキャッシュを更新") }
-    var onlyOnPress: String { t("누를 때만 Keychain 확인 — 최초 1회 '항상 허용'하면 이후 자동 갱신", "Checks Keychain only when pressed — grant 'Always Allow' once, then it auto-refreshes", "押した時のみKeychain確認 — 初回に'常に許可'すると以降は自動更新") }
+    var onlyOnPress: String { t("누를 때만 Keychain 을 읽어요 — 자동 폴링은 안 읽어 팝업이 안 떠요. 토큰 만료 후 이 버튼으로 한도 갱신", "Reads Keychain only when pressed — auto-polling never does, so no pop-ups. Refresh limits here after the token expires", "押した時のみKeychainを読みます — 自動更新では読まずポップアップも出ません。トークン期限切れ後はこのボタンで上限を更新") }
     var launchAtLogin: String { t("로그인 시 자동 시작", "Launch at login", "ログイン時に自動起動") }
     var bundledOnly: String { t(".app 번들로 설치된 경우에만 사용 가능 (scripts/build-app.sh)", "Available only when installed as an .app bundle (scripts/build-app.sh)", ".appバンドルでインストールした場合のみ利用可能 (scripts/build-app.sh)") }
     var notificationsSection: String { t("알림", "Notifications", "通知") }

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -78,39 +78,29 @@ private actor OAuthAccessTokenCache {
             return cachedCredential.accessToken
         }
 
-        // 자동(무프롬프트) 경로에서 login 키체인이 잠겨 있으면 키체인 접근을 일절 하지 않는다.
-        // no-UI 플래그(kSecUseAuthenticationUIFail/LAContext)는 '인증' 프롬프트만 억제할 뿐
-        // 잠긴 키체인의 '암호 입력' 다이얼로그는 못 막는다 → 잠긴 아침마다 사용자에게 팝업이 뜨는
-        // 결함의 원인. 잠겨 있으면 파일 크리덴셜만 시도하고(키체인 무관), 없으면 조용히 실패한다.
-        if !allowKeychainPrompt, Self.isDefaultKeychainLocked() {
-            if let credential = try Self.readClaudeCredentialsFile() {
-                cachedCredential = credential   // 잠긴 키체인에는 캐시 write 안 함(그 write 도 프롬프트 유발)
-                return credential.accessToken
-            }
-            throw LimitsError.keychainInteractionNotAllowed
-        }
-
+        // 파일 크리덴셜(~/.claude/.credentials.json) — 키체인 무관, 프롬프트 없음.
         if let credential = try Self.readClaudeCredentialsFile() {
             cachedCredential = credential
             return credential.accessToken
         }
-        // 무프롬프트(no-UI) Claude Keychain 읽기. 사용자가 과거 한 번 '항상 허용'했다면
-        // 앱 cdhash 가 항목 ACL 에 등록돼 *프롬프트 없이* 성공한다. 아직 허용 전이거나 접근
-        // 불가면 errSecInteractionNotAllowed 로 조용히 실패 — 다이얼로그가 뜨지 않는다.
-        // 이 경로 덕분에 자동 새로고침이 만료된 토큰을 스스로 재취득해 한도(주간 리셋 포함)를
-        // 갱신한다. 수동 버튼 없이 자동 동작하게 하는 핵심.
-        if let credential = Self.readClaudeKeychainSilently() {
-            cachedCredential = credential
-            return credential.accessToken
-        }
-        // 무프롬프트로 토큰을 못 구함 → 명시적 사용자 동작(설정의 갱신 버튼)일 때만 프롬프트를
-        // 동반해 읽는다(최초 1회 '항상 허용' 유도). 이후엔 위 무프롬프트 경로로 자동 동작한다.
-        // `security` CLI 보조 경로는 별도 신원이라 두 번째 ACL 프롬프트를 띄워 제거함.
+
+        // 자동(타이머) 경로는 Claude Keychain 을 일절 읽지 않는다. no-UI 쿼리(kSecUseAuthenticationUIFail
+        // /LAContext)로도 잠긴·미승인 login 키체인의 '암호 입력' 다이얼로그는 억제되지 않는다 —
+        // 실측: 캐시 만료 폴 도중 SecItemCopyMatching 이 13초간 블록하며 팝업을 띄웠다(하루 몇 회).
+        // → Keychain 읽기는 명시적 사용자 동작(설정/팝오버의 갱신 버튼, allowKeychainPrompt=true)에서만
+        // 수행한다. 캐시된 토큰이 살아있는 동안은 자동 폴링이 그 토큰으로 계속 한도를 갱신하고, 만료되면
+        // 한도는 마지막 값으로 stale 표시된 뒤 사용자가 갱신을 누를 때 재취득된다.
         guard allowKeychainPrompt else {
             throw LimitsError.keychainInteractionNotAllowed
         }
 
-        let credential = try Self.readClaudeKeychain(allowKeychainPrompt: allowKeychainPrompt)
+        // 사용자 동작 경로: 무프롬프트로 먼저 시도(과거 '항상 허용'했다면 조용히 성공), 안 되면 프롬프트를
+        // 동반해 읽어 최초 1회 '항상 허용'을 유도한다.
+        if let credential = Self.readClaudeKeychainSilently() {
+            cachedCredential = credential
+            return credential.accessToken
+        }
+        let credential = try Self.readClaudeKeychain(allowKeychainPrompt: true)
         cachedCredential = credential
         return credential.accessToken
     }
@@ -127,17 +117,6 @@ private actor OAuthAccessTokenCache {
             AppLog.write("silent claude keychain read failed: \(error)")
             return nil
         }
-    }
-
-    /// login(기본) 키체인 잠금 여부. GetStatus 는 프롬프트 없이 상태만 읽는다(안전).
-    /// SecKeychain* 는 deprecated 지만 파일 기반 login 키체인의 잠금 상태를 무프롬프트로 조회하는
-    /// 유일한 API — 대체재 없음. 조회 실패 시 '잠기지 않음'으로 간주(기존 경로 유지, 보수적).
-    private nonisolated static func isDefaultKeychainLocked() -> Bool {
-        var keychain: SecKeychain?
-        guard SecKeychainCopyDefault(&keychain) == errSecSuccess, let keychain else { return false }
-        var status = SecKeychainStatus()
-        guard SecKeychainGetStatus(keychain, &status) == errSecSuccess else { return false }
-        return (status & SecKeychainStatus(kSecUnlockStateStatus)) == 0   // unlock 비트 꺼짐 = 잠김
     }
 
     /// 마지막으로 사용한 자격증명의 플랜 정보. accessToken() 이 모든 경로에서 cachedCredential 을

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -275,6 +275,12 @@ struct PopoverView: View {
                 .foregroundStyle(.secondary)
             if selectedSnapshot?.providerID == "claude_code", store.limitsAuthExpired {
                 claudeAuthExpiredNotice
+            } else if selectedSnapshot?.providerID == "claude_code",
+                      !store.disableKeychainAccess,
+                      store.limits == nil || store.claudeLimitsStale {
+                // 자동 폴링은 Keychain 을 안 읽으므로(팝업 방지), 최초/만료 후 공식 한도는 이 원탭으로
+                // 사용자가 직접 갱신한다. 프롬프트가 뜨더라도 사용자 행동에 의한 것이라 예상 가능하다.
+                claudeLimitsRefreshRow
             }
             if selectedSnapshot?.providerID == "claude_code", let limits = store.limits {
                 // 플랜(계정 속성) — Codex codexMetaRow 와 동일 스타일. 구독 정보 있을 때만 노출.
@@ -282,10 +288,6 @@ struct PopoverView: View {
                     Text(l.plan(plan))
                         .font(.caption)
                         .foregroundStyle(.tertiary)
-                }
-                // 세션 만료 안내가 이미 있으면 stale 배지는 생략(중복 신호 방지)
-                if store.claudeLimitsStale, !store.limitsAuthExpired {
-                    staleBadge(updatedAt: store.limitsUpdatedAt)
                 }
                 // 세션 만료 시 표시값은 만료 전 기준 → 흐리게 처리해 "현재 값 아님"을 시각적으로 전달
                 VStack(alignment: .leading, spacing: 8) {
@@ -420,6 +422,33 @@ struct PopoverView: View {
         }
         .padding(8)
         .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    /// Claude 공식 한도 — 최초 로드/만료(stale) 시 사용자가 원탭으로 Keychain 을 읽어 갱신.
+    /// 자동 폴링이 Keychain 을 안 읽는 대신 여기서 명시적 사용자 동작으로만 재취득한다.
+    @ViewBuilder
+    private var claudeLimitsRefreshRow: some View {
+        HStack(spacing: 6) {
+            if store.limits == nil {
+                Text(l.limitsTapToLoad)
+                    .font(.caption).foregroundStyle(.secondary)
+            } else {
+                (Text(l.staleLimits) + Text(" · ") + Text(store.limitsUpdatedAt ?? Date(), style: .relative))
+                    .font(.caption).foregroundStyle(.orange)
+            }
+            Spacer()
+            Button {
+                Task { await store.refreshLimitTokenFromKeychain() }
+            } label: {
+                if store.isRefreshingLimitToken {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text(l.refresh)
+                }
+            }
+            .controlSize(.small)
+            .disabled(store.isRefreshingLimitToken)
+        }
     }
 
     /// 한도 스냅샷 갱신 지연 배지 — Claude/Codex 공용 (마지막 성공 시각 상대 표시).

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -55,6 +55,18 @@ private struct FakeCodexLimits: CodexLimitsProviding {
     func fetch() async throws -> CodexRateLimitStatus? { status }
 }
 
+/// 호출마다 allowKeychainPrompt 값을 기록 — 자동/수동 경로가 올바른 플래그를 쓰는지 회귀 검증용.
+private final class RecordingClaudeLimits: ClaudeLimitsProviding, @unchecked Sendable {
+    nonisolated(unsafe) var promptFlags: [Bool] = []
+    nonisolated(unsafe) var status: LimitStatus?
+    init(status: LimitStatus? = nil) { self.status = status }
+    func fetch(allowKeychainPrompt: Bool) async throws -> LimitStatus {
+        promptFlags.append(allowKeychainPrompt)
+        guard let status else { throw LimitsError.keychainInteractionNotAllowed }
+        return status
+    }
+}
+
 private final class FakeStatusProvider: ProviderStatusProviding, @unchecked Sendable {
     nonisolated(unsafe) var result: [String: ProviderStatus]
     init(_ result: [String: ProviderStatus] = [:]) { self.result = result }
@@ -128,6 +140,30 @@ final class UsageStoreTests: XCTestCase {
         return UsageStore(providers: [claude], claudeLimitsProvider: FakeClaudeLimits(status: nil),
                           codexLimitsProvider: FakeCodexLimits(status: nil), statusProvider: stub,
                           autoRefresh: false, defaults: testDefaults)
+    }
+
+    // MARK: Keychain 프롬프트 경로 분리 (회귀)
+
+    /// 회귀 가드: 자동 폴링은 프롬프트 없는 경로(allowKeychainPrompt=false)로만 한도를 조회하고,
+    /// macOS Keychain 암호 다이얼로그를 유발할 수 있는 경로는 사용자 명시 동작(설정/팝오버 버튼)에서만
+    /// 쓴다. 자동 경로에 true 를 넘기면(과거 회귀: 캐시 만료 폴이 하루 몇 번 암호 팝업을 띄움) 실패한다.
+    func testAutoRefreshUsesNoPromptPathManualUsesPromptPath() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(1_000))
+        let limits = RecordingClaudeLimits(status: claudeLimits(fiveHourUtil: 10))
+        let store = UsageStore(providers: [claude],
+                               claudeLimitsProvider: limits,
+                               codexLimitsProvider: FakeCodexLimits(status: nil),
+                               autoRefresh: false,
+                               defaults: testDefaults)
+
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertFalse(limits.promptFlags.isEmpty, "자동 refresh 가 한도를 조회해야 한다")
+        XCTAssertTrue(limits.promptFlags.allSatisfy { $0 == false },
+                      "자동 폴링은 절대 Keychain 프롬프트 경로(true)를 쓰면 안 된다 — 암호 다이얼로그 유발")
+
+        await store.refreshLimitTokenFromKeychain()
+        XCTAssertEqual(limits.promptFlags.last, true,
+                       "수동 갱신(사용자 버튼)만 프롬프트 허용 경로를 쓴다")
     }
 
     // MARK: 프로바이더 상태(인시던트) 표시


### PR DESCRIPTION
The 2-minute auto-poll read the Claude OAuth token from the login keychain to
fetch official limit %, which triggered a macOS "enter login keychain password"
dialog several times a day — at each token expiry, when the in-memory cache
missed and a fresh keychain read was needed. The no-UI flags
(kSecUseAuthenticationUIFail / LAContext) do not suppress that unlock/password
dialog (measured as a 13s block during the poll), and a self-signed app's
"Always Allow" grant is unstable.

Move every keychain read behind an explicit-user-action guard. The auto path now
uses only the in-memory cache and the CLI-written credentials file under
~/.claude; the keychain is read solely via the manual refresh button and a new
popover row. While the cached token is valid, auto-poll keeps limits live off
that token; after it expires, limits show the last value (stale) until a one-tap
refresh. Tokens/cost (from local JSONL) are unaffected.

- OAuthLimitsProvider.accessToken: `guard allowKeychainPrompt` now sits before
  every keychain read; remove the now-unused isDefaultKeychainLocked.
- PopoverView: claudeLimitsRefreshRow — one-tap load/refresh shown when Claude
  limits are missing or stale (and keychain access is not disabled).
- Localization: correct onlyOnPress copy; add refresh / limitsTapToLoad (ko/en/ja).
- Test: testAutoRefreshUsesNoPromptPathManualUsesPromptPath asserts the auto path
  uses the no-prompt flag and manual refresh uses the prompt flag.

Trade-off: official limits go stale after token expiry until a one-tap refresh;
a fully persistent one-time grant would require Developer ID notarization.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
