### PR TITLE
refactor: version-agnostic Codex model fallback

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -131,7 +131,9 @@ enum LocalUsageReader {
         guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
         var entries: [Entry] = []
         var turn = 0
-        var model = "gpt-5.5"   // 세션 모델(없으면 기본)
+        // 실모델은 아래 codexModel 이 로그에서 동적 추출(신모델 자동 대응). 이 값은 세션에 model 라인이
+        // 아예 없을 때만 쓰는 버전무관 폴백 — Codex 비용은 항상 0이라 표시 숫자엔 영향 없다(업데이트 불필요).
+        var model = "codex"
         for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
             autoreleasepool {   // JSONSerialization 의 autoreleased 객체를 라인마다 배출(콜드 파싱 피크 억제)
                 if line.contains("\"model\""), let m = codexModel(String(line)) { model = m }


### PR DESCRIPTION
## Summary

`parseCodexFile`'s fallback model was a specific version string (`"gpt-5.5"`) that looked like it needed updating whenever a new Codex/GPT model shipped. In reality:
- The **actual model is read dynamically** from the logs (`codexModel()` → `payload.model` / `turn_context.model`), so new models are picked up with no code change.
- The literal is only a fallback for sessions with **no model line at all**.
- **Codex cost is always $0** (`LocalCodexProvider`) and token totals are model-independent — so this value never affects a displayed number.

Replaced with the version-agnostic `"codex"` (+ a clarifying comment) so it never looks stale.

For context, model handling elsewhere is already drift-resilient: the Claude and Gemini parsers read the model dynamically with version-agnostic fallbacks (`"unknown"` / `"gemini"`), and `ModelPricing.rate(for:)` has a family fallback (opus / sonnet / haiku / gpt / gemini) so new versions inherit family pricing, degrading to `$0` for truly-unknown families — token counts are never affected.

## Type of change

- [x] Refactor (no behavior change)

## Checklist

- [x] `swift build` and `swift test` pass locally (274 tests, 0 failures)
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
