### PR TITLE
fix: weekly total under-counts in the first days of each month

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -79,7 +79,9 @@ private actor LocalAdditionalUsageCache {
         }
         if let task = inFlight[source] { return await task.value }
 
-        let periodStart = min(LocalUsageReader.startOfMonth(now), now.addingTimeInterval(-7 * 86400))
+        // 스캔 하한은 enrichment 의 세 윈도우(블록·주·월) 중 가장 이른 시작 — 월초 경계 흡수.
+        // (Claude/Codex/Gemini 경로와 이 단일 소스를 공유해 과거의 window 드리프트를 원천 차단.)
+        let periodStart = LocalUsageReader.enrichmentScanStart(now: now)
         // OpenCode messages are immutable. After the cold monthly read, only query
         // records at and after the newest cached timestamp (with a small overlap).
         // This keeps minute-by-minute refreshes cheap even for large databases.

--- a/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
@@ -14,8 +14,9 @@ struct LocalClaudeProvider: UsageProvider {
     func fetchEnrichment() async -> ProviderEnrichment {
         let now = Date()
         let monthStart = LocalUsageReader.startOfMonth(now)
-        // 월 범위 한 번 스캔으로 블록·주·월을 모두 도출.
-        let entries = await LocalUsageCache.shared.claudeEntries(modifiedSince: monthStart)
+        // 한 번 스캔으로 블록·주·월을 모두 도출 — 하한은 세 윈도우 중 가장 이른 시작(월초 경계 흡수).
+        let entries = await LocalUsageCache.shared.claudeEntries(
+            modifiedSince: LocalUsageReader.enrichmentScanStart(now: now))
         let fmt = LocalUsageReader.localDayFormatter()
         var r = ProviderEnrichment()
         r.activeBlock = LocalUsageReader.activeBlock(entries: entries, now: now)
@@ -47,7 +48,8 @@ struct LocalGeminiProvider: UsageProvider {
     func fetchEnrichment() async -> ProviderEnrichment {
         let now = Date()
         let monthStart = LocalUsageReader.startOfMonth(now)
-        let entries = await LocalUsageCache.shared.geminiEntries(modifiedSince: monthStart)
+        let entries = await LocalUsageCache.shared.geminiEntries(
+            modifiedSince: LocalUsageReader.enrichmentScanStart(now: now))
         let fmt = LocalUsageReader.localDayFormatter()
         var r = ProviderEnrichment()
         // 블록(burn rate) 계산은 프로바이더 공통 — companion 리듬이 전 프로바이더를 따르게.
@@ -81,7 +83,8 @@ struct LocalCodexProvider: UsageProvider {
     func fetchEnrichment() async -> ProviderEnrichment {
         let now = Date()
         let monthStart = LocalUsageReader.startOfMonth(now)
-        let entries = await LocalUsageCache.shared.codexEntries(modifiedSince: monthStart)
+        let entries = await LocalUsageCache.shared.codexEntries(
+            modifiedSince: LocalUsageReader.enrichmentScanStart(now: now))
         let fmt = LocalUsageReader.localDayFormatter()
         var r = ProviderEnrichment()
         // 블록(burn rate) 계산은 프로바이더 공통 — companion 리듬이 전 프로바이더를 따르게.

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -11,6 +11,9 @@ import Foundation
 /// 성능: mtime 윈도우로 스캔 파일을 한정(범위 시작 이전에 수정된 파일은 범위 내 엔트리가 없음).
 enum LocalUsageReader {
 
+    /// 활성 블록(번 레이트)과 enrichment 스캔 하한이 공유하는 5시간 롤링 윈도우 길이.
+    static let blockWindow: TimeInterval = 5 * 3600
+
     // MARK: 정규화 레코드
 
     struct Entry: Sendable, Codable {
@@ -273,7 +276,7 @@ enum LocalUsageReader {
 
     /// 최근 5시간 롤링 윈도우 기반 활성 블록(번 레이트 추정용).
     static func activeBlock(entries: [Entry], now: Date) -> BlockUsage? {
-        let windowStart = now.addingTimeInterval(-5 * 3600)
+        let windowStart = now.addingTimeInterval(-blockWindow)
         let recent = entries.filter { $0.date >= windowStart }.sorted { $0.date < $1.date }
         guard let first = recent.first else { return nil }
         var b = Bucket()
@@ -284,7 +287,7 @@ enum LocalUsageReader {
         return BlockUsage(
             id: "block-\(Int(first.date.timeIntervalSince1970))",
             startTime: iso.string(from: first.date),
-            endTime: iso.string(from: first.date.addingTimeInterval(5 * 3600)),
+            endTime: iso.string(from: first.date.addingTimeInterval(blockWindow)),
             isActive: true, totalTokens: b.total, costUSD: b.cost, tokensPerMinute: tpm)
     }
 
@@ -297,6 +300,19 @@ enum LocalUsageReader {
 
     static func startOfWeek(_ date: Date) -> Date {
         Calendar.current.dateInterval(of: .weekOfYear, for: date)?.start ?? date
+    }
+
+    /// enrichment(활성 블록·이번 주·이번 달)를 한 번의 스캔에서 모두 도출하므로, mtime 하한은
+    /// 그 세 윈도우 중 **가장 이른 시작**이어야 한다. append-only 로그에서 "범위 시작 이전에 수정된
+    /// 파일엔 범위 내 엔트리가 없다"는 전제가 성립하려면 스캔 하한 ≤ 모든 표시 윈도우의 시작이어야 하기 때문.
+    ///
+    /// 함정: monthStart 만 하한으로 쓰면 **월초**에 이번 주 시작(weekStart)이 지난달로 넘어가고
+    /// (2026년 12개월 중 11개월이 그렇다) 자정 직후엔 5h 블록이 어제로 넘어가, 지난달에 수정된 세션
+    /// 파일이 스캔에서 빠지며 주간 합계·번레이트가 며칠간 과소집계된다. min 으로 그 경계를 흡수한다.
+    /// (OpenCode/Hermes 경로엔 이미 `now-7일` 하한이 있었으나 Claude/Codex/Gemini 경로엔 없어
+    /// 드리프트했다 — 네 프로바이더가 이 단일 소스를 공유하게 통일.)
+    static func enrichmentScanStart(now: Date) -> Date {
+        min(startOfMonth(now), startOfWeek(now), now.addingTimeInterval(-blockWindow))
     }
 
     static func monthKey(_ date: Date) -> String {

--- a/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
@@ -201,4 +201,45 @@ final class LocalUsageCacheTests: XCTestCase {
         XCTAssertEqual(entries[0].output, 7)
         XCTAssertEqual(entries[0].cacheWrite, 0)
     }
+
+    /// 월초 경계 회귀: 이번 주가 지난달로 넘어가는 시점(2026년 12개월 중 11개월)엔 enrichment 스캔
+    /// 하한이 monthStart 면 지난달에 수정된 '이번 주' 세션 파일이 mtime 필터에서 빠져 주간 합계가
+    /// 과소집계된다. enrichmentScanStart(=weekStart 등 더 이른 시작)를 하한으로 써야 잡힌다.
+    /// (실제 mtime 필터를 밟는 통합 테스트 — 순수 경로만 봤다면 못 걸렀을 결함 조건을 재현.)
+    func testEnrichmentScanStartCatchesWeekStraddlingMonthBoundary() async throws {
+        let cal = Calendar.current
+        // 이번 주 시작이 지난달로 넘어가는 '월초' 시각을 하나 찾는다(로케일 firstWeekday 무관 결정적).
+        let base = cal.date(from: DateComponents(year: 2026, month: 1, day: 1, hour: 12))!
+        var straddle: Date?
+        for offset in 0..<14 {
+            guard let candidate = cal.date(byAdding: .month, value: offset, to: base) else { continue }
+            if LocalUsageReader.startOfWeek(candidate) < LocalUsageReader.startOfMonth(candidate) {
+                straddle = candidate; break
+            }
+        }
+        let now = try XCTUnwrap(straddle, "이번 주가 지난달로 straddle 하는 월초를 못 찾음")
+        let monthStart = LocalUsageReader.startOfMonth(now)
+        let weekStart = LocalUsageReader.startOfWeek(now)
+        XCTAssertLessThan(weekStart, monthStart, "전제: 이번 주가 지난달로 넘어간다")
+
+        // 이번 주에 속하지만 지난달인 날의 세션 — 그 이후 수정 안 됨(파일 mtime = 그날).
+        let fmt = LocalUsageReader.localDayFormatter()
+        let straddleDay = weekStart.addingTimeInterval(3600)   // weekStart 직후(지난달·이번 주)
+        let ts = ISO8601DateFormatter().string(from: straddleDay)
+        try writeFile("straddle.jsonl", lines: [claudeLine(id: "s", output: 500, ts: ts)], mtime: straddleDay)
+
+        let cache = makeCache(now: { now })
+        // (버그 조건) monthStart 하한 → 지난달 mtime 파일이 필터에서 빠진다.
+        let monthScoped = await cache.claudeEntries(modifiedSince: monthStart)
+        XCTAssertTrue(monthScoped.isEmpty, "monthStart 하한은 지난달에 수정된 이번 주 세션을 놓친다")
+
+        // (수정) enrichmentScanStart 하한 → 포함되고, 이번 주 합계에 반영된다.
+        let fixed = await cache.claudeEntries(
+            modifiedSince: LocalUsageReader.enrichmentScanStart(now: now))
+        XCTAssertEqual(fixed.count, 1, "enrichmentScanStart 는 이번 주 세션을 포함해야 한다")
+        let week = LocalUsageReader.period(
+            entries: fixed, periodKey: "w",
+            fromDay: fmt.string(from: weekStart), toDay: fmt.string(from: now))
+        XCTAssertGreaterThan(week.totalTokens, 0, "이번 주 합계에 반영돼야 한다")
+    }
 }

--- a/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
@@ -107,4 +107,32 @@ final class LocalUsageReaderTests: XCTestCase {
         // recent 는 오늘, old 도 (10h 전이라 같은 날일 수 있음) → 최소 recent 포함
         XCTAssertGreaterThanOrEqual(p.totalTokens, 600_000)
     }
+
+    // MARK: enrichment 스캔 하한 (월초 경계 흡수)
+
+    /// 스캔 하한은 블록(now-5h)·이번 주(weekStart)·이번 달(monthStart) 세 윈도우 시작을 모두 덮어야
+    /// append-only 로그의 "하한 이전 파일엔 범위 내 엔트리 없음" 전제가 성립한다. 월초엔 weekStart 가
+    /// 지난달로 넘어가므로 하한 < monthStart 여야 한다(monthStart-only 였던 과거 회귀를 순수 경로로 고정).
+    func testEnrichmentScanStartCoversAllWindows() throws {
+        let cal = Calendar.current
+        let base = cal.date(from: DateComponents(year: 2026, month: 1, day: 1, hour: 2))!
+        var straddle: Date?
+        for offset in 0..<14 {
+            guard let candidate = cal.date(byAdding: .month, value: offset, to: base) else { continue }
+            if LocalUsageReader.startOfWeek(candidate) < LocalUsageReader.startOfMonth(candidate) {
+                straddle = candidate; break
+            }
+        }
+        let now = try XCTUnwrap(straddle)
+        let scan = LocalUsageReader.enrichmentScanStart(now: now)
+        XCTAssertLessThanOrEqual(scan, LocalUsageReader.startOfMonth(now))
+        XCTAssertLessThanOrEqual(scan, LocalUsageReader.startOfWeek(now))
+        XCTAssertLessThanOrEqual(scan, now.addingTimeInterval(-LocalUsageReader.blockWindow))
+        XCTAssertLessThan(scan, LocalUsageReader.startOfMonth(now),
+                          "월초엔 weekStart 가 더 이르므로 하한이 monthStart 보다 앞서야 한다")
+
+        // 월 중순: monthStart 가 가장 이르므로 하한 == monthStart (경계 밖 과다 스캔 없음).
+        let mid = cal.date(from: DateComponents(year: 2026, month: 7, day: 20, hour: 12))!
+        XCTAssertEqual(LocalUsageReader.enrichmentScanStart(now: mid), LocalUsageReader.startOfMonth(mid))
+    }
 }


### PR DESCRIPTION
## Problem

The weekly / monthly / 5-hour-block "enrichment" pass for the Claude, Codex, and
Gemini providers scans usage logs with a single mtime lower bound of
`startOfMonth(now)`. Usage is derived from append-only session logs, so a file
whose mtime falls before that bound is assumed to contain no in-range entries.

That assumption breaks at the **start of a month**: the current ISO week — and,
just after midnight, the current 5-hour block — can begin in the *previous* month,
so `weekStart < monthStart`. Session files last written in the previous month are
then skipped by the `mtime >= monthStart` filter, and their tokens are dropped from
the "this week" total and the burn-rate block, even though those days belong to the
current week.

In 2026, 11 of 12 months have a week that straddles the month boundary, so the
weekly total silently under-counts for the first few days of nearly every month.
(Being mid-month, the bug is dormant right now — it next triggers at the start of
the following month, which is why it is easy to miss.)

### Root cause

The scan-window computation was duplicated across providers and drifted. The
OpenCode/Hermes provider (added more recently) already guarded this with
`min(startOfMonth, now - 7 days)`, but the three original providers
(Claude / Codex / Gemini) were never updated.

## Fix

Introduce one shared helper, `LocalUsageReader.enrichmentScanStart(now:)`, returning
the earliest of the three windows the scan must cover:

```
min(startOfMonth(now), startOfWeek(now), now - blockWindow)
```

All four providers now route through this single definition, so the window can no
longer drift per provider. Mid-month it equals `startOfMonth` (no extra scanning);
at a month boundary it reaches back to `weekStart` / the block start as needed.

## Tests

- `LocalUsageReaderTests.testEnrichmentScanStartCoversAllWindows` — pure: the bound is
  ≤ each of the month / week / block starts, and equals `startOfMonth` mid-month.
- `LocalUsageCacheTests.testEnrichmentScanStartCatchesWeekStraddlingMonthBoundary` —
  exercises the real mtime filter: with a month-boundary `now`, a session dated in the
  current week but the previous month is dropped under the old `monthStart` bound and
  retained under `enrichmentScanStart`, and lands in the weekly total.

`swift test` — all 298 tests pass (5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
