### PR TITLE
feat: add Shiny Charm shop item — permanent, raises shiny hatch odds

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -86,12 +86,14 @@ enum PokemonBalance {
 enum ItemKind: String, Codable, Sendable, CaseIterable {
     case rareCandy
     case mint
+    case shinyCharm
 
     /// PokéAPI 아이템 스프라이트 파일명(.../sprites/items/{name}.png). nil = 스프라이트 없음(이모지 폴백만).
     var spriteName: String? {
         switch self {
         case .rareCandy: return "rare-candy"
         case .mint: return nil   // PokéAPI 에 민트 스프라이트 없음(8세대 아이템) → 이모지 폴백
+        case .shinyCharm: return "shiny-charm"
         }
     }
     /// 스프라이트 로딩 전/미제공/실패 시 폴백 이모지.
@@ -99,6 +101,7 @@ enum ItemKind: String, Codable, Sendable, CaseIterable {
         switch self {
         case .rareCandy: return "🍬"
         case .mint: return "🌿"
+        case .shinyCharm: return "✨"
         }
     }
     /// 상점 판매가(재화 = 사용한 토큰). nil = 상점 미판매.
@@ -106,6 +109,14 @@ enum ItemKind: String, Codable, Sendable, CaseIterable {
         switch self {
         case .rareCandy: return RareCandy.price
         case .mint: return Mint.price
+        case .shinyCharm: return ShinyCharm.price
+        }
+    }
+    /// 보유형(패시브) 아이템 — 소비하지 않고 보유하는 동안 상시 효과. 1회 구매(재구매 불가), 가방엔 "적용 중" 표시.
+    var isPassive: Bool {
+        switch self {
+        case .rareCandy, .mint: return false
+        case .shinyCharm: return true
         }
     }
 }
@@ -130,6 +141,15 @@ enum Mint {
     /// 사탕(500M)의 1/5로 싸게 둬서 성격을 마음에 들 때까지 굴려보는 가벼운 재미. 성장을 안 줘서
     /// 이중계산 이슈도 없음(가격 = 순수 소비).
     static let price = 100_000_000
+}
+
+/// 이로치 부적 밸런스 상수 — 보유형(1회 구매·영구, 소비 안 됨).
+enum ShinyCharm {
+    /// 상점 구매가. 앞으로의 모든 부화에 적용되는 영구 럭 업그레이드라 프리미엄(레어 1마리 졸업분=3B).
+    static let price = 3_000_000_000
+    /// 보유 시 이로치 부화 확률 분모 — 1/64 → 1/48 (+33%). 본가 '반짝이 부적'(이로치 확률↑) 오마주.
+    /// ×2(1/32)는 과해 절제. 이미 부화한 개체엔 소급 없음(이로치는 부화 순간 확정).
+    static let shinyDenominator: UInt64 = 48
 }
 
 /// 사탕 지급 대상 한도 창의 분류 — session=1개·weekly=weeklyGrant.

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -297,6 +297,8 @@ final class CompanionStore {
 
     var rareCandyCount: Int { itemCount(.rareCandy) }
     func itemCount(_ kind: ItemKind) -> Int { state.inventory[kind.rawValue] ?? 0 }
+    /// 이로치 부적 보유 여부 — 보유형이라 개수>0 = 소유(부화 shiny 분모를 낮춘다).
+    var ownsShinyCharm: Bool { itemCount(.shinyCharm) > 0 }
 
     /// 소유 아이템(개수>0) — 가방 목록. 정렬은 ItemKind.allCases 순서.
     var ownedItems: [(kind: ItemKind, count: Int)] {
@@ -363,6 +365,7 @@ final class CompanionStore {
     /// 구매 가능 — 잔액이 그 아이템 가격 이상(상점 미판매면 false). 활성/알 무관(재고는 미리 쌓아둘 수 있음).
     func canBuy(_ kind: ItemKind) -> Bool {
         guard let price = kind.shopPrice else { return false }
+        if kind.isPassive && itemCount(kind) > 0 { return false }   // 보유형은 1회만(재구매 불가)
         return availableTokens >= price
     }
 
@@ -371,6 +374,7 @@ final class CompanionStore {
     @discardableResult
     func buy(_ kind: ItemKind) -> Bool {
         guard let price = kind.shopPrice, availableTokens >= price else { return false }
+        if kind.isPassive && itemCount(kind) > 0 { return false }   // 보유형 중복 구매 방지(방어)
         state.spentTokens += price
         state.inventory[kind.rawValue, default: 0] += 1
         save()
@@ -516,6 +520,11 @@ final class CompanionStore {
         rarity == .common && totalForms >= 2 && roll % PokemonOdds.dittoDisguiseDenominator == 0
     }
 
+    /// 이로치 부화 판정(순수) — 미리 뽑은 roll 값 % 분모(부적 보유 48, 없으면 64)==0. (부수효과 없이 xctest)
+    nonisolated static func rollsShiny(roll: UInt64, charmOwned: Bool) -> Bool {
+        roll % (charmOwned ? ShinyCharm.shinyDenominator : PokemonOdds.shinyDenominator) == 0
+    }
+
     /// 실제 부화 로직 — isHatching 락은 호출자(hatch / hatchIfNeeded)가 소유·해제한다.
     private func hatchCore(baseID: Int) async {
         guard let line = try? await provider.line(baseSpeciesID: baseID) else {
@@ -527,7 +536,7 @@ final class CompanionStore {
         let overflow = max(0, state.eggUsage - PokemonBalance.eggHatchThreshold)
         state.eggUsage = 0
         // 개체 롤 — shiny(1/64)·성격(25종)은 부화 순간 확정, 진화해도 유지.
-        let isShiny = rng.next() % PokemonOdds.shinyDenominator == 0
+        let isShiny = Self.rollsShiny(roll: rng.next(), charmOwned: ownsShinyCharm)
         let nature = PokemonNature.allCases[Int(rng.next() % UInt64(PokemonNature.allCases.count))]
         // 메타몽 위장 롤 — common·≥2형태에 한해 1/128. .app 게이트(&& 단락 → 비앱에선 rng 미소비로
         // 기존 테스트 RNG 시퀀스 무영향). 위장/리빌 로직은 상태 기반으로 별도 테스트한다.

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -325,6 +325,7 @@ struct L {
         switch kind {
         case .rareCandy: return t("이상한 사탕", "Rare Candy", "ふしぎなアメ")
         case .mint:      return t("민트", "Mint", "ミント")
+        case .shinyCharm: return t("이로치 부적", "Shiny Charm", "ひかるおまもり")
         }
     }
     func itemDescription(_ kind: ItemKind) -> String {
@@ -338,6 +339,10 @@ struct L {
             return t("현재 포켓몬의 성격을 랜덤으로 바꾼다.",
                      "Randomly changes your Pokémon's nature.",
                      "ポケモンのせいかくをランダムに変える。")
+        case .shinyCharm:
+            return t("보유하면 이로치 포켓몬이 태어날 확률이 올라가요.",
+                     "While owned, raises the chance of hatching a shiny.",
+                     "持っていると色違いが生まれる確率が上がります。")
         }
     }
     /// 가방 사용 컨트롤의 효과 힌트 — 민트("성격 랜덤 변경", 사탕의 "+XP" 자리).
@@ -352,6 +357,8 @@ struct L {
     var notEnoughTokens: String { t("토큰이 부족해요", "Not enough tokens", "トークンが足りません") }
     func ownedCount(_ n: Int) -> String { t("보유 ×\(n)", "Owned ×\(n)", "所持 ×\(n)") }
     var shopPriceLabel: String { t("가격", "Price", "価格") }
+    var ownedAlready: String { t("보유 중", "Owned", "所持済み") }
+    var shinyCharmEffectHint: String { t("이로치 확률 ↑ · 적용 중", "Shiny rate ↑ · active", "色違い率↑ · 適用中") }
 
     // MARK: 사탕 획득 알림 ("왜 받는지" = 토큰 한도를 다 채운 수고에 대한 보상)
     func notifCandyTitle(item: String, count: Int) -> String {

--- a/Sources/PokeTokenBar/UI/BagView.swift
+++ b/Sources/PokeTokenBar/UI/BagView.swift
@@ -51,8 +51,10 @@ private struct ItemCard: View {
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 6) {
                         Text(l.itemName(kind)).font(.callout.weight(.semibold))
-                        Text("×\(count)").font(.caption.weight(.bold))
-                            .foregroundStyle(.secondary).monospacedDigit()
+                        if !kind.isPassive {   // 보유형은 개수 개념이 없음(1회 구매·영구)
+                            Text("×\(count)").font(.caption.weight(.bold))
+                                .foregroundStyle(.secondary).monospacedDigit()
+                        }
                     }
                     Text(l.itemDescription(kind))
                         .font(.caption).foregroundStyle(.secondary)
@@ -72,6 +74,7 @@ private struct ItemCard: View {
         switch kind {
         case .rareCandy: return store.canUseRareCandy
         case .mint:      return store.canUseMint
+        case .shinyCharm: return false   // 보유형 — 사용 개념 없음(상시 효과)
         }
     }
     /// 사용 컨트롤 효과 힌트 ("+XP" / "성격 랜덤 변경").
@@ -79,18 +82,27 @@ private struct ItemCard: View {
         switch kind {
         case .rareCandy: return "+\(TokenFormatter.compact(RareCandy.xp)) XP"
         case .mint:      return l.mintEffectHint
+        case .shinyCharm: return l.shinyCharmEffectHint
         }
     }
     private func performUse() {
         switch kind {
         case .rareCandy: _ = store.useRareCandy()
         case .mint:      _ = store.useMint()
+        case .shinyCharm: break   // 보유형 — 사용 동작 없음
         }
     }
 
     @ViewBuilder
     private func useControls(_ l: L) -> some View {
-        if canUse {
+        if kind.isPassive {
+            // 보유형(이로치 부적) — 사용 버튼 대신 상시 효과 표시.
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.seal.fill").font(.caption2).foregroundStyle(.green)
+                Text(l.shinyCharmEffectHint).font(.caption2.weight(.semibold)).foregroundStyle(.green)
+                Spacer()
+            }
+        } else if canUse {
             if confirming {
                 HStack(spacing: 8) {
                     Text(l.useOnCurrent(store.displayName))

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -54,7 +54,7 @@ private struct ShopItemCard: View {
                     HStack(spacing: 6) {
                         Text(l.itemName(kind)).font(.callout.weight(.semibold))
                         let owned = store.itemCount(kind)
-                        if owned > 0 {
+                        if owned > 0 && !kind.isPassive {
                             Text(l.ownedCount(owned)).font(.caption2.weight(.bold))
                                 .foregroundStyle(.secondary).monospacedDigit()
                         }
@@ -74,7 +74,14 @@ private struct ShopItemCard: View {
 
     @ViewBuilder
     private func buyControls(_ l: L) -> some View {
-        if confirming {
+        if kind.isPassive && store.itemCount(kind) > 0 {
+            // 보유형(이로치 부적 등) — 1회 구매라 소유 후엔 "보유 중" 표시(재구매 버튼 없음).
+            HStack(spacing: 5) {
+                Image(systemName: "checkmark.seal.fill").font(.caption2).foregroundStyle(.green)
+                Text(l.ownedAlready).font(.caption2.weight(.semibold)).foregroundStyle(.green)
+                Spacer()
+            }
+        } else if confirming {
             HStack(spacing: 8) {
                 Text(l.buyConfirm(l.itemName(kind)))
                     .font(.caption2).foregroundStyle(.secondary).lineLimit(1)

--- a/Tests/PokeTokenBarTests/ShinyCharmTests.swift
+++ b/Tests/PokeTokenBarTests/ShinyCharmTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import PokeTokenBar
+
+// MARK: 이로치 부적 (보유형 · 부화 shiny 확률↑)
+
+private func scNode(_ id: Int, _ ch: [EvoNode] = []) -> EvoNode { EvoNode(speciesID: id, children: ch) }
+private func scLine(base: Int) -> EvoLine {
+    EvoLine(baseID: base, tree: scNode(base), rarity: .common,
+            names: [base: ["en": "P\(base)", "ko": "포\(base)", "ja": "ポ\(base)"]])
+}
+private struct CharmStubProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine { scLine(base: baseSpeciesID) }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: 1, captureRate: 255)] }
+}
+
+@MainActor
+final class ShinyCharmTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// 지갑/부적 보유를 지정한 알(active=null) 상태 스토어.
+    private func store(used: Int = 5_000_000_000, spent: Int = 0, charm: Bool = false, seed: UInt64 = 7) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("charm-\(UUID().uuidString).json")
+        let inv = charm ? ",\"inventory\":{\"shinyCharm\":1}" : ""
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":\(used),\"spentTokens\":\(spent),"
+            + "\"lastDate\":\"d\",\"active\":null,\"dex\":[],\"collectedFinals\":[]\(inv)}"
+        try? json.data(using: .utf8)!.write(to: url)
+        return CompanionStore(provider: CharmStubProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: seed))
+    }
+
+    // MARK: 순수 판정 — 부적 유무로 분모가 48/64 로 바뀌며 판정이 뒤집힌다
+
+    func testRollsShinyFlipsWithCharm() {
+        // roll=48: 부적 있으면 shiny(48%48==0), 없으면 아님(48%64≠0)
+        XCTAssertTrue(CompanionStore.rollsShiny(roll: 48, charmOwned: true))
+        XCTAssertFalse(CompanionStore.rollsShiny(roll: 48, charmOwned: false))
+        // roll=64: 부적 없으면 shiny, 있으면 아님(64%48≠0)
+        XCTAssertTrue(CompanionStore.rollsShiny(roll: 64, charmOwned: false))
+        XCTAssertFalse(CompanionStore.rollsShiny(roll: 64, charmOwned: true))
+        // roll=96: 부적 있으면 shiny(96%48==0), 없으면 아님(96%64≠0)
+        XCTAssertTrue(CompanionStore.rollsShiny(roll: 96, charmOwned: true))
+        XCTAssertFalse(CompanionStore.rollsShiny(roll: 96, charmOwned: false))
+        // roll=0: 둘 다 shiny · roll=1: 둘 다 아님
+        XCTAssertTrue(CompanionStore.rollsShiny(roll: 0, charmOwned: true))
+        XCTAssertTrue(CompanionStore.rollsShiny(roll: 0, charmOwned: false))
+        XCTAssertFalse(CompanionStore.rollsShiny(roll: 1, charmOwned: true))
+        XCTAssertFalse(CompanionStore.rollsShiny(roll: 1, charmOwned: false))
+    }
+
+    func testConstantsAndPassiveFlag() {
+        XCTAssertEqual(ShinyCharm.price, 3_000_000_000)
+        XCTAssertEqual(ShinyCharm.shinyDenominator, 48)
+        XCTAssertTrue(ItemKind.shinyCharm.isPassive)
+        XCTAssertFalse(ItemKind.rareCandy.isPassive)
+        XCTAssertFalse(ItemKind.mint.isPassive)
+        XCTAssertEqual(ItemKind.shinyCharm.spriteName, "shiny-charm")
+    }
+
+    // MARK: 구매 / 보유 (보유형 = 1회 구매)
+
+    func testBuyDeductsAndOwns() {
+        let s = store(used: 5_000_000_000, spent: 0, charm: false)
+        XCTAssertFalse(s.ownsShinyCharm)
+        XCTAssertTrue(s.purchasableItems.contains(.shinyCharm), "상점에 노출")
+        XCTAssertTrue(s.canBuy(.shinyCharm))
+        XCTAssertTrue(s.buy(.shinyCharm))
+        XCTAssertTrue(s.ownsShinyCharm)
+        XCTAssertEqual(s.itemCount(.shinyCharm), 1)
+        XCTAssertEqual(s.state.spentTokens, ShinyCharm.price, "지갑에서 3B 차감")
+        XCTAssertEqual(s.availableTokens, 5_000_000_000 - ShinyCharm.price)
+    }
+
+    /// 보유형은 재구매 불가 — canBuy false, buy no-op, 지출/개수 불변.
+    func testBuyOnceNoRepurchase() {
+        let s = store(used: 10_000_000_000, charm: true)
+        XCTAssertTrue(s.ownsShinyCharm)
+        XCTAssertFalse(s.canBuy(.shinyCharm), "보유형은 재구매 불가")
+        let spentBefore = s.state.spentTokens
+        XCTAssertFalse(s.buy(.shinyCharm), "재구매 no-op")
+        XCTAssertEqual(s.state.spentTokens, spentBefore, "지출 불변")
+        XCTAssertEqual(s.itemCount(.shinyCharm), 1, "개수 1 유지(2 안 됨)")
+    }
+
+    func testCanBuyNeedsEnoughTokens() {
+        let s = store(used: 2_000_000_000)   // 3B 미만
+        XCTAssertFalse(s.canBuy(.shinyCharm))
+        XCTAssertFalse(s.buy(.shinyCharm))
+        XCTAssertFalse(s.ownsShinyCharm)
+    }
+
+    func testOwnsReflectsInventory() {
+        XCTAssertFalse(store(charm: false).ownsShinyCharm)
+        XCTAssertTrue(store(charm: true).ownsShinyCharm)
+    }
+
+    // MARK: 부화 통합 (스모크) — 부적 보유 상태에서 hatchCore 경로가 정상 동작
+
+    func testHatchWorksWithCharmOwned() async {
+        let s = store(used: 5_000_000_000, charm: true, seed: 7)
+        await s.hatch(baseID: 1)
+        XCTAssertNotNil(s.state.active, "부적 보유 상태에서도 정상 부화")
+        XCTAssertEqual(s.currentSpeciesID, 1)
+    }
+}


### PR DESCRIPTION
## Summary

A new shop item: the **Shiny Charm** — a **passive, buy-once** item (not a consumable). Bought once for **3B** tokens, and while owned it lowers the shiny hatch denominator **64 → 48** for all future hatches. Only future hatches benefit (shiny is fixed at hatch); an already-hatched companion is unaffected.

- `ItemKind.shinyCharm` (sprite `shiny-charm`, ✨ fallback) + a new `isPassive` flag. `ShinyCharm` enum: price `3_000_000_000`, `shinyDenominator` 48.
- `CompanionStore`: `ownsShinyCharm`; pure `rollsShiny(roll:charmOwned:)`; `hatchCore` uses it. `canBuy`/`buy` reject a passive item already owned (buy-once).
- **Shop** shows "Owned" for an owned passive item (no re-buy button). **Bag** shows it as an active passive effect ("Shiny rate ↑ · active") — no use button or count.
- Localization ko/en/ja. The item description says the odds go up **without stating a specific ratio**.

## Type of change

- [x] New feature (shop item)

## Checklist

- [x] `swift build` and `swift test` pass locally (274 tests, 0 failures)
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
