### PR TITLE
docs: add auto-updating contributors section to READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -144,6 +144,10 @@ swift test                   # ユニットテスト
 - **Keychain（任意）。** 公式の上限を表示するため、Claude OAuth 資格情報を **1回**（パスワードのプロンプト1回）読み取り、アプリ自身の Keychain 項目にキャッシュして再利用します。設定でオフにすると上限セクションが非表示になります。
 - **ポケモンのアセット** はランタイムに PokéAPI から取得し、`~/Library/Application Support/PokeTokenBar/` にのみキャッシュされます。著作物はこのリポジトリやリリースにバンドルしません。
 
+## コントリビューター
+
+[![Contributors](https://contrib.rocks/image?repo=chattymin/PokeTokenBar)](https://github.com/chattymin/PokeTokenBar/graphs/contributors)
+
 ## ライセンス & 免責
 
 **MIT** — [LICENSE](LICENSE) を参照。MIT は本プロジェクトの**オリジナルソースコードのみ**を対象とし、アプリを通じてアクセスされる第三者の商標・アートワーク・データに関する権利を付与するものではありません。

--- a/README.ko.md
+++ b/README.ko.md
@@ -144,6 +144,10 @@ swift test                   # 단위 테스트
 - **Keychain(선택).** 공식 한도를 보여주려면 Claude OAuth 자격증명을 **1회**(비밀번호 프롬프트 1번) 읽고, 앱 자체 Keychain 항목에 캐시해 재사용합니다. 설정에서 끄면 한도 섹션만 숨겨집니다.
 - **포켓몬 에셋**은 런타임에 PokéAPI에서 받아오며 `~/Library/Application Support/PokeTokenBar/`에만 캐시됩니다. 저작물은 레포나 릴리스에 번들하지 않습니다.
 
+## 기여자
+
+[![Contributors](https://contrib.rocks/image?repo=chattymin/PokeTokenBar)](https://github.com/chattymin/PokeTokenBar/graphs/contributors)
+
 ## 라이선스 & 면책
 
 **MIT** — [LICENSE](LICENSE) 참고. MIT는 본 프로젝트의 **원본 소스 코드에만** 적용되며, 앱을 통해 접근하는 제3자의 상표·아트워크·데이터에 대한 권리는 부여하지 않습니다.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ swift test                   # unit tests
 - **Keychain (optional).** To show official limits it reads the Claude OAuth credential **once** (a single password prompt), then caches it in the app's own Keychain item for reuse. Turn it off in Settings — the limits section simply hides.
 - **Pokémon assets** are fetched at runtime from PokéAPI and cached only under `~/Library/Application Support/PokeTokenBar/`. Nothing copyrighted is bundled in this repository or its releases.
 
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=chattymin/PokeTokenBar)](https://github.com/chattymin/PokeTokenBar/graphs/contributors)
+
 ## License & disclaimer
 
 **MIT** — see [LICENSE](LICENSE). The MIT license covers this project's original source code only; it grants no rights to any third-party trademarks, artwork, or data accessed through the app.


### PR DESCRIPTION
## Summary
- Add a **Contributors** section between Privacy and License in all three READMEs (en/ko/ja).
- Renders the GitHub contributor avatars via [contrib.rocks](https://contrib.rocks), so new contributors appear automatically — no manual list to maintain.

## Type of change
- [x] Docs

## Checklist
- [x] en/ko/ja parity (localized headings: Contributors / 기여자 / コントリビューター)
- [x] Image URL points at this repo (`chattymin/PokeTokenBar`) and returns 200
- [x] Link targets the canonical `/graphs/contributors` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
