### PR TITLE
fix: provider tabs wrap mid-word once six services are detected

### DIFF
--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 enum PopoverTab { case home, shop, bag, collection }
@@ -162,24 +163,10 @@ struct PopoverView: View {
     }
 
     private var providerTabBar: some View {
-        HStack(spacing: 6) {
-            ForEach(store.snapshots) { snap in
-                let isSelected = snap.providerID == selectedSnapshot?.providerID
-                Button {
-                    nav.providerID = snap.providerID
-                } label: {
-                    Text(snap.displayName)
-                        .font(.caption.weight(isSelected ? .semibold : .regular))
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
-                        .background(isSelected ? Color.accentColor.opacity(0.18) : Color.secondary.opacity(0.08))
-                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
-                        .clipShape(Capsule())
-                }
-                .buttonStyle(.plain)
-            }
-            Spacer()
-        }
+        ProviderTabBar(
+            snapshots: store.snapshots,
+            selectedID: selectedSnapshot?.providerID,
+            onSelect: { nav.providerID = $0 })
     }
 
     private func periodLabel(_ name: String, tokens: Int, cost: Double?) -> some View {
@@ -607,5 +594,40 @@ struct PopoverView: View {
             .buttonStyle(.borderless)
             .help(l.quit)
         }
+    }
+}
+
+/// 서비스 전환 탭. 프로바이더가 늘면 캡슐 합계 폭이 `PopoverMetrics.contentWidth` 를 넘는다
+/// (6개 기준 439pt vs 332pt). 폭 제한만 있고 줄바꿈을 막지 않으면 SwiftUI 가 캡슐 텍스트를 눌러
+/// "Curso/r"·"Code/x" 처럼 **단어 중간에서** 접고 탭 바가 2~3줄이 된다.
+/// 가로 스크롤 + `lineLimit(1)`/`fixedSize` 로 각 탭이 항상 자연 폭 한 줄을 유지한다.
+/// (`Spacer()` 는 가로 ScrollView 안에서 무한 확장하므로 쓰지 않는다.)
+struct ProviderTabBar: View {
+    let snapshots: [ProviderSnapshot]
+    let selectedID: String?
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(snapshots) { snap in
+                    let isSelected = snap.providerID == selectedID
+                    Button { onSelect(snap.providerID) } label: {
+                        Text(snap.displayName)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .font(.caption.weight(isSelected ? .semibold : .regular))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                            .background(isSelected ? Color.accentColor.opacity(0.18) : Color.secondary.opacity(0.08))
+                            .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        // 탭이 적으면(대부분의 사용자) 스크롤·바운스가 생기지 않아 기존과 동일하게 보인다.
+        .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
     }
 }

--- a/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import SwiftUI
+@testable import PokeTokenBar
+
+// 프로바이더 탭 바 가로 오버플로 가드.
+// 등록 프로바이더가 6개가 되면서 캡슐 합계 폭이 팝오버 콘텐츠 폭(332pt)을 넘었고, 줄바꿈을 막지
+// 않은 탓에 SwiftUI 가 캡슐 텍스트를 눌러 "Curso/r"·"Code/x" 처럼 단어 중간에서 접었다.
+// (5개 시점에 이미 넘고 있었다 — Cursor 추가로 드러났을 뿐이다.)
+//
+// EvoLineLayoutTests 와 같은 방식으로 트리거 브랜치를 직접 재현한다: 탭들이 실제로 넘치는지까지
+// 확인해야 "fit 어서션이 애초에 통과할 조건이었다"는 false confidence 를 막는다.
+@MainActor
+final class ProviderTabLayoutTests: XCTestCase {
+
+    private func snapshot(_ id: String, _ name: String) -> ProviderSnapshot {
+        ProviderSnapshot(providerID: id, displayName: name, today: nil, activeBlock: nil,
+                         weekTotal: nil, monthTotal: nil, fetchedAt: Date())
+    }
+
+    /// 현재 등록된 6개 프로바이더의 표시 이름 — UsageStore.init 기본 배열과 같은 순서.
+    private var allProviders: [ProviderSnapshot] {
+        [("claude_code", "Claude Code"), ("codex", "Codex"), ("gemini", "Gemini"),
+         ("opencode", "OpenCode"), ("hermes", "Hermes Agent"), ("cursor", "Cursor")]
+            .map { snapshot($0.0, $0.1) }
+    }
+
+    private func bar(_ snaps: [ProviderSnapshot]) -> ProviderTabBar {
+        ProviderTabBar(snapshots: snaps, selectedID: snaps.first?.providerID, onSelect: { _ in })
+    }
+
+    /// 팝오버가 실제로 제안하는 폭으로 뷰를 재어 렌더 크기를 얻는다.
+    private func rendered(_ view: some View, proposing: CGFloat) -> CGSize {
+        NSHostingController(rootView: view).sizeThatFits(in: CGSize(width: proposing, height: 600))
+    }
+
+    /// 트리거 재현: 스크롤 없이 나열하면 6개 탭은 팝오버 콘텐츠 폭을 넘는다(= 버그 조건).
+    /// 넘치지 않으면 아래 단일 행 검증이 무의미해지므로 이 테스트가 먼저 실패해야 한다.
+    func testAllProviderTabsExceedPopoverContentWidthWhenLaidOutInOneRow() {
+        let natural = HStack(spacing: 6) {
+            ForEach(allProviders) { snap in
+                Text(snap.displayName)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 10).padding(.vertical, 4)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+        }
+        let w = rendered(natural, proposing: .greatestFiniteMagnitude).width
+        XCTAssertGreaterThan(w, PopoverMetrics.contentWidth,
+                             "6개 탭은 한 줄로 펼치면 콘텐츠 폭을 넘어야 한다 — 안 넘으면 이 가드가 무의미하다")
+    }
+
+    /// 수정 후: 탭이 6개여도 탭 바는 한 행 높이를 유지한다(= 캡슐 텍스트가 접히지 않는다).
+    /// 기준선은 탭 2개짜리 바 — 넘치지 않는 대조군이다.
+    func testProviderTabBarStaysSingleRowWithAllProviders() {
+        let baseline = rendered(bar(Array(allProviders.prefix(2))),
+                                proposing: PopoverMetrics.contentWidth).height
+        let full = rendered(bar(allProviders), proposing: PopoverMetrics.contentWidth).height
+        XCTAssertEqual(full, baseline, accuracy: 0.5,
+                       "6개 탭 바 높이 \(full) 가 2개 기준선 \(baseline) 을 넘으면 캡슐 텍스트가 접힌 것이다")
+    }
+
+    /// 탭 바 자체는 주어진 폭 안에 머문다(넘친 자식이 부모 VStack 을 부풀려 팝오버를 자르지 않게).
+    func testProviderTabBarFitsPopoverContentWidth() {
+        let w = rendered(bar(allProviders), proposing: PopoverMetrics.contentWidth).width
+        XCTAssertLessThanOrEqual(w, PopoverMetrics.contentWidth)
+    }
+
+    /// 탭 하나가 단독으로 콘텐츠 폭을 넘으면 스크롤로도 못 구한다 — 새 프로바이더 이름 길이 가드.
+    func testNoSingleProviderTabExceedsContentWidth() {
+        for snap in allProviders {
+            let w = rendered(bar([snap]), proposing: PopoverMetrics.contentWidth).width
+            XCTAssertLessThanOrEqual(w, PopoverMetrics.contentWidth,
+                                     "\(snap.displayName) 탭 하나가 콘텐츠 폭을 넘는다")
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Found during pre-release QA. The service switcher (`providerTabBar`) was a plain `HStack` with no scroll container and no line limit, so its capsules are laid out against the 332pt popover content width:

| Providers | Capsule width needed | Result |
|---|---|---|
| 4 | 281pt | fits |
| 5 (before this release) | 379pt | **overflows by 47pt** |
| 6 (with Cursor) | 439pt | **overflows by 107pt** |

SwiftUI compresses each capsule and wraps its label, breaking words mid-syllable. Rendering the real `PopoverView` with six providers produces:

`Claud/e/Code` · `Code/x` · `Gemi/ni` · `Open/Code` · `Herme/s/Agent` · `Curso/r`

The row grows to three lines. This already happened at five providers; adding Cursor made it wider and more likely to be hit.

## Fix

The bar is extracted into a `ProviderTabBar` view and wrapped in a horizontal `ScrollView`, with `lineLimit(1)` and `fixedSize(horizontal: true, vertical: false)` on the label so each tab keeps its natural width on a single row.

The trailing `Spacer()` is removed — inside a horizontal `ScrollView` it expands to infinity. `scrollBounceBehavior(.basedOnSize, axes: .horizontal)` keeps the common two- or three-provider case visually identical to before: no scroll, no bounce.

## Tests

`ProviderTabLayoutTests` measures the real bar through `NSHostingController.sizeThatFits`, following the pattern in `EvoLineLayoutTests`:

- **Trigger reproduced first** — six tabs laid out in one row must exceed the content width. Without this the fit assertions could pass for the wrong reason.
- Six tabs must render at the same height as the two-tab baseline (21pt) — a taller bar means the labels wrapped.
- The bar stays within the offered width, so it can't inflate the parent `VStack` and clip the popover.
- No single tab may exceed the content width on its own — a guard for future provider names, since scrolling can't rescue a tab that is too wide by itself.

Verified the height test fails on the pre-fix code (47pt against the 21pt baseline) and passes after.

`swift test`: 388 passing, 0 failures.

## Type of change

- [x] Bug fix
- [ ] New feature

## UI changes

Tab row keeps one line at any provider count. With five or more providers the row scrolls horizontally; with fewer it is unchanged.