### PR TITLE
ci: migrate GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     # (swift-tools-version: 6.0, platform macOS 14).
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Show Swift version
         run: swift --version
@@ -36,12 +36,12 @@ jobs:
     name: secret-scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history so gitleaks can diff the whole PR commit range.
           fetch-depth: 0
 
       - name: Scan for committed secrets
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

`actions/checkout@v4` and `gitleaks/gitleaks-action@v2` both declare the **Node 20** runtime, which GitHub is retiring:

- **2026-06-02** — the runner forces these actions onto Node 24; every run prints a deprecation annotation (`Node.js 20 ... being forced to run on Node.js 24`).
- **2026-09-16** — Node 20 is removed from GitHub-hosted runners entirely, at which point the pinned majors stop running regardless of any opt-out flag.

Today CI only passes because of that temporary force. This bumps both actions to their first Node 24-native major before the hard deadline.

## What

| Action | Before | After | Used by |
| --- | --- | --- | --- |
| `actions/checkout` | `@v4` | `@v5` | `build-test`, `secret-scan` |
| `gitleaks/gitleaks-action` | `@v2` | `@v3` | `secret-scan` |

`gitleaks-action@v3` is a runtime-only migration — its release notes state **no changes to inputs, outputs, or behavior** — so the `secret-scan` job keeps the same `GITHUB_TOKEN` env and `fetch-depth: 0` checkout.

## Verification

`secret-scan` is a required status check, so this PR's own CI run confirms both jobs still pass on the new majors before merge.
