### PR TITLE
perf: cut menu-bar idle wake-ups ~47/s to ~5/s (diff-gate + lower fps)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,4 +129,8 @@
   리드로우는 WindowServer 부하(데스크톱 비컨볼) 위험. **status-item 전용 앱은 occlusion 이 실제로 잘 안
   떠서**(앱이 status item 표시 중엔 occluded 안 됨) occlusion 게이팅은 보조 — 슬립/열림 게이팅이 실질 방어.
   검증 함정: bare/`open -n` 보조 인스턴스는 애니메이션이 안 돌아 14%를 **재현 못 함** → 실측은 설치된
-  primary 앱 교체로만. (Agent Team 조사 + 실측, 2026-07-22.)
+  primary 앱 교체로만. **배터리(idle wakeup) 차원:** CPU% 낮아도 button.image 대입마다 레이어 dirty →
+  CA 커밋 → WindowServer 디스플레이 사이클 왕복이 wakeup을 증폭한다(실측 ~47 wakeup/s). `setStatusImage`
+  diff-gate(동일 프레임 객체 재대입 스킵 — 애니 프레임은 서로 다른 객체라 정상 통과) + GIF fps 하한 0.4s(≈2.5fps)
+  + `Timer.tolerance` 0.5(코얼레싱)로 ~5 wakeup/s(−89%), 애니메이션 유지. 배터리-vs-AC/thermal 적응·CADisplayLink
+  전환은 1인 로컬 노트북 기준 수확체감으로 판정, 미도입(필요 시 Agent Team 계획 참조). (Agent Team 조사 + 실측, 2026-07-22.)

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -197,8 +197,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             guard let data else { return }
             let raw = GIFDecoder.frames(from: data)
             guard raw.count > 1, gen == self.menuLoadGen else { return }
-            // 메뉴바 GIF 는 delay 하한 0.2s(≈5fps)로 캡 — 22px 스프라이트엔 충분하고 저전력.
-            self.setMenuFrames(raw.map { (Self.menuBarImage(from: $0.image, up: false), max(0.2, $0.delay)) })
+            // 메뉴바 GIF delay 하한 0.4s(≈2.5fps)로 캡 — 22px 스프라이트엔 5fps와 구분 안 되고, 프레임당
+            // 상태바 재합성(CA 커밋 → 디스플레이 사이클 wakeup)을 절반으로 줄여 배터리 절약. bob(0.5s/2fps)과 유사.
+            self.setMenuFrames(raw.map { (Self.menuBarImage(from: $0.image, up: false), max(0.4, $0.delay)) })
         }
     }
 
@@ -208,11 +209,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         advanceMenu()
     }
 
-    /// 상태아이템 이미지 교체 — 암묵적 CA 전환(NSStatusItemScene updateSettings:transition) 억제.
-    /// 레이어 백드 NSStatusBarButton 은 button.image 대입마다 전환 애니메이션을 돌려 상태바를 재합성한다
-    /// (측정: idle CPU 주범 — updateSettings:transition → NSAnimationContext runAnimationGroup → 셀 리드로우).
-    /// setDisableActions 로 전환 없이 즉시 반영해 프레임당 비용을 값싼 리드로우로 낮춘다.
+    private var lastStatusImage: NSImage?
+
+    /// 상태아이템 이미지 교체. ① **diff-gate**: 같은 이미지 재대입이면 스킵 — 레이어 dirty → CA 커밋 →
+    /// WindowServer 디스플레이 사이클 왕복(= idle wakeup)을 제거한다(배터리). 단일프레임 스프라이트·중복
+    /// advanceMenu 패스에서 같은 프레임을 반복 대입하던 것을 걸러낸다(애니메이션 프레임은 서로 다른 객체라
+    /// 정상 통과). ② **암묵적 CA 전환 억제**: 레이어 백드 NSStatusBarButton 은 대입마다 NSStatusItemScene
+    /// 전환 애니메이션을 돌려 상태바를 재합성한다(측정: idle CPU 주범) → setDisableActions 로 전환 없이 즉시 반영.
     private func setStatusImage(_ image: NSImage?) {
+        guard image !== lastStatusImage else { return }
+        lastStatusImage = image
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         statusItem.button?.image = image
@@ -236,7 +242,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 self.advanceMenu()
             }
         }
-        timer.tolerance = frame.delay * 0.3   // 웨이크업 코얼레싱 (배터리)
+        timer.tolerance = frame.delay * 0.5   // 웨이크업 코얼레싱 (배터리) — 넓힐수록 다른 wakeup 과 합쳐짐
         RunLoop.main.add(timer, forMode: .common)
         menuTimer = timer
     }


### PR DESCRIPTION
## Summary
On top of the CPU fix (#99), idle wake-ups were ~47/s — Energy Impact weights wake-ups heavily, so this was the remaining battery cost even at ~2% CPU. Root-caused: each `statusItem.button.image` assignment marks the layer-backed status button dirty → a Core Animation commit the WindowServer services at the next display refresh; the app↔WindowServer handshake registers several wake-ups per display cycle. `setDisableActions` (#99) removed the transition animation but not the per-assignment layer-dirty.

- **Diff-gate** `setStatusImage`: skip the assignment (and its CA commit) when the incoming frame is the same object already shown — drops redundant re-assignments (single-frame sprites, duplicate `advanceMenu` passes) while distinct animation frames still pass through.
- **Lower the live-GIF frame-rate floor** 5fps → 2.5fps (imperceptible at a 22px glyph) and **widen the Timer tolerance** so fires coalesce with other wakes.

**Measured on the installed app: idle wake-ups ~47/s → ~5/s (−89%)**, CPU ~2% → ~1.3%, animation still running (sample: frame-swaps present, no `runAnimationGroup`/`placeChildren`). Deeper levers (battery-vs-AC throttling, CADisplayLink pacing) judged diminishing-returns for a single-user laptop and deferred (rationale in CLAUDE.md).

## Type of change
- [x] Performance fix

## Checklist
- [x] Self-reviewed + code-reviewer APPROVE
- [x] `swift build` clean; 284 tests pass
- [x] Empirically verified on the installed app (before/after `top` idlew)
- [x] Recurrence note added to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
