### PR TITLE
fix: branching evolution lines overflow the popover and clip its content

### DIFF
--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -135,17 +135,176 @@ struct SpriteView: View {
 }
 
 /// 진화 라인(초기→최종, 다음 후보 미리보기). done/cur/future.
+///
+/// 분기 라인은 "현재 경로 + 다음 후보 전부"라 길다(이브이 = 본체 1 + 후보 8 → 40pt 기준 472pt).
+/// 폭 제한 없는 HStack 은 팝오버 콘텐츠 폭(332pt)을 넘고, **넘친 자식이 부모 VStack 폭을 부풀려
+/// 팝오버 전체가 좌우로 잘린다**(진화줄뿐 아니라 탭바·합계까지). `maxWidth` 를 주면 그 폭 안에서
+/// 가로 스크롤한다 — 썸네일 크기는 유지하고, 가장자리 페이드 + 셰브론으로 스크롤 가능함을 알린다.
 struct EvoLineView: View {
     let nodes: [(id: Int, kind: String)]
     var thumb: CGFloat = 40
     var shiny: Bool = false     // 개체가 shiny 면 라인 전체를 shiny 스프라이트로
     var names: [Int: String]? = nil   // 제공되면 각 스프라이트 밑에 작은 이름 라벨(도감 단계별 이름)
+    /// 한 줄이 쓸 수 있는 가로 폭. 기본 .infinity = 제한 없음(스크롤 없이 나열).
+    var maxWidth: CGFloat = .infinity
+
+    private static let spacing: CGFloat = 2
+    /// 화살표 칸 폭 = 썸네일 × 이 비율. 고정 frame 을 줘 SF Symbol 글리프 폭에 의존하지 않게 한다 —
+    /// rowWidth 가 실제 렌더 폭과 어긋나면 스크롤 판정이 틀어진다.
+    private static let arrowRatio: CGFloat = 0.25
+    /// 이름 라벨이 썸네일보다 넓어질 수 있는 최대치.
+    private static let nameSlack: CGFloat = 6
+    private static let fadeWidth: CGFloat = 24
+
+    @State private var scrollX: CGFloat = 0        // 현재 가로 스크롤 오프셋
+    @State private var contentWidth: CGFloat = 0   // 실제 렌더된 한 줄 폭(측정값)
+
+    /// 한 줄이 차지하는 가로 폭. 레이아웃과 같은 식을 쓰는 순수 함수 — 이름 라벨은 상한만 알 수
+    /// 있어(`.frame(maxWidth:)`) names 가 있으면 실제 폭이 이 값 이하일 수 있다.
+    static func rowWidth(count: Int, thumb: CGFloat, hasNames: Bool) -> CGFloat {
+        guard count > 0 else { return 0 }
+        let column = thumb + (hasNames ? nameSlack : 0)
+        let arrows = CGFloat(count - 1) * thumb * arrowRatio
+        // 아이템 수 = 썸네일 count + 화살표 (count-1) → 사이 간격은 (2*count - 2)개
+        let gaps = CGFloat(2 * count - 2) * spacing
+        return CGFloat(count) * column + arrows + gaps
+    }
+
+    /// 스크롤 컨테이너가 필요한가 — 한 줄이 `maxWidth` 를 넘는가. 순수 함수(오버플로 회귀 테스트 대상).
+    /// 안 넘으면 기존과 완전히 동일한 평범한 HStack 을 그린다(대부분의 2~3단계 라인).
+    static func needsScroll(count: Int, thumb: CGFloat, hasNames: Bool, maxWidth: CGFloat) -> Bool {
+        guard maxWidth.isFinite, maxWidth > 0 else { return false }
+        return rowWidth(count: count, thumb: thumb, hasNames: hasNames) > maxWidth
+    }
+
     var body: some View {
-        HStack(alignment: .top, spacing: 2) {
+        if Self.needsScroll(count: nodes.count, thumb: thumb,
+                            hasNames: names != nil, maxWidth: maxWidth) {
+            scrollableRow
+        } else {
+            row
+        }
+    }
+
+    // MARK: 스크롤 라인 + 스크롤 가능 신호
+
+    /// 어느 쪽에 스크롤 여지가 남았는지 — 페이드와 셰브론이 공유하는 순수 판정.
+    /// 남은 쪽에만 띄워야 끝에 도달한 뒤 "눌러도 안 움직이는 셰브론"이 남지 않는다.
+    static func scrollAffordance(scrollX: CGFloat, contentWidth: CGFloat,
+                                 maxWidth: CGFloat) -> (back: Bool, forward: Bool) {
+        guard contentWidth > maxWidth + 0.5 else { return (false, false) }
+        return (scrollX > 0.5, scrollX < contentWidth - maxWidth - 0.5)
+    }
+
+    /// 페이드/셰브론 판정에 쓸 한 줄 폭. 측정 전(첫 프레임)엔 rowWidth 추정치를 쓴다 — 측정값만
+    /// 믿으면 팝오버를 연 직후 한 프레임 동안 "스크롤 가능" 신호가 없어 그냥 잘린 것처럼 보인다.
+    private var effectiveContentWidth: CGFloat {
+        contentWidth > 0 ? contentWidth
+                         : Self.rowWidth(count: nodes.count, thumb: thumb, hasNames: names != nil)
+    }
+    private var canScrollBack: Bool {
+        Self.scrollAffordance(scrollX: scrollX, contentWidth: effectiveContentWidth,
+                              maxWidth: maxWidth).back
+    }
+    private var canScrollForward: Bool {
+        Self.scrollAffordance(scrollX: scrollX, contentWidth: effectiveContentWidth,
+                              maxWidth: maxWidth).forward
+    }
+
+    private var scrollableRow: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal) {
+                row
+                    .background(
+                        GeometryReader { geo in
+                            let frame = geo.frame(in: .named(Self.scrollSpace))
+                            Color.clear
+                                .onChange(of: frame.minX, initial: true) { _, minX in scrollX = -minX }
+                                .onChange(of: frame.width, initial: true) { _, w in contentWidth = w }
+                        }
+                    )
+            }
+            // 페이드+셰브론이 같은 역할을 하고, "스크롤 막대 항상 표시" 설정에선 두꺼운 legacy
+            // 스크롤러가 줄 높이까지 먹는다. `.hidden` 은 그 경우를 못 막아 `.never` 여야 한다.
+            .scrollIndicators(.never)
+            .coordinateSpace(name: Self.scrollSpace)
+            .frame(maxWidth: maxWidth, alignment: .leading)
+            // 넘치는 쪽 가장자리를 흐리게 — 잘린 게 아니라 "이어진다"는 표시.
+            .mask(edgeFade)
+            .overlay(alignment: .topLeading) { chevron(forward: false, proxy: proxy) }
+            .overlay(alignment: .topTrailing) { chevron(forward: true, proxy: proxy) }
+            .animation(.easeInOut(duration: 0.15), value: canScrollBack)
+            .animation(.easeInOut(duration: 0.15), value: canScrollForward)
+        }
+    }
+
+    private static let scrollSpace = "evoLineScroll"
+
+    /// 스크롤 여지가 있는 쪽만 페이드아웃하는 마스크(가운데는 불투명).
+    private var edgeFade: some View {
+        let f = Self.fadeWidth / maxWidth   // 이 경로는 needsScroll 통과 = maxWidth 유한·양수
+        return LinearGradient(
+            stops: [
+                .init(color: canScrollBack ? .clear : .black, location: 0),
+                .init(color: .black, location: f),
+                .init(color: .black, location: 1 - f),
+                .init(color: canScrollForward ? .clear : .black, location: 1),
+            ],
+            startPoint: .leading, endPoint: .trailing)
+    }
+
+    /// 한 화면씩 넘기는 셰브론. 스크롤 여지가 있는 쪽에만 떠서 신호를 겸한다
+    /// (스크롤바를 껐으므로 이게 유일한 시각 단서이자 마우스 사용자의 조작 수단).
+    @ViewBuilder
+    private func chevron(forward: Bool, proxy: ScrollViewProxy) -> some View {
+        if forward ? canScrollForward : canScrollBack {
+            Button {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    // 앵커는 항상 .leading — 콘텐츠 끝을 넘는 요청이 clamp 되어 끝에 정확히 닿는다.
+                    // .trailing 은 마지막 칸에서 끝에 못 미쳐 멈췄다(실측).
+                    proxy.scrollTo(pageTarget(forward: forward), anchor: .leading)
+                }
+            } label: {
+                Image(systemName: forward ? "chevron.right" : "chevron.left")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16, height: 16)
+                    .background(.regularMaterial, in: Circle())
+                    .overlay(Circle().strokeBorder(Color.primary.opacity(0.12)))
+            }
+            .buttonStyle(.plain)
+            .padding(forward ? .trailing : .leading, 1)
+            .padding(.top, max(0, thumb / 2 - 8))   // 16pt 버튼의 중심을 스프라이트 중심에
+            .transition(.opacity)
+        }
+    }
+
+    private func pageTarget(forward: Bool) -> Int {
+        Self.pageTarget(forward: forward, scrollX: scrollX, count: nodes.count,
+                        thumb: thumb, hasNames: names != nil, maxWidth: maxWidth)
+    }
+
+    /// 셰브론 한 번에 이동할 칸 인덱스 — 왼쪽 끝 칸에서 "한 화면에 보이는 칸 수"만큼 앞/뒤로.
+    /// 현재 위치 기준이라 누를 때마다 목표가 바뀐다(고정 목표는 재클릭 시 제자리 — 겪은 회귀).
+    static func pageTarget(forward: Bool, scrollX: CGFloat, count: Int,
+                           thumb: CGFloat, hasNames: Bool, maxWidth: CGFloat) -> Int {
+        guard count > 0 else { return 0 }
+        let stride = thumb + (hasNames ? nameSlack : 0) + thumb * arrowRatio + spacing * 2
+        let visible = max(1, Int(maxWidth / stride))
+        let first = max(0, Int((scrollX / stride).rounded()))
+        return min(max(0, first + (forward ? visible : -visible)), count - 1)
+    }
+
+    // MARK: 라인 본체
+
+    private var row: some View {
+        HStack(alignment: .top, spacing: Self.spacing) {
             ForEach(Array(nodes.enumerated()), id: \.offset) { i, node in
                 if i > 0 {
                     Image(systemName: "arrow.right").font(.system(size: thumb * 0.2))
-                        .foregroundStyle(.tertiary).padding(.top, thumb * 0.4)   // 스프라이트 세로 중앙에 정렬
+                        .foregroundStyle(.tertiary)
+                        .frame(width: thumb * Self.arrowRatio)
+                        .padding(.top, thumb * 0.4)   // 스프라이트 세로 중앙에 정렬
                 }
                 VStack(spacing: 1) {
                     SpriteView(speciesID: node.id, size: thumb, shiny: shiny)
@@ -159,9 +318,10 @@ struct EvoLineView: View {
                     if let names {
                         Text(names[node.id] ?? "…")
                             .font(.system(size: 8)).foregroundStyle(.secondary)
-                            .lineLimit(1).minimumScaleFactor(0.7).frame(maxWidth: thumb + 6)
+                            .lineLimit(1).minimumScaleFactor(0.7).frame(maxWidth: thumb + Self.nameSlack)
                     }
                 }
+                .id(i)   // 셰브론 페이징(ScrollViewProxy.scrollTo) 대상
             }
         }
     }
@@ -274,7 +434,9 @@ struct CompanionHeader: View {
                 Spacer()
             }
             if store.hasActive, !store.lineNodes.isEmpty {
-                EvoLineView(nodes: store.lineNodes, shiny: store.currentIsShiny)
+                // 폭을 안 주면 분기 라인(이브이)이 넘쳐 팝오버 콘텐츠 전체가 좌우로 잘린다.
+                EvoLineView(nodes: store.lineNodes, shiny: store.currentIsShiny,
+                            maxWidth: PopoverMetrics.contentWidth)
             }
             if let g = store.justGraduated {
                 Text(store.l.graduated(g))
@@ -494,6 +656,9 @@ private struct DexEntryRow: View {
     let entry: DexEntry
     @State private var resolved: [Int: String] = [:]
 
+    /// 카드 안쪽 여백. 진화 라인이 쓸 수 있는 폭 계산과 단일 소스를 공유한다.
+    private static let cardPadding: CGFloat = 8
+
     var body: some View {
         // 저장분 우선(즉시·언어대응), 없으면 async 로 채운 resolved 사용.
         let names = resolved.isEmpty ? store.dexStoredChainNames(entry) : resolved
@@ -520,12 +685,13 @@ private struct DexEntryRow: View {
                 }
             }
             EvoLineView(nodes: entry.chainOrder.map { ($0, "done") }, thumb: 56,
-                        shiny: entry.isShiny, names: names)
+                        shiny: entry.isShiny, names: names,
+                        maxWidth: PopoverMetrics.contentWidth - Self.cardPadding * 2)
             if let caughtAt = entry.caughtAt {
                 Text(caughtAt, style: .relative).font(.system(size: 9)).foregroundStyle(.tertiary)
             }
         }
-        .padding(8)
+        .padding(Self.cardPadding)
         .background(Color.secondary.opacity(0.06))
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .task(id: "\(entry.id)-\(store.language.rawValue)") {

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -2,6 +2,15 @@ import SwiftUI
 
 enum PopoverTab { case home, shop, bag, collection }
 
+/// 팝오버 치수의 단일 소스. 자식이 쓸 수 있는 폭을 알아야 할 때 이 값을 쓴다 — 넘치는 자식이
+/// 부모 폭을 부풀리므로 GeometryReader 로 재면 순환한다.
+enum PopoverMetrics {
+    static let width: CGFloat = 360
+    static let padding: CGFloat = 14
+    /// 이 폭을 넘는 자식은 팝오버 창에 좌우로 잘린다.
+    static let contentWidth: CGFloat = width - padding * 2
+}
+
 /// 팝오버 내부 내비게이션 상태(현재 탭 / 설정 표시 여부).
 /// NSHostingController 는 팝오버를 닫아도 재사용되어 @State 가 유지되므로, 화면 상태를 이
 /// Observable 로 분리해 AppDelegate 가 팝오버를 열 때마다 reset() 한다 — 닫혔다 열리면 항상 Home.
@@ -41,7 +50,7 @@ struct PopoverView: View {
                 mainContent
             }
         }
-        .frame(width: 360)
+        .frame(width: PopoverMetrics.width)
     }
 
     @ViewBuilder
@@ -99,7 +108,7 @@ struct PopoverView: View {
             }
             footer
         }
-        .padding(14)
+        .padding(PopoverMetrics.padding)
     }
 
     // MARK: 헤더 — 오늘 합계 + provider/토큰타입 분해

--- a/Tests/PokeTokenBarTests/EvoLineLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/EvoLineLayoutTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+import SwiftUI
+@testable import PokeTokenBar
+
+// 진화 라인 가로 오버플로 가드.
+// 분기 라인(이브이 = 본체 1 + 진화 후보 8)은 폭 제한이 없으면 팝오버 콘텐츠 폭(332pt)을 훌쩍 넘고,
+// 넘친 자식이 부모 VStack 폭을 부풀려 팝오버 콘텐츠 "전체"가 좌우로 잘렸다. maxWidth 를 주면
+// 그 폭 안에서 가로 스크롤한다.
+//
+// 트리거 브랜치를 직접 재현한다: maxWidth 없는 라인이 실제로 넘치는지까지 확인해야
+// "fit 어서션이 애초에 통과할 조건이었다"는 false confidence 를 막는다.
+@MainActor
+final class EvoLineLayoutTests: XCTestCase {
+
+    /// 홈 화면의 이브이 노드 — 현재 개체 + 진화 후보 전부(샤미드·쥬피썬더·부스터·에브이·블래키·
+    /// 리피아·글레이시아·님피아). PokéAPI evolution-chain 이 그대로 주는 분기 폭.
+    private var eeveeNodes: [(id: Int, kind: String)] {
+        [(id: 133, kind: "cur")]
+            + [134, 135, 136, 196, 197, 470, 471, 700].map { (id: $0, kind: "future") }
+    }
+
+    /// 3단계 일반 라인(이상해씨 계열) — 스크롤이 붙으면 안 되는 대조군.
+    private var threeStageNodes: [(id: Int, kind: String)] {
+        [(id: 1, kind: "done"), (id: 2, kind: "cur"), (id: 3, kind: "future")]
+    }
+
+    /// 팝오버가 실제로 제안하는 폭으로 뷰를 재어 렌더 폭을 얻는다.
+    private func renderedWidth(_ view: some View, proposing: CGFloat) -> CGFloat {
+        NSHostingController(rootView: view)
+            .sizeThatFits(in: CGSize(width: proposing, height: 600)).width
+    }
+
+    // MARK: 렌더 폭 — 실제 레이아웃 회귀
+
+    /// 트리거 재현: 폭 제한이 없으면 이브이 라인은 팝오버 콘텐츠 폭을 넘는다(= 버그 조건).
+    func testEeveeLineWithoutMaxWidthOverflowsPopoverContent() {
+        let w = renderedWidth(EvoLineView(nodes: eeveeNodes),
+                              proposing: PopoverMetrics.contentWidth)
+        XCTAssertGreaterThan(w, PopoverMetrics.contentWidth,
+                             "폭 제한 없는 진화 라인은 넘쳐야 한다 — 안 넘치면 아래 fit 검증이 무의미해진다")
+    }
+
+    /// 수정 후: 팝오버가 주는 폭을 넘지 않는다(→ 부모 VStack 이 안 부풀고 팝오버가 안 잘린다).
+    func testEeveeLineFitsPopoverContentWidth() {
+        let w = renderedWidth(EvoLineView(nodes: eeveeNodes, maxWidth: PopoverMetrics.contentWidth),
+                              proposing: PopoverMetrics.contentWidth)
+        XCTAssertLessThanOrEqual(w, PopoverMetrics.contentWidth)
+    }
+
+    /// 도감 행(썸네일 56 + 이름 라벨)도 카드 안쪽 폭을 넘지 않는다.
+    func testLongDexChainFitsCardWidth() {
+        let cardWidth = PopoverMetrics.contentWidth - 16   // DexEntryRow 카드 좌우 패딩 8pt
+        let nodes = [1, 2, 3, 4, 5].map { (id: $0, kind: "done") }
+        let names = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, "이상해씨") })
+        let w = renderedWidth(
+            EvoLineView(nodes: nodes, thumb: 56, names: names, maxWidth: cardWidth),
+            proposing: cardWidth)
+        XCTAssertLessThanOrEqual(w, cardWidth)
+    }
+
+    /// 짧은 라인은 스크롤 컨테이너 없이 예전과 똑같은 폭으로 그려진다(일반 라인 시각 회귀 방지).
+    func testShortChainRendersInlineAtNaturalWidth() {
+        // 3칸 = 40*3 + 화살표 10*2 + 간격 2*4 = 148pt
+        let expected = EvoLineView.rowWidth(count: 3, thumb: 40, hasNames: false)
+        XCTAssertEqual(expected, 148)
+        let w = renderedWidth(EvoLineView(nodes: threeStageNodes, maxWidth: PopoverMetrics.contentWidth),
+                              proposing: PopoverMetrics.contentWidth)
+        XCTAssertEqual(w, expected, accuracy: 0.5)
+    }
+
+    // MARK: 순수 판정 — 스크롤 전환 경계
+
+    /// rowWidth 는 레이아웃과 같은 식이어야 한다(측정값과 일치 — 어긋나면 스크롤 판정이 틀어진다).
+    func testRowWidthMatchesRenderedWidth() {
+        for count in 1...9 {
+            let nodes = (1...count).map { (id: $0, kind: "done") }
+            let rendered = renderedWidth(EvoLineView(nodes: nodes), proposing: 4000)
+            XCTAssertEqual(rendered,
+                           EvoLineView.rowWidth(count: count, thumb: 40, hasNames: false),
+                           accuracy: 0.5, "count=\(count)")
+        }
+    }
+
+    /// 홈 라인(썸네일 40)은 6칸까지 그대로, 7칸부터 스크롤.
+    func testNeedsScrollBoundaryForHomeLine() {
+        let w = PopoverMetrics.contentWidth
+        XCTAssertFalse(EvoLineView.needsScroll(count: 6, thumb: 40, hasNames: false, maxWidth: w))
+        XCTAssertTrue(EvoLineView.needsScroll(count: 7, thumb: 40, hasNames: false, maxWidth: w))
+        XCTAssertTrue(EvoLineView.needsScroll(count: 9, thumb: 40, hasNames: false, maxWidth: w))
+    }
+
+    /// 도감 행(썸네일 56 + 이름)은 4칸까지 그대로, 5칸부터 스크롤.
+    func testNeedsScrollBoundaryForDexRow() {
+        let w = PopoverMetrics.contentWidth - 16
+        XCTAssertFalse(EvoLineView.needsScroll(count: 4, thumb: 56, hasNames: true, maxWidth: w))
+        XCTAssertTrue(EvoLineView.needsScroll(count: 5, thumb: 56, hasNames: true, maxWidth: w))
+    }
+
+    /// maxWidth 를 안 주면(기본 .infinity) 스크롤을 붙이지 않는다 — 폭이 고정되지 않은 호출부용 기본값.
+    func testUnboundedWidthNeverScrolls() {
+        XCTAssertFalse(EvoLineView.needsScroll(count: 99, thumb: 40, hasNames: false, maxWidth: .infinity))
+    }
+
+    // MARK: 스크롤 가능 신호 — 남은 방향에만 뜬다
+
+    /// 페이드·셰브론은 "그쪽에 더 있을 때만" 떠야 한다. 스냅샷으로는 첫 프레임(맨 왼쪽)밖에 못 봐서
+    /// 스크롤 중간/끝 상태는 이 순수 판정으로 잠근다.
+    func testAffordanceShowsOnlyWhereContentRemains() {
+        let content = EvoLineView.rowWidth(count: 9, thumb: 40, hasNames: false)   // 472
+        let view = PopoverMetrics.contentWidth                                      // 332
+
+        // 맨 왼쪽 — 오른쪽으로만 더 있다
+        var a = EvoLineView.scrollAffordance(scrollX: 0, contentWidth: content, maxWidth: view)
+        XCTAssertFalse(a.back); XCTAssertTrue(a.forward)
+
+        // 중간 — 양쪽 다
+        a = EvoLineView.scrollAffordance(scrollX: 70, contentWidth: content, maxWidth: view)
+        XCTAssertTrue(a.back); XCTAssertTrue(a.forward)
+
+        // 끝까지 스크롤 — 왼쪽으로만 (끝에서 오른쪽 셰브론이 남으면 눌러도 안 움직인다)
+        a = EvoLineView.scrollAffordance(scrollX: content - view, contentWidth: content, maxWidth: view)
+        XCTAssertTrue(a.back); XCTAssertFalse(a.forward)
+    }
+
+    /// 셰브론은 누를 때마다 더 나아가야 한다 — 목표가 현재 위치에 따라 바뀌는지, 범위를 안 넘는지.
+    /// (고정 목표로 두면 한 번 이동한 뒤 다시 눌러도 제자리가 된다.)
+    func testPageTargetAdvancesAndStaysInBounds() {
+        let w = PopoverMetrics.contentWidth
+        func target(_ forward: Bool, at scrollX: CGFloat) -> Int {
+            EvoLineView.pageTarget(forward: forward, scrollX: scrollX, count: 9,
+                                   thumb: 40, hasNames: false, maxWidth: w)
+        }
+        // 맨 왼쪽에서 앞으로 = 한 화면(332/54 = 6칸)만큼
+        XCTAssertEqual(target(true, at: 0), 6)
+        // 이동한 뒤 또 누르면 더 앞으로 (제자리 금지)
+        XCTAssertGreaterThan(target(true, at: 54), target(true, at: 0))
+        // 마지막 칸을 안 넘음
+        XCTAssertEqual(target(true, at: 300), 8)
+        // 0 아래로 안 내려감
+        XCTAssertEqual(target(false, at: 0), 0)
+        XCTAssertEqual(target(false, at: 140), 0)
+    }
+
+    /// 넘치지 않는 줄에는 어느 쪽 신호도 뜨지 않는다.
+    func testAffordanceHiddenWhenContentFits() {
+        let a = EvoLineView.scrollAffordance(scrollX: 0, contentWidth: 148,
+                                             maxWidth: PopoverMetrics.contentWidth)
+        XCTAssertFalse(a.back); XCTAssertFalse(a.forward)
+    }
+}


### PR DESCRIPTION
## Summary

Raising a Pokémon whose evolution line branches makes the popover render wider than itself, and the
whole popover content — tab bar, today's totals, provider row, limit rows — is clipped on **both**
edges, not just the evolution line. This constrains the line to the popover width and scrolls it
horizontally instead. Closes #117.

### Root cause

`EvoLineView` lays its nodes out in an `HStack` with no width constraint, and
`CompanionStore.lineNodes` returns *the current path plus every next candidate*. A branching line is
therefore far longer than a linear one:

- Eevee at stage 0 → 1 node + 8 candidates (Vaporeon … Sylveon) = **9 nodes**.
- Measured row width at the default 40pt thumbnail is `54N − 14`, so **N = 9 → 472pt**, against a
  popover content box of `360 − 14×2 = 332pt`. Overflow already starts at **7 nodes**.

`PopoverView` pins the popover with `.frame(width: 360)`, and that modifier *centers* an oversized
child instead of shrinking it. The excess (~70pt per side) hangs outside the popover window on both
sides, where the window clips it — which is why unrelated rows are cut off too. Linear lines are 2–3
nodes (≤ 148pt) and stay well inside the box, so this never showed up before a branching line was
raised.

### Fix

`EvoLineView` takes a `maxWidth` and scrolls horizontally once the row exceeds it, **keeping the
40pt thumbnails**. Rows that fit take the previous code path unchanged, so ordinary 2–3 stage lines
and every Pokédex row render exactly as before.

Scaling the thumbnails down to fit was the alternative. It was rejected because fitting 9 nodes into
332pt drops them to ~27pt, which makes the sprites hard to tell apart at exactly the moment they
matter most — choosing between eight Eevee evolutions — and it would make sprite size vary with
branch count, so the same species would look different depending on where it sits in its line.

The available width cannot be measured with a `GeometryReader`: the popover width is fixed and an
overflowing child inflates its parent, so the measurement would be circular. `PopoverMetrics` now
holds the popover width and padding as the single source that `PopoverView` and its children share.

Scrollability has to be discoverable, so:

- **Edge fade** on whichever side still has content — it reads as "continues", not "cut off".
- **Chevron button** on that same side, which doubles as the affordance and as the control for mouse
  users. It pages from the current offset with a `.leading` anchor; a fixed target with a
  `.trailing` anchor stopped short of the end and then did nothing on a second press.
- **Native indicator disabled.** With the "always show scroll bars" setting macOS draws a thick
  legacy scroller that also steals row height. `.hidden` does not suppress that — only `.never` does.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

Only the evolution line changes, and only when it does not fit.

| Before | After |
| --- | --- |
| <img width="884" height="1132" alt="before_clean" src="https://github.com/user-attachments/assets/2921224c-abdc-4cec-844b-64350595f439" /> | <img width="884" height="1132" alt="after_clean" src="https://github.com/user-attachments/assets/0330bae3-13ad-4fd5-9baf-869aee560522" /> | 
Content bleeds past both edges and is clipped by the window — the `홈` tab, the leading digits of the today's total and the `Claude Code` label are all cut mid-glyph. | The line is bounded and scrolls at unchanged 40pt thumbnails; every other row is fully visible. The trailing edge fades under a `›` button. |

Pressing `›` lands exactly at the end of the line, where the button flips to `‹` and the last
evolution is fully visible:

- **Linear lines (2–3 nodes)** are untouched — no scroll container, no fade, no buttons, and the same
  rendered width as before (asserted by a test).
- **Pokédex rows** are unchanged; their chains are at most 3 nodes and never reach the threshold.

## Testing

`EvoLineLayoutTests` measures rendered width through `NSHostingController.sizeThatFits(in:)`:

- `testEeveeLineWithoutMaxWidthOverflowsPopoverContent` — reproduces the trigger, so the fit
  assertion below cannot pass vacuously.
- `testEeveeLineFitsPopoverContentWidth` / `testLongDexChainFitsCardWidth` — the bounded line stays
  within the popover and the Pokédex card.
- `testShortChainRendersInlineAtNaturalWidth`, `testRowWidthMatchesRenderedWidth` — the width formula
  agrees with the real layout, and short lines keep their previous width.
- `testNeedsScrollBoundaryForHomeLine` / `...ForDexRow`, `testAffordanceShowsOnlyWhereContentRemains`,
  `testAffordanceHiddenWhenContentFits`, `testPageTargetAdvancesAndStaysInBounds` — pure coverage of
  the scroll threshold, the affordance direction at start / middle / end, and chevron paging bounds.

`swift build` clean; `swift test` — all 315 tests pass (5 skipped). Also verified in a real build by
raising an Eevee: the popover is no longer clipped, one chevron press lands exactly at the end of
the line and the forward chevron disappears, one press back returns to the start.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change
