### PR TITLE
docs: link the Contributors section to CONTRIBUTING per language

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -146,6 +146,8 @@ swift test                   # ユニットテスト
 
 ## コントリビューター
 
+大小を問わずあらゆる貢献を歓迎します — ビルド・テスト・プルリクエストの方法は [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) をご覧ください。
+
 [![Contributors](https://contrib.rocks/image?repo=chattymin/PokeTokenBar)](https://github.com/chattymin/PokeTokenBar/graphs/contributors)
 
 ## ライセンス & 免責

--- a/README.ko.md
+++ b/README.ko.md
@@ -146,6 +146,8 @@ swift test                   # 단위 테스트
 
 ## 기여자
 
+크기에 상관없이 모든 기여를 환영합니다 — 빌드·테스트·풀 리퀘스트 방법은 [CONTRIBUTING.ko.md](CONTRIBUTING.ko.md)를 참고하세요.
+
 [![Contributors](https://contrib.rocks/image?repo=chattymin/PokeTokenBar)](https://github.com/chattymin/PokeTokenBar/graphs/contributors)
 
 ## 라이선스 & 면책

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ swift test                   # unit tests
 
 ## Contributors
 
+Contributions of all sizes are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for how to build, test, and open a pull request.
+
 [![Contributors](https://contrib.rocks/image?repo=chattymin/PokeTokenBar)](https://github.com/chattymin/PokeTokenBar/graphs/contributors)
 
 ## License & disclaimer


### PR DESCRIPTION
## Summary
- Add a short blurb + a language-matched `CONTRIBUTING` link to the Contributors section of each README (en → CONTRIBUTING.md, ko → CONTRIBUTING.ko.md, ja → CONTRIBUTING.ja.md).

## Type of change
- [x] Docs

## Checklist
- [x] en/ko/ja parity
- [x] Each link points at the matching-language CONTRIBUTING file (all three exist)
