### PR TITLE
ci: add coverage gate and secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,22 @@ jobs:
       - name: Build
         run: swift build -v
 
-      - name: Test
-        run: swift test -v
+      # test-gate.sh runs `swift test --enable-code-coverage` and then enforces a
+      # line-coverage floor on the logic-core files. It replaces a bare `swift test`:
+      # the tests still run, and a coverage regression now fails the build.
+      - name: Test + coverage gate
+        run: ./scripts/test-gate.sh
+
+  secret-scan:
+    name: secret-scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so gitleaks can diff the whole PR commit range.
+          fetch-depth: 0
+
+      - name: Scan for committed secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

The CI workflow ran only `swift build` + `swift test`. This lets two classes of regression reach `main` unchecked:

1. **Coverage drift** — a PR can delete or bypass tests and stay green.
2. **Leaked secrets** — a secret committed in a fork PR is never scanned.

## Changes

- **Coverage gate.** Replace the bare `swift test` step with `scripts/test-gate.sh`, which runs the tests with `--enable-code-coverage` and fails the build if logic-core line coverage drops below the 75% floor. Current coverage is **84.81%**, so there is headroom. This stays inside the existing `build-test` job, which is already a required status check.
- **Secret scan.** Add a parallel `secret-scan` job (gitleaks on `ubuntu-latest`) that scans each PR's commit range. Runs alongside the macOS build so it adds no wall-clock time to the critical path.

## Notes

- No new dependencies. `test-gate.sh` already existed and was run locally only; this wires it into CI.
- `secret-scan` is informational until it is added to the branch-protection required checks (follow-up after merge).
- Out of scope (intentionally deferred): SwiftFormat lint, Dependabot for GitHub Actions.