### PR TITLE
feat: preselect branching evolution paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ docs/
 
 # Agent worktrees / local state
 .claude/
+.worktrees/

--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -226,6 +226,27 @@ struct EvoNode: Codable, Sendable {
     }
 }
 
+enum EvoLineItemContent: Equatable, Sendable {
+    case species(Int)
+    case mystery
+}
+
+enum EvoLineItemState: Equatable, Sendable {
+    case done
+    case current
+    case future
+}
+
+struct EvoLineItem: Equatable, Sendable {
+    let content: EvoLineItemContent
+    let state: EvoLineItemState
+
+    init(_ content: EvoLineItemContent, _ state: EvoLineItemState) {
+        self.content = content
+        self.state = state
+    }
+}
+
 /// 부화 시 확정되는 라인 정보(트리 + 희귀도 + 다국어 이름).
 struct EvoLine: Sendable {
     let baseID: Int
@@ -303,6 +324,7 @@ enum PokemonOdds {
 struct MonState: Codable, Sendable {
     var baseID: Int
     var pathIDs: [Int]      // 실제 진화 경로(분기 선택 반영)
+    var plannedPathIDs: [Int] // 사전에 선택한 전체 진화 경로
     var stageIndex: Int     // pathIDs 내 현재 위치
     var usedAtStage: Int    // 현재 형태에서 누적 사용량
     var rarity: Rarity
@@ -315,11 +337,16 @@ struct MonState: Codable, Sendable {
     // pathIDs 가 비면(손상된 상태 파일) baseID 로 폴백 — 렌더마다 읽히므로 out-of-bounds 크래시 방지.
     var currentID: Int { pathIDs.isEmpty ? baseID : pathIDs[min(stageIndex, pathIDs.count - 1)] }
 
-    init(baseID: Int, pathIDs: [Int], stageIndex: Int, usedAtStage: Int,
+    init(baseID: Int, pathIDs: [Int], plannedPathIDs: [Int]? = nil, stageIndex: Int, usedAtStage: Int,
          rarity: Rarity, totalForms: Int, isShiny: Bool = false, nature: PokemonNature? = nil,
          dittoDisguise: Int? = nil, dittoRevealed: Bool = false) {
         self.baseID = baseID
         self.pathIDs = pathIDs
+        if let plannedPathIDs, !plannedPathIDs.isEmpty {
+            self.plannedPathIDs = plannedPathIDs
+        } else {
+            self.plannedPathIDs = pathIDs
+        }
         self.stageIndex = stageIndex
         self.usedAtStage = usedAtStage
         self.rarity = rarity
@@ -338,6 +365,11 @@ struct MonState: Codable, Sendable {
         // 빈 pathIDs 는 손상 상태 → 디코드 실패시켜 전체 CompanionState 가 기본(알)로 폴백되게 한다.
         guard !pathIDs.isEmpty else {
             throw DecodingError.dataCorruptedError(forKey: .pathIDs, in: c, debugDescription: "empty pathIDs")
+        }
+        if let savedPlan = try c.decodeIfPresent([Int].self, forKey: .plannedPathIDs), !savedPlan.isEmpty {
+            plannedPathIDs = savedPlan
+        } else {
+            plannedPathIDs = pathIDs
         }
         stageIndex = try c.decode(Int.self, forKey: .stageIndex)
         usedAtStage = try c.decode(Int.self, forKey: .usedAtStage)

--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -371,7 +371,8 @@ struct MonState: Codable, Sendable {
         } else {
             plannedPathIDs = pathIDs
         }
-        stageIndex = try c.decode(Int.self, forKey: .stageIndex)
+        let decodedStageIndex = try c.decode(Int.self, forKey: .stageIndex)
+        stageIndex = min(max(0, decodedStageIndex), pathIDs.count - 1)
         usedAtStage = try c.decode(Int.self, forKey: .usedAtStage)
         rarity = try c.decode(Rarity.self, forKey: .rarity)
         totalForms = try c.decode(Int.self, forKey: .totalForms)

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -40,15 +40,20 @@ final class CompanionStore {
     private let clock: () -> Date
     private let fileURL: URL
     private var rng: any RandomNumberGenerator
+    private let dittoDisguiseRollingEnabled: Bool
+    /// 세션 내 활성 개체 교체 감지용. await 뒤 이전 개체의 결과가 새 개체를 덮지 않게 한다.
+    private var activeGeneration = 0
 
     init(provider: any PokeProviding = PokeAPIClient.shared,
          clock: @escaping () -> Date = Date.init,
          fileURL: URL? = nil,
-         rng: any RandomNumberGenerator = SystemRandomNumberGenerator()) {
+         rng: any RandomNumberGenerator = SystemRandomNumberGenerator(),
+         dittoDisguiseRollingEnabled: Bool = AppEnv.isBundledApp) {
         self.provider = provider
         self.clock = clock
         self.fileURL = fileURL ?? Self.defaultURL()
         self.rng = rng
+        self.dittoDisguiseRollingEnabled = dittoDisguiseRollingEnabled
         load()
         if state.active != nil { displayState = .idle }
     }
@@ -116,15 +121,29 @@ final class CompanionStore {
     }
     var tokensToNext: Int { guard let a = state.active else { return 0 }; return max(0, threshold - a.usedAtStage) }
 
-    /// 진화 라인 표시용: 현재까지 경로 + 다음 후보. (id, kind) kind: done/cur/future
-    var lineNodes: [(id: Int, kind: String)] {
+    /// 진화 라인 표시용: 실현된 경로 + 다음 단계 미리보기.
+    /// 유일하게 이어지는 단계 뒤에 분기가 있으면, 그 확정 접두어와 하나의 미지 항목을 함께 보여 준다.
+    /// 분기 후보는 부화 시 계획됐더라도 실제 진화 전까지 하나의 미지 항목으로 숨긴다.
+    var lineNodes: [EvoLineItem] {
         guard let a = state.active, let line = currentLine else { return [] }
-        var out: [(Int, String)] = []
+        var out: [EvoLineItem] = []
         for (i, id) in a.pathIDs.enumerated() {
-            out.append((id, i < a.stageIndex ? "done" : (i == a.stageIndex ? "cur" : "future")))
+            out.append(EvoLineItem(.species(id), i == a.pathIDs.count - 1 ? .current : .done))
         }
-        if let cur = line.tree.node(withID: a.currentID) {
-            for ch in cur.children { out.append((ch.speciesID, "future")) }
+        if let current = line.tree.node(withID: a.currentID) {
+            var node = current
+            var guaranteedPrefix: [EvoNode] = []
+            while node.children.count == 1, let child = node.children.first {
+                guaranteedPrefix.append(child)
+                node = child
+            }
+
+            if node.children.count > 1 {
+                out += guaranteedPrefix.map { EvoLineItem(.species($0.speciesID), .future) }
+                out.append(EvoLineItem(.mystery, .future))
+            } else {
+                out += guaranteedPrefix.map { EvoLineItem(.species($0.speciesID), .future) }
+            }
         }
         return out
     }
@@ -280,7 +299,16 @@ final class CompanionStore {
             if node.children.isEmpty {
                 graduate(); break
             } else {
-                let next = pickNextChild(node, baseID: a.baseID)
+                let nextIndex = a.stageIndex + 1
+                guard a.plannedPathIDs.indices.contains(nextIndex) else {
+                    AppLog.write("evolve: invalid planned path index \(nextIndex) for base \(a.baseID)")
+                    break
+                }
+                let nextID = a.plannedPathIDs[nextIndex]
+                guard let next = node.children.first(where: { $0.speciesID == nextID }) else {
+                    AppLog.write("evolve: planned child \(nextID) is invalid for current \(a.currentID)")
+                    break
+                }
                 state.active!.pathIDs = Array(a.pathIDs.prefix(a.stageIndex + 1)) + [next.speciesID]
                 state.active!.stageIndex += 1
                 state.active!.usedAtStage = a.usedAtStage - thr   // 초과분 이월
@@ -296,12 +324,58 @@ final class CompanionStore {
         save()
     }
 
-    private func pickNextChild(_ node: EvoNode, baseID: Int) -> EvoNode {
+    private func pickPlannedChild(_ node: EvoNode, baseID: Int) -> EvoNode {
         let fresh = node.children.filter { ch in
             ch.finalIDs.contains { !state.collectedFinals.contains("\(baseID):\($0)") }
         }
         let pool = fresh.isEmpty ? node.children : fresh
         return pool[Int(rng.next() % UInt64(pool.count))]
+    }
+
+    private func makeEvolutionPlan(from root: EvoNode, baseID: Int) -> [Int] {
+        var plan = [root.speciesID]
+        var node = root
+        while !node.children.isEmpty {
+            let next = pickPlannedChild(node, baseID: baseID)
+            plan.append(next.speciesID)
+            node = next
+        }
+        return plan
+    }
+
+    /// 루트부터 실제로 이어지는 가장 긴 ID 경로와 마지막 유효 노드. 첫 ID가 루트와 다르면 루트로 복구한다.
+    private func longestValidPath(_ ids: [Int], from root: EvoNode) -> (path: [Int], lastNode: EvoNode) {
+        var path = [root.speciesID]
+        var node = root
+        guard ids.first == root.speciesID else { return (path, node) }
+        for id in ids.dropFirst() {
+            guard let child = node.children.first(where: { $0.speciesID == id }) else { break }
+            path.append(id)
+            node = child
+        }
+        return (path, node)
+    }
+
+    /// 저장된 실제 경로와 계획을 현재 에셋 트리에 맞춘다. 완전한 계획만 재사용해 재시작 시 RNG를 소비하지 않는다.
+    private func normalizedEvolutionState(_ saved: MonState, from root: EvoNode) -> MonState {
+        var normalized = saved
+        let realized = longestValidPath(saved.pathIDs, from: root)
+        let candidate = longestValidPath(saved.plannedPathIDs, from: root)
+        let canReusePlan = candidate.path == saved.plannedPathIDs
+            && candidate.path.starts(with: realized.path)
+            && candidate.lastNode.children.isEmpty
+        let plan: [Int]
+        if canReusePlan {
+            plan = candidate.path
+        } else {
+            let suffix = makeEvolutionPlan(from: realized.lastNode, baseID: saved.baseID)
+            plan = realized.path + suffix.dropFirst()
+        }
+        normalized.pathIDs = realized.path
+        normalized.plannedPathIDs = plan
+        normalized.stageIndex = realized.path.count - 1
+        normalized.totalForms = plan.count
+        return normalized
     }
 
     private func graduate() {
@@ -320,6 +394,7 @@ final class CompanionStore {
         notifyCompanionEvent(l.notifGraduateTitle, l.notifGraduateBody(name))
         eventUntil = clock().addingTimeInterval(6)
         state.active = nil
+        activeGeneration += 1
         currentLine = nil
         state.eggUsage = 0   // 새 알은 처음부터 인큐베이션
         // "알을 받는 순간" 즉시 프리패칭 시작 — 다음 부화의 종·라인·스프라이트 예열.
@@ -462,6 +537,7 @@ final class CompanionStore {
         guard canBuyFreshEgg else { return false }
         state.spentTokens += FreshEgg.price
         state.active = nil            // 폐기 (졸업 아님 — dex/collectedFinals 미변경)
+        activeGeneration += 1
         currentLine = nil
         state.eggUsage = 0            // 새 알은 처음부터 인큐베이션(재부화에 5M 필요)
         state.pendingHatchID = nil    // 다음 부화는 새로 롤
@@ -624,15 +700,18 @@ final class CompanionStore {
         // 메타몽 위장 롤 — common·≥2형태에 한해 1/128. .app 게이트(&& 단락 → 비앱에선 rng 미소비로
         // 기존 테스트 RNG 시퀀스 무영향). 위장/리빌 로직은 상태 기반으로 별도 테스트한다.
         var dittoDisguise: Int?
-        if AppEnv.isBundledApp, Self.dittoDisguiseHit(rarity: line.rarity, totalForms: line.totalForms, roll: rng.next()) {
+        if dittoDisguiseRollingEnabled,
+           Self.dittoDisguiseHit(rarity: line.rarity, totalForms: line.totalForms, roll: rng.next()) {
             dittoDisguise = line.baseID
         }
+        let evolutionPlan = makeEvolutionPlan(from: line.tree, baseID: line.baseID)
         // 위장 중엔 이로치를 숨긴다 — 부화 알림·연출도 일반체로(정체는 리빌 때 공개).
         let showShiny = isShiny && dittoDisguise == nil
-        state.active = MonState(baseID: line.baseID, pathIDs: [line.baseID], stageIndex: 0,
-                                usedAtStage: 0, rarity: line.rarity, totalForms: line.totalForms,
+        activeGeneration += 1
+        state.active = MonState(baseID: line.baseID, pathIDs: [line.baseID], plannedPathIDs: evolutionPlan,
+                                stageIndex: 0, usedAtStage: 0, rarity: line.rarity, totalForms: evolutionPlan.count,
                                 isShiny: isShiny, nature: nature, dittoDisguise: dittoDisguise)
-        AppLog.write("hatch: base=\(line.baseID) rarity=\(line.rarity) shiny=\(isShiny) forms=\(line.totalForms) ditto=\(dittoDisguise != nil)")
+        AppLog.write("hatch: base=\(line.baseID) rarity=\(line.rarity) shiny=\(isShiny) forms=\(evolutionPlan.count) ditto=\(dittoDisguise != nil)")
         let name = line.localizedName(line.baseID, state.language)
         notifyCompanionEvent(showShiny ? l.notifShinyHatchTitle : l.notifHatchTitle,
                              showShiny ? l.notifShinyHatchBody(name) : l.notifHatchBody(name))
@@ -650,6 +729,7 @@ final class CompanionStore {
     /// Ditto 라인 로드 후 상태 변환(rare·단일형태·초과분 이월, isShiny/nature 유지) + 연출·알림.
     private func revealDitto() async {
         guard let a = state.active, a.dittoDisguise != nil, !a.dittoRevealed, !isRevealingDitto else { return }
+        let generation = activeGeneration
         let firstEvoThr = PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0)
         guard a.usedAtStage >= firstEvoThr else { return }   // 임계 미달 방어
         isRevealingDitto = true
@@ -657,15 +737,20 @@ final class CompanionStore {
         guard let dittoLine = try? await provider.line(baseSpeciesID: PokemonOdds.dittoSpeciesID) else {
             AppLog.write("ditto reveal: line fetch failed — retry next tick"); return
         }
-        guard var m = state.active, m.dittoDisguise != nil, !m.dittoRevealed else { return }   // await 사이 변화 방어
+        guard activeGeneration == generation,
+              var m = state.active, m.dittoDisguise != nil, !m.dittoRevealed else { return }
+        let latestFirstEvoThr = PokemonBalance.phaseThreshold(rarity: m.rarity, totalForms: m.totalForms, stageIndex: 0)
+        guard m.usedAtStage >= latestFirstEvoThr else { return }
         let disguiseName = currentLine?.localizedName(m.baseID, state.language) ?? "#\(m.baseID)"
-        let carryOver = max(0, m.usedAtStage - firstEvoThr)   // 위장체 첫 진화 초과분 → 메타몽 성장 이월
+        let carryOver = max(0, m.usedAtStage - latestFirstEvoThr)   // 위장체 첫 진화 초과분 → 메타몽 성장 이월
         // 메타몽으로 전환 — rarity/forms 는 로드한 라인에서, isShiny/nature/dittoDisguise 는 유지.
         m.baseID = dittoLine.baseID
+        let evolutionPlan = makeEvolutionPlan(from: dittoLine.tree, baseID: dittoLine.baseID)
         m.pathIDs = [dittoLine.baseID]
+        m.plannedPathIDs = evolutionPlan
         m.stageIndex = 0
         m.rarity = dittoLine.rarity
-        m.totalForms = dittoLine.totalForms
+        m.totalForms = evolutionPlan.count
         m.usedAtStage = carryOver
         m.dittoRevealed = true
         let shiny = m.isShiny
@@ -683,22 +768,17 @@ final class CompanionStore {
 
     private func loadCurrentLine() async {
         guard let a = state.active, currentLine == nil, !isHatching else { return }
+        let generation = activeGeneration
         isHatching = true
         defer { isHatching = false }
         if let line = try? await provider.line(baseSpeciesID: a.baseID) {
-            // 구버전 저장은 PokéAPI 원본 체인의 GIF 미지원 후대 진화형까지 포함할 수 있다.
-            // 현재 에셋 트리에서 실제로 이어지는 경로까지만 복구하고 단계 수도 함께 마이그레이션한다.
-            var path = [line.tree.speciesID]
-            var node = line.tree
-            for id in a.pathIDs.dropFirst() {
-                guard let child = node.children.first(where: { $0.speciesID == id }) else { break }
-                path.append(id)
-                node = child
-            }
-            state.active?.pathIDs = path
-            state.active?.stageIndex = path.count - 1
-            state.active?.totalForms = line.totalForms
+            // await 중 사용량·민트 등 활성 상태는 계속 바뀔 수 있다. 요청 당시 스냅샷을 다시 쓰지 말고
+            // 같은 개체가 아직 활성인 경우에만 최신 상태를 정규화한다.
+            guard activeGeneration == generation,
+                  let latest = state.active, latest.baseID == a.baseID, currentLine == nil else { return }
+            state.active = normalizedEvolutionState(latest, from: line.tree)
             currentLine = line
+            save()   // 마이그레이션 선택을 사용량 재평가 전에 영속화해 재시작마다 다시 롤리지 않는다.
             applyUsage(0)   // 라인 미로딩 동안 적립된 사용량이 임계를 넘었으면 지금 진화 판정
         }
     }

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -126,10 +126,7 @@ final class CompanionStore {
     /// 분기 후보는 부화 시 계획됐더라도 실제 진화 전까지 하나의 미지 항목으로 숨긴다.
     var lineNodes: [EvoLineItem] {
         guard let a = state.active, let line = currentLine else { return [] }
-        var out: [EvoLineItem] = []
-        for (i, id) in a.pathIDs.enumerated() {
-            out.append(EvoLineItem(.species(id), i == a.pathIDs.count - 1 ? .current : .done))
-        }
+        var out = Self.realizedLineItems(pathIDs: a.pathIDs, stageIndex: a.stageIndex)
         if let current = line.tree.node(withID: a.currentID) {
             var node = current
             var guaranteedPrefix: [EvoNode] = []
@@ -146,6 +143,12 @@ final class CompanionStore {
             }
         }
         return out
+    }
+
+    static func realizedLineItems(pathIDs: [Int], stageIndex: Int) -> [EvoLineItem] {
+        pathIDs.enumerated().map { i, id in
+            EvoLineItem(.species(id), i == stageIndex ? .current : .done)
+        }
     }
     /// 도감에는 영구 보존된 졸업 개체와 현재 키우는 포켓몬을 함께 표시한다.
     /// 현재 개체는 영속 dex 에 중복 저장하지 않고 화면용 항목으로 합성한다. 졸업 시 active 가 사라지고
@@ -300,14 +303,18 @@ final class CompanionStore {
                 graduate(); break
             } else {
                 let nextIndex = a.stageIndex + 1
-                guard a.plannedPathIDs.indices.contains(nextIndex) else {
-                    AppLog.write("evolve: invalid planned path index \(nextIndex) for base \(a.baseID)")
-                    break
-                }
-                let nextID = a.plannedPathIDs[nextIndex]
-                guard let next = node.children.first(where: { $0.speciesID == nextID }) else {
-                    AppLog.write("evolve: planned child \(nextID) is invalid for current \(a.currentID)")
-                    break
+                let next: EvoNode
+                if a.plannedPathIDs.indices.contains(nextIndex),
+                   let planned = node.children.first(where: { $0.speciesID == a.plannedPathIDs[nextIndex] }) {
+                    next = planned
+                } else {
+                    next = pickPlannedChild(node, baseID: a.baseID)
+                    let fallbackRoute = [node.speciesID] + makeEvolutionPlan(from: next, baseID: a.baseID)
+                    let repaired = Self.repairedPlan(realizedPath: a.pathIDs, stageIndex: a.stageIndex,
+                                                     fallbackRoute: fallbackRoute)
+                    state.active!.plannedPathIDs = repaired
+                    state.active!.totalForms = repaired.count
+                    AppLog.write("evolve: repaired invalid planned path for base \(a.baseID)")
                 }
                 state.active!.pathIDs = Array(a.pathIDs.prefix(a.stageIndex + 1)) + [next.speciesID]
                 state.active!.stageIndex += 1
@@ -341,6 +348,14 @@ final class CompanionStore {
             node = next
         }
         return plan
+    }
+
+    static func repairedPlan(realizedPath: [Int], stageIndex: Int, fallbackRoute: [Int]) -> [Int] {
+        guard !realizedPath.isEmpty else { return fallbackRoute }
+        let currentIndex = min(stageIndex, realizedPath.count - 1)
+        let prefix = Array(realizedPath.prefix(currentIndex + 1))
+        guard fallbackRoute.first == prefix.last else { return prefix }
+        return prefix + fallbackRoute.dropFirst()
     }
 
     /// 루트부터 실제로 이어지는 가장 긴 ID 경로와 마지막 유효 노드. 첫 ID가 루트와 다르면 루트로 복구한다.

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -193,6 +193,7 @@ struct L {
     // MARK: 컴패니언
     var finalForm: String { t("최종 진화체", "Final form", "最終進化") }
     func stage(_ i: Int, _ k: Int) -> String { t("진화 단계 \(i) / \(k)", "Stage \(i) / \(k)", "進化段階 \(i) / \(k)") }
+    var unknownNextEvolution: String { t("알 수 없는 다음 진화", "Unknown next evolution", "次の進化先は不明") }
     var eggIncubating: String { t("🥚 부화 준비 중", "🥚 Incubating", "🥚 孵化の準備中") }
     func eggToHatch(_ amount: String) -> String { t("부화까지 \(amount)", "\(amount) to hatch", "孵化まで \(amount)") }
     func toNextEvolution(_ amount: String) -> String { t("다음 진화까지 \(amount)", "\(amount) to next evolution", "次の進化まで \(amount)") }

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -141,7 +141,8 @@ struct SpriteView: View {
 /// 팝오버 전체가 좌우로 잘린다**(진화줄뿐 아니라 탭바·합계까지). `maxWidth` 를 주면 그 폭 안에서
 /// 가로 스크롤한다 — 썸네일 크기는 유지하고, 가장자리 페이드 + 셰브론으로 스크롤 가능함을 알린다.
 struct EvoLineView: View {
-    let nodes: [(id: Int, kind: String)]
+    let nodes: [EvoLineItem]
+    let language: AppLanguage
     var thumb: CGFloat = 40
     var shiny: Bool = false     // 개체가 shiny 면 라인 전체를 shiny 스프라이트로
     var names: [Int: String]? = nil   // 제공되면 각 스프라이트 밑에 작은 이름 라벨(도감 단계별 이름)
@@ -307,16 +308,26 @@ struct EvoLineView: View {
                         .padding(.top, thumb * 0.4)   // 스프라이트 세로 중앙에 정렬
                 }
                 VStack(spacing: 1) {
-                    SpriteView(speciesID: node.id, size: thumb, shiny: shiny)
-                        .opacity(node.kind == "future" ? 0.32 : 1)
-                        .saturation(node.kind == "future" ? 0.4 : 1)
+                    Group {
+                        switch node.content {
+                        case .species(let id):
+                            SpriteView(speciesID: id, size: thumb, shiny: shiny)
+                        case .mystery:
+                            Text("?")
+                                .font(.system(size: thumb * 0.55, weight: .bold, design: .rounded))
+                                .frame(width: thumb, height: thumb)
+                                .accessibilityLabel(Text(L(language).unknownNextEvolution))
+                        }
+                    }
+                        .opacity(node.state == .future ? 0.32 : 1)
+                        .saturation(node.state == .future ? 0.4 : 1)
                         .overlay(alignment: .bottom) {
-                            if node.kind == "cur" {
+                            if node.state == .current {
                                 Circle().fill(Color.accentColor).frame(width: 4, height: 4).offset(y: 2)
                             }
                         }
-                    if let names {
-                        Text(names[node.id] ?? "…")
+                    if let names, case .species(let id) = node.content {
+                        Text(names[id] ?? "…")
                             .font(.system(size: 8)).foregroundStyle(.secondary)
                             .lineLimit(1).minimumScaleFactor(0.7).frame(maxWidth: thumb + Self.nameSlack)
                     }
@@ -435,7 +446,7 @@ struct CompanionHeader: View {
             }
             if store.hasActive, !store.lineNodes.isEmpty {
                 // 폭을 안 주면 분기 라인(이브이)이 넘쳐 팝오버 콘텐츠 전체가 좌우로 잘린다.
-                EvoLineView(nodes: store.lineNodes, shiny: store.currentIsShiny,
+                EvoLineView(nodes: store.lineNodes, language: store.language, shiny: store.currentIsShiny,
                             maxWidth: PopoverMetrics.contentWidth)
             }
             if let g = store.justGraduated {
@@ -684,7 +695,8 @@ private struct DexEntryRow: View {
                         .font(.system(size: 9)).foregroundStyle(.secondary)
                 }
             }
-            EvoLineView(nodes: entry.chainOrder.map { ($0, "done") }, thumb: 56,
+            EvoLineView(nodes: entry.chainOrder.map { EvoLineItem(.species($0), .done) },
+                        language: store.language, thumb: 56,
                         shiny: entry.isShiny, names: names,
                         maxWidth: PopoverMetrics.contentWidth - Self.cardPadding * 2)
             if let caughtAt = entry.caughtAt {

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -142,7 +142,7 @@ struct SpriteView: View {
 /// 가로 스크롤한다 — 썸네일 크기는 유지하고, 가장자리 페이드 + 셰브론으로 스크롤 가능함을 알린다.
 struct EvoLineView: View {
     let nodes: [EvoLineItem]
-    let language: AppLanguage
+    let mysteryLabel: String
     var thumb: CGFloat = 40
     var shiny: Bool = false     // 개체가 shiny 면 라인 전체를 shiny 스프라이트로
     var names: [Int: String]? = nil   // 제공되면 각 스프라이트 밑에 작은 이름 라벨(도감 단계별 이름)
@@ -316,7 +316,7 @@ struct EvoLineView: View {
                             Text("?")
                                 .font(.system(size: thumb * 0.55, weight: .bold, design: .rounded))
                                 .frame(width: thumb, height: thumb)
-                                .accessibilityLabel(Text(L(language).unknownNextEvolution))
+                                .accessibilityLabel(Text(mysteryLabel))
                         }
                     }
                         .opacity(node.state == .future ? 0.32 : 1)
@@ -332,6 +332,7 @@ struct EvoLineView: View {
                             .lineLimit(1).minimumScaleFactor(0.7).frame(maxWidth: thumb + Self.nameSlack)
                     }
                 }
+                .frame(width: thumb + (names == nil ? 0 : Self.nameSlack))
                 .id(i)   // 셰브론 페이징(ScrollViewProxy.scrollTo) 대상
             }
         }
@@ -446,7 +447,7 @@ struct CompanionHeader: View {
             }
             if store.hasActive, !store.lineNodes.isEmpty {
                 // 폭을 안 주면 분기 라인(이브이)이 넘쳐 팝오버 콘텐츠 전체가 좌우로 잘린다.
-                EvoLineView(nodes: store.lineNodes, language: store.language, shiny: store.currentIsShiny,
+                EvoLineView(nodes: store.lineNodes, mysteryLabel: store.l.unknownNextEvolution, shiny: store.currentIsShiny,
                             maxWidth: PopoverMetrics.contentWidth)
             }
             if let g = store.justGraduated {
@@ -696,7 +697,7 @@ private struct DexEntryRow: View {
                 }
             }
             EvoLineView(nodes: entry.chainOrder.map { EvoLineItem(.species($0), .done) },
-                        language: store.language, thumb: 56,
+                        mysteryLabel: store.l.unknownNextEvolution, thumb: 56,
                         shiny: entry.isShiny, names: names,
                         maxWidth: PopoverMetrics.contentWidth - Self.cardPadding * 2)
             if let caughtAt = entry.caughtAt {

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -486,6 +486,19 @@ final class CompanionStoreTests: XCTestCase {
         ])
     }
 
+    func testRealizedLineItemsUsesStageIndexForCurrentMarker() {
+        XCTAssertEqual(CompanionStore.realizedLineItems(pathIDs: [1, 2], stageIndex: 0), [
+            EvoLineItem(.species(1), .current),
+            EvoLineItem(.species(2), .done),
+        ])
+    }
+
+    func testRepairedPlanAppendsFallbackRouteToCurrentPath() {
+        XCTAssertEqual(CompanionStore.repairedPlan(
+            realizedPath: [265], stageIndex: 0, fallbackRoute: [265, 266, 267]),
+            [265, 266, 267])
+    }
+
     func testLineNodesHidesUnresolvedWurmpleBranchAsSingleMystery() async {
         let s = store(wurmpleLine)
         await s.hatch(baseID: 265)

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -52,11 +52,62 @@ struct SeededRNG: RandomNumberGenerator {
     }
 }
 
+final class CountingRNG: RandomNumberGenerator {
+    private var base: SeededRNG
+    private(set) var callCount = 0
+
+    init(seed: UInt64) { base = SeededRNG(seed: seed) }
+
+    func next() -> UInt64 {
+        callCount += 1
+        return base.next()
+    }
+}
+
+@MainActor
+private func waitUntil(timeout: TimeInterval = 1, _ condition: @escaping () -> Bool) async -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if condition() { return true }
+        try? await Task.sleep(nanoseconds: 1_000_000)
+    }
+    return condition()
+}
+
 struct StubProvider: PokeProviding {
     let value: EvoLine
     func line(baseSpeciesID: Int) async throws -> EvoLine { value }
     // 인덱스 = 자기 라인 base 단일 항목 → 선택 롤 1회 소비 후 항상 그 base (테스트 rng 재생 단순화)
     func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: value.baseID, captureRate: 255)] }
+}
+
+private actor SuspendedLineProvider: PokeProviding {
+    private let value: EvoLine
+    private var continuation: CheckedContinuation<EvoLine, Never>?
+    private var suspended = false
+
+    init(value: EvoLine) { self.value = value }
+
+    func line(baseSpeciesID: Int) async throws -> EvoLine {
+        await withCheckedContinuation { continuation in
+            precondition(self.continuation == nil, "only one line request may be suspended")
+            self.continuation = continuation
+            suspended = true
+        }
+    }
+
+    func baseSpeciesIndex() async throws -> [BaseSpecies] {
+        [BaseSpecies(id: value.baseID, captureRate: 255)]
+    }
+
+    func isSuspended() -> Bool { suspended }
+
+    func resume() {
+        let pending = continuation
+        continuation = nil
+        suspended = false
+        pending?.resume(returning: value)
+    }
 }
 
 // 테스트 스텁 공통 — base 판정을 주입 인덱스에서 파생. REST 폴백 경로는 실클라이언트만 override.
@@ -105,6 +156,10 @@ private func node(_ id: Int, _ children: [EvoNode] = []) -> EvoNode { EvoNode(sp
 private let linear3 = makeLine(base: 1, tree: node(1, [node(2, [node(3)])]))
 // 분기: 10 → {11,12,13}
 private let branch3 = makeLine(base: 10, tree: node(10, [node(11), node(12), node(13)]))
+// Wurmple: 265 → {266 → 267, 268 → 269}
+private let wurmpleLine = makeLine(base: 265, tree: node(265, [node(266, [node(267)]), node(268, [node(269)])]))
+// Oddish: 43 → 44 → {45, 182}
+private let delayedBranchLine = makeLine(base: 43, tree: node(43, [node(44, [node(45), node(182)])]))
 // 무진화: 20
 private let noEvo = makeLine(base: 20, tree: node(20))
 private let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
@@ -346,6 +401,12 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(L(.ja).dexRaising, "育成中")
     }
 
+    func testUnknownNextEvolutionAccessibilityLabelLocalized() {
+        XCTAssertEqual(L(.ko).unknownNextEvolution, "알 수 없는 다음 진화")
+        XCTAssertEqual(L(.en).unknownNextEvolution, "Unknown next evolution")
+        XCTAssertEqual(L(.ja).unknownNextEvolution, "次の進化先は不明")
+    }
+
     func testEggOverflowCarriesToHatchedMon() async {
         let s = store(linear3)
         base(s)
@@ -414,6 +475,55 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(s.dexEntries[0].chainOrder, [20])
     }
 
+    func testLineNodesPreviewsCompleteLinearEvolution() async {
+        let s = store(linear3)
+        await s.hatch(baseID: 1)
+
+        XCTAssertEqual(s.lineNodes, [
+            EvoLineItem(.species(1), .current),
+            EvoLineItem(.species(2), .future),
+            EvoLineItem(.species(3), .future),
+        ])
+    }
+
+    func testLineNodesHidesUnresolvedWurmpleBranchAsSingleMystery() async {
+        let s = store(wurmpleLine)
+        await s.hatch(baseID: 265)
+
+        XCTAssertEqual(s.lineNodes, [
+            EvoLineItem(.species(265), .current),
+            EvoLineItem(.mystery, .future),
+        ])
+    }
+
+    func testLineNodesShowsKnownPrefixBeforeDownstreamBranchAsMystery() async {
+        let s = store(delayedBranchLine)
+        await s.hatch(baseID: 43)
+
+        XCTAssertEqual(s.lineNodes, [
+            EvoLineItem(.species(43), .current),
+            EvoLineItem(.species(44), .future),
+            EvoLineItem(.mystery, .future),
+        ])
+    }
+
+    func testLineNodesRevealsChosenWurmpleBranchAfterEvolution() async throws {
+        let s = store(wurmpleLine)
+        await s.hatch(baseID: 265)
+        let plan = try XCTUnwrap(s.state.active?.plannedPathIDs)
+        XCTAssertEqual(plan.count, 3)
+        guard plan.count == 3 else { return }
+
+        s.applyUsage(PokemonBalance.phaseThreshold(
+            rarity: .common, totalForms: plan.count, stageIndex: 0))
+
+        XCTAssertEqual(s.lineNodes, [
+            EvoLineItem(.species(265), .done),
+            EvoLineItem(.species(plan[1]), .current),
+            EvoLineItem(.species(plan[2]), .future),
+        ])
+    }
+
     func testBranchingPrefersUncollectedFinals() async {
         let s = store(branch3)
         let evo = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 2, stageIndex: 0)
@@ -429,6 +539,29 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(Set(finals), [11, 12, 13])
     }
 
+    func testHatchPreselectsWurmpleRouteAndEvolutionDoesNotConsumeRNG() async {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
+        let rng = CountingRNG(seed: 7)
+        let s = CompanionStore(provider: StubProvider(value: wurmpleLine), clock: { fixedNow }, fileURL: url, rng: rng)
+
+        await s.hatch(baseID: 265)
+
+        guard let hatched = s.state.active else { return XCTFail("Wurmple should hatch") }
+        let plan = hatched.plannedPathIDs
+        XCTAssertTrue([[265, 266, 267], [265, 268, 269]].contains(plan), "plan must be one complete root-to-leaf route")
+        XCTAssertEqual(hatched.pathIDs, [265], "realized path starts at the base only")
+        XCTAssertEqual(hatched.totalForms, plan.count)
+
+        guard plan.count > 1 else { return }
+
+        let callsAfterHatch = rng.callCount
+        s.applyUsage(PokemonBalance.phaseThreshold(rarity: hatched.rarity, totalForms: hatched.totalForms, stageIndex: 0))
+
+        XCTAssertEqual(rng.callCount, callsAfterHatch, "evolution must consume the stored plan without rolling RNG")
+        XCTAssertEqual(s.state.active?.pathIDs, Array(plan.prefix(2)))
+        XCTAssertEqual(s.currentSpeciesID, plan[1])
+    }
+
     func testPersistenceRoundTrip() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-persist-\(UUID().uuidString).json")
         let s1 = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 1))
@@ -441,6 +574,147 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(s2.language, .ja)
     }
 
+    func testReloadPreservesCompleteShortPlannedRouteLength() async {
+        let line = makeLine(base: 1, tree: node(1, [node(2), node(3, [node(4)])]))
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-reload-plan-\(UUID().uuidString).json")
+        let s1 = CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 7))
+        await s1.hatch(baseID: 1)
+        XCTAssertEqual(s1.state.active?.plannedPathIDs, [1, 2], "seed selects the short complete route")
+
+        var opposing = SeededRNG(seed: 1)
+        XCTAssertEqual(opposing.next() % 2, 1, "a reroll would select the opposite branch (3)")
+        let rng = CountingRNG(seed: 1)
+        let s2 = CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: rng)
+        s2.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+                  burnTier: .idle, limitWarning: false, hasUsageData: true)
+        let loaded = await waitUntil { s2.currentLine != nil }
+        XCTAssertTrue(loaded, "line should load before evolution")
+
+        XCTAssertNotNil(s2.currentLine)
+        XCTAssertEqual(s2.state.active?.plannedPathIDs, [1, 2])
+        XCTAssertEqual(s2.state.active?.totalForms, 2)
+        let callsAfterLoad = rng.callCount
+        s2.applyUsage(PokemonBalance.phaseThreshold(rarity: .common, totalForms: 2, stageIndex: 0))
+        XCTAssertEqual(s2.currentSpeciesID, 2, "persisted route must beat the post-restart RNG branch")
+        XCTAssertEqual(rng.callCount, callsAfterLoad, "load and evolution must not reroll the persisted route")
+    }
+
+    func testReloadLegacyIncompletePlanMigratesToPersistedCompleteRoute() async throws {
+        let line = wurmpleLine
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-reload-legacy-\(UUID().uuidString).json")
+        let legacy = #"{"active":{"baseID":265,"pathIDs":[265],"stageIndex":0,"usedAtStage":0,"rarity":"common","totalForms":1}}"#
+        try Data(legacy.utf8).write(to: url)
+        let rng = CountingRNG(seed: 7)
+        let s = CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: rng)
+
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        let loaded = await waitUntil { s.currentLine != nil }
+        XCTAssertTrue(loaded, "line should load legacy state")
+
+        let migratedPlan = s.state.active?.plannedPathIDs
+        XCTAssertTrue([[265, 266, 267], [265, 268, 269]].contains(migratedPlan ?? []))
+        XCTAssertEqual(s.state.active?.pathIDs, [265], "realized path must remain intact")
+        XCTAssertEqual(s.state.active?.totalForms, migratedPlan?.count)
+        XCTAssertEqual(rng.callCount, 2, "Wurmple suffix selection rolls once per evolution edge")
+
+        let reloadRNG = CountingRNG(seed: 1)
+        let reloaded = CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: reloadRNG)
+        reloaded.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+                        burnTier: .idle, limitWarning: false, hasUsageData: true)
+        let reloadedLine = await waitUntil { reloaded.currentLine != nil }
+        XCTAssertTrue(reloadedLine)
+        XCTAssertEqual(reloaded.state.active?.plannedPathIDs, migratedPlan, "migration must persist its one-time choice")
+        XCTAssertEqual(reloadRNG.callCount, 0, "a persisted complete route must not reroll on restart")
+    }
+
+    func testReloadRepairsInvalidPlanSuffixWithoutRewindingRealizedPath() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-invalid-plan-\(UUID().uuidString).json")
+        let saved = #"{"active":{"baseID":265,"pathIDs":[265,266],"plannedPathIDs":[265,266,269],"stageIndex":1,"usedAtStage":42,"rarity":"common","totalForms":3}}"#
+        try Data(saved.utf8).write(to: url)
+        let s = CompanionStore(provider: StubProvider(value: wurmpleLine), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 9))
+
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        let loaded = await waitUntil { s.currentLine != nil }
+        XCTAssertTrue(loaded)
+
+        XCTAssertEqual(s.state.active?.pathIDs, [265, 266])
+        XCTAssertEqual(s.state.active?.plannedPathIDs, [265, 266, 267])
+        XCTAssertEqual(s.state.active?.stageIndex, 1)
+        XCTAssertEqual(s.state.active?.totalForms, 3)
+        XCTAssertEqual(s.state.active?.usedAtStage, 42)
+    }
+
+    func testReloadWrongRootNormalizesPathWithoutChangingIdentityOrDisguise() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-wrong-root-\(UUID().uuidString).json")
+        let saved = #"{"active":{"baseID":265,"pathIDs":[999],"plannedPathIDs":[999],"stageIndex":0,"usedAtStage":42,"rarity":"common","totalForms":1,"isShiny":true,"nature":"timid","dittoDisguise":265}}"#
+        try Data(saved.utf8).write(to: url)
+        let s = CompanionStore(provider: StubProvider(value: wurmpleLine), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 9))
+
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        let loaded = await waitUntil { s.currentLine != nil }
+        XCTAssertTrue(loaded)
+
+        XCTAssertEqual(s.state.active?.pathIDs, [265])
+        XCTAssertTrue([[265, 266, 267], [265, 268, 269]].contains(s.state.active?.plannedPathIDs ?? []))
+        XCTAssertEqual(s.state.active?.usedAtStage, 42)
+        XCTAssertTrue(s.state.active?.isShiny ?? false)
+        XCTAssertEqual(s.state.active?.nature, .timid)
+        XCTAssertEqual(s.state.active?.dittoDisguise, 265)
+        XCTAssertFalse(s.state.active?.dittoRevealed ?? true)
+    }
+
+    func testReloadLeafCurrentPlanDoesNotConsumeRNG() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-leaf-plan-\(UUID().uuidString).json")
+        let saved = #"{"active":{"baseID":265,"pathIDs":[265,266,267],"plannedPathIDs":[265,266,267],"stageIndex":2,"usedAtStage":42,"rarity":"common","totalForms":3}}"#
+        try Data(saved.utf8).write(to: url)
+        let rng = CountingRNG(seed: 9)
+        let s = CompanionStore(provider: StubProvider(value: wurmpleLine), clock: { fixedNow }, fileURL: url, rng: rng)
+
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        let loaded = await waitUntil { s.currentLine != nil }
+        XCTAssertTrue(loaded)
+
+        XCTAssertEqual(s.state.active?.pathIDs, [265, 266, 267])
+        XCTAssertEqual(s.state.active?.plannedPathIDs, [265, 266, 267])
+        XCTAssertEqual(rng.callCount, 0)
+    }
+
+    func testLineLoadPreservesUpdatesMadeWhileProviderIsSuspended() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-load-race-\(UUID().uuidString).json")
+        let saved = #"{"active":{"baseID":1,"pathIDs":[1],"stageIndex":0,"usedAtStage":0,"rarity":"common","totalForms":1,"nature":"adamant"},"inventory":{"mint":1}}"#
+        try Data(saved.utf8).write(to: url)
+        let provider = SuspendedLineProvider(value: linear3)
+        let s = CompanionStore(provider: provider, clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 7))
+
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        let suspensionDeadline = Date().addingTimeInterval(1)
+        while !(await provider.isSuspended()), Date() < suspensionDeadline {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        let isSuspended = await provider.isSuspended()
+        XCTAssertTrue(isSuspended, "line fetch should be suspended")
+
+        s.applyUsage(42)
+        let changedNature = try XCTUnwrap(s.useMint())
+        XCTAssertEqual(s.state.active?.usedAtStage, 42)
+        XCTAssertEqual(s.state.active?.nature, changedNature)
+
+        await provider.resume()
+        let loaded = await waitUntil { s.currentLine != nil }
+        XCTAssertTrue(loaded)
+
+        XCTAssertEqual(s.state.active?.usedAtStage, 42)
+        XCTAssertEqual(s.state.active?.nature, changedNature)
+        let persisted = try JSONDecoder().decode(CompanionState.self, from: Data(contentsOf: url))
+        XCTAssertEqual(persisted.active?.usedAtStage, 42)
+        XCTAssertEqual(persisted.active?.nature, changedNature)
+    }
+
     func testLocalizedName() async {
         let s = store(linear3)
         await s.hatch(baseID: 1)
@@ -449,21 +723,20 @@ final class CompanionStoreTests: XCTestCase {
         s.setLanguage(.ja); XCTAssertEqual(s.displayName, "ポ1")
     }
 
-    /// [문서화] 비대칭 깊이 분기 — totalForms=tree.depth(최장 경로)라 짧은 분기를 뽑으면 실제 경로가
-    /// totalForms 보다 짧다. 실 Gen1-5 라인은 분기 깊이가 대칭(뷰티플라이·이브이 등)이라 발생하지 않는다
-    /// (CompanionModel depth 주석 "분기는 보통 같은 깊이" 가정). 크래시·무한루프 없이 최종체에서 졸업하고
-    /// 실제 경로가 보존됨을 잠근다.
+    /// [문서화] 비대칭 깊이 분기에서도 부화 시 선택한 경로 길이를 totalForms 로 고정한다.
+    /// 크래시·무한루프 없이 최종체에서 졸업하고 실제 경로가 보존됨을 잠근다.
     func testAsymmetricBranchGraduatesSafely() async {
         let line = makeLine(base: 1, tree: node(1, [node(2), node(3, [node(4)])]))   // depth=3, 분기 {2, 3→4}
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-asym-\(UUID().uuidString).json")
         let s = CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 7))
         await s.hatch(baseID: 1)
-        XCTAssertEqual(s.state.active?.totalForms, 3, "totalForms = 최장 경로 깊이")
+        XCTAssertEqual(s.state.active?.totalForms, s.state.active?.plannedPathIDs.count,
+                       "totalForms = 선택된 계획 경로 길이")
         var guardCount = 0
         while s.state.active != nil, guardCount < 12 {
             guardCount += 1
             let stage = s.state.active!.stageIndex
-            s.applyUsage(PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: stage))
+            s.applyUsage(PokemonBalance.phaseThreshold(rarity: .common, totalForms: s.state.active!.totalForms, stageIndex: stage))
         }
         XCTAssertNil(s.state.active, "어느 분기든 최종체에서 졸업(크래시·무한루프 없음)")
         XCTAssertEqual(s.dexEntries.count, 1)
@@ -596,6 +869,7 @@ final class CompanionIdentityTests: XCTestCase {
          "collectedFinals":["4:6"],"language":"ko"}
         """
         let s = try JSONDecoder().decode(CompanionState.self, from: Data(old.utf8))
+        XCTAssertEqual(s.active?.plannedPathIDs, [1])
         XCTAssertEqual(s.active?.isShiny, false)
         XCTAssertNil(s.active?.nature)
         XCTAssertEqual(s.dex[0].isShiny, false)
@@ -690,6 +964,7 @@ final class CompanionIdentityTests: XCTestCase {
 
         XCTAssertNotNil(s.currentLine)
         XCTAssertEqual(s.state.active?.pathIDs, [56, 57])
+        XCTAssertEqual(s.state.active?.plannedPathIDs, [56, 57])
         XCTAssertEqual(s.state.active?.stageIndex, 1)
         XCTAssertEqual(s.state.active?.totalForms, 2)
         XCTAssertEqual(s.state.active?.usedAtStage, 123)

--- a/Tests/PokeTokenBarTests/DittoTests.swift
+++ b/Tests/PokeTokenBarTests/DittoTests.swift
@@ -31,6 +31,29 @@ private struct PrunedDittoTestProvider: PokeProviding {
     func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: 206, captureRate: 190)] }
 }
 
+private actor DelayedDittoProvider: PokeProviding {
+    private var continuation: CheckedContinuation<EvoLine, Never>?
+    private var suspended = false
+
+    func line(baseSpeciesID: Int) async throws -> EvoLine {
+        guard baseSpeciesID == PokemonOdds.dittoSpeciesID else { return disguiseLine }
+        return await withCheckedContinuation { continuation in
+            precondition(self.continuation == nil, "only one Ditto request may be suspended")
+            self.continuation = continuation
+            suspended = true
+        }
+    }
+
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: 1, captureRate: 255)] }
+    func isSuspended() -> Bool { suspended }
+    func resume() {
+        let pending = continuation
+        continuation = nil
+        suspended = false
+        pending?.resume(returning: dittoLine)
+    }
+}
+
 // MARK: 위장 롤 판정(순수) — 부화 롤은 .app 게이트라 실앱에서만 발동, 판정 로직은 순수 함수로 검증
 
 final class DittoDisguiseRollTests: XCTestCase {
@@ -103,6 +126,8 @@ final class DittoRevealTests: XCTestCase {
         XCTAssertEqual(s.state.active?.rarity, .rare, "메타몽 rare")
         XCTAssertEqual(s.state.active?.totalForms, 1, "메타몽 단일형태")
         XCTAssertEqual(s.state.active?.stageIndex, 0)
+        XCTAssertEqual(s.state.active?.pathIDs, [132])
+        XCTAssertEqual(s.state.active?.plannedPathIDs, [132])
         XCTAssertEqual(s.state.active?.usedAtStage, 300_000_000 - 125_000_000, "첫 진화 초과분 이월")
         XCTAssertNotNil(s.state.active?.dittoDisguise, "위장 마커 보존")
         XCTAssertEqual(s.celebration, .dittoReveal(shiny: false), "리빌 연출 발화")
@@ -114,7 +139,7 @@ final class DittoRevealTests: XCTestCase {
         let threshold = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 1, stageIndex: 0)
         XCTAssertEqual(threshold, 750_000_000)
         XCTAssertTrue(prunedDisguiseLine.tree.children.isEmpty, "#982 제거 후 #206은 leaf여야 한다")
-        let active = "{\"baseID\":206,\"pathIDs\":[206],\"stageIndex\":0,"
+        let active = "{\"baseID\":206,\"pathIDs\":[206],\"plannedPathIDs\":[206,982],\"stageIndex\":0,"
             + "\"usedAtStage\":\(threshold),\"rarity\":\"common\",\"totalForms\":2,\"isShiny\":true,"
             + "\"nature\":\"timid\",\"dittoDisguise\":206,\"dittoRevealed\":false}"
         let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":1000000000,\"lastDate\":\"d1\","
@@ -128,6 +153,7 @@ final class DittoRevealTests: XCTestCase {
         let revealed = try XCTUnwrap(s.state.active)
         XCTAssertEqual(revealed.baseID, PokemonOdds.dittoSpeciesID)
         XCTAssertEqual(revealed.pathIDs, [PokemonOdds.dittoSpeciesID])
+        XCTAssertEqual(revealed.plannedPathIDs, [PokemonOdds.dittoSpeciesID])
         XCTAssertEqual(revealed.usedAtStage, 0, "정규화된 단일형태 임계의 초과분만 이월")
         XCTAssertEqual(revealed.dittoDisguise, 206)
         XCTAssertTrue(revealed.dittoRevealed)
@@ -135,6 +161,47 @@ final class DittoRevealTests: XCTestCase {
         XCTAssertEqual(revealed.nature, .timid)
         XCTAssertFalse(s.state.dex.contains { $0.finalID == 206 }, "위장체를 졸업 처리하면 안 된다")
         XCTAssertFalse(s.state.collectedFinals.contains("206:206"))
+    }
+
+    func testDelayedRevealDoesNotConvertSameBaseReplacementDisguise() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("ditto-race-\(UUID().uuidString).json")
+        let active = #"{"baseID":1,"pathIDs":[1],"plannedPathIDs":[1,2,3],"stageIndex":0,"usedAtStage":125000000,"rarity":"common","totalForms":3,"dittoDisguise":1}"#
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":2000000000,\"lastDate\":\"d1\",\"active\":\(active),\"dex\":[],\"collectedFinals\":[]}"
+        try Data(json.utf8).write(to: url)
+        let provider = DelayedDittoProvider()
+        var seed: UInt64?
+        for candidate: UInt64 in 0..<100_000 {
+            var rng = SeededRNG(seed: candidate)
+            _ = rng.next(); _ = rng.next()
+            if rng.next() % PokemonOdds.dittoDisguiseDenominator == 0 { seed = candidate; break }
+        }
+        let selectedSeed = try XCTUnwrap(seed)
+        let s = CompanionStore(provider: provider, clock: { dNow }, fileURL: url,
+                               rng: SeededRNG(seed: selectedSeed), dittoDisguiseRollingEnabled: true)
+
+        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        let deadline = Date().addingTimeInterval(1)
+        while !(await provider.isSuspended()), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        let isSuspended = await provider.isSuspended()
+        XCTAssertTrue(isSuspended)
+
+        XCTAssertTrue(s.buyFreshEgg())
+        await s.hatch(baseID: 1)
+        XCTAssertEqual(s.state.active?.baseID, 1)
+        XCTAssertFalse(s.state.active?.dittoRevealed ?? true)
+        XCTAssertNotNil(s.state.active?.dittoDisguise)
+        XCTAssertEqual(s.state.active?.usedAtStage, 0)
+
+        await provider.resume()
+        for _ in 0..<200 { await Task.yield() }
+        XCTAssertEqual(s.state.active?.baseID, 1)
+        XCTAssertFalse(s.state.active?.dittoRevealed ?? true)
+        XCTAssertNotNil(s.state.active?.dittoDisguise)
+        XCTAssertEqual(s.state.active?.usedAtStage, 0)
+        XCTAssertNotEqual(s.currentSpeciesID, PokemonOdds.dittoSpeciesID)
     }
 
     /// 리빌 후 이로치가 공개된다(위장 중 숨겼던 것) + 이로치 리빌 연출.

--- a/Tests/PokeTokenBarTests/EvoLineLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/EvoLineLayoutTests.swift
@@ -3,25 +3,24 @@ import SwiftUI
 @testable import PokeTokenBar
 
 // 진화 라인 가로 오버플로 가드.
-// 분기 라인(이브이 = 본체 1 + 진화 후보 8)은 폭 제한이 없으면 팝오버 콘텐츠 폭(332pt)을 훌쩍 넘고,
-// 넘친 자식이 부모 VStack 폭을 부풀려 팝오버 콘텐츠 "전체"가 좌우로 잘렸다. maxWidth 를 주면
-// 그 폭 안에서 가로 스크롤한다.
+// 긴 진화 라인은 폭 제한이 없으면 팝오버 콘텐츠 폭(332pt)을 훌쩍 넘고, 넘친 자식이 부모 VStack 폭을
+// 부풀려 팝오버 콘텐츠 "전체"가 좌우로 잘렸다. maxWidth 를 주면 그 폭 안에서 가로 스크롤한다.
 //
 // 트리거 브랜치를 직접 재현한다: maxWidth 없는 라인이 실제로 넘치는지까지 확인해야
 // "fit 어서션이 애초에 통과할 조건이었다"는 false confidence 를 막는다.
 @MainActor
 final class EvoLineLayoutTests: XCTestCase {
 
-    /// 홈 화면의 이브이 노드 — 현재 개체 + 진화 후보 전부(샤미드·쥬피썬더·부스터·에브이·블래키·
-    /// 리피아·글레이시아·님피아). PokéAPI evolution-chain 이 그대로 주는 분기 폭.
-    private var eeveeNodes: [(id: Int, kind: String)] {
-        [(id: 133, kind: "cur")]
-            + [134, 135, 136, 196, 197, 470, 471, 700].map { (id: $0, kind: "future") }
+    /// 긴 라인 합성 입력. 홈 화면의 미확정 분기는 `?` 하나로 숨기지만, EvoLineView 자체의
+    /// 오버플로 방어는 어떤 긴 노드 배열에도 유지돼야 한다.
+    private var longNodes: [EvoLineItem] {
+        [EvoLineItem(.species(133), .current)]
+            + [134, 135, 136, 196, 197, 470, 471, 700].map { EvoLineItem(.species($0), .future) }
     }
 
     /// 3단계 일반 라인(이상해씨 계열) — 스크롤이 붙으면 안 되는 대조군.
-    private var threeStageNodes: [(id: Int, kind: String)] {
-        [(id: 1, kind: "done"), (id: 2, kind: "cur"), (id: 3, kind: "future")]
+    private var threeStageNodes: [EvoLineItem] {
+        [EvoLineItem(.species(1), .done), EvoLineItem(.species(2), .current), EvoLineItem(.species(3), .future)]
     }
 
     /// 팝오버가 실제로 제안하는 폭으로 뷰를 재어 렌더 폭을 얻는다.
@@ -32,17 +31,17 @@ final class EvoLineLayoutTests: XCTestCase {
 
     // MARK: 렌더 폭 — 실제 레이아웃 회귀
 
-    /// 트리거 재현: 폭 제한이 없으면 이브이 라인은 팝오버 콘텐츠 폭을 넘는다(= 버그 조건).
-    func testEeveeLineWithoutMaxWidthOverflowsPopoverContent() {
-        let w = renderedWidth(EvoLineView(nodes: eeveeNodes),
+    /// 트리거 재현: 폭 제한이 없으면 긴 라인은 팝오버 콘텐츠 폭을 넘는다(= 버그 조건).
+    func testLongEvolutionLineWithoutMaxWidthOverflowsPopoverContent() {
+        let w = renderedWidth(EvoLineView(nodes: longNodes, language: .en),
                               proposing: PopoverMetrics.contentWidth)
         XCTAssertGreaterThan(w, PopoverMetrics.contentWidth,
                              "폭 제한 없는 진화 라인은 넘쳐야 한다 — 안 넘치면 아래 fit 검증이 무의미해진다")
     }
 
     /// 수정 후: 팝오버가 주는 폭을 넘지 않는다(→ 부모 VStack 이 안 부풀고 팝오버가 안 잘린다).
-    func testEeveeLineFitsPopoverContentWidth() {
-        let w = renderedWidth(EvoLineView(nodes: eeveeNodes, maxWidth: PopoverMetrics.contentWidth),
+    func testLongEvolutionLineFitsPopoverContentWidth() {
+        let w = renderedWidth(EvoLineView(nodes: longNodes, language: .en, maxWidth: PopoverMetrics.contentWidth),
                               proposing: PopoverMetrics.contentWidth)
         XCTAssertLessThanOrEqual(w, PopoverMetrics.contentWidth)
     }
@@ -50,10 +49,11 @@ final class EvoLineLayoutTests: XCTestCase {
     /// 도감 행(썸네일 56 + 이름 라벨)도 카드 안쪽 폭을 넘지 않는다.
     func testLongDexChainFitsCardWidth() {
         let cardWidth = PopoverMetrics.contentWidth - 16   // DexEntryRow 카드 좌우 패딩 8pt
-        let nodes = [1, 2, 3, 4, 5].map { (id: $0, kind: "done") }
-        let names = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, "이상해씨") })
+        let ids = [1, 2, 3, 4, 5]
+        let nodes = ids.map { EvoLineItem(.species($0), .done) }
+        let names = Dictionary(uniqueKeysWithValues: ids.map { ($0, "이상해씨") })
         let w = renderedWidth(
-            EvoLineView(nodes: nodes, thumb: 56, names: names, maxWidth: cardWidth),
+            EvoLineView(nodes: nodes, language: .ko, thumb: 56, names: names, maxWidth: cardWidth),
             proposing: cardWidth)
         XCTAssertLessThanOrEqual(w, cardWidth)
     }
@@ -63,7 +63,7 @@ final class EvoLineLayoutTests: XCTestCase {
         // 3칸 = 40*3 + 화살표 10*2 + 간격 2*4 = 148pt
         let expected = EvoLineView.rowWidth(count: 3, thumb: 40, hasNames: false)
         XCTAssertEqual(expected, 148)
-        let w = renderedWidth(EvoLineView(nodes: threeStageNodes, maxWidth: PopoverMetrics.contentWidth),
+        let w = renderedWidth(EvoLineView(nodes: threeStageNodes, language: .en, maxWidth: PopoverMetrics.contentWidth),
                               proposing: PopoverMetrics.contentWidth)
         XCTAssertEqual(w, expected, accuracy: 0.5)
     }
@@ -73,8 +73,8 @@ final class EvoLineLayoutTests: XCTestCase {
     /// rowWidth 는 레이아웃과 같은 식이어야 한다(측정값과 일치 — 어긋나면 스크롤 판정이 틀어진다).
     func testRowWidthMatchesRenderedWidth() {
         for count in 1...9 {
-            let nodes = (1...count).map { (id: $0, kind: "done") }
-            let rendered = renderedWidth(EvoLineView(nodes: nodes), proposing: 4000)
+            let nodes = (1...count).map { EvoLineItem(.species($0), .done) }
+            let rendered = renderedWidth(EvoLineView(nodes: nodes, language: .en), proposing: 4000)
             XCTAssertEqual(rendered,
                            EvoLineView.rowWidth(count: count, thumb: 40, hasNames: false),
                            accuracy: 0.5, "count=\(count)")

--- a/Tests/PokeTokenBarTests/EvoLineLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/EvoLineLayoutTests.swift
@@ -33,7 +33,7 @@ final class EvoLineLayoutTests: XCTestCase {
 
     /// 트리거 재현: 폭 제한이 없으면 긴 라인은 팝오버 콘텐츠 폭을 넘는다(= 버그 조건).
     func testLongEvolutionLineWithoutMaxWidthOverflowsPopoverContent() {
-        let w = renderedWidth(EvoLineView(nodes: longNodes, language: .en),
+        let w = renderedWidth(EvoLineView(nodes: longNodes, mysteryLabel: L(.en).unknownNextEvolution),
                               proposing: PopoverMetrics.contentWidth)
         XCTAssertGreaterThan(w, PopoverMetrics.contentWidth,
                              "폭 제한 없는 진화 라인은 넘쳐야 한다 — 안 넘치면 아래 fit 검증이 무의미해진다")
@@ -41,7 +41,8 @@ final class EvoLineLayoutTests: XCTestCase {
 
     /// 수정 후: 팝오버가 주는 폭을 넘지 않는다(→ 부모 VStack 이 안 부풀고 팝오버가 안 잘린다).
     func testLongEvolutionLineFitsPopoverContentWidth() {
-        let w = renderedWidth(EvoLineView(nodes: longNodes, language: .en, maxWidth: PopoverMetrics.contentWidth),
+        let w = renderedWidth(EvoLineView(nodes: longNodes, mysteryLabel: L(.en).unknownNextEvolution,
+                                          maxWidth: PopoverMetrics.contentWidth),
                               proposing: PopoverMetrics.contentWidth)
         XCTAssertLessThanOrEqual(w, PopoverMetrics.contentWidth)
     }
@@ -53,7 +54,8 @@ final class EvoLineLayoutTests: XCTestCase {
         let nodes = ids.map { EvoLineItem(.species($0), .done) }
         let names = Dictionary(uniqueKeysWithValues: ids.map { ($0, "이상해씨") })
         let w = renderedWidth(
-            EvoLineView(nodes: nodes, language: .ko, thumb: 56, names: names, maxWidth: cardWidth),
+            EvoLineView(nodes: nodes, mysteryLabel: L(.ko).unknownNextEvolution,
+                        thumb: 56, names: names, maxWidth: cardWidth),
             proposing: cardWidth)
         XCTAssertLessThanOrEqual(w, cardWidth)
     }
@@ -63,7 +65,8 @@ final class EvoLineLayoutTests: XCTestCase {
         // 3칸 = 40*3 + 화살표 10*2 + 간격 2*4 = 148pt
         let expected = EvoLineView.rowWidth(count: 3, thumb: 40, hasNames: false)
         XCTAssertEqual(expected, 148)
-        let w = renderedWidth(EvoLineView(nodes: threeStageNodes, language: .en, maxWidth: PopoverMetrics.contentWidth),
+        let w = renderedWidth(EvoLineView(nodes: threeStageNodes, mysteryLabel: L(.en).unknownNextEvolution,
+                                          maxWidth: PopoverMetrics.contentWidth),
                               proposing: PopoverMetrics.contentWidth)
         XCTAssertEqual(w, expected, accuracy: 0.5)
     }
@@ -73,12 +76,27 @@ final class EvoLineLayoutTests: XCTestCase {
     /// rowWidth 는 레이아웃과 같은 식이어야 한다(측정값과 일치 — 어긋나면 스크롤 판정이 틀어진다).
     func testRowWidthMatchesRenderedWidth() {
         for count in 1...9 {
-            let nodes = (1...count).map { EvoLineItem(.species($0), .done) }
-            let rendered = renderedWidth(EvoLineView(nodes: nodes, language: .en), proposing: 4000)
+            let nodes = (1...count).map { i in
+                i == count ? EvoLineItem(.mystery, .future) : EvoLineItem(.species(i), .done)
+            }
+            let rendered = renderedWidth(EvoLineView(nodes: nodes, mysteryLabel: L(.en).unknownNextEvolution),
+                                         proposing: 4000)
             XCTAssertEqual(rendered,
                            EvoLineView.rowWidth(count: count, thumb: 40, hasNames: false),
                            accuracy: 0.5, "count=\(count)")
         }
+    }
+
+    /// mystery 는 이름이 없더라도 도감 라인의 이름 열 폭을 예약해야 rowWidth 기반 스크롤 판정과 일치한다.
+    func testNamedMysteryCellReservesNameColumnWidth() {
+        let nodes = [EvoLineItem(.species(1), .done), EvoLineItem(.mystery, .future)]
+        let names = [1: String(repeating: "W", count: 20)]
+        let rendered = renderedWidth(EvoLineView(nodes: nodes, mysteryLabel: L(.en).unknownNextEvolution, names: names),
+                                     proposing: 4000)
+
+        XCTAssertEqual(rendered,
+                       EvoLineView.rowWidth(count: nodes.count, thumb: 40, hasNames: true),
+                       accuracy: 0.5)
     }
 
     /// 홈 라인(썸네일 40)은 6칸까지 그대로, 7칸부터 스크롤.

--- a/Tests/PokeTokenBarTests/ModelLogicTests.swift
+++ b/Tests/PokeTokenBarTests/ModelLogicTests.swift
@@ -202,6 +202,17 @@ final class StatePersistenceLogicTests: XCTestCase {
         XCTAssertEqual(over.currentID, 1)
     }
 
+    func testMonStateDecodeClampsStageIndexToRealizedPathBounds() throws {
+        let upper = #"{"baseID":1,"pathIDs":[1,2],"stageIndex":5,"usedAtStage":0,"rarity":"common","totalForms":2}"#
+        let lower = #"{"baseID":1,"pathIDs":[1,2],"stageIndex":-1,"usedAtStage":0,"rarity":"common","totalForms":2}"#
+
+        let decodedUpper = try JSONDecoder().decode(MonState.self, from: Data(upper.utf8))
+        let decodedLower = try JSONDecoder().decode(MonState.self, from: Data(lower.utf8))
+
+        XCTAssertEqual(decodedUpper.stageIndex, 1)
+        XCTAssertEqual(decodedLower.stageIndex, 0)
+    }
+
     func testMonStateRoundTripPreservesDistinctPlannedPath() throws {
         let state = MonState(baseID: 265, pathIDs: [265], plannedPathIDs: [265, 266, 267],
                              stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 3)

--- a/Tests/PokeTokenBarTests/ModelLogicTests.swift
+++ b/Tests/PokeTokenBarTests/ModelLogicTests.swift
@@ -202,6 +202,44 @@ final class StatePersistenceLogicTests: XCTestCase {
         XCTAssertEqual(over.currentID, 1)
     }
 
+    func testMonStateRoundTripPreservesDistinctPlannedPath() throws {
+        let state = MonState(baseID: 265, pathIDs: [265], plannedPathIDs: [265, 266, 267],
+                             stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 3)
+
+        let decoded = try JSONDecoder().decode(MonState.self, from: JSONEncoder().encode(state))
+
+        XCTAssertEqual(decoded.pathIDs, [265])
+        XCTAssertEqual(decoded.plannedPathIDs, [265, 266, 267])
+    }
+
+    func testMonStateLegacyDecodeUsesRealizedPathAsPlan() throws {
+        let legacy = """
+        {"baseID":265,"pathIDs":[265,266],"stageIndex":1,"usedAtStage":0,"rarity":"common","totalForms":3}
+        """
+
+        let decoded = try JSONDecoder().decode(MonState.self, from: Data(legacy.utf8))
+
+        XCTAssertEqual(decoded.pathIDs, [265, 266])
+        XCTAssertEqual(decoded.plannedPathIDs, [265, 266])
+    }
+
+    func testMonStateEmptySavedPlanUsesRealizedPath() throws {
+        let saved = """
+        {"baseID":265,"pathIDs":[265,266],"plannedPathIDs":[],"stageIndex":1,"usedAtStage":0,"rarity":"common","totalForms":3}
+        """
+
+        let decoded = try JSONDecoder().decode(MonState.self, from: Data(saved.utf8))
+
+        XCTAssertEqual(decoded.plannedPathIDs, [265, 266])
+    }
+
+    func testMonStateEmptyInitialPlanUsesRealizedPath() {
+        let state = MonState(baseID: 265, pathIDs: [265, 266], plannedPathIDs: [],
+                             stageIndex: 1, usedAtStage: 0, rarity: .common, totalForms: 3)
+
+        XCTAssertEqual(state.plannedPathIDs, [265, 266])
+    }
+
     func testCompanionStateEncodeDecodeRoundTrip() throws {
         var st = CompanionState()
         st.installBaselineSet = true


### PR DESCRIPTION
## Summary

- Preselect and persist a complete evolution path when a companion hatches.
- Render complete linear evolution chains while keeping unrevealed branches hidden as `?`.
- Reveal only the selected branch as the companion evolves.
- Validate and migrate saved companion states so existing progress remains intact.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

| Before | After |
| ------ | ----- |
| Branching evolution trees could appear as a misleading linear chain of sibling forms. | Complete linear chains are shown, while unresolved branches are represented by `?`. |
| The next branch was selected only when evolution occurred. | The complete route is selected at hatch time and remains stable across relaunches. |

### Tested cases

| Case | Evolution line |
| --- | --- |
| Linear three-stage evolution<br>Bulbasaur → Ivysaur → Venusaur | <img width="360" alt="Bulbasaur linear evolution" src="https://github.com/user-attachments/assets/a763dc05-6365-4a56-91af-20b16acc1672" /> |
| Direct branch<br>Wurmple → ? | <img width="360" alt="Wurmple direct branch" src="https://github.com/user-attachments/assets/d1eb1a74-b952-466c-b8d7-1f0e9f35bcf6" /> |
| Multiple direct branches<br>Eevee → ? | <img width="360" alt="Eevee multiple branches" src="https://github.com/user-attachments/assets/207eb38e-1d05-494d-873e-68e344fef5b0" /> |
| Delayed branch<br>Oddish → Gloom → ? | <img width="360" alt="Oddish delayed branch" src="https://github.com/user-attachments/assets/dbded805-ccbf-4ef2-b145-f47e3f1a84da" /> |

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change