### PR TITLE
feat: add egg-reroll shop item and real egg sprite

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -152,6 +152,14 @@ enum ShinyCharm {
     static let shinyDenominator: UInt64 = 48
 }
 
+/// 새 알(리롤) 밸런스 상수 — 상점 구매 시 현재 포켓몬을 폐기하고 새 알로 되돌린다.
+enum FreshEgg {
+    /// 상점 구매가. 마음에 안 드는 부화를 리롤하는 프리미엄(쌓인 토큰의 활용처). 폐기 개체는 졸업이
+    /// 아니라 그냥 사라지므로 도감·확률(collectedFinals)에 무영향 — "뽑은 적 없던 것처럼". 새 알은
+    /// 처음부터 재인큐베이션(5M) 필요 + 성장(usedAtStage) 소멸이라 스팸/파밍이 자연 억제된다.
+    static let price = 1_000_000_000
+}
+
 /// 사탕 지급 대상 한도 창의 분류 — session=1개·weekly=weeklyGrant.
 enum WindowClass: Sendable { case session, weekly }
 

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -359,8 +359,18 @@ final class CompanionStore {
     /// 여기선 읽기만 — 구매는 spentTokens 만 올려 잔액을 깎는다(진화 진행·오늘/주/월 통계 무영향).
     var availableTokens: Int { max(0, state.usedSinceInstall - state.spentTokens) }
 
-    /// 상점 판매 아이템 — shopPrice 있는 것만(ItemKind.allCases 순서).
-    var purchasableItems: [ItemKind] { ItemKind.allCases.filter { $0.shopPrice != nil } }
+    /// 상점 판매 아이템 — shopPrice 있는 것만. 가격 저렴한 순, 단 구매 완료한 보유형은 맨 아래로.
+    var purchasableItems: [ItemKind] {
+        ItemKind.allCases
+            .filter { $0.shopPrice != nil }
+            .sorted { a, b in
+                // 구매 완료한 보유형(이로치 부적 등)은 맨 아래로 — 재구매 불가라 위에 있을 이유가 없다.
+                let aDone = a.isPassive && itemCount(a) > 0
+                let bDone = b.isPassive && itemCount(b) > 0
+                if aDone != bDone { return !aDone }
+                return (a.shopPrice ?? 0) < (b.shopPrice ?? 0)   // 나머지는 가격 저렴한 순
+            }
+    }
 
     /// 구매 가능 — 잔액이 그 아이템 가격 이상(상점 미판매면 false). 활성/알 무관(재고는 미리 쌓아둘 수 있음).
     func canBuy(_ kind: ItemKind) -> Bool {
@@ -385,6 +395,29 @@ final class CompanionStore {
     var canBuyRareCandy: Bool { canBuy(.rareCandy) }
     @discardableResult
     func buyRareCandy() -> Bool { buy(.rareCandy) }
+
+    // MARK: 새 알 (리롤 — 현재 포켓몬 폐기, 도감·확률 무영향)
+
+    /// 새 알 구매 가능 — 폐기할 활성 포켓몬이 있고 지갑이 가격 이상일 때만(알 상태에선 리롤할 게 없음).
+    var canBuyFreshEgg: Bool { hasActive && availableTokens >= FreshEgg.price }
+
+    /// 새 알 구매 — 현재 포켓몬을 폐기하고 처음부터 인큐베이션하는 새 알로. 지갑에서 가격 차감.
+    /// graduate() 의 알-리셋만 미러링하고 dex/collectedFinals(도감·확률 가중)는 손대지 않는다
+    /// → "뽑은 적 없던 것처럼". 성장(usedAtStage)은 소멸(추가 비용).
+    @discardableResult
+    func buyFreshEgg() -> Bool {
+        guard canBuyFreshEgg else { return false }
+        state.spentTokens += FreshEgg.price
+        state.active = nil            // 폐기 (졸업 아님 — dex/collectedFinals 미변경)
+        currentLine = nil
+        state.eggUsage = 0            // 새 알은 처음부터 인큐베이션(재부화에 5M 필요)
+        state.pendingHatchID = nil    // 다음 부화는 새로 롤
+        justGraduated = nil; justEvolvedTo = nil; eventUntil = nil
+        AppLog.write("fresh egg: discarded active, reverted to egg")
+        Task { await self.ensureEggPrefetch() }   // 다음 부화 예열
+        save()
+        return true
+    }
 
     /// 지급 판정(순수·엣지 트리거) — 한도 창이 100% 를 새로 넘어선 순간에만 지급.
     /// - 100% 미만 → 맵에서 제거(재무장). resets_at 등 휘발 필드는 key 에 없다(안정 식별자만).

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -17,7 +17,7 @@ struct L {
 
     // MARK: 탭
     var home: String { t("홈", "Home", "ホーム") }
-    var collection: String { t("컬렉션", "Collection", "コレクション") }
+    var collection: String { t("도감", "Collection", "コレクション") }
 
     // MARK: 헤더 (오늘/주/월)
     var todayTokens: String { t("오늘 사용한 토큰", "Today's tokens", "本日のトークン") }
@@ -332,13 +332,13 @@ struct L {
         switch kind {
         case .rareCandy:
             let xp = TokenFormatter.compact(RareCandy.xp)   // 상수에서 파생(하드코딩 드리프트 방지)
-            return t("현재 포켓몬의 경험치를 \(xp) 상승시킨다.",
+            return t("현재 포켓몬의 경험치를 \(xp) 올려줘요.",
                      "Raises your Pokémon's EXP by \(xp).",
-                     "ポケモンの経験値を\(xp)上げる。")
+                     "ポケモンの経験値を\(xp)上げます。")
         case .mint:
-            return t("현재 포켓몬의 성격을 랜덤으로 바꾼다.",
+            return t("현재 포켓몬의 성격을 랜덤으로 바꿔줘요.",
                      "Randomly changes your Pokémon's nature.",
-                     "ポケモンのせいかくをランダムに変える。")
+                     "ポケモンのせいかくをランダムに変えます。")
         case .shinyCharm:
             return t("보유하면 이로치 포켓몬이 태어날 확률이 올라가요.",
                      "While owned, raises the chance of hatching a shiny.",
@@ -359,6 +359,14 @@ struct L {
     var shopPriceLabel: String { t("가격", "Price", "価格") }
     var ownedAlready: String { t("보유 중", "Owned", "所持済み") }
     var shinyCharmEffectHint: String { t("이로치 확률 ↑ · 적용 중", "Shiny rate ↑ · active", "色違い率↑ · 適用中") }
+    // 새 알 (리롤)
+    var freshEggName: String { t("포켓몬 알", "Pokémon Egg", "ポケモンのタマゴ") }
+    var freshEggDescription: String { t("지금 포켓몬을 보내주고 새 알로 다시 시작해요.",
+                                        "Send off your current Pokémon and start fresh with a new egg.",
+                                        "いまのポケモンを手放して新しいタマゴからやり直します。") }
+    func freshEggConfirm(_ name: String) -> String { t("\(name)을(를) 보내고 새 알로 바꿀까요?", "Send off \(name) for a fresh egg?", "\(name) を手放して新しいタマゴにしますか？") }
+    var freshEggShinyWarning: String { t("⚠️ 이로치 포켓몬이에요! 정말 보낼까요?", "⚠️ This one is shiny! Really send it off?", "⚠️ 色違いです！本当に手放しますか？") }
+    var freshEggDiscardShiny: String { t("이로치 보내기", "Send shiny off", "手放す") }
 
     // MARK: 사탕 획득 알림 ("왜 받는지" = 토큰 한도를 다 채운 수고에 대한 보상)
     func notifCandyTitle(item: String, count: Int) -> String {

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -59,10 +59,11 @@ struct SpriteView: View {
         self.bob = bob
         self.animated = animated
         self.shiny = shiny
-        // 캐시에 있으면 즉시(동기) 표시 — 재렌더 플래시 방지 + 정적 스냅샷에서도 보임
-        let cached = speciesID.flatMap { SpriteLoader.cachedImage(speciesID: $0, shiny: shiny) }
+        // 캐시에 있으면 즉시(동기) 표시 — 재렌더 플래시 방지 + 정적 스냅샷에서도 보임.
+        // speciesID==nil(알 상태)이면 알 스프라이트를 시드(없으면 body 가 🥚 폴백).
+        let cached = speciesID.map { SpriteLoader.cachedImage(speciesID: $0, shiny: shiny) } ?? SpriteLoader.cachedEggImage()
         _img = State(initialValue: cached)
-        _loadedID = State(initialValue: cached != nil ? speciesID : nil)
+        _loadedID = State(initialValue: (speciesID != nil && cached != nil) ? speciesID : nil)
     }
 
     var body: some View {
@@ -85,7 +86,12 @@ struct SpriteView: View {
             // animated 프레임은 id/shiny 변경 시 항상 초기화(이전 개체 프레임 잔상 방지)
             frames = []
             frameIndex = 0
-            guard let id = speciesID else { img = nil; loadedID = nil; return }
+            guard let id = speciesID else {
+                // 알 상태 — 정적 알 스프라이트 로드(애니메이션 알은 없음). 실패/오프라인이면 body 가 🥚 폴백.
+                if img == nil { img = await SpriteLoader.eggImage() }
+                loadedID = nil
+                return
+            }
             // 정적 스프라이트 먼저(즉시 표시 + 폴백 보장). 캐시 시드로 이미 같은 id 면 재요청 생략(플래시 방지)
             if loadedID != id {
                 img = await SpriteLoader.image(speciesID: id, animated: false, shiny: shiny)

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -85,7 +85,7 @@ struct PopoverView: View {
             } else if nav.tab == .bag {
                 BagView(store: companion, nav: nav)
             } else if nav.tab == .shop {
-                ShopView(store: companion)
+                ShopView(store: companion, nav: nav)
             } else {
                 CompanionHeader(store: companion)
                 Divider()

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// 고아 시트가 이후 클릭을 먹통내는 결함 회피).
 struct ShopView: View {
     let store: CompanionStore
+    let nav: PopoverNavigation
 
     var body: some View {
         let l = store.l
@@ -14,6 +15,10 @@ struct ShopView: View {
                 walletHeader(l)
                 ForEach(store.purchasableItems, id: \.self) { kind in
                     ShopItemCard(store: store, kind: kind)
+                }
+                // 새 알(리롤) — 폐기할 활성 포켓몬이 있을 때만. 즉시 액션이라 ItemKind 가 아님.
+                if store.hasActive {
+                    FreshEggCard(store: store, nav: nav)
                 }
             }
         }
@@ -110,5 +115,84 @@ private struct ShopItemCard: View {
     private func buyNow() {
         confirming = false
         _ = store.buy(kind)
+    }
+}
+
+/// 새 알(리롤) 카드 — 구매 = 즉시 현재 포켓몬 폐기 후 새 알로. 인라인 2단계 확인:
+/// 일반은 1회, 이로치면 한 번 더(사고 폐기 방지). 성공하면 Home 으로 전환해 새 알을 보여준다.
+private struct FreshEggCard: View {
+    let store: CompanionStore
+    let nav: PopoverNavigation
+    @State private var stage: Stage = .idle
+    private enum Stage { case idle, confirm, shinyConfirm }
+
+    var body: some View {
+        let l = store.l
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 10) {
+                // 크롭+정사각 보정한 알. 레이아웃은 30(다른 아이템 아이콘과 정렬 일치)으로 두되 알 자체는 26으로
+                // 살짝 작게 — 프레임에 여백이 생겨 꽉 찬 "뚱뚱" 느낌이 줄고 크기도 약간 작아진다.
+                SpriteView(speciesID: nil, size: 26)
+                    .frame(width: 30, height: 30)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(l.freshEggName).font(.callout.weight(.semibold))
+                    Text(l.freshEggDescription)
+                        .font(.caption).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer()
+            }
+            controls(l)
+        }
+        .padding(10)
+        .background(Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    @ViewBuilder
+    private func controls(_ l: L) -> some View {
+        switch stage {
+        case .idle:
+            HStack {
+                Text("\(l.shopPriceLabel) \(TokenFormatter.compact(FreshEgg.price))")
+                    .font(.caption2).foregroundStyle(.tertiary).monospacedDigit()
+                Spacer()
+                if store.canBuyFreshEgg {
+                    Button(l.buy) { stage = .confirm }
+                        .buttonStyle(.bordered).controlSize(.small)
+                } else {
+                    Text(l.notEnoughTokens).font(.caption2).foregroundStyle(.tertiary)
+                }
+            }
+        case .confirm:
+            HStack(spacing: 8) {
+                Text(l.freshEggConfirm(store.displayName))
+                    .font(.caption2).foregroundStyle(.secondary).lineLimit(2)
+                Spacer()
+                // 이로치면 한 번 더 경고, 아니면 즉시 실행.
+                Button(l.buy) {
+                    if store.currentIsShiny { stage = .shinyConfirm } else { commit() }
+                }
+                .buttonStyle(.borderedProminent).controlSize(.small)
+                Button(l.cancel) { stage = .idle }
+                    .buttonStyle(.borderless).controlSize(.small)
+            }
+        case .shinyConfirm:
+            HStack(spacing: 8) {
+                Text(l.freshEggShinyWarning)
+                    .font(.caption2.weight(.semibold)).foregroundStyle(.orange).lineLimit(2)
+                Spacer()
+                Button(l.freshEggDiscardShiny) { commit() }
+                    .buttonStyle(.borderedProminent).controlSize(.small).tint(.orange)
+                Button(l.cancel) { stage = .idle }
+                    .buttonStyle(.borderless).controlSize(.small)
+            }
+        }
+    }
+
+    /// 리롤 실행 → 새 알을 볼 수 있게 Home 으로 전환(가방 사용과 동일 패턴).
+    private func commit() {
+        stage = .idle
+        if store.buyFreshEgg() { nav.tab = .home }
     }
 }

--- a/Sources/PokeTokenBar/UI/SpriteLoader.swift
+++ b/Sources/PokeTokenBar/UI/SpriteLoader.swift
@@ -56,6 +56,20 @@ actor SpriteStore {
         return d
     }
 
+    /// 알 스프라이트(정적, pokemon/egg.png) — 애니메이션 알은 없음. 포켓몬/아이템과 같은 메모리·디스크 캐시(키 "egg").
+    func eggData() async -> Data? {
+        let key = "egg"
+        if let d = mem[key] { touch(key); return d }
+        let file = dir.appendingPathComponent("egg.png")
+        if let d = try? Data(contentsOf: file) { remember(key, d); return d }
+        guard let url = URL(string: "\(base)/egg.png"),
+              let (d, resp) = try? await URLSession.shared.data(from: url),
+              (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
+        try? d.write(to: file, options: .atomic)
+        remember(key, d)
+        return d
+    }
+
     /// in-memory 캐시에 넣고 LRU 상한 유지(#H1) — 세션 중 종이 여러 번 바뀌어도 무한 성장 방지.
     private func remember(_ key: String, _ data: Data) {
         mem[key] = data
@@ -117,5 +131,44 @@ enum SpriteLoader {
     static func itemImage(name: String) async -> NSImage? {
         guard let d = await SpriteStore.shared.data(itemName: name), let img = NSImage(data: d) else { return nil }
         return img
+    }
+
+    /// 알 스프라이트는 96×96 캔버스에 실제 알이 28×30(≈29%)만 차지 — 그대로 쓰면 프레임에서 아주 작게
+    /// 보인다(🥚 이모지는 여백이 없어 꽉 찼음). 콘텐츠 경계로 1회 크롭해 여백을 제거하고 캐시 →
+    /// 상점·홈 등 모든 크기에서 이모지처럼 프레임을 꽉 채운다.
+    private static var croppedEgg: NSImage?
+
+    /// 크롭 완료분만 동기 반환(미준비면 nil — 동기 크롭 안 함, 히치 방지). 첫 표시 때만 🥚 폴백 후 eggImage 로 교체.
+    static func cachedEggImage() -> NSImage? { croppedEgg }
+
+    /// 알 스프라이트 — 런타임 로드 + 콘텐츠 크롭(최초 1회 메모이즈). 오프라인/실패면 nil(뷰가 🥚 폴백).
+    static func eggImage() async -> NSImage? {
+        if let c = croppedEgg { return c }
+        guard let d = await SpriteStore.shared.eggData(), let img = NSImage(data: d) else { return nil }
+        croppedEgg = cropToContent(img)
+        return croppedEgg
+    }
+
+    /// 비투명(alpha>0) 콘텐츠 경계로 크롭 — 큰 투명 여백 제거. 96×96 1회만 수행(메모이즈).
+    private static func cropToContent(_ image: NSImage) -> NSImage {
+        guard let tiff = image.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff) else { return image }
+        let w = rep.pixelsWide, h = rep.pixelsHigh
+        var minX = w, minY = h, maxX = -1, maxY = -1
+        for y in 0..<h {
+            for x in 0..<w where (rep.colorAt(x: x, y: y)?.alphaComponent ?? 0) > 0.01 {
+                if x < minX { minX = x }; if x > maxX { maxX = x }
+                if y < minY { minY = y }; if y > maxY { maxY = y }
+            }
+        }
+        guard maxX >= minX, maxY >= minY else { return image }
+        // 콘텐츠 bbox 를 정사각(긴 변 기준)으로 확장해 중앙 정렬 — 알 콘텐츠는 28×30(세로가 김)이라 그대로
+        // 크롭하면 SpriteView 의 size×size 정사각 프레임에서 가로로 늘어나 뚱뚱해진다. 정사각 크롭이면 비율 보존.
+        let bw = maxX - minX + 1, bh = maxY - minY + 1
+        let side = min(max(bw, bh), min(w, h))
+        let sx = max(0, min(minX - (side - bw) / 2, w - side))
+        let sy = max(0, min(minY - (side - bh) / 2, h - side))
+        guard let cg = rep.cgImage?.cropping(to: CGRect(x: sx, y: sy, width: side, height: side))
+        else { return image }
+        return NSImage(cgImage: cg, size: NSSize(width: cg.width, height: cg.height))
     }
 }

--- a/Tests/PokeTokenBarTests/FreshEggTests.swift
+++ b/Tests/PokeTokenBarTests/FreshEggTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import PokeTokenBar
+
+// MARK: 새 알 (리롤 — 현재 포켓몬 폐기, 도감·확률 무영향)
+
+private struct FreshEggNoProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine { throw URLError(.notConnectedToInternet) }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [] }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { nil }
+}
+
+@MainActor
+final class FreshEggTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// 활성 포켓몬(baseID 10, common 3형태, 성장 200M) + 도감 1개 + 수집기록 1개(1:3) + 지갑.
+    /// active=false 면 알(활성 없음) 상태.
+    private func store(active: Bool = true, shiny: Bool = false, used: Int = 5_000_000_000,
+                       spent: Int = 0) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("egg-\(UUID().uuidString).json")
+        let mon = "{\"baseID\":10,\"pathIDs\":[10],\"stageIndex\":0,\"usedAtStage\":200000000,"
+            + "\"rarity\":\"common\",\"totalForms\":3,\"isShiny\":\(shiny)}"
+        let dex = "{\"baseID\":1,\"finalID\":3,\"chainOrder\":[1,2,3],\"rarity\":\"common\"}"
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":\(used),\"spentTokens\":\(spent),"
+            + "\"lastDate\":\"d\",\"active\":\(active ? mon : "null"),\"dex\":[\(dex)],\"collectedFinals\":[\"1:3\"]}"
+        try? json.data(using: .utf8)!.write(to: url)
+        return CompanionStore(provider: FreshEggNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: 7))
+    }
+
+    func testPriceIsOneBillion() { XCTAssertEqual(FreshEgg.price, 1_000_000_000) }
+
+    /// [핵심] 리롤 = 폐기: active 사라지고 새 알(eggUsage 0). **도감·확률(collectedFinals) 불변** = "뽑은 적 없던 것처럼".
+    func testBuyFreshEggDiscardsWithoutDexOrProbabilityImpact() {
+        let s = store(used: 5_000_000_000, spent: 0)
+        let dexBefore = s.dexEntries.count
+        let collectedBefore = s.state.collectedFinals
+        XCTAssertTrue(s.hasActive)
+        XCTAssertTrue(s.buyFreshEgg())
+        XCTAssertNil(s.state.active, "현재 포켓몬 폐기")
+        XCTAssertTrue(s.isEgg)
+        XCTAssertEqual(s.state.eggUsage, 0, "새 알은 처음부터 인큐베이션")
+        XCTAssertNil(s.state.pendingHatchID)
+        XCTAssertEqual(s.dexEntries.count, dexBefore, "도감 불변 — 졸업이 아니라 폐기")
+        XCTAssertEqual(s.state.collectedFinals, collectedBefore, "확률 가중(collectedFinals) 불변")
+        XCTAssertEqual(s.state.spentTokens, FreshEgg.price, "지갑에서 1B 차감")
+        XCTAssertEqual(s.availableTokens, 5_000_000_000 - FreshEgg.price)
+    }
+
+    /// 폐기한 개체(baseID 10)의 종은 collectedFinals 에 들어가지 않는다(이후 부화 확률에 영향 없음).
+    func testDiscardedSpeciesNotCollected() {
+        let s = store()
+        XCTAssertTrue(s.buyFreshEgg())
+        XCTAssertFalse(s.state.collectedFinals.contains { $0.hasPrefix("10:") },
+                       "폐기 개체 종은 수집 기록에 없어야 함")
+    }
+
+    /// 알 상태(활성 없음)에선 리롤할 게 없어 불가.
+    func testCannotRerollWhenEgg() {
+        let s = store(active: false, used: 5_000_000_000)
+        XCTAssertFalse(s.hasActive)
+        XCTAssertFalse(s.canBuyFreshEgg)
+        XCTAssertFalse(s.buyFreshEgg())
+        XCTAssertEqual(s.state.spentTokens, 0, "no-op")
+    }
+
+    /// 잔액이 가격 미만이면 불가 — 활성 유지.
+    func testCannotRerollWithoutFunds() {
+        let s = store(used: 500_000_000)   // 1B 미만
+        XCTAssertFalse(s.canBuyFreshEgg)
+        XCTAssertFalse(s.buyFreshEgg())
+        XCTAssertNotNil(s.state.active, "활성 유지")
+        XCTAssertEqual(s.state.spentTokens, 0)
+    }
+
+    /// 이로치도 폐기 가능(추가 경고는 UI 단계, 로직은 동일) — 리롤 후 흔적 없음.
+    func testShinyCanBeRerolled() {
+        let s = store(shiny: true)
+        XCTAssertTrue(s.currentIsShiny)
+        XCTAssertTrue(s.buyFreshEgg())
+        XCTAssertNil(s.state.active)
+        XCTAssertFalse(s.currentIsShiny)
+    }
+}

--- a/Tests/PokeTokenBarTests/ShopTests.swift
+++ b/Tests/PokeTokenBarTests/ShopTests.swift
@@ -120,4 +120,26 @@ final class ShopTests: XCTestCase {
         XCTAssertEqual(s2.state.spentTokens, RareCandy.price, "지출 영속")
         XCTAssertEqual(s2.availableTokens, 1_000_000_000 - RareCandy.price)
     }
+
+    // MARK: 정렬 (가격 저렴한 순 + 구매 완료 보유형 맨 아래)
+
+    /// 상점 목록은 가격 오름차순(민트 100M < 사탕 500M < 이로치 부적 3B).
+    func testItemsSortedByPriceAscending() {
+        let items = store(used: 0).purchasableItems
+        XCTAssertEqual(items, [.mint, .rareCandy, .shinyCharm])
+        let prices = items.compactMap(\.shopPrice)
+        XCTAssertEqual(prices, prices.sorted(), "shopPrice 오름차순 — 가격 상수가 바뀌어도 정렬 불변식 유지")
+    }
+
+    /// 구매 완료한 보유형(이로치 부적)은 맨 아래로. 재구매 불가라 상단에 둘 이유 없음.
+    /// (현재 부적이 최고가라 가격순 결과와 일치하지만, 향후 저가 보유형이 생겨도 규칙이 유지되도록 게이트.)
+    func testOwnedPassiveSinksToBottom() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("shop-sort-\(UUID().uuidString).json")
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":0,\"spentTokens\":0,"
+            + "\"lastDate\":\"d\",\"dex\":[],\"collectedFinals\":[],\"inventory\":{\"shinyCharm\":1}}"
+        try? json.data(using: .utf8)!.write(to: url)
+        let s = CompanionStore(provider: ShopNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: 1))
+        XCTAssertTrue(s.itemCount(.shinyCharm) > 0)
+        XCTAssertEqual(s.purchasableItems.last, .shinyCharm, "구매 완료 보유형은 최하단")
+    }
 }


### PR DESCRIPTION
## Summary
- **Egg-reroll shop item.** Buy it to discard the current companion and start over from a fresh egg. Priced at 1B (a sink for accumulated tokens). The discarded companion leaves **no trace** — it isn't added to the collection and doesn't affect future hatch odds, as if it never hatched. Discarding a shiny requires an extra confirmation step.
- **Real egg sprite.** The egg (incubation) state now uses the real static egg sprite instead of the 🥚 emoji, on both the home view and the shop card. The sprite canvas is ~71% transparent padding, so it's cropped to its content bounding box (expanded to a centered square to preserve aspect) — otherwise it renders tiny/stretched. No animated egg sprite exists, so the egg stays static; the about-to-hatch wiggle is unchanged.
- **Shop ordering.** The shop list sorts by price ascending; owned one-time (passive) items sink to the bottom.
- **Copy polish.** Unify item-description tone to the polite form (Korean "~요" / Japanese "ます") across all shop items, and use a more natural label for the reroll item.

## Type of change
- [x] New feature
- [x] UI change

## Checklist
- [x] Self-reviewed
- [x] `swift build` clean; all 282 tests pass (added reroll + shop-sort tests)
- [x] Backward compatible — no state-schema change; the reroll is an instant action, not persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
