### PR TITLE
i18n: name the bubble toggle after the channel, not today's only alert

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -115,8 +115,9 @@ struct L {
           "ポケモンが画面の上に浮かびます — ドラッグで移動できます")
     }
     var floatingPetSizeLabel: String { t("크기", "Size", "サイズ") }
+    /// 지금은 한도 알림만 말풍선으로 뜨지만, 알림 종류가 늘어도 이 라벨은 그대로 쓴다.
     var floatingPetBubbleAlertsLabel: String {
-        t("한도 알림을 말풍선으로", "Limit alerts as bubbles", "上限アラートを吹き出しで")
+        t("말풍선으로 알림 받기", "Show notifications as bubbles", "通知を吹き出しで表示")
     }
     var floatingPetMenuOpen: String { t("토큰 바 열기", "Open Token Bar", "トークンバーを開く") }
     var floatingPetMenuHide: String {


### PR DESCRIPTION
## Why

The floating-pet toggle read "Limit alerts as bubbles", which names *the one notification that happens to use the bubble today* rather than what the toggle actually controls. Any second kind of bubble notification would make the label wrong and force a rename.

## Change

| | Before | After |
|---|---|---|
| ko | 한도 알림을 말풍선으로 | **말풍선으로 알림 받기** |
| en | Limit alerts as bubbles | **Show notifications as bubbles** |
| ja | 上限アラートを吹き出しで | **通知を吹き出しで表示** |

Behaviour is unchanged — limit alerts are still the only thing that renders a bubble. The `floatingPetBubbleAlerts` defaults key is untouched, so existing user settings carry over.

## Layout

Measured against the 260pt available in a settings row (332pt content − 24pt row padding − 10pt spacing − 38pt switch):

| Locale | Width | Margin |
|---|---|---|
| ko | 108.4pt | 151pt |
| en | 180.8pt | 79pt |
| ja | 112.5pt | 147pt |

English grew by 44pt but still clears the row with 79pt to spare, so no wrapping.

`swift test`: 388 passing.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / wording

## UI changes

Settings → Floating Pet → toggle label only.