### PR TITLE
fix: shop fresh-egg price order and "release" wording, plus manual-install docs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -108,6 +108,17 @@ brew install --cask chattymin/tap/poke-token-bar
 
 ad-hoc／自己署名アプリのため、Cask インストール時に隔離属性を自動で除去します。
 
+### 手動インストール（Homebrew なし）
+
+Homebrew を使わない場合は、[最新リリース](https://github.com/chattymin/PokeTokenBar/releases/latest) から `PokeTokenBar.zip` をダウンロードして展開し、`PokeTokenBar.app` を `/Applications` にドラッグします。
+
+このアプリは ad-hoc／自己署名（Apple Developer アカウントでの公証なし）のため、初回起動時に Gatekeeper が「開発元が未確認」の警告を表示します。次のいずれかで一度だけ解除してください。
+
+- **Finder:** `PokeTokenBar.app` を右クリック（または Control+クリック）→ **開く** → ダイアログで再度 **開く**。
+- **ターミナル:** `xattr -dr com.apple.quarantine /Applications/PokeTokenBar.app`
+
+（Homebrew Cask は隔離属性を自動で除去するため、この手順は不要です。）
+
 ### ソースからビルド
 
 ```bash

--- a/README.ko.md
+++ b/README.ko.md
@@ -108,6 +108,17 @@ brew install --cask chattymin/tap/poke-token-bar
 
 ad-hoc/자체 서명 앱이라 Cask 설치 시 격리 속성을 자동 제거합니다.
 
+### 직접 설치 (Homebrew 없이)
+
+Homebrew를 쓰지 않는다면 [최신 릴리스](https://github.com/chattymin/PokeTokenBar/releases/latest)에서 `PokeTokenBar.zip`을 내려받아 압축을 풀고 `PokeTokenBar.app`을 `/Applications`로 드래그합니다.
+
+이 앱은 ad-hoc/자체 서명(Apple 개발자 계정 공증 없음)이라 첫 실행 시 Gatekeeper가 "확인되지 않은 개발자" 경고를 띄웁니다. 아래 둘 중 하나로 한 번만 해제하면 됩니다.
+
+- **Finder:** `PokeTokenBar.app`을 우클릭(또는 Control+클릭) → **열기** → 대화상자에서 **열기**를 다시 클릭.
+- **터미널:** `xattr -dr com.apple.quarantine /Applications/PokeTokenBar.app`
+
+(Homebrew Cask는 격리 속성을 자동 제거하므로 이 과정이 필요 없습니다.)
+
 ### 소스 빌드
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ brew install --cask chattymin/tap/poke-token-bar
 
 ad-hoc/self-signed; the cask strips the quarantine attribute on install.
 
+### Manual install (without Homebrew)
+
+Prefer not to use Homebrew? Download `PokeTokenBar.zip` from the [latest release](https://github.com/chattymin/PokeTokenBar/releases/latest), unzip it, and drag `PokeTokenBar.app` into `/Applications`.
+
+Because the app is ad-hoc/self-signed (not notarized under an Apple Developer account), Gatekeeper shows an "unidentified developer" warning on first launch. Clear it once, either way:
+
+- **Finder:** right-click (or Control-click) `PokeTokenBar.app` → **Open** → **Open** again in the dialog.
+- **Terminal:** `xattr -dr com.apple.quarantine /Applications/PokeTokenBar.app`
+
+(The Homebrew cask strips quarantine for you, so it needs no extra step.)
+
 ### Build from source
 
 ```bash

--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -160,6 +160,20 @@ enum FreshEgg {
     static let price = 1_000_000_000
 }
 
+/// 상점 표시 한 줄 — 판매 아이템(ItemKind) 또는 새 알 리롤(즉시 액션이라 ItemKind 가 아님).
+/// CompanionStore.shopEntries 가 이 둘을 가격 오름차순으로 병합해 뷰가 단일 목록으로 그린다.
+enum ShopEntry: Hashable, Sendable {
+    case item(ItemKind)
+    case freshEgg
+
+    var price: Int {
+        switch self {
+        case .item(let kind): return kind.shopPrice ?? 0
+        case .freshEgg: return FreshEgg.price
+        }
+    }
+}
+
 /// 사탕 지급 대상 한도 창의 분류 — session=1개·weekly=weeklyGrant.
 enum WindowClass: Sendable { case session, weekly }
 

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -372,6 +372,26 @@ final class CompanionStore {
             }
     }
 
+    /// 상점 표시 순서 — 판매 아이템 + (활성 포켓몬 있을 때) 새 알 리롤을 하나의 가격 오름차순 목록으로 병합.
+    /// 정렬 규칙은 purchasableItems 와 동일: 구매 완료한 보유형은 맨 아래, 나머지는 가격 저렴한 순.
+    /// 새 알(1B)은 즉시 액션이라 '보유' 개념이 없어 가격 순서에만 참여한다 → 사탕(500M)과 이로치 부적(3B) 사이.
+    var shopEntries: [ShopEntry] {
+        var entries: [ShopEntry] = purchasableItems.map { ShopEntry.item($0) }
+        if hasActive { entries.append(.freshEgg) }
+        return entries.sorted { a, b in
+            let aDone = isPurchasedPassive(a)
+            let bDone = isPurchasedPassive(b)
+            if aDone != bDone { return !aDone }
+            return a.price < b.price
+        }
+    }
+
+    /// 구매 완료한 보유형(이로치 부적 등)인지 — shopEntries 정렬에서 맨 아래로 보낼 판정.
+    private func isPurchasedPassive(_ entry: ShopEntry) -> Bool {
+        guard case .item(let kind) = entry else { return false }   // 새 알은 즉시 액션 — 보유 개념 없음
+        return kind.isPassive && itemCount(kind) > 0
+    }
+
     /// 구매 가능 — 잔액이 그 아이템 가격 이상(상점 미판매면 false). 활성/알 무관(재고는 미리 쌓아둘 수 있음).
     func canBuy(_ kind: ItemKind) -> Bool {
         guard let price = kind.shopPrice else { return false }

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -361,12 +361,12 @@ struct L {
     var shinyCharmEffectHint: String { t("이로치 확률 ↑ · 적용 중", "Shiny rate ↑ · active", "色違い率↑ · 適用中") }
     // 새 알 (리롤)
     var freshEggName: String { t("포켓몬 알", "Pokémon Egg", "ポケモンのタマゴ") }
-    var freshEggDescription: String { t("지금 포켓몬을 보내주고 새 알로 다시 시작해요.",
+    var freshEggDescription: String { t("지금 포켓몬을 놓아주고 새 알로 다시 시작해요.",
                                         "Send off your current Pokémon and start fresh with a new egg.",
                                         "いまのポケモンを手放して新しいタマゴからやり直します。") }
-    func freshEggConfirm(_ name: String) -> String { t("\(name)을(를) 보내고 새 알로 바꿀까요?", "Send off \(name) for a fresh egg?", "\(name) を手放して新しいタマゴにしますか？") }
-    var freshEggShinyWarning: String { t("⚠️ 이로치 포켓몬이에요! 정말 보낼까요?", "⚠️ This one is shiny! Really send it off?", "⚠️ 色違いです！本当に手放しますか？") }
-    var freshEggDiscardShiny: String { t("이로치 보내기", "Send shiny off", "手放す") }
+    func freshEggConfirm(_ name: String) -> String { t("\(name)을(를) 놓아주고 새 알로 바꿀까요?", "Send off \(name) for a fresh egg?", "\(name) を手放して新しいタマゴにしますか？") }
+    var freshEggShinyWarning: String { t("⚠️ 이로치 포켓몬이에요! 정말 놓아줄까요?", "⚠️ This one is shiny! Really send it off?", "⚠️ 色違いです！本当に手放しますか？") }
+    var freshEggDiscardShiny: String { t("이로치 놓아주기", "Send shiny off", "手放す") }
 
     // MARK: 사탕 획득 알림 ("왜 받는지" = 토큰 한도를 다 채운 수고에 대한 보상)
     func notifCandyTitle(item: String, count: Int) -> String {

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -13,12 +13,15 @@ struct ShopView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 10) {
                 walletHeader(l)
-                ForEach(store.purchasableItems, id: \.self) { kind in
-                    ShopItemCard(store: store, kind: kind)
-                }
-                // 새 알(리롤) — 폐기할 활성 포켓몬이 있을 때만. 즉시 액션이라 ItemKind 가 아님.
-                if store.hasActive {
-                    FreshEggCard(store: store, nav: nav)
+                // shopEntries = 판매 아이템 + 새 알(리롤)을 가격 오름차순으로 병합한 단일 목록.
+                // 새 알은 활성 포켓몬이 있을 때만 shopEntries 에 포함된다(즉시 액션이라 ItemKind 가 아님).
+                ForEach(store.shopEntries, id: \.self) { entry in
+                    switch entry {
+                    case .item(let kind):
+                        ShopItemCard(store: store, kind: kind)
+                    case .freshEgg:
+                        FreshEggCard(store: store, nav: nav)
+                    }
                 }
             }
         }

--- a/Tests/PokeTokenBarTests/ShopTests.swift
+++ b/Tests/PokeTokenBarTests/ShopTests.swift
@@ -142,4 +142,30 @@ final class ShopTests: XCTestCase {
         XCTAssertTrue(s.itemCount(.shinyCharm) > 0)
         XCTAssertEqual(s.purchasableItems.last, .shinyCharm, "구매 완료 보유형은 최하단")
     }
+
+    // MARK: shopEntries (판매 아이템 + 새 알 리롤을 하나의 가격 오름차순 목록으로 병합)
+
+    /// 활성 포켓몬이 있으면 새 알(1B)이 사탕(500M)과 이로치 부적(3B) 사이에 끼워져 전체가 가격 오름차순.
+    /// (회귀: 알이 ForEach 밖에서 무조건 맨 아래로 append 돼 3B 부적보다 아래에 놓이던 표시.)
+    func testShopEntriesInterleavesFreshEggByPrice() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("shop-entries-\(UUID().uuidString).json")
+        let mon = "{\"baseID\":10,\"pathIDs\":[10],\"stageIndex\":0,\"usedAtStage\":200000000,"
+            + "\"rarity\":\"common\",\"totalForms\":3,\"isShiny\":false}"
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":5000000000,\"spentTokens\":0,"
+            + "\"lastDate\":\"d\",\"active\":\(mon),\"dex\":[],\"collectedFinals\":[]}"
+        try? json.data(using: .utf8)!.write(to: url)
+        let s = CompanionStore(provider: ShopNoProvider(), clock: { self.now }, fileURL: url, rng: SeededRNG(seed: 1))
+        XCTAssertTrue(s.hasActive)
+        XCTAssertEqual(s.shopEntries, [.item(.mint), .item(.rareCandy), .freshEgg, .item(.shinyCharm)])
+        let prices = s.shopEntries.map(\.price)
+        XCTAssertEqual(prices, prices.sorted(), "가격 상수가 바뀌어도 오름차순 불변식 유지")
+    }
+
+    /// 활성 포켓몬이 없으면(알 상태) 리롤 대상이 없어 새 알은 목록에서 빠진다 — 판매 아이템만.
+    func testShopEntriesOmitsFreshEggWhenNoActive() {
+        let s = store(used: 5_000_000_000)   // active 없음
+        XCTAssertFalse(s.hasActive)
+        XCTAssertEqual(s.shopEntries, [.item(.mint), .item(.rareCandy), .item(.shinyCharm)])
+        XCTAssertFalse(s.shopEntries.contains(.freshEgg))
+    }
 }


### PR DESCRIPTION
## Shop
- The fresh-egg reroll card was rendered outside the price-sorted list — appended after the `ForEach` and pinned to the bottom regardless of its 1B price, so it appeared below the 3B shiny charm and broke the ascending order introduced in #98.
- Add a `ShopEntry` enum (`.item(ItemKind)` / `.freshEgg`) and a `shopEntries` computed property that merges the egg into the same price-sorted list (egg included only when a companion is active). Order is now mint 100M → rare candy 500M → egg 1B → shiny charm 3B.
- Refine the Korean reroll wording from "보내다" (send off) to "놓아주다" (release) across the description, confirm, shiny-warning, and button strings. English/Japanese unchanged.
- Regression tests: the egg interleaves by price, and is omitted when no companion is active.

## Docs
- Add a "Manual install (without Homebrew)" subsection to README (en/ko/ja) with first-launch Gatekeeper steps (right-click Open / `xattr`), scoped to the direct-download path so the Homebrew path stays warning-free.
- The gh-pages landing page was updated in parallel (already live) with a matching `inst.gatekeeper` note.

## Verification
- Build passes; 40 tests pass (2 new shop regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)