### PR TITLE
fix: surface the "enable Claude limits" prompt on first launch

### DIFF
--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -229,7 +229,10 @@ struct PopoverView: View {
     /// 선택된 프로바이더에 표시할 공식 한도가 있는가 (Gemini 는 공식 한도 API 없음 → 섹션 생략).
     private var selectedProviderHasLimits: Bool {
         switch selectedSnapshot?.providerID {
-        case "claude_code": return store.limits != nil || store.limitsAuthExpired
+        // Keychain 이 꺼져있지 않으면 한도가 아직 없어도 섹션을 노출한다 — 그래야 최초 실행에
+        // claudeLimitsRefreshRow("탭해서 로드")가 보여, 설정까지 안 들어가도 원탭으로 켤 수 있다.
+        // (자동 Keychain 읽기는 팝업 방지로 여전히 안 함 — 발견성만 살린다.)
+        case "claude_code": return !store.disableKeychainAccess || store.limits != nil || store.limitsAuthExpired
         case "codex": return store.codexLimits?.hasVisibleLimit == true
         default: return false
         }


### PR DESCRIPTION
## Summary

After #91 removed the automatic Keychain read (to stop the recurring password prompt that blocked the app), Claude's official limits stay unavailable until the user reads the Keychain by an explicit action. But `selectedProviderHasLimits` returned `false` while `limits == nil`, so the entire limits section — **including the one-tap `claudeLimitsRefreshRow` ("tap to load")** — was hidden in the popover on first launch. The only way to enable limits was **Settings → Advanced → Refresh**, which is far too hidden.

This shows the limits section for a Claude provider whenever Keychain access isn't disabled, so the one-tap enable prompt appears right in the popover. **Auto Keychain reads are still not performed** (the anti-popup fix from #91 stands) — this only restores discoverability of the user-initiated enable action.

- Before: first launch → limits section hidden → enable only via Settings → Advanced.
- After: first launch → popover shows "Official limits · tap to load [Refresh]" → one tap enables it.

## Type of change

- [x] UX fix

## Checklist

- [x] `swift build` and `swift test` pass locally (274 tests, 0 failures)
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
