### PR TITLE
fix: align evolution stages with animated assets

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -192,6 +192,16 @@ struct CandyGrant: Equatable, Sendable {
     let count: Int
 }
 
+/// 현재 서비스가 제공하는 움직이는 포켓몬 스프라이트 범위.
+/// PokéAPI 의 Gen-V animated 에셋은 전국도감 #1...649까지만 존재한다.
+enum PokemonAssets {
+    static let animatedSpeciesIDs = 1...649
+
+    static func hasAnimatedSprite(speciesID: Int) -> Bool {
+        animatedSpeciesIDs.contains(speciesID)
+    }
+}
+
 /// PokéAPI evolution-chain 을 파싱한 트리. 분기(evolves_to 다수)를 children 으로.
 struct EvoNode: Codable, Sendable {
     let speciesID: Int
@@ -208,6 +218,12 @@ struct EvoNode: Codable, Sendable {
     var finalIDs: [Int] {
         children.isEmpty ? [speciesID] : children.flatMap(\.finalIDs)
     }
+
+    /// 서비스에 GIF 에셋이 있는 종만 남긴 진화 트리. 지원하지 않는 종부터 그 하위 체인도 제외한다.
+    func keepingAnimatedSprites() -> EvoNode? {
+        guard PokemonAssets.hasAnimatedSprite(speciesID: speciesID) else { return nil }
+        return EvoNode(speciesID: speciesID, children: children.compactMap { $0.keepingAnimatedSprites() })
+    }
 }
 
 /// 부화 시 확정되는 라인 정보(트리 + 희귀도 + 다국어 이름).
@@ -218,6 +234,14 @@ struct EvoLine: Sendable {
     /// speciesID → (langCode → name)
     let names: [Int: [String: String]]
     var totalForms: Int { tree.depth }
+
+    init(baseID: Int, tree: EvoNode, rarity: Rarity, names: [Int: [String: String]]) {
+        self.baseID = baseID
+        self.tree = tree.keepingAnimatedSprites() ?? EvoNode(speciesID: baseID, children: [])
+        self.rarity = rarity
+        self.names = names
+    }
+
     func localizedName(_ id: Int, _ lang: AppLanguage) -> String {
         lang.resolveName(names[id] ?? [:]) ?? "#\(id)"   // 폴백 순서는 AppLanguage.resolveName 단일 소스
     }

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -271,15 +271,15 @@ final class CompanionStore {
             let thr = PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: a.stageIndex)
             guard a.usedAtStage >= thr else { break }
             guard let node = line.tree.node(withID: a.currentID) else { break }
+            // 위장체는 부화 때는 다형태지만, 에셋 정규화/마이그레이션 뒤 leaf가 될 수 있다.
+            // 따라서 terminal 졸업보다 먼저 리빌해야 위장 종이 도감으로 잘못 졸업하지 않는다.
+            if a.dittoDisguise != nil, !a.dittoRevealed {
+                if !isRevealingDitto { Task { await revealDitto() } }
+                break
+            }
             if node.children.isEmpty {
                 graduate(); break
             } else {
-                // 메타몽 위장: 진화 못 하는 메타몽 → 첫 진화 순간 진화 대신 정체를 드러낸다(리빌).
-                // 라인 로드가 필요해 여기선 진화만 멈추고(임계 이상 유지) 리빌은 비동기 revealDitto 가 처리.
-                if a.dittoDisguise != nil, !a.dittoRevealed {
-                    if !isRevealingDitto { Task { await revealDitto() } }
-                    break
-                }
                 let next = pickNextChild(node, baseID: a.baseID)
                 state.active!.pathIDs = Array(a.pathIDs.prefix(a.stageIndex + 1)) + [next.speciesID]
                 state.active!.stageIndex += 1
@@ -686,6 +686,18 @@ final class CompanionStore {
         isHatching = true
         defer { isHatching = false }
         if let line = try? await provider.line(baseSpeciesID: a.baseID) {
+            // 구버전 저장은 PokéAPI 원본 체인의 GIF 미지원 후대 진화형까지 포함할 수 있다.
+            // 현재 에셋 트리에서 실제로 이어지는 경로까지만 복구하고 단계 수도 함께 마이그레이션한다.
+            var path = [line.tree.speciesID]
+            var node = line.tree
+            for id in a.pathIDs.dropFirst() {
+                guard let child = node.children.first(where: { $0.speciesID == id }) else { break }
+                path.append(id)
+                node = child
+            }
+            state.active?.pathIDs = path
+            state.active?.stageIndex = path.count - 1
+            state.active?.totalForms = line.totalForms
             currentLine = line
             applyUsage(0)   // 라인 미로딩 동안 적립된 사용량이 임계를 넘었으면 지금 진화 판정
         }
@@ -716,12 +728,13 @@ final class CompanionStore {
         return await chooseBaseViaREST()
     }
 
-    /// REST 폴백 — 1~649 중 무작위 id 를 뽑아 base 인지 pokemon-species 로 확인(rejection sampling).
+    /// REST 폴백 — animated 에셋 지원 범위에서 무작위 id 를 뽑아 base 인지 확인(rejection sampling).
     /// GraphQL 인덱스가 죽어도 부화가 되게 한다. 가중치(capture_rate)는 생략 — 희귀도는 부화 후
     /// line() 이 실제 capture_rate 로 계산하므로 결과 개체의 등급은 정확하다. 인덱스 복구 시 가중 선택 재개.
     private func chooseBaseViaREST() async -> Int? {
         for attempt in 1...16 {
-            let id = Int(rng.next() % 649) + 1
+            let ids = PokemonAssets.animatedSpeciesIDs
+            let id = Int(rng.next() % UInt64(ids.count)) + ids.lowerBound
             do {
                 if let bs = try await provider.baseSpecies(id: id) {
                     AppLog.write("hatch: REST fallback picked base \(id) (cap \(bs.captureRate), \(attempt) tries)")

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -114,7 +114,7 @@ actor PokeAPIClient: PokeProviding {
         var bases: [BaseSpecies] = []
         let batchSize = 6
         var start = 1
-        let maxID = 649   // Gen-V 애니메이션 스프라이트 상한 (fetchBaseIndex GraphQL 쿼리와 동일 범위)
+        let maxID = PokemonAssets.animatedSpeciesIDs.upperBound
         while start <= maxID {
             let end = min(start + batchSize - 1, maxID)
             let found = await withTaskGroup(of: BaseSpecies?.self) { group -> [BaseSpecies] in
@@ -147,7 +147,8 @@ actor PokeAPIClient: PokeProviding {
         req.timeoutInterval = 15
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         // 메타몽(#132)은 위장 리빌 전용 → 일반 부화 풀에서 제외(_neq).
-        let query = "{ pokemonspecies(where: {evolves_from_species_id: {_is_null: true}, id: {_lte: 649, _neq: \(PokemonOdds.dittoSpeciesID)}}, order_by: {id: asc}) { id capture_rate } }"
+        let maxID = PokemonAssets.animatedSpeciesIDs.upperBound
+        let query = "{ pokemonspecies(where: {evolves_from_species_id: {_is_null: true}, id: {_lte: \(maxID), _neq: \(PokemonOdds.dittoSpeciesID)}}, order_by: {id: asc}) { id capture_rate } }"
         req.httpBody = try JSONSerialization.data(withJSONObject: ["query": query])
         let (data, resp) = try await URLSession.shared.data(for: req)
         guard (resp as? HTTPURLResponse)?.statusCode == 200 else { throw URLError(.badServerResponse) }

--- a/Sources/PokeTokenBar/UI/SpriteLoader.swift
+++ b/Sources/PokeTokenBar/UI/SpriteLoader.swift
@@ -21,6 +21,7 @@ actor SpriteStore {
     }
 
     func data(speciesID: Int, animated: Bool, shiny: Bool = false) async -> Data? {
+        if animated, !PokemonAssets.hasAnimatedSprite(speciesID: speciesID) { return nil }
         let key = Self.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny)
         if let d = mem[key] { touch(key); return d }
         let ext = animated ? "gif" : "png"

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -609,6 +609,27 @@ final class CompanionIdentityTests: XCTestCase {
         XCTAssertEqual(s2.state.active?.usedAtStage, 300_000_000 - 125_000_000)   // 초과분 이월
     }
 
+    /// [회귀] 구버전 상태가 GIF 미지원 후대 진화형까지 진행했어도, 라인 재로딩 시 마지막 지원 형태로
+    /// 복구하고 단계 수를 현재 에셋 개수에 맞춘다. 그렇지 않으면 트리에서 현재 종을 못 찾아 성장이 멈춘다.
+    func testLineLoadMigratesPersistedUnsupportedEvolution() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-assets-\(UUID().uuidString).json")
+        let json = #"{"installBaselineSet":true,"lastDate":"d1","active":{"baseID":56,"pathIDs":[56,57,979],"stageIndex":2,"usedAtStage":123,"rarity":"common","totalForms":3},"dex":[]}"#
+        try Data(json.utf8).write(to: url)
+        let supportedLine = makeLine(base: 56, tree: node(56, [node(57, [node(979)])]))
+        let s = CompanionStore(provider: StubProvider(value: supportedLine), clock: { fixedNow },
+                               fileURL: url, rng: SeededRNG(seed: 5))
+
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        for _ in 0..<50 where s.currentLine == nil { await Task.yield() }
+
+        XCTAssertNotNil(s.currentLine)
+        XCTAssertEqual(s.state.active?.pathIDs, [56, 57])
+        XCTAssertEqual(s.state.active?.stageIndex, 1)
+        XCTAssertEqual(s.state.active?.totalForms, 2)
+        XCTAssertEqual(s.state.active?.usedAtStage, 123)
+    }
+
     /// [회귀] 부화 이월(overflow)로 즉시 진화해도 마지막 연출은 hatch(shiny) — evolve 가 버스트를 덮지 않는다.
     func testShinyBurstSurvivesOverflowEvolve() async {
         // hatchIfNeeded 경로: chooseBase(1) → shiny(2) → nature(3) 순 rng 소비. shiny 시드 탐색.

--- a/Tests/PokeTokenBarTests/DittoTests.swift
+++ b/Tests/PokeTokenBarTests/DittoTests.swift
@@ -11,6 +11,7 @@ private func dLine(base: Int, tree: EvoNode, rarity: Rarity) -> EvoLine {
     return EvoLine(baseID: base, tree: tree, rarity: rarity, names: names)
 }
 private let disguiseLine = dLine(base: 1, tree: dNode(1, [dNode(2, [dNode(3)])]), rarity: .common) // 커먼 3형태: 첫 진화 125M
+private let prunedDisguiseLine = dLine(base: 206, tree: dNode(206, [dNode(982)]), rarity: .common)
 private let dittoLine = dLine(base: 132, tree: dNode(132), rarity: .rare)                           // 메타몽: rare 단일형태
 private let dNow = Date(timeIntervalSince1970: 1_700_000_000)
 
@@ -20,6 +21,14 @@ private struct DittoTestProvider: PokeProviding {
         baseSpeciesID == PokemonOdds.dittoSpeciesID ? dittoLine : disguiseLine
     }
     func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: 1, captureRate: 255)] }
+}
+
+/// #982는 애니메이션 에셋이 없어 EvoLine 초기화 때 제거되고, #206만 leaf로 남는다.
+private struct PrunedDittoTestProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine {
+        baseSpeciesID == PokemonOdds.dittoSpeciesID ? dittoLine : prunedDisguiseLine
+    }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: 206, captureRate: 190)] }
 }
 
 // MARK: 위장 롤 판정(순수) — 부화 롤은 .app 게이트라 실앱에서만 발동, 판정 로직은 순수 함수로 검증
@@ -97,6 +106,35 @@ final class DittoRevealTests: XCTestCase {
         XCTAssertEqual(s.state.active?.usedAtStage, 300_000_000 - 125_000_000, "첫 진화 초과분 이월")
         XCTAssertNotNil(s.state.active?.dittoDisguise, "위장 마커 보존")
         XCTAssertEqual(s.celebration, .dittoReveal(shiny: false), "리빌 연출 발화")
+    }
+
+    /// [회귀] 에셋 정규화로 위장체가 leaf가 되어도, 위장체로 졸업하지 않고 현재 단일형태 임계에서 리빌한다.
+    func testPrunedLeafDisguiseRevealsBeforeGraduation() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("ditto-pruned-\(UUID().uuidString).json")
+        let threshold = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 1, stageIndex: 0)
+        XCTAssertEqual(threshold, 750_000_000)
+        XCTAssertTrue(prunedDisguiseLine.tree.children.isEmpty, "#982 제거 후 #206은 leaf여야 한다")
+        let active = "{\"baseID\":206,\"pathIDs\":[206],\"stageIndex\":0,"
+            + "\"usedAtStage\":\(threshold),\"rarity\":\"common\",\"totalForms\":2,\"isShiny\":true,"
+            + "\"nature\":\"timid\",\"dittoDisguise\":206,\"dittoRevealed\":false}"
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":1000000000,\"lastDate\":\"d1\","
+            + "\"active\":\(active),\"dex\":[],\"collectedFinals\":[]}"
+        try Data(json.utf8).write(to: url)
+        let s = CompanionStore(provider: PrunedDittoTestProvider(), clock: { dNow }, fileURL: url,
+                               rng: SeededRNG(seed: 7))
+
+        await drainReveal(s)
+
+        let revealed = try XCTUnwrap(s.state.active)
+        XCTAssertEqual(revealed.baseID, PokemonOdds.dittoSpeciesID)
+        XCTAssertEqual(revealed.pathIDs, [PokemonOdds.dittoSpeciesID])
+        XCTAssertEqual(revealed.usedAtStage, 0, "정규화된 단일형태 임계의 초과분만 이월")
+        XCTAssertEqual(revealed.dittoDisguise, 206)
+        XCTAssertTrue(revealed.dittoRevealed)
+        XCTAssertTrue(revealed.isShiny)
+        XCTAssertEqual(revealed.nature, .timid)
+        XCTAssertFalse(s.state.dex.contains { $0.finalID == 206 }, "위장체를 졸업 처리하면 안 된다")
+        XCTAssertFalse(s.state.collectedFinals.contains("206:206"))
     }
 
     /// 리빌 후 이로치가 공개된다(위장 중 숨겼던 것) + 이로치 리빌 연출.

--- a/Tests/PokeTokenBarTests/ModelLogicTests.swift
+++ b/Tests/PokeTokenBarTests/ModelLogicTests.swift
@@ -36,6 +36,24 @@ final class EvoLineNameTests: XCTestCase {
     }
 }
 
+// MARK: EvoLine 에셋 지원 범위
+
+final class EvoLineAssetTests: XCTestCase {
+    /// PokéAPI 원본 체인에 Gen-V 이후 진화형이 이어져도, 서비스가 제공하는 GIF가 있는 형태만
+    /// 실제 진화 라인과 단계 수에 남아야 한다. 예: 망키(#56) → 성원숭(#57) → 저승갓숭(#979).
+    func testKeepsOnlyFormsWithAnimatedAssets() {
+        let line = EvoLine(
+            baseID: 56,
+            tree: evoNode(56, [evoNode(57, [evoNode(979)])]),
+            rarity: .common,
+            names: [:])
+
+        XCTAssertEqual(line.totalForms, 2)
+        XCTAssertEqual(line.tree.finalIDs, [57])
+        XCTAssertNil(line.tree.node(withID: 979))
+    }
+}
+
 // MARK: EvoNode 트리 연산
 
 final class EvoNodeTests: XCTestCase {


### PR DESCRIPTION
## Summary

Align evolution-stage data with the animated GIF assets available in the app.

PokéAPI evolution chains can include species beyond National Pokédex #649, while the app provides animated GIF sprites only through #649. This could leave an empty sprite slot and show an incorrect stage count.

- Centralize the supported animated-sprite range.
- Prune unsupported species and descendants from evolution trees.
- Normalize persisted active evolution paths to supported forms.
- Prevent legacy Ditto disguises from graduating when pruning turns the disguise into a leaf.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

| Case | Expected display | Screenshot |
| --- | --- | --- |
| Teddiursa | `Evolution stage 1 / 2` | <img width="360" alt="Teddiursa evolution stage 1 of 2" src="https://github.com/user-attachments/assets/bf2f9eee-c0c9-404f-a35f-f670f68081c3" /> |
| Pawniard | `Evolution stage 1 / 2` | <img width="360" alt="Pawniard evolution stage 1 of 2" src="https://github.com/user-attachments/assets/4d081a0b-4d8c-4fdc-b5a2-7864af1b925a" /> |
| Dunsparce | `Final evolution` | <img width="360" alt="Dunsparce final evolution" src="https://github.com/user-attachments/assets/4516ad93-b1ce-4898-99e5-f096da150e80" /> |


| Before | After |
| ------ | ----- |
| PokéAPI could expose Mankey → Primeape → Annihilape as three stages, even though Annihilape has no animated GIF in the app. This left an empty sprite slot and a mismatched stage count. | The animated-asset tree is Mankey → Primeape. The popover now shows `Stage 1 / 2`, and persisted active paths are normalized to supported forms. |

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change