### PR TITLE
fix: coalesce overlapping usage refreshes and harden companion-state decoding

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -397,6 +397,24 @@ struct DexEntry: Codable, Sendable, Identifiable {
     }
 }
 
+/// 배열 항목별 격리 디코딩 래퍼 — 손상된 한 항목이 배열 전체(및 상위 상태) 디코드를 실패시키지 않게.
+/// 각 항목을 `try?` 로 감싸므로 실패 항목은 `value == nil` 이 되고 배열 디코드 자체는 성공한다.
+private struct Lossy<T: Decodable>: Decodable {
+    let value: T?
+    init(from decoder: Decoder) throws { value = try? decoder.singleValueContainer().decode(T.self) }
+}
+
+private extension KeyedDecodingContainer {
+    /// 관대 디코드 — 키 없음/null/타입 불일치를 모두 기본값으로 흡수한다. 한 필드 손상이 상태 전체
+    /// (도감·인벤토리)를 날리지 않게(부분 복원 > 전면 리셋). 최상위가 JSON 객체가 아닌 전면 손상은 여전히 throw.
+    func lenient<T: Decodable>(_ type: T.Type, forKey key: Key, default def: T) -> T {
+        (try? decode(type, forKey: key)) ?? def
+    }
+    func lenientOptional<T: Decodable>(_ type: T.Type, forKey key: Key) -> T? {
+        try? decode(type, forKey: key)
+    }
+}
+
 /// 영속 상태(Application Support JSON). 포켓몬 전환 — 이전 커스텀 캐릭터 상태는 폐기(새로 시작).
 struct CompanionState: Codable, Sendable {
     // 토큰: 설치 이후만 측정
@@ -427,23 +445,27 @@ struct CompanionState: Codable, Sendable {
 
     init() {}
 
-    // 하위호환 디코딩: 누락 키는 기본값(필드 추가가 기존 저장을 깨지 않도록).
+    // 하위호환 + 손상 복원 디코딩: 누락 키·타입 불일치·일부 손상 필드를 모두 기본값으로 흡수한다 —
+    // 한 필드가 깨져도 상태 전체(도감·인벤토리)를 날리지 않는다(부분 복원). 최상위가 JSON 객체가 아닌
+    // 전면 손상만 throw → load() 가 원본을 .corrupt 로 백업하고 fresh 로 시작.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        installBaselineSet = try c.decodeIfPresent(Bool.self, forKey: .installBaselineSet) ?? false
-        usedSinceInstall = try c.decodeIfPresent(Int.self, forKey: .usedSinceInstall) ?? 0
-        spentTokens = try c.decodeIfPresent(Int.self, forKey: .spentTokens) ?? 0
-        eggUsage = try c.decodeIfPresent(Int.self, forKey: .eggUsage) ?? 0
-        pendingHatchID = try c.decodeIfPresent(Int.self, forKey: .pendingHatchID)
-        claimedTodayTokens = try c.decodeIfPresent(Int.self, forKey: .claimedTodayTokens) ?? 0
-        lastDate = try c.decodeIfPresent(String.self, forKey: .lastDate) ?? ""
-        active = try c.decodeIfPresent(MonState.self, forKey: .active)
-        dex = try c.decodeIfPresent([DexEntry].self, forKey: .dex) ?? []
-        collectedFinals = try c.decodeIfPresent(Set<String>.self, forKey: .collectedFinals) ?? []
-        language = try c.decodeIfPresent(AppLanguage.self, forKey: .language) ?? .systemDefault
-        inventory = try c.decodeIfPresent([String: Int].self, forKey: .inventory) ?? [:]
-        candyGrantTier = try c.decodeIfPresent([String: Int].self, forKey: .candyGrantTier) ?? [:]
-        candyFeatureSeeded = try c.decodeIfPresent(Bool.self, forKey: .candyFeatureSeeded) ?? false
+        installBaselineSet = c.lenient(Bool.self, forKey: .installBaselineSet, default: false)
+        usedSinceInstall   = c.lenient(Int.self, forKey: .usedSinceInstall, default: 0)
+        spentTokens        = c.lenient(Int.self, forKey: .spentTokens, default: 0)
+        eggUsage           = c.lenient(Int.self, forKey: .eggUsage, default: 0)
+        pendingHatchID     = c.lenientOptional(Int.self, forKey: .pendingHatchID)
+        claimedTodayTokens = c.lenient(Int.self, forKey: .claimedTodayTokens, default: 0)
+        lastDate           = c.lenient(String.self, forKey: .lastDate, default: "")
+        // active 손상(빈 pathIDs 등) → 알로 폴백하되 도감·인벤토리는 보존.
+        active             = c.lenientOptional(MonState.self, forKey: .active)
+        // 도감은 항목별 격리 — 손상 항목 하나가 도감 전체를 날리지 않게.
+        dex                = c.lenient([Lossy<DexEntry>].self, forKey: .dex, default: []).compactMap(\.value)
+        collectedFinals    = c.lenient(Set<String>.self, forKey: .collectedFinals, default: [])
+        language           = c.lenient(AppLanguage.self, forKey: .language, default: .systemDefault)
+        inventory          = c.lenient([String: Int].self, forKey: .inventory, default: [:])
+        candyGrantTier     = c.lenient([String: Int].self, forKey: .candyGrantTier, default: [:])
+        candyFeatureSeeded = c.lenient(Bool.self, forKey: .candyFeatureSeeded, default: false)
     }
 }
 

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -764,8 +764,16 @@ final class CompanionStore {
 
     // MARK: 영속
     private func load() {
-        guard let data = try? Data(contentsOf: fileURL),
-              let s = try? JSONDecoder().decode(CompanionState.self, from: data) else { return }
+        guard let data = try? Data(contentsOf: fileURL) else { return }   // 파일 없음 = 신규 설치
+        guard let s = try? JSONDecoder().decode(CompanionState.self, from: data) else {
+            // 디코드 실패(전면 손상/미래 스키마) → fresh 로 시작하되, 다음 save() 가 원본을 덮어써 영구
+            // 유실되기 전에 .corrupt 로 보존해 수동 복구 여지를 남긴다(도감 per-entry 격리로 못 살린 경우 대비).
+            let backup = fileURL.appendingPathExtension("corrupt")
+            try? FileManager.default.removeItem(at: backup)
+            try? FileManager.default.moveItem(at: fileURL, to: backup)
+            AppLog.write("companion state decode failed — original backed up to \(backup.lastPathComponent), starting fresh")
+            return
+        }
         state = s
     }
     private func save() {

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -26,6 +26,7 @@ final class UsageStore {
     private(set) var statuses: [String: ProviderStatus] = [:]
     private(set) var lastUpdated: Date?
     private(set) var isRefreshing = false
+    private var refreshPending = false          // 진행 중 refresh 에 겹친 요청을 1회 코얼레싱(드롭 방지)
     private(set) var isRefreshingLimitToken = false
     private(set) var lastErrorDescription: String?
     private(set) var limitTokenRefreshError: String?
@@ -406,7 +407,10 @@ final class UsageStore {
     // MARK: 갱신
 
     func refresh(scheduleEmptyRetry: Bool = true) async {
-        guard !isRefreshing else { return }
+        // 진행 중이면 드롭하지 말고 예약 — 완료 후 1회 재실행(코얼레싱). 수동모드(interval 0)에서 키체인
+        // 재활성(disableKeychainAccess didSet)의 refresh 가 in-flight 폴에 묻혀, 자동폴이 없는 탓에
+        // Claude 한도가 다음 수동 액션까지 빈 채로 남던 회귀 방지.
+        if isRefreshing { refreshPending = true; return }
         isRefreshing = true
         // App Nap 방지 — 백그라운드 스로틀로 ccusage 가 타임아웃되는 것을 막는다 (시스템 슬립은 허용)
         let activity = ProcessInfo.processInfo.beginActivity(
@@ -414,6 +418,11 @@ final class UsageStore {
         defer {
             ProcessInfo.processInfo.endActivity(activity)
             isRefreshing = false
+            // 진행 중 겹쳐 들어온 요청을 1회 반영. 요청 도착률이 유한하므로 무한 재실행 없음.
+            if refreshPending {
+                refreshPending = false
+                Task { await self.refresh(scheduleEmptyRetry: scheduleEmptyRetry) }
+            }
         }
 
         let todayKey = LocalUsageReader.todayKey()

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -118,6 +118,68 @@ final class CompanionStoreTests: XCTestCase {
         return CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: seed))
     }
 
+    // MARK: 상태 파일 decode 복원력 (회귀)
+
+    /// [회귀] 도감 항목 하나가 손상돼도(구버전/필드 누락) 나머지 도감·companion·인벤토리를 지킨다 —
+    /// 예전엔 `[DexEntry]` 배열 전체 decode 가 throw 돼 상태가 전면 초기화됐다(항목별 격리로 수정).
+    func testCorruptDexEntryDroppedWhileRestSurvives() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-dex-\(UUID().uuidString).json")
+        // 유효 2개 + 손상 1개(finalID/chainOrder 누락).
+        let json = #"{"dex":[{"baseID":1,"finalID":3,"chainOrder":[1,2,3],"rarity":"common"},"#
+            + #"{"baseID":99,"rarity":"rare"},"#
+            + #"{"baseID":7,"finalID":9,"chainOrder":[7,8,9],"rarity":"uncommon"}],"inventory":{"rareCandy":2}}"#
+        try Data(json.utf8).write(to: url)
+
+        let s = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow },
+                               fileURL: url, rng: SeededRNG(seed: 7))
+
+        XCTAssertEqual(s.state.dex.count, 2, "손상 항목만 드롭, 유효 2개 유지")
+        XCTAssertEqual(Set(s.state.dex.map(\.baseID)), [1, 7])
+        XCTAssertEqual(s.state.inventory["rareCandy"], 2, "도감 손상이 다른 상태(인벤토리)를 날리지 않음")
+    }
+
+    /// [회귀] 전면 손상 상태 파일은 fresh 로 시작하되, 다음 save() 가 덮어써 영구 유실되기 전에
+    /// 원본을 `.corrupt` 로 백업해 수동 복구 여지를 남긴다.
+    func testCorruptStateFileBackedUpBeforeReset() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-corrupt-\(UUID().uuidString).json")
+        let garbage = "this is not valid json {{{ 손상"
+        try Data(garbage.utf8).write(to: url)
+
+        let s = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow },
+                               fileURL: url, rng: SeededRNG(seed: 7))
+
+        XCTAssertTrue(s.state.dex.isEmpty)
+        XCTAssertNil(s.state.active)
+        XCTAssertEqual(s.state.usedSinceInstall, 0, "fresh state 로 시작")
+
+        let backup = url.appendingPathExtension("corrupt")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backup.path), "손상 원본이 .corrupt 로 백업돼야 한다")
+        XCTAssertEqual(try String(contentsOf: backup, encoding: .utf8), garbage, "백업 내용 = 원본 그대로")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path), "원본은 이동돼 사라짐")
+        try? FileManager.default.removeItem(at: backup)
+    }
+
+    /// [회귀] active(현재 포켓몬)가 손상돼도(pathIDs 누락 등) 알로 폴백하되 도감·인벤토리·누적은 보존한다 —
+    /// 예전엔 active decode 실패가 CompanionState 전체를 throw 시켜 전면 초기화됐다(필드별 관대화로 수정).
+    func testCorruptActiveFallsBackToEggWhileRestSurvives() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-active-corrupt-\(UUID().uuidString).json")
+        // active 는 pathIDs 누락 → MonState decode 실패. dex/inventory/usedSinceInstall 은 유효.
+        let json = #"{"active":{"baseID":1},"#
+            + #""dex":[{"baseID":1,"finalID":3,"chainOrder":[1,2,3],"rarity":"common"}],"#
+            + #""inventory":{"rareCandy":3},"usedSinceInstall":5000}"#
+        try Data(json.utf8).write(to: url)
+
+        let s = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow },
+                               fileURL: url, rng: SeededRNG(seed: 7))
+
+        XCTAssertNil(s.state.active, "손상 active 는 nil(알)로 폴백")
+        XCTAssertEqual(s.state.dex.count, 1, "도감 보존")
+        XCTAssertEqual(s.state.inventory["rareCandy"], 3, "인벤토리 보존")
+        XCTAssertEqual(s.state.usedSinceInstall, 5000, "누적 토큰 보존")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.appendingPathExtension("corrupt").path),
+                       "부분 복원 — 전면 리셋/백업 아님")
+    }
+
     // MARK: 도감 이름 (컬렉션 표시)
 
     /// 저장된 체인 종별 다국어 이름을 현재 언어로 해석 — 없으면 nil(뷰가 async 조회로 폴백).
@@ -543,15 +605,18 @@ final class CompanionIdentityTests: XCTestCase {
         XCTAssertEqual(round.active?.isShiny, false)
     }
 
-    /// [출시 안전] 손상된 상태 파일: active.pathIDs 가 비면 디코드가 실패해야 한다
-    /// (→ load() 가 기본 알 상태로 폴백 → currentID out-of-bounds 크래시 방지).
-    func testEmptyPathIDsRejectedOnDecode() {
+    /// [출시 안전] 손상된 상태 파일: active.pathIDs 가 비면 그 active 만 nil(알)로 폴백하되 나머지 상태는
+    /// 보존한다(필드별 관대화). 깨진 active 를 살려두면 currentID out-of-bounds 위험이므로 nil 이어야 한다
+    /// (예전엔 전체 디코드를 throw 시켜 상태 전면 초기화 → 도감·인벤토리까지 유실됐다).
+    func testEmptyPathIDsActiveFallsBackToNilPreservingRest() {
         let corrupt = """
         {"installBaselineSet":true,"eggUsage":0,"lastDate":"d1",
          "active":{"baseID":1,"pathIDs":[],"stageIndex":0,"usedAtStage":0,"rarity":"common","totalForms":3}}
         """
-        XCTAssertThrowsError(try JSONDecoder().decode(CompanionState.self, from: Data(corrupt.utf8)),
-                             "빈 pathIDs 는 디코드 거부돼야 한다")
+        let state = try? JSONDecoder().decode(CompanionState.self, from: Data(corrupt.utf8))
+        XCTAssertNotNil(state, "빈 pathIDs 는 active 만 무효화 — 전체 디코드는 성공(부분 복원)")
+        XCTAssertNil(state?.active, "빈 pathIDs active 는 nil(알)로 폴백 — 깨진 active 를 살려두지 않는다")
+        XCTAssertEqual(state?.installBaselineSet, true, "나머지 필드는 보존")
     }
 
     /// currentID 는 pathIDs 가 비어도(방어) baseID 로 폴백 — 크래시 없음.

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -28,6 +28,30 @@ private final class FakeUsageProvider: UsageProvider, @unchecked Sendable {
     func fetchEnrichment() async -> ProviderEnrichment { enrichment }
 }
 
+/// 첫 fetchDaily 호출을 continuation 으로 붙잡아, in-flight refresh 중 두 번째 refresh 를 겹치게 하는 스텁.
+/// 게이트 상태는 actor 로 격리(백그라운드 fetchDaily ↔ 테스트 폴링/release 간 데이터레이스 없음).
+private actor GatedUsageProvider: UsageProvider {
+    nonisolated let id = "claude_code"
+    nonisolated let displayName = "Claude Code"
+    private let dailyValue: DailyUsage
+    private var calls = 0
+    private var gate: CheckedContinuation<Void, Never>?
+    private var released = false
+    init(daily: DailyUsage) { self.dailyValue = daily }
+    var dailyCalls: Int { calls }
+    func fetchDaily() async throws -> DailyUsage? {
+        calls += 1
+        if calls == 1 {
+            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+                if released { c.resume() } else { gate = c }   // release()가 먼저 왔으면 즉시 통과
+            }
+        }
+        return dailyValue
+    }
+    func fetchEnrichment() async -> ProviderEnrichment { ProviderEnrichment() }
+    func release() { released = true; let c = gate; gate = nil; c?.resume() }
+}
+
 private struct FakeClaudeLimits: ClaudeLimitsProviding {
     var status: LimitStatus?
     func fetch(allowKeychainPrompt: Bool) async throws -> LimitStatus {
@@ -140,6 +164,32 @@ final class UsageStoreTests: XCTestCase {
         return UsageStore(providers: [claude], claudeLimitsProvider: FakeClaudeLimits(status: nil),
                           codexLimitsProvider: FakeCodexLimits(status: nil), statusProvider: stub,
                           autoRefresh: false, defaults: testDefaults)
+    }
+
+    // MARK: refresh 코얼레싱 (회귀)
+
+    /// [회귀] 진행 중 refresh 에 겹친 refresh 는 드롭이 아니라 완료 후 1회 재실행(코얼레싱)돼야 한다.
+    /// 수동모드(interval 0)에서 키체인 재활성 refresh 가 in-flight 폴에 묻혀 Claude 한도가 빈 채로
+    /// 남던 회귀 가드 — 겹친 요청이 그냥 무시되면 fetchDaily 는 1회로 끝난다.
+    func testConcurrentRefreshIsCoalescedNotDropped() async {
+        let p = GatedUsageProvider(daily: todayDaily(1_000))
+        let store = UsageStore(providers: [p],
+                               claudeLimitsProvider: FakeClaudeLimits(status: nil),
+                               codexLimitsProvider: FakeCodexLimits(status: nil),
+                               statusProvider: FakeStatusProvider([:]),
+                               autoRefresh: false, defaults: testDefaults)
+        // A: 첫 refresh — fetchDaily 의 gate 에 걸려 in-flight 로 멈춘다.
+        let a = Task { await store.refresh(scheduleEmptyRetry: false) }
+        for _ in 0..<500 { if await p.dailyCalls >= 1 { break }; await Task.yield() }
+        XCTAssertTrue(store.isRefreshing, "A 가 in-flight 여야 한다")
+        // B: 겹친 refresh — 드롭 대신 예약(즉시 리턴).
+        await store.refresh(scheduleEmptyRetry: false)
+        // gate 해제 → A 완료 → defer 가 예약분을 1회 재실행.
+        await p.release()
+        await a.value
+        for _ in 0..<500 { if await p.dailyCalls >= 2 { break }; await Task.yield() }
+        let calls = await p.dailyCalls
+        XCTAssertGreaterThanOrEqual(calls, 2, "겹친 refresh 는 완료 후 1회 재실행돼야 한다(드롭 금지)")
     }
 
     // MARK: Keychain 프롬프트 경로 분리 (회귀)


### PR DESCRIPTION
## Summary

Two resilience fixes from a code audit.

### Refresh coalescing
`refresh()` dropped any call that overlapped an in-flight refresh
(`guard !isRefreshing`). Re-enabling keychain access while a poll was
running dropped the reload; in "manual" (interval 0) mode there is no
follow-up poll, so Claude limits stayed blank until the next manual action.
Overlapping calls now set a `refreshPending` flag and the in-flight refresh
re-runs once on completion.

### Companion-state decode resilience
One corrupt or legacy field in `companion-state.json` could throw the whole
decode, silently resetting the entire companion, Pokedex, and inventory.

- The Pokedex decodes per-entry (one broken entry is dropped, the rest kept).
- Every field absorbs missing/null/type-mismatch into its default — a
  corrupt `active` falls back to an egg while the dex and inventory survive.
- Only a non-object top-level still fails; `load()` then backs the original
  up to `.corrupt` before starting fresh, leaving room for manual recovery.

## Testing

- New tests: refresh coalescing (actor-gated overlap), per-entry dex
  isolation, corrupt-active fallback, corrupt-file backup.
- `./scripts/test-gate.sh` — 322 tests pass, 85% core line coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
