### PR TITLE
feat: add floating desktop pet (opt-in, static position, size control)

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -106,6 +106,16 @@ struct L {
     var todayCost: String { t("오늘 비용 ($)", "Today's cost ($)", "本日のコスト ($)") }
     var limitPercent: String { t("한도 %", "Limit %", "上限 %") }
     var allOffHint: String { t("전부 끄면 캐릭터만 표시됩니다", "All off shows only the character", "すべてオフにするとキャラクターのみ表示") }
+    // MARK: 플로팅 펫
+    var floatingPetSectionTitle: String { t("플로팅 펫", "Floating Pet", "フローティングペット") }
+    var floatingPetEnableLabel: String { t("플로팅 펫 표시", "Show floating pet", "フローティングペットを表示") }
+    var floatingPetHint: String {
+        t("포켓몬이 화면 위에 떠 있어요 — 드래그로 위치를 옮길 수 있어요",
+          "Your Pokémon floats over the screen — drag to reposition",
+          "ポケモンが画面の上に浮かびます — ドラッグで移動できます")
+    }
+    var floatingPetSizeLabel: String { t("크기", "Size", "サイズ") }
+
     var disableKeychain: String { t("Keychain 접근 끄기", "Disable Keychain access", "Keychainアクセスを無効化") }
     var disableKeychainHint: String { t("켜면 Keychain 접근 허용 팝업이 더 안 뜹니다 — 공식 한도(%)만 숨겨지고 토큰·비용은 그대로", "When on, no more Keychain permission pop-ups — only official limits (%) are hidden; tokens/cost stay", "オンにするとKeychain許可のポップアップが出なくなります — 公式上限(%)のみ非表示、トークン・費用はそのまま") }
     var refreshLimitToken: String { t("한도 토큰 캐시 갱신", "Refresh limit token cache", "上限トークンキャッシュを更新") }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -70,6 +70,14 @@ final class UsageStore {
     var statusChecksEnabled: Bool {
         didSet { defaults.set(statusChecksEnabled, forKey: "statusChecksEnabled") }
     }
+    // 플로팅 펫 (데스크톱 위 고정 오버레이 — 스스로 이동하지 않음, 드래그로만 위치 변경)
+    var floatingPetEnabled: Bool {
+        didSet { defaults.set(floatingPetEnabled, forKey: "floatingPetEnabled") }
+    }
+    /// 플로팅 펫 스프라이트 한 변 크기(pt).
+    var floatingPetSize: Double {
+        didSet { defaults.set(floatingPetSize, forKey: "floatingPetSize") }
+    }
     var disableKeychainAccess: Bool {
         didSet {
             defaults.set(disableKeychainAccess, forKey: "disableKeychainAccess")   // 저장 누락이던 기존 버그 — 재시작 후 풀렸음
@@ -330,6 +338,8 @@ final class UsageStore {
         companionNotifications = d.object(forKey: "companionNotifications") as? Bool ?? true
         updateNotificationsEnabled = d.object(forKey: "updateNotificationsEnabled") as? Bool ?? true
         statusChecksEnabled = d.object(forKey: "statusChecksEnabled") as? Bool ?? true
+        floatingPetEnabled = d.object(forKey: "floatingPetEnabled") as? Bool ?? false
+        floatingPetSize = d.object(forKey: "floatingPetSize") as? Double ?? 96
         disableKeychainAccess = d.object(forKey: "disableKeychainAccess") as? Bool ?? false
 
         reschedule()

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var store: UsageStore!
     private var companion: CompanionStore!
     private var updater: UpdateChecker!
+    private var floatingPet: FloatingPetController!
     private let navigation = PopoverNavigation()
 
     // 메뉴바 캐릭터 애니메이션 — 단일 타이머로 프레임 순환.
@@ -46,6 +47,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         updater = UpdateChecker()
         store.localizationLanguage = companion.language   // 알림 현지화용 미러 시드
         store.onRefresh = { [weak self] in self?.onStoreRefreshed() }   // 한도 로드 후 companion·사탕 지급
+        floatingPet = FloatingPetController(store: store, companion: companion)   // 데스크톱 플로팅 펫(옵트인)
         Task { await updater.check() }                    // 기동 시 1회 업데이트 확인
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -351,6 +353,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private func setDisplayAwake(_ awake: Bool) {
         displayAwake = awake
         syncMenuAnimation()
+        floatingPet.setDisplayAwake(awake)   // 슬립 중엔 펫 호스팅 트리 해제(GIF 루프 정지)
     }
 
     /// menuShouldAnimate 상태에 맞춰 애니메이션을 재개/정지한다(멱등 — 중복 호출 안전).

--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -1,0 +1,138 @@
+import AppKit
+import SwiftUI
+
+/// 데스크톱 위에 떠 있는 컴패니언 포켓몬 오버레이(옵트인, 설정 → 플로팅 펫).
+/// - 스스로 움직이지 않는다: 화면을 돌아다니는 로직이 없고, 위치는 사용자가 드래그로만 옮긴다.
+/// - 위치는 UserDefaults 에 영속 — 재실행/재표시 시 복원, 화면 구성이 바뀌어 화면 밖이면 기본 위치로.
+/// - 에너지: 숨김·디스플레이 슬립 시 SwiftUI 호스팅 트리를 해제한다(숨은 트리 상주 재레이아웃
+///   비용 제거 — AppDelegate 의 popoverDidClose 패턴과 동일).
+@MainActor
+final class FloatingPetController: NSObject, NSWindowDelegate {
+    private let store: UsageStore
+    private let companion: CompanionStore
+    private let defaults: UserDefaults
+    private var panel: NSPanel?
+    private var displayAwake = true
+
+    private static let originXKey = "floatingPetOriginX"
+    private static let originYKey = "floatingPetOriginY"
+
+    init(store: UsageStore, companion: CompanionStore, defaults: UserDefaults = .standard) {
+        self.store = store
+        self.companion = companion
+        self.defaults = defaults
+        super.init()
+        observeSettings()
+        sync()
+    }
+
+    /// AppDelegate 의 디스플레이 슬립 게이팅과 연동 — 꺼진 화면 뒤에서 GIF 프레임 루프가 돌지 않게.
+    func setDisplayAwake(_ awake: Bool) {
+        displayAwake = awake
+        sync()
+    }
+
+    /// 설정(켬/끔·크기) 변경 관찰 — 재등록 패턴(AppDelegate.observeStore 와 동일).
+    /// 종/이로치 변경은 패널 내부 SwiftUI 가 environment 관찰로 스스로 갱신하므로 여기선 안 본다.
+    private func observeSettings() {
+        withObservationTracking {
+            _ = store.floatingPetEnabled
+            _ = store.floatingPetSize
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.sync()
+                self.observeSettings()
+            }
+        }
+    }
+
+    /// 설정·디스플레이 상태에 맞춰 표시/숨김·크기를 반영한다(멱등).
+    private func sync() {
+        guard store.floatingPetEnabled, displayAwake else { hide(); return }
+        show()
+    }
+
+    private func show() {
+        let p = panel ?? makePanel()
+        panel = p
+        if p.contentView == nil {
+            p.contentView = PetHostingView(rootView: AnyView(
+                FloatingPetView().environment(store).environment(companion)))
+        }
+        p.setFrame(targetFrame(size: CGFloat(store.floatingPetSize)), display: true)
+        p.orderFrontRegardless()
+    }
+
+    private func hide() {
+        guard let p = panel else { return }
+        p.orderOut(nil)
+        p.contentView = nil   // 숨은 SwiftUI 트리 해제(GIF 프레임 루프 정지 포함)
+    }
+
+    /// 표시 프레임 — 저장된 위치(드래그 영속) 우선, 없으면 주 화면 우하단. 화면 밖이면 기본 위치로 복귀.
+    private func targetFrame(size: CGFloat) -> NSRect {
+        var origin: NSPoint
+        if let x = defaults.object(forKey: Self.originXKey) as? Double,
+           let y = defaults.object(forKey: Self.originYKey) as? Double {
+            origin = NSPoint(x: x, y: y)
+        } else {
+            origin = Self.defaultOrigin(size: size)
+        }
+        var frame = NSRect(origin: origin, size: NSSize(width: size, height: size))
+        // 화면 구성 변경(모니터 분리 등)으로 어떤 화면과도 안 겹치면 기본 위치로.
+        if !NSScreen.screens.contains(where: { $0.visibleFrame.intersects(frame) }) {
+            frame.origin = Self.defaultOrigin(size: size)
+        }
+        return frame
+    }
+
+    private static func defaultOrigin(size: CGFloat) -> NSPoint {
+        guard let visible = NSScreen.main?.visibleFrame else { return NSPoint(x: 120, y: 120) }
+        return NSPoint(x: visible.maxX - size - 24, y: visible.minY + 24)
+    }
+
+    private func makePanel() -> NSPanel {
+        let p = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 96, height: 96),
+                        styleMask: [.borderless, .nonactivatingPanel],
+                        backing: .buffered, defer: false)
+        p.isOpaque = false
+        p.backgroundColor = .clear
+        p.hasShadow = false
+        p.level = .floating
+        p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        p.isMovableByWindowBackground = true   // 유일한 이동 수단 — 자율 이동 없음
+        p.hidesOnDeactivate = false
+        p.isReleasedWhenClosed = false
+        p.becomesKeyOnlyIfNeeded = true
+        p.animationBehavior = .none
+        p.delegate = self
+        return p
+    }
+
+    // MARK: NSWindowDelegate — 드래그 위치 영속
+
+    func windowDidMove(_ notification: Notification) {
+        guard let p = panel, p.isVisible else { return }
+        defaults.set(Double(p.frame.origin.x), forKey: Self.originXKey)
+        defaults.set(Double(p.frame.origin.y), forKey: Self.originYKey)
+    }
+}
+
+/// NSHostingView 는 콘텐츠에 따라 배경 드래그 이동을 막을 수 있어 명시 허용 — 패널 어디를 잡아도 이동.
+private final class PetHostingView: NSHostingView<AnyView> {
+    override var mouseDownCanMoveWindow: Bool { true }
+}
+
+/// 패널 콘텐츠 — 현재 컴패니언(알 포함)을 설정 크기로 표시. 종/이로치/크기 변경은 environment 관찰로 자동 반영.
+struct FloatingPetView: View {
+    @Environment(UsageStore.self) private var store
+    @Environment(CompanionStore.self) private var companion
+
+    var body: some View {
+        let size = CGFloat(store.floatingPetSize)
+        SpriteView(speciesID: companion.currentSpeciesID, size: size, animated: true,
+                   shiny: companion.currentIsShiny)
+            .frame(width: size, height: size)
+    }
+}

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -33,6 +33,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 18) {
                     generalGroup(store)
                     menuBarGroup(store)
+                    floatingPetGroup(store)
                     notificationsGroup(store)
                     updateGroup(store)
                     advancedGroup(store)
@@ -150,6 +151,31 @@ struct SettingsView: View {
                 toggleRow(l.limitPercent, $store.showLimitInMenu)
             }
             Text(l.allOffHint).font(.caption2).foregroundStyle(.tertiary).padding(.leading, 4)
+        }
+    }
+
+    @ViewBuilder
+    private func floatingPetGroup(_ store: UsageStore) -> some View {
+        @Bindable var store = store
+        settingsSection(l.floatingPetSectionTitle) {
+            groupRow {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(l.floatingPetEnableLabel)
+                    Text(l.floatingPetHint).font(.caption2).foregroundStyle(.tertiary)
+                }
+                Spacer()
+                Toggle("", isOn: $store.floatingPetEnabled)
+                    .labelsHidden().toggleStyle(.switch).controlSize(.small)
+            }
+            if store.floatingPetEnabled {
+                Divider()
+                groupRow {
+                    Text(l.floatingPetSizeLabel).font(.callout)
+                    Slider(value: $store.floatingPetSize, in: 48...192, step: 8)
+                    Text("\(Int(store.floatingPetSize))px")
+                        .font(.caption).monospacedDigit().frame(width: 44, alignment: .trailing)
+                }
+            }
         }
     }
 

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -166,6 +166,23 @@ final class UsageStoreTests: XCTestCase {
                        "수동 갱신(사용자 버튼)만 프롬프트 허용 경로를 쓴다")
     }
 
+    // MARK: 플로팅 펫 설정 (기본값 + 영속)
+
+    /// 플로팅 펫은 기본 꺼짐(96px). 토글·크기 변경은 defaults 에 영속돼 재시작 후 유지된다.
+    func testFloatingPetSettingsDefaultAndPersistence() {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(1_000))
+        let store = makeStore(providers: [claude])
+        XCTAssertFalse(store.floatingPetEnabled, "옵트인 기능 — 기본은 꺼짐")
+        XCTAssertEqual(store.floatingPetSize, 96)
+
+        store.floatingPetEnabled = true
+        store.floatingPetSize = 144
+
+        let reloaded = makeStore(providers: [claude])   // 같은 suite 재로딩 = 앱 재시작
+        XCTAssertTrue(reloaded.floatingPetEnabled)
+        XCTAssertEqual(reloaded.floatingPetSize, 144)
+    }
+
     // MARK: 프로바이더 상태(인시던트) 표시
 
     /// statuspage.io status.json 파싱(순수) — indicator/description 매핑 + 미지값 unknown + malformed nil.


### PR DESCRIPTION
## Summary

Adds an opt-in **floating desktop pet**: the current companion Pokémon (or egg) floats over the desktop in a borderless transparent panel.

- **Never moves on its own** — no wandering logic. The sprite only animates in place (Gen-V GIF); the user repositions it by dragging. The origin is persisted in UserDefaults and restored on relaunch, falling back to the bottom-right corner of the main screen when the saved position is off-screen (monitor layout change).
- **Settings → Floating Pet group** — enable toggle (default **off**) and a size slider (48–192 px, step 8, default 96). Both persisted via the existing UserDefaults pattern in `UsageStore`; en/ko/ja strings added.

## Implementation

- New `FloatingPetController` (`UI/FloatingPetPanel.swift`): non-activating borderless `NSPanel` at `.floating` level, visible on all Spaces (`canJoinAllSpaces` + `fullScreenAuxiliary`), `isMovableByWindowBackground` as the only way it moves. Enable/size changes are observed with the `withObservationTracking` re-register pattern (same as `AppDelegate.observeStore`); species/shiny changes propagate through SwiftUI environment observation inside the panel.
- **Energy discipline** (per the status-item idle-CPU rules): when disabled or on display sleep, the hosting content view is torn down (same pattern as `popoverDidClose`) so the SwiftUI tree and the GIF frame loop fully stop; it is rebuilt on wake/re-enable. Wired into `AppDelegate.setDisplayAwake`.
- Reuses `SpriteView` as-is (static-first load, animated GIF with shiny fallback, egg glyph fallback) — no new sprite plumbing.

## Testing

- `swift test`: 283 tests passed (3 skipped), including new `testFloatingPetSettingsDefaultAndPersistence` covering defaults (off / 96 px) and persistence across a store reload.
- Manually verified on the installed app: panel appears bottom-right at 96×96 on the floating window layer (checked via CGWindowList), drag-to-reposition persists, toggle/size react live from Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)