### PR TITLE
refactor: unify the ".app" bundle check into AppEnv.isBundledApp

### DIFF
--- a/Sources/PokeTokenBar/Core/AppEnv.swift
+++ b/Sources/PokeTokenBar/Core/AppEnv.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// 실행 환경 판별 — 한 곳에서만 정의해 중복 게이트의 drift(일부만 조건이 어긋나는 것)를 막는다.
+enum AppEnv {
+    /// 정식 `.app` 번들로 실행 중인가. 알림 전송·키체인 읽기·스프라이트 프리패치·프로덕션 로그 기록 등
+    /// "실앱 전용" 부수효과의 단일 게이트 — `swift test`/로우 바이너리(dev 실행)에선 false.
+    /// bundleIdentifier(Info.plist)와 경로 접미사를 함께 확인(둘 다 실앱에서만 참).
+    static var isBundledApp: Bool {
+        Bundle.main.bundleIdentifier != nil && Bundle.main.bundlePath.hasSuffix(".app")
+    }
+}

--- a/Sources/PokeTokenBar/Core/AppLog.swift
+++ b/Sources/PokeTokenBar/Core/AppLog.swift
@@ -23,7 +23,7 @@ enum AppLog {
         // 실제 .app 실행에서만 기록 — swift test / 로우 바이너리 실행이 프로덕션 로그를 오염시키지
         // 않게(형제 write 경로 writeParitySnapshot·checkLimitNotifications 와 동일 가드). 테스트가
         // 크래시 진단 로그에 fixture 값을 남기고 회전으로 실이력을 밀어내던 결함 차단.
-        guard Bundle.main.bundleIdentifier != nil, Bundle.main.bundlePath.hasSuffix(".app") else { return }
+        guard AppEnv.isBundledApp else { return }
         let line = "[\(ISO8601DateFormatter().string(from: Date()))] \(message)\n"
         queue.async {
             if let size = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int,

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -436,7 +436,7 @@ final class CompanionStore {
     /// companion 이벤트 시스템 알림(.app + 토글 ON 일 때만). 한도 알림과 독립.
     private var notifSeq = 0
     private func notifyCompanionEvent(_ title: String, _ body: String) {
-        guard Bundle.main.bundleIdentifier != nil, Bundle.main.bundlePath.hasSuffix(".app") else { return }
+        guard AppEnv.isBundledApp else { return }
         guard UserDefaults.standard.object(forKey: "companionNotifications") as? Bool ?? true else { return }
         notifSeq += 1
         let content = UNMutableNotificationContent()
@@ -495,7 +495,7 @@ final class CompanionStore {
         guard let line = try? await provider.line(baseSpeciesID: id) else { return }   // 라인 예열
         // 스프라이트 예열 — 부화 직후 보일 것들: base 정적+애니메이션, shiny 롤(1/64) 대비 shiny 애니메이션.
         // .app 번들에서만(단위 테스트가 실네트워크에 닿지 않도록 — 알림과 동일한 게이트).
-        if Bundle.main.bundlePath.hasSuffix(".app") {
+        if AppEnv.isBundledApp {
             _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: false, shiny: false)
             _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: true, shiny: false)
             _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: true, shiny: true)
@@ -511,9 +511,6 @@ final class CompanionStore {
     }
 
     // MARK: 메타몽 위장/리빌
-
-    /// .app 번들 실행 여부 — 알림/프리패치와 동일 게이트. 위장 롤을 실앱에서만 발동(테스트/개발실행 제외).
-    static var isAppBundle: Bool { Bundle.main.bundleIdentifier != nil && Bundle.main.bundlePath.hasSuffix(".app") }
 
     /// 메타몽 위장 롤 판정(순수) — common·≥2형태만, 미리 뽑은 roll 값으로 1/128. (부수효과 없이 xctest)
     nonisolated static func dittoDisguiseHit(rarity: Rarity, totalForms: Int, roll: UInt64) -> Bool {
@@ -541,7 +538,7 @@ final class CompanionStore {
         // 메타몽 위장 롤 — common·≥2형태에 한해 1/128. .app 게이트(&& 단락 → 비앱에선 rng 미소비로
         // 기존 테스트 RNG 시퀀스 무영향). 위장/리빌 로직은 상태 기반으로 별도 테스트한다.
         var dittoDisguise: Int?
-        if Self.isAppBundle, Self.dittoDisguiseHit(rarity: line.rarity, totalForms: line.totalForms, roll: rng.next()) {
+        if AppEnv.isBundledApp, Self.dittoDisguiseHit(rarity: line.rarity, totalForms: line.totalForms, roll: rng.next()) {
             dittoDisguise = line.baseID
         }
         // 위장 중엔 이로치를 숨긴다 — 부화 알림·연출도 일반체로(정체는 리빌 때 공개).

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -704,7 +704,7 @@ final class UsageStore {
     /// 팝오버 첫 오픈 등 사용자 의도 시점에 1회만 알림 권한 요청(멱등).
     func requestNotificationAuthorizationIfNeeded() {
         guard !notifAuthRequested else { return }
-        guard Bundle.main.bundleIdentifier != nil, Bundle.main.bundlePath.hasSuffix(".app") else { return }
+        guard AppEnv.isBundledApp else { return }
         notifAuthRequested = true
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
     }
@@ -747,7 +747,7 @@ final class UsageStore {
 
     private func checkLimitNotifications() {
         guard limitNotifications else { return }
-        guard Bundle.main.bundleIdentifier != nil, Bundle.main.bundlePath.hasSuffix(".app") else { return }
+        guard AppEnv.isBundledApp else { return }
         let l = L(localizationLanguage)
         // (유일 key, 표시 name, utilization). key 는 창 정체성(tier·identifier), name 은 알림 본문.
         // 팝오버가 한도 행으로 보여주는 모든 창을 알림 대상에 1:1 로 포함한다(표시=알림 일치).
@@ -810,7 +810,7 @@ final class UsageStore {
 
     private func writeParitySnapshot() {
         // .app 번들에서만 기록 — 테스트가 실제 사용자 데이터 디렉토리의 스냅샷을 덮어쓰지 않도록.
-        guard Bundle.main.bundlePath.hasSuffix(".app") else { return }
+        guard AppEnv.isBundledApp else { return }
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("PokeTokenBar")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -15,9 +15,7 @@ struct SettingsView: View {
 
     private var l: L { companion.l }
 
-    private var isBundledApp: Bool {
-        Bundle.main.bundlePath.hasSuffix(".app")
-    }
+    private var isBundledApp: Bool { AppEnv.isBundledApp }
 
     /// 현재 앱 버전 — 업데이트 적용 여부 확인용으로 설정창 하단에 표기.
     private static var appVersion: String {


### PR DESCRIPTION
## Summary

Part of a full-codebase quality/stability/performance/size audit. The audit found the codebase already well-defended (no `try!`/`as!`/`fatalError`, guarded force-unwraps, LRU-evicted sprite cache, `withTaskGroup` + `[weak self]` concurrency, no `print`/TODO debt, 274 passing tests). The one concrete, safe improvement it surfaced was a duplicated environment gate.

The "are we running as a real `.app` bundle" check — which guards notifications, keychain reads, sprite prefetch, production logging, and the Ditto disguise roll — was duplicated across **9 sites in 4 files**, some checking `bundleIdentifier != nil && hasSuffix(".app")` and some only the suffix. This consolidates them into a single **`AppEnv.isBundledApp`**, so a security/behavior-relevant check can't drift out of sync.

- New `Core/AppEnv.swift`.
- Replaced inline checks in `CompanionStore`, `UsageStore`, `AppLog`, `SettingsView`; removed the redundant `CompanionStore.isAppBundle`.
- **No behavior change** — a real `.app` satisfies both conjuncts; a dev binary / test run satisfies neither.

## Type of change

- [x] Refactor (no behavior change)

## Checklist

- [x] `swift build` and `swift test` pass locally (274 tests, 0 failures)
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
