### PR TITLE
test: harden flaky prefetch-fallback test

### DIFF
--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -695,7 +695,13 @@ final class CompanionIdentityTests: XCTestCase {
         await s.hatchIfNeeded()                        // 여전히 오프라인 → 알 유지
         XCTAssertNil(s.state.active)
         p.failAll = false                              // 네트워크 복구
-        await s.hatchIfNeeded()                        // 부화 시점 롤 폴백
+        // 초기 update() 가 띄운 프리패치 Task 가 아직 in-flight 면 hatchIfNeeded 가 prefetchInFlight
+        // 가드로 조기 반환할 수 있다(고정 yield 횟수로는 CI 스케줄 지연에서 못 소진 — 플래키 원인).
+        // 부화할 때까지 재시도해 결정적으로 만든다(in-flight 는 몇 틱 내 실패로 해제됨).
+        for _ in 0..<50 where s.state.active == nil {
+            await s.hatchIfNeeded()                    // 부화 시점 롤 폴백
+            await Task.yield()
+        }
         XCTAssertEqual(s.state.active?.baseID, 88)
     }
 


### PR DESCRIPTION
## Summary

`testPrefetchOfflineFallsBackToHatchTimeRoll` intermittently failed in CI (`nil != Optional(88)`) — a flaky test, unrelated to the change it happened to block.

It drained the initial prefetch with a fixed `for _ in 0..<10 { await Task.yield() }`, then asserted a **single** `hatchIfNeeded()` hatched. Under slower scheduling (CI), the `update()`-spawned prefetch `Task` could still be in flight, so `hatchIfNeeded` returned early on its `prefetchInFlight` guard and nothing hatched.

Retry `hatchIfNeeded` until `state.active` is set (bounded to 50), draining any in-flight prefetch between attempts — deterministic regardless of scheduler timing. Verified 8/8 local runs of the isolated test. **No product code change.**

(The other async drains in the suite already use condition-based loops — `for _ in 0..<N where <condition>` — so this was the only fixed-count case.)

## Type of change

- [x] Test hardening (flaky fix)

## Checklist

- [x] `swift build` and `swift test` pass locally (274 tests, 0 failures)
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
