### PR TITLE
perf: extend idle-wakeup discipline to the floating pet (fps floor + low-power)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,3 +134,11 @@
   diff-gate(동일 프레임 객체 재대입 스킵 — 애니 프레임은 서로 다른 객체라 정상 통과) + GIF fps 하한 0.4s(≈2.5fps)
   + `Timer.tolerance` 0.5(코얼레싱)로 ~5 wakeup/s(−89%), 애니메이션 유지. 배터리-vs-AC/thermal 적응·CADisplayLink
   전환은 1인 로컬 노트북 기준 수확체감으로 판정, 미도입(필요 시 Agent Team 계획 참조). (Agent Team 조사 + 실측, 2026-07-22.)
+- **항상 뜬 애니메이션 표면은 메뉴바와 같은 idle 규율을 공유한다.** 플로팅 펫(`FloatingPetPanel`)처럼 상시
+  표시되는 두 번째 GIF 표면을 더할 땐 메뉴바 규율을 그대로 상속해야 회귀(#102 후속)를 안 만든다: ① GIF fps
+  하한(`SpriteView(minFrameDelay:)` — 펫은 `FloatingPetView.frameFloor` 0.4s≈2.5fps, 팝오버 등 *일시적* 표시는
+  0=네이티브) + `Task.sleep(for:tolerance:)` 코얼레싱, ② 저전력 모드 정적화(`FloatingPetController.shouldAnimate(lowPower:)`
+  — `NSProcessInfoPowerStateDidChange` 관찰 후 콘텐츠 재구성), ③ 숨김/슬립 시 `contentView=nil` 로 프레임 루프 정지
+  (팝오버 `popoverDidClose` 패턴). 회귀 가드: `FloatingPetEnergyTests`(fps 하한 clamp·`frameFloor>0`·팝오버 불변·
+  low-power 정적화 순수 판정 — SwiftUI `.task` 타이밍 자체는 호스트 없이 xctest 불가라 순수 경로만 잠금). occlusion 게이팅은
+  all-spaces/`.floating` 펫이 실제로 거의 안 가려져 메뉴바와 동일 수확체감으로 미도입. (#102 리뷰 지적 반영, 2026-07-22.)

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -47,24 +47,33 @@ struct SpriteView: View {
     var bob: Bool = false
     var animated: Bool = false
     var shiny: Bool = false
+    /// GIF 프레임 지속의 하한(초). 0=원본 delay 그대로. >0 이면 fps 상한 + wakeup 코얼레싱을 적용해
+    /// idle 배터리를 통제한다 — 항상 떠 있는 플로팅 펫(0.4s≈2.5fps)이 메뉴바 GIF 규율과 동치가 되게.
+    /// 팝오버 등 일시적 표시는 0(기본)으로 두어 네이티브 fps 유지.
+    var minFrameDelay: TimeInterval = 0
     @State private var img: NSImage?
     @State private var up = false
     @State private var loadedID: Int?   // img 가 어느 speciesID 것인지(id 변경 시 갱신 판단)
     @State private var frames: [(image: NSImage, delay: TimeInterval)] = []
     @State private var frameIndex = 0
 
-    init(speciesID: Int?, size: CGFloat = 84, bob: Bool = false, animated: Bool = false, shiny: Bool = false) {
+    init(speciesID: Int?, size: CGFloat = 84, bob: Bool = false, animated: Bool = false,
+         shiny: Bool = false, minFrameDelay: TimeInterval = 0) {
         self.speciesID = speciesID
         self.size = size
         self.bob = bob
         self.animated = animated
         self.shiny = shiny
+        self.minFrameDelay = minFrameDelay
         // 캐시에 있으면 즉시(동기) 표시 — 재렌더 플래시 방지 + 정적 스냅샷에서도 보임.
         // speciesID==nil(알 상태)이면 알 스프라이트를 시드(없으면 body 가 🥚 폴백).
         let cached = speciesID.map { SpriteLoader.cachedImage(speciesID: $0, shiny: shiny) } ?? SpriteLoader.cachedEggImage()
         _img = State(initialValue: cached)
         _loadedID = State(initialValue: (speciesID != nil && cached != nil) ? speciesID : nil)
     }
+
+    /// 프레임 지속(초) = max(원본 delay, 하한). 순수·테스트용 — fps 상한 회귀 가드.
+    static func frameDelay(base: TimeInterval, floor: TimeInterval) -> TimeInterval { max(base, floor) }
 
     var body: some View {
         Group {
@@ -109,8 +118,11 @@ struct SpriteView: View {
             frames = raw
             // delay 기반 프레임 advance. .task 취소 시(speciesID 변경/뷰 소멸) 루프 종료 — 누수 없음
             while !Task.isCancelled {
-                let delay = frames[frameIndex % frames.count].delay
-                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                let delay = Self.frameDelay(base: frames[frameIndex % frames.count].delay, floor: minFrameDelay)
+                // minFrameDelay>0(플로팅 펫): fps 상한 + tolerance 로 wakeup 코얼레싱 — 메뉴바
+                // max(0.4,delay)+timer.tolerance 규율과 동치(항상 뜬 표면의 idle 배터리 통제). 0 이면 네이티브.
+                try? await Task.sleep(for: .seconds(delay),
+                                      tolerance: minFrameDelay > 0 ? .seconds(delay * 0.5) : .zero)
                 if Task.isCancelled { break }
                 frameIndex = (frameIndex + 1) % frames.count
             }

--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -13,6 +13,8 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
     private let defaults: UserDefaults
     private var panel: NSPanel?
     private var displayAwake = true
+    private var builtAnimated: Bool?        // 현재 contentView 가 어떤 animated 상태로 지어졌나(nil=없음)
+    private var powerObserver: NSObjectProtocol?
 
     private static let originXKey = "floatingPetOriginX"
     private static let originYKey = "floatingPetOriginY"
@@ -23,6 +25,7 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
         self.defaults = defaults
         super.init()
         observeSettings()
+        observePowerState()
         sync()
     }
 
@@ -47,6 +50,18 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
         }
     }
 
+    /// 저전력 모드 토글 관찰 — 켜지면 정적, 꺼지면 애니메이션 재개(패널 콘텐츠 재구성). 메뉴바 low-power 규율과 동일.
+    private func observePowerState() {
+        powerObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.NSProcessInfoPowerStateDidChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.sync() }
+        }
+    }
+
+    /// 저전력 모드면 애니메이션을 멈추고 정적 스프라이트로 — 배터리 절약. 순수·테스트용.
+    static func shouldAnimate(lowPower: Bool) -> Bool { !lowPower }
+
     /// 설정·디스플레이 상태에 맞춰 표시/숨김·크기를 반영한다(멱등).
     private func sync() {
         guard store.floatingPetEnabled, displayAwake else { hide(); return }
@@ -56,9 +71,12 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
     private func show() {
         let p = panel ?? makePanel()
         panel = p
-        if p.contentView == nil {
+        // 저전력 모드가 토글되면 animated 플래그가 바뀌므로 콘텐츠를 재구성(정적↔애니메이션 전환).
+        let wantAnimated = Self.shouldAnimate(lowPower: ProcessInfo.processInfo.isLowPowerModeEnabled)
+        if p.contentView == nil || builtAnimated != wantAnimated {
             p.contentView = PetHostingView(rootView: AnyView(
-                FloatingPetView().environment(store).environment(companion)))
+                FloatingPetView(animated: wantAnimated).environment(store).environment(companion)))
+            builtAnimated = wantAnimated
         }
         p.setFrame(targetFrame(size: CGFloat(store.floatingPetSize)), display: true)
         p.orderFrontRegardless()
@@ -68,6 +86,7 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
         guard let p = panel else { return }
         p.orderOut(nil)
         p.contentView = nil   // 숨은 SwiftUI 트리 해제(GIF 프레임 루프 정지 포함)
+        builtAnimated = nil
     }
 
     /// 표시 프레임 — 저장된 위치(드래그 영속) 우선, 없으면 주 화면 우하단. 화면 밖이면 기본 위치로 복귀.
@@ -125,14 +144,20 @@ private final class PetHostingView: NSHostingView<AnyView> {
 }
 
 /// 패널 콘텐츠 — 현재 컴패니언(알 포함)을 설정 크기로 표시. 종/이로치/크기 변경은 environment 관찰로 자동 반영.
+/// `animated`=false(저전력 모드)면 정적 스프라이트로 고정. 애니메이션 시엔 fps 하한 0.4s(≈2.5fps)로
+/// 캡 — 항상 떠 있는 표면이라 메뉴바 GIF 규율과 동일하게 idle wakeup 을 통제한다.
 struct FloatingPetView: View {
+    /// GIF fps 하한(초). >0 필수 — 0 이면 네이티브 fps 로 새어 메뉴바에서 고친 idle wakeup 회귀가 재발한다.
+    /// 상시 표시 표면이라 메뉴바와 동일한 0.4s(≈2.5fps) 캡. 값 조정 시 여기 한 곳만 — 회귀 가드는 `frameFloor>0`.
+    static let frameFloor: TimeInterval = 0.4
+    var animated: Bool = true
     @Environment(UsageStore.self) private var store
     @Environment(CompanionStore.self) private var companion
 
     var body: some View {
         let size = CGFloat(store.floatingPetSize)
-        SpriteView(speciesID: companion.currentSpeciesID, size: size, animated: true,
-                   shiny: companion.currentIsShiny)
+        SpriteView(speciesID: companion.currentSpeciesID, size: size, animated: animated,
+                   shiny: companion.currentIsShiny, minFrameDelay: Self.frameFloor)
             .frame(width: size, height: size)
     }
 }

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -125,3 +125,36 @@ final class StoreTerminationTests: XCTestCase {
         }
     }
 }
+
+// MARK: 플로팅 펫 / 스프라이트 idle 배터리 규율
+
+/// 항상 떠 있는 플로팅 펫은 두 번째 GIF 표면이라, 메뉴바에서 고친 idle wakeup 증폭이 재발하지 않게
+/// 같은 규율(fps 하한 + 저전력 정적화)을 공유한다. 여기선 그 순수 판정만 고정한다.
+@MainActor
+final class FloatingPetEnergyTests: XCTestCase {
+    /// [회귀] 플로팅 펫 GIF 는 fps 하한(0.4s≈2.5fps)으로 캡 — 네이티브 fps 로 돌면 프레임마다
+    /// 재합성(CA 커밋→디스플레이 사이클 wakeup)이 늘어 메뉴바 회귀를 그대로 반복한다.
+    func testPetFrameDelayHonorsFloor() {
+        XCTAssertEqual(SpriteView.frameDelay(base: 0.1, floor: 0.4), 0.4, accuracy: 1e-9)   // 빠른 프레임 → 캡
+        XCTAssertEqual(SpriteView.frameDelay(base: 0.6, floor: 0.4), 0.6, accuracy: 1e-9)   // 이미 느리면 원본 유지
+    }
+
+    /// 팝오버 등 일시적 표시(floor=0)는 네이티브 delay 그대로 — 캡은 항상 뜬 펫에만 적용.
+    func testTransientSpriteKeepsNativeDelay() {
+        XCTAssertEqual(SpriteView.frameDelay(base: 0.1, floor: 0), 0.1, accuracy: 1e-9)
+        XCTAssertEqual(SpriteView.frameDelay(base: 0.03, floor: 0), 0.03, accuracy: 1e-9)
+    }
+
+    /// 저전력 모드면 펫 애니메이션을 정지(정적)해 배터리를 아낀다. 정상 모드면 애니메이션.
+    func testPetFreezesUnderLowPower() {
+        XCTAssertFalse(FloatingPetController.shouldAnimate(lowPower: true))
+        XCTAssertTrue(FloatingPetController.shouldAnimate(lowPower: false))
+    }
+
+    /// [회귀] 펫은 반드시 fps 캡이 걸려야 한다 — frameFloor 가 0 으로 돌아가면(네이티브 fps) 메뉴바에서
+    /// 고친 wakeup 회귀가 재발한다. 뷰가 실제로 넘기는 상수를 그대로 가드한다(리터럴 유실 방지).
+    func testPetFrameFloorIsCapped() {
+        XCTAssertGreaterThan(FloatingPetView.frameFloor, 0, "펫 fps 캡이 해제되면 idle wakeup 회귀")
+        XCTAssertEqual(FloatingPetView.frameFloor, 0.4, accuracy: 1e-9, "메뉴바와 동일한 0.4s≈2.5fps 캡")
+    }
+}


### PR DESCRIPTION
## Summary

The opt-in floating desktop pet (#102) is a persistent, always-on GIF surface but lacked the idle-wakeup discipline the menu-bar status item already has — it animated at the native GIF rate (~10fps) whenever shown, re-introducing the CA-commit / WindowServer wakeup amplification that #99 / #100 fixed for the menu bar.

## Change — give the pet parity through the shared `SpriteView`

- **fps floor**: `SpriteView` gains `minFrameDelay`; the pet caps at 0.4s (~2.5fps, same as the menu bar) via `FloatingPetView.frameFloor`, and the loop uses `Task.sleep(for:tolerance:)` (tolerance = `delay * 0.5`) to coalesce wakeups. Popover / Pokédex / Bag keep `minFrameDelay = 0` → native, unchanged.
- **low-power**: freeze to a static sprite when Low Power Mode is on, observing `NSProcessInfoPowerStateDidChange` and rebuilding the panel content.
- teardown (`contentView = nil`) on hide / display-sleep was already in place.

`occlusion` gating is intentionally skipped — an all-Spaces `.floating` panel is rarely occluded (same diminishing-returns call as the menu bar).

## Testing

- New `FloatingPetEnergyTests`: frame-delay clamp, transient-native path, low-power decision, and `frameFloor > 0` (cap-disabled regression guard).
- `swift build` clean; `./scripts/test-gate.sh` → **289 tests pass** (3 skipped), 84.62% core line coverage.
- SwiftUI `.task` timing isn't unit-testable without a host, so the loop wiring is verified by build + review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
