### PR TITLE
feat: add Grok CLI as a usage provider

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor）を、macOS メニューバーの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
+PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor・Grok CLI）を、macOS メニューバーの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
 
-> トークン使用量はローカルの Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor データから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
+> トークン使用量はローカルの Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor・Grok CLI データから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
 
 ## なぜ
 
@@ -33,7 +33,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 
 ## しくみ
 
-1. 🥚 **いつも通りコーディング。** Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor で使うトークンがタマゴを温めます — 追加の操作は不要です。
+1. 🥚 **いつも通りコーディング。** Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor・Grok CLI で使うトークンがタマゴを温めます — 追加の操作は不要です。
 2. 🐣 **孵化。** [PokéAPI](https://pokeapi.co/) の**第1〜5世代すべての進化系統（起点329種）**から、公式の捕獲率で重み付けされて生まれます — よくいるポケモンは頻繁に、伝説は129回に1回。孵化したポケモンは育成中もすぐに **図鑑** に表示されます。孵化ごとに25種類のせいかくがひとつ決まり — **ごくまれな偶然で ✨ 色違いが生まれます**。
 3. ⚡ **進化。** コーディングを続けると実際の進化ツリー（1/2/3段階、分岐）に沿って育ち、各段階で小さな演出が流れます。
 4. 🎓 **卒業 & 収集。** 最終進化 + 閾値で **図鑑** に永久保存されます — レアなほど時間がかかり（ヘビーユーザーで common ≈3日 → legendary ≈24日）— 新しいタマゴが届きます。
@@ -97,7 +97,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 ## そのほかにも
 
 - **インタラクティブなフローティングペット** — ホバーで今日の使用量、クリックでメイン画面、右クリックでメニュー。上限アラートは吹き出しでも表示。
-- **サービス別タブ** — Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor のうち2つ以上が検出されると、小さなタブでサービス別の詳細を切替（今日の合計は合算のまま）。
+- **サービス別タブ** — Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor・Grok CLI のうち2つ以上が検出されると、小さなタブでサービス別の詳細を切替（今日の合計は合算のまま）。
 - **公式の上限** — Claude・Codex の5時間／週間使用率とリセットのカウントダウンを、今日の数字のすぐ下に。
 - **消費予測** — 現在の5時間ウィンドウが100%に達する時刻を予測。
 - **アプリ内アップデート** — ワンクリックの更新確認、設定に現在のバージョンを表示。
@@ -112,6 +112,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 | **OpenCode** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Hermes Agent** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Cursor** | 今日 · 5時間ブロック · 週 · 月 | — |
+| **Grok CLI** | 今日 · 5時間ブロック · 週 · 月 | — |
 
 すべてローカルから読み取り — 外部の使用量CLIは不要。ツール追加はプロバイダーファイル1つで完結します（[CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) 参照）。
 
@@ -119,7 +120,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 
 ### 必要条件
 
-macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor データから直接読み取り、外部の使用量 CLI は不要です。
+macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor・Grok CLI データから直接読み取り、外部の使用量 CLI は不要です。
 
 ### Homebrew
 
@@ -158,6 +159,7 @@ swift test                   # ユニットテスト
 | `~/.local/share/opencode/opencode.db` | OpenCode daily/blocks/weekly/monthly | SQLite 読み取り専用；レガシー `storage/message` JSON にも対応 |
 | `~/.hermes/state.db` | Hermes Agent daily/blocks/weekly/monthly | SQLite 読み取り専用；セッショントークン合計と保存済みコスト |
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite 読み取り専用；`cursorDiskKV` バブルエントリの `tokenCount` |
+| `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` レコード（ターン単位の `usage`、サーバー報告のコスト）；サブエージェントのセッションは親ターンに合算済みのため除外 |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 公式 5h/週間 % | 非公式 endpoint；Keychain は**更新ボタンを押した時のみ**読み取り — 自動更新では読みません |
 | `codex app-server` | Codex 公式 5h/週間 % | ローカル子プロセス；アカウント snapshot のみ、モデル turn なし |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | ポケモンの種・進化 | ランタイム取得；ローカルキャッシュ、バンドルしない |
@@ -167,7 +169,7 @@ swift test                   # ユニットテスト
 
 ## プライバシー & 権限
 
-- **オンデバイス。** トークン使用量はローカルの Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor データから直接読み取ります。使用量のアップロードやモデル turn の実行は行いません。
+- **オンデバイス。** トークン使用量はローカルの Claude Code・Codex・Gemini CLI・OpenCode・Hermes Agent・Cursor・Grok CLI データから直接読み取ります。使用量のアップロードやモデル turn の実行は行いません。
 - **外部リクエスト。** 本アプリは完全オフラインではありません。7つのホストに接続します — `pokeapi.co`・`graphql.pokeapi.co`（種・進化）、`raw.githubusercontent.com`（スプライト）、`api.anthropic.com`（Claude 公式の上限）、`status.claude.com`・`status.openai.com`（障害バナー — 設定でオフ可）、`api.github.com`（アップデート確認）。**いずれのリクエストにも使用量・トークン・プロンプト・プロジェクトのパスは含まれません** — 送られるのはリクエストそのものだけです。
 - **Keychain（任意）。** Claude OAuth 資格情報は**更新ボタンを押した時のみ**読み取ります（設定、またはポップオーバーの上限行）。自動更新では Keychain に触れないためパスワードのプロンプトは表示されず、`~/.claude/.credentials.json` があればそちらから取得します。トークンはメモリ上にのみ保持し、**アプリ自身の Keychain 項目は作成しません。** トークンが期限切れになると、上限は更新するまで以前の値（stale）として表示されます。設定でオフにすると上限セクションが非表示になります。
 - **ポケモンのアセット** はランタイムに PokéAPI から取得し、`~/Library/Application Support/PokeTokenBar/` にのみキャッシュされます。アプリのバイナリおよびリリース成果物にポケモンのアセットは含まれません。

--- a/README.ja.md
+++ b/README.ja.md
@@ -159,7 +159,7 @@ swift test                   # ユニットテスト
 | `~/.local/share/opencode/opencode.db` | OpenCode daily/blocks/weekly/monthly | SQLite 読み取り専用；レガシー `storage/message` JSON にも対応 |
 | `~/.hermes/state.db` | Hermes Agent daily/blocks/weekly/monthly | SQLite 読み取り専用；セッショントークン合計と保存済みコスト |
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite 読み取り専用；`cursorDiskKV` バブルエントリの `tokenCount` |
-| `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` レコード（ターン単位の `usage`、サーバー報告のコスト）；サブエージェントのセッションは親ターンに合算済みのため除外 |
+| `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` レコード（ターン単位の `usage`、サーバー報告のコスト）；`$GROK_HOME` を設定していればそのパス；サブエージェントのセッションは親ターンに合算済みのため除外 |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 公式 5h/週間 % | 非公式 endpoint；Keychain は**更新ボタンを押した時のみ**読み取り — 自動更新では読みません |
 | `codex app-server` | Codex 公式 5h/週間 % | ローカル子プロセス；アカウント snapshot のみ、モデル turn なし |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | ポケモンの種・進化 | ランタイム取得；ローカルキャッシュ、バンドルしない |

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · OpenCode · Hermes Agent · Cursor)을 macOS 메뉴바 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
+PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · OpenCode · Hermes Agent · Cursor · Grok CLI)을 macOS 메뉴바 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
 
-> 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor 데이터에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
+> 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor·Grok CLI 데이터에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
 
 ## 왜
 
@@ -33,7 +33,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 
 ## 어떻게 자라나요
 
-1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
+1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor·Grok CLI에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
 2. 🐣 **부화.** [PokéAPI](https://pokeapi.co/)의 **1~5세대 모든 진화 계보(시작점 329종)**에서 공식 capture rate 가중으로 태어납니다 — 흔한 포켓몬은 자주, 전설은 부화 129번에 1번. 부화한 포켓몬은 키우는 동안에도 **도감**에 바로 나타납니다. 부화마다 25종 성격 중 하나가 정해지고 — **아주 특별한 우연으론 ✨ 이로치가 태어납니다**.
 3. ⚡ **진화.** 계속 코딩하면 실제 진화 트리(1/2/3단, 분기)를 따라 자라고, 단계마다 작은 연출이 반겨줍니다.
 4. 🎓 **졸업 & 수집.** 최종 진화 + 임계 도달 시 **도감**에 영구 보존됩니다 — 희귀할수록 오래 걸리고(헤비 유저 기준 common ≈3일 → legendary ≈24일) — 새 알이 도착합니다.
@@ -97,7 +97,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 ## 이 밖에도
 
 - **인터랙티브 플로팅 펫** — 호버로 오늘 사용량, 클릭으로 메인 창, 우클릭 메뉴; 한도 알림은 말풍선으로도 표시.
-- **서비스별 탭** — Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor 중 2개 이상 감지되면 작은 탭으로 상세를 서비스별 전환(오늘 합계는 통합 유지).
+- **서비스별 탭** — Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor·Grok CLI 중 2개 이상 감지되면 작은 탭으로 상세를 서비스별 전환(오늘 합계는 통합 유지).
 - **공식 한도** — Claude·Codex 5시간/주간 사용률 + 리셋 카운트다운을 오늘 숫자 바로 아래에.
 - **소진 예측** — 현재 5시간 창이 100%에 도달할 시각 예측.
 - **인앱 업데이트** — 원클릭 업데이트 확인, 설정에 현재 버전 표시.
@@ -112,6 +112,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 | **OpenCode** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Hermes Agent** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Cursor** | 오늘 · 5시간 블록 · 주 · 월 | — |
+| **Grok CLI** | 오늘 · 5시간 블록 · 주 · 월 | — |
 
 모두 로컬에서 읽습니다 — 외부 사용량 CLI 불필요. 도구 추가는 프로바이더 파일 하나면 됩니다([CONTRIBUTING.ko.md](CONTRIBUTING.ko.md) 참고).
 
@@ -119,7 +120,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 
 ### 요구사항
 
-macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor 데이터에서 직접 읽으며 외부 사용량 CLI가 필요 없습니다.
+macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor·Grok CLI 데이터에서 직접 읽으며 외부 사용량 CLI가 필요 없습니다.
 
 ### Homebrew
 
@@ -158,6 +159,7 @@ swift test                   # 단위 테스트
 | `~/.local/share/opencode/opencode.db` | OpenCode daily/blocks/weekly/monthly | SQLite 읽기 전용; 레거시 `storage/message` JSON도 지원 |
 | `~/.hermes/state.db` | Hermes Agent daily/blocks/weekly/monthly | SQLite 읽기 전용; 세션 토큰 합계와 저장된 비용 |
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite 읽기 전용; `cursorDiskKV` 버블 엔트리의 `tokenCount` |
+| `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` 레코드(턴 단위 `usage`, 서버 보고 비용); 서브에이전트 세션은 토큰이 부모 턴에 이미 포함돼 제외 |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 공식 5h/주간 % | 비공식 endpoint; Keychain 은 **갱신 버튼을 누를 때만** 읽음 — 자동 폴링은 읽지 않음 |
 | `codex app-server` | Codex 공식 5h/주간 % | 로컬 자식 프로세스; 계정 snapshot만, 모델 turn 없음 |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | 포켓몬 종·진화 | 런타임 fetch; 로컬 캐시, 번들 안 함 |
@@ -167,7 +169,7 @@ swift test                   # 단위 테스트
 
 ## 프라이버시 & 권한
 
-- **온디바이스.** 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor 데이터에서 직접 읽습니다. 사용량을 업로드하거나 모델 turn을 실행하지 않습니다.
+- **온디바이스.** 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·OpenCode·Hermes Agent·Cursor·Grok CLI 데이터에서 직접 읽습니다. 사용량을 업로드하거나 모델 turn을 실행하지 않습니다.
 - **외부 요청.** 앱은 완전 오프라인이 아닙니다. 7개 호스트에 접속합니다 — `pokeapi.co`·`graphql.pokeapi.co`(종·진화), `raw.githubusercontent.com`(스프라이트), `api.anthropic.com`(Claude 공식 한도), `status.claude.com`·`status.openai.com`(장애 배너 — 설정에서 끌 수 있음), `api.github.com`(업데이트 확인). **어느 요청에도 사용량·토큰·프롬프트·프로젝트 경로는 담기지 않습니다** — 요청 자체만 나갑니다.
 - **Keychain(선택).** Claude OAuth 자격증명은 **갱신 버튼을 누를 때만** 읽습니다(설정, 또는 팝오버의 한도 행). 자동 폴링은 Keychain 을 건드리지 않으므로 비밀번호 프롬프트가 뜨지 않고, `~/.claude/.credentials.json` 이 있으면 그쪽에서 가져옵니다. 토큰은 메모리에만 두며 **앱 자체 Keychain 항목은 만들지 않습니다.** 토큰이 만료되면 한도는 갱신 전까지 이전 값(stale)으로 표시됩니다. 설정에서 끄면 한도 섹션만 숨겨집니다.
 - **포켓몬 에셋**은 런타임에 PokéAPI에서 받아오며 `~/Library/Application Support/PokeTokenBar/`에만 캐시됩니다. 앱 바이너리와 릴리스 아티팩트에는 포켓몬 에셋이 포함되지 않습니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -159,7 +159,7 @@ swift test                   # 단위 테스트
 | `~/.local/share/opencode/opencode.db` | OpenCode daily/blocks/weekly/monthly | SQLite 읽기 전용; 레거시 `storage/message` JSON도 지원 |
 | `~/.hermes/state.db` | Hermes Agent daily/blocks/weekly/monthly | SQLite 읽기 전용; 세션 토큰 합계와 저장된 비용 |
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite 읽기 전용; `cursorDiskKV` 버블 엔트리의 `tokenCount` |
-| `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` 레코드(턴 단위 `usage`, 서버 보고 비용); 서브에이전트 세션은 토큰이 부모 턴에 이미 포함돼 제외 |
+| `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` 레코드(턴 단위 `usage`, 서버 보고 비용); `$GROK_HOME` 설정 시 그 경로; 서브에이전트 세션은 토큰이 부모 턴에 이미 포함돼 제외 |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 공식 5h/주간 % | 비공식 endpoint; Keychain 은 **갱신 버튼을 누를 때만** 읽음 — 자동 폴링은 읽지 않음 |
 | `codex app-server` | Codex 공식 5h/주간 % | 로컬 자식 프로세스; 계정 snapshot만, 모델 turn 없음 |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | 포켓몬 종·진화 | 런타임 fetch; 로컬 캐시, 번들 안 함 |

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent & Cursor — into a growing **Pokémon companion** in your macOS menu bar. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
+PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, Cursor & Grok CLI — into a growing **Pokémon companion** in your macOS menu bar. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
 
-> Token usage is read directly from local Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, and Cursor data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
+> Token usage is read directly from local Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, Cursor, and Grok CLI data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
 
 ## Why
 
@@ -33,7 +33,7 @@ PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, 
 
 ## How it works
 
-1. 🥚 **Code as usual.** The tokens you burn in Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, or Cursor incubate an egg — nothing extra to run.
+1. 🥚 **Code as usual.** The tokens you burn in Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, Cursor, or Grok CLI incubate an egg — nothing extra to run.
 2. 🐣 **Hatch.** Eggs hatch into Pokémon with real evolution lines from [PokéAPI](https://pokeapi.co/) — any Gen 1–5 line (329 possible starts), weighted by the official capture rate: commons hatch often, a legendary is a 1-in-129 event. It appears in your **Pokédex** immediately while you raise it. Every hatch rolls one of 25 natures — and once in a rare while, the egg hatches **✨ Shiny**.
 3. ⚡ **Evolve.** Keep coding and it grows through its actual evolution tree (1/2/3 stages, branching), with a little flash celebration at each step.
 4. 🎓 **Graduate & collect.** Final form + threshold permanently archives it in your **Pokédex** — rarer takes longer (≈3 days common → ≈24 days legendary at heavy use) — and a fresh egg arrives.
@@ -97,7 +97,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 ## Also in the box
 
 - **Interactive floating pet** — hover for today's usage, click to open the main window, right-click for a menu; limit alerts can pop up as speech bubbles.
-- **Per-service tabs** — when two or more of Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, and Cursor are detected, compact tabs switch between them; today's total stays combined.
+- **Per-service tabs** — when two or more of Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, Cursor, and Grok CLI are detected, compact tabs switch between them; today's total stays combined.
 - **Official limits** — Claude & Codex 5-hour / weekly utilization with reset countdowns, right under today's numbers.
 - **Burn-rate forecast** — projects when the current 5h window hits 100%.
 - **In-app updates** — one-click update check; current version shown in Settings.
@@ -112,6 +112,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 | **OpenCode** | today · 5h block · week · month | — |
 | **Hermes Agent** | today · 5h block · week · month | — |
 | **Cursor** | today · 5h block · week · month | — |
+| **Grok CLI** | today · 5h block · week · month | — |
 
 All read locally — no external usage CLI required. Adding a tool is one provider file (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 
@@ -119,7 +120,7 @@ All read locally — no external usage CLI required. Adding a tool is one provid
 
 ### Requirements
 
-macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from local Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, and Cursor data, with no external usage CLI required.
+macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from local Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, Cursor, and Grok CLI data, with no external usage CLI required.
 
 ### Homebrew
 
@@ -158,6 +159,7 @@ swift test                   # unit tests
 | `~/.local/share/opencode/opencode.db` | OpenCode daily/blocks/weekly/monthly | SQLite read-only; legacy `storage/message` JSON is also supported |
 | `~/.hermes/state.db` | Hermes Agent daily/blocks/weekly/monthly | SQLite read-only; session token totals and persisted cost |
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite read-only; `cursorDiskKV` bubble entries with `tokenCount` |
+| `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` records (per-turn `usage`, server-reported cost); subagent sessions are skipped because their tokens are already folded into the parent turn |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude official 5h/weekly % | unofficial endpoint; the Keychain is read **only when you press refresh** — auto-polling never reads it |
 | `codex app-server` | Codex official 5h/weekly % | local child process; account snapshot only, no model turn |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | Pokémon species &amp; evolution | runtime fetch; cached locally, never bundled |
@@ -167,7 +169,7 @@ swift test                   # unit tests
 
 ## Privacy & permissions
 
-- **On-device.** Token usage is read directly from local Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, and Cursor data. The app never uploads usage or runs model turns.
+- **On-device.** Token usage is read directly from local Claude Code, Codex, Gemini CLI, OpenCode, Hermes Agent, Cursor, and Grok CLI data. The app never uploads usage or runs model turns.
 - **Outbound requests.** The app is not fully offline. It talks to seven hosts: `pokeapi.co` and `graphql.pokeapi.co` (species/evolution), `raw.githubusercontent.com` (sprites), `api.anthropic.com` (Claude official limits), `status.claude.com` and `status.openai.com` (incident banner — off switch in Settings), and `api.github.com` (update check). **None of them carry your usage, tokens, prompts, or project paths** — only the request itself.
 - **Keychain (optional).** The Claude OAuth credential is read **only when you press a refresh button** (Settings, or the limits row in the popover). Automatic polling never touches the Keychain, so it never raises a password prompt; when available, the credential is taken from `~/.claude/.credentials.json` instead. The token is held in memory only — the app creates no Keychain item of its own. Once the token expires, limits stay visible but stale until you refresh. Turn it off in Settings — the limits section simply hides.
 - **Pokémon assets** are fetched at runtime from PokéAPI and cached only under `~/Library/Application Support/PokeTokenBar/`. The app binary and its release artifacts contain no Pokémon assets.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ swift test                   # unit tests
 | `~/.local/share/opencode/opencode.db` | OpenCode daily/blocks/weekly/monthly | SQLite read-only; legacy `storage/message` JSON is also supported |
 | `~/.hermes/state.db` | Hermes Agent daily/blocks/weekly/monthly | SQLite read-only; session token totals and persisted cost |
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite read-only; `cursorDiskKV` bubble entries with `tokenCount` |
-| `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` records (per-turn `usage`, server-reported cost); subagent sessions are skipped because their tokens are already folded into the parent turn |
+| `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` records (per-turn `usage`, server-reported cost); honours `$GROK_HOME`; subagent sessions are skipped because their tokens are already folded into the parent turn |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude official 5h/weekly % | unofficial endpoint; the Keychain is read **only when you press refresh** — auto-polling never reads it |
 | `codex app-server` | Codex official 5h/weekly % | local child process; account snapshot only, no model turn |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | Pokémon species &amp; evolution | runtime fetch; cached locally, never bundled |

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -111,10 +111,12 @@ actor LocalUsageCache {
     func grokEntries(modifiedSince: Date) -> [LocalUsageReader.Entry] {
         ensureLoaded()
         let fmt = LocalUsageReader.localDayFormatter()
-        // updates.jsonl 만 본다 — 같은 세션 디렉토리의 chat_history/events 는 토큰이 없어
-        // 파싱해도 빈 blob 만 캐시에 쌓인다(스냅샷 비대).
+        // updates.jsonl 만, 그리고 서브에이전트 세션은 제외한다(부모 턴에 이미 포함). 이 판정은
+        // 파싱 캐시 **앞**에 있어야 한다 — blob 은 updates.jsonl 의 mtime·size 로만 무효화되는데
+        // 서브에이전트 판정 근거는 옆 파일(summary.json)이라, 파싱 안에서 걸러내면 늦게 쓰인
+        // session_kind 가 blob 에 굳어 이중집계가 영구화된다.
         let all = collect(root: grokRoot ?? LocalUsageReader.grokSessionsDir, since: modifiedSince,
-                          cache: &grokCache, fileName: LocalUsageReader.grokUpdatesFileName) {
+                          cache: &grokCache, include: LocalUsageReader.isGrokUsageFile) {
             LocalUsageReader.parseGrokFile($0, fmt: fmt)
         }
         saveIfNeeded()
@@ -122,8 +124,10 @@ actor LocalUsageCache {
         return LocalUsageReader.dedupKeepMax(all)
     }
 
+    /// `include` 는 blob 캐시 조회 **전에** 평가된다 — 파일 밖 상태(옆 파일 등)에 의존하는 판정을
+    /// 캐시에 굳히지 않기 위해서다.
     private func collect(root: URL, since: Date, cache: inout [String: Blob],
-                         allowJSON: Bool = false, fileName: String? = nil,
+                         allowJSON: Bool = false, include: ((URL) -> Bool)? = nil,
                          parse: (URL) -> [LocalUsageReader.Entry]) -> [LocalUsageReader.Entry] {
         let fm = FileManager.default
         guard let en = fm.enumerator(
@@ -135,7 +139,7 @@ actor LocalUsageCache {
             // 기본 .jsonl. .json 은 Gemini 루트에서만(allowJSON) — Claude 루트의 대량
             // .meta.json 등을 스캔/빈 blob 으로 캐시하지 않도록 스코프 제한.
             guard url.pathExtension == "jsonl" || (allowJSON && url.pathExtension == "json") else { continue }
-            if let fileName, url.lastPathComponent != fileName { continue }
+            if let include, !include(url) { continue }
             guard let v = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
                   let mtime = v.contentModificationDate, mtime >= since else { continue }
             let size = v.fileSize ?? 0

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -13,31 +13,41 @@ actor LocalUsageCache {
         var claude: [String: Blob]
         var codex: [String: Blob]
         var gemini: [String: Blob]
+        var grok: [String: Blob]
         var codexParserVersion: Int
+        var grokParserVersion: Int
 
-        init(claude: [String: Blob], codex: [String: Blob], gemini: [String: Blob], codexParserVersion: Int) {
+        init(claude: [String: Blob], codex: [String: Blob], gemini: [String: Blob],
+             grok: [String: Blob], codexParserVersion: Int, grokParserVersion: Int) {
             self.claude = claude
             self.codex = codex
             self.gemini = gemini
+            self.grok = grok
             self.codexParserVersion = codexParserVersion
+            self.grokParserVersion = grokParserVersion
         }
 
-        // 하위호환: gemini 키가 없는 구버전 스냅샷도 로드(콜드 스타트 재발 방지).
+        // 하위호환: gemini/grok 키가 없는 구버전 스냅샷도 로드(콜드 스타트 재발 방지).
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             claude = try c.decodeIfPresent([String: Blob].self, forKey: .claude) ?? [:]
             codex = try c.decodeIfPresent([String: Blob].self, forKey: .codex) ?? [:]
             gemini = try c.decodeIfPresent([String: Blob].self, forKey: .gemini) ?? [:]
+            grok = try c.decodeIfPresent([String: Blob].self, forKey: .grok) ?? [:]
             codexParserVersion = try c.decodeIfPresent(Int.self, forKey: .codexParserVersion) ?? 0
+            grokParserVersion = try c.decodeIfPresent(Int.self, forKey: .grokParserVersion) ?? 0
         }
     }
 
     /// forked rollout의 선행 replay burst 처리 변경 시 Codex blob만 재파싱한다.
     private static let codexParserVersion = 2
+    /// Grok 토큰 매핑(캐시분 분리·비용 신뢰 조건) 변경 시 Grok blob만 재파싱한다.
+    private static let grokParserVersion = 1
 
     private var claudeCache: [String: Blob] = [:]
     private var codexCache: [String: Blob] = [:]
     private var geminiCache: [String: Blob] = [:]
+    private var grokCache: [String: Blob] = [:]
     private var loaded = false
     private var dirty = false
     private var lastSave: Date?
@@ -46,14 +56,16 @@ actor LocalUsageCache {
     private let claudeRoot: URL?
     private let codexRoot: URL?
     private let geminiRoot: URL?
+    private let grokRoot: URL?
     private let fileURL: URL
     private let now: @Sendable () -> Date
 
-    init(claudeRoot: URL? = nil, codexRoot: URL? = nil, geminiRoot: URL? = nil, fileURL: URL? = nil,
-         now: @escaping @Sendable () -> Date = Date.init) {
+    init(claudeRoot: URL? = nil, codexRoot: URL? = nil, geminiRoot: URL? = nil, grokRoot: URL? = nil,
+         fileURL: URL? = nil, now: @escaping @Sendable () -> Date = Date.init) {
         self.claudeRoot = claudeRoot
         self.codexRoot = codexRoot
         self.geminiRoot = geminiRoot
+        self.grokRoot = grokRoot
         self.fileURL = fileURL ?? Self.defaultFileURL
         self.now = now
     }
@@ -96,8 +108,22 @@ actor LocalUsageCache {
         return r
     }
 
+    func grokEntries(modifiedSince: Date) -> [LocalUsageReader.Entry] {
+        ensureLoaded()
+        let fmt = LocalUsageReader.localDayFormatter()
+        // updates.jsonl 만 본다 — 같은 세션 디렉토리의 chat_history/events 는 토큰이 없어
+        // 파싱해도 빈 blob 만 캐시에 쌓인다(스냅샷 비대).
+        let all = collect(root: grokRoot ?? LocalUsageReader.grokSessionsDir, since: modifiedSince,
+                          cache: &grokCache, fileName: LocalUsageReader.grokUpdatesFileName) {
+            LocalUsageReader.parseGrokFile($0, fmt: fmt)
+        }
+        saveIfNeeded()
+        // fork 세션이 부모 updates 를 복사해도 같은 턴은 한 번만(전역 dedup).
+        return LocalUsageReader.dedupKeepMax(all)
+    }
+
     private func collect(root: URL, since: Date, cache: inout [String: Blob],
-                         allowJSON: Bool = false,
+                         allowJSON: Bool = false, fileName: String? = nil,
                          parse: (URL) -> [LocalUsageReader.Entry]) -> [LocalUsageReader.Entry] {
         let fm = FileManager.default
         guard let en = fm.enumerator(
@@ -109,6 +135,7 @@ actor LocalUsageCache {
             // 기본 .jsonl. .json 은 Gemini 루트에서만(allowJSON) — Claude 루트의 대량
             // .meta.json 등을 스캔/빈 blob 으로 캐시하지 않도록 스코프 제한.
             guard url.pathExtension == "jsonl" || (allowJSON && url.pathExtension == "json") else { continue }
+            if let fileName, url.lastPathComponent != fileName { continue }
             guard let v = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
                   let mtime = v.contentModificationDate, mtime >= since else { continue }
             let size = v.fileSize ?? 0
@@ -137,9 +164,14 @@ actor LocalUsageCache {
         claudeCache = snap.claude
         codexCache = snap.codex
         geminiCache = snap.gemini
+        grokCache = snap.grok
 
         if snap.codexParserVersion != Self.codexParserVersion {
             codexCache = [:]
+            dirty = true
+        }
+        if snap.grokParserVersion != Self.grokParserVersion {
+            grokCache = [:]
             dirty = true
         }
     }
@@ -151,6 +183,7 @@ actor LocalUsageCache {
         claudeCache = claudeCache.filter { $0.value.mtime >= cutoff }
         codexCache = codexCache.filter { $0.value.mtime >= cutoff }
         geminiCache = geminiCache.filter { $0.value.mtime >= cutoff }
+        grokCache = grokCache.filter { $0.value.mtime >= cutoff }
     }
 
     /// 변경이 있으면 디스크에 저장(최소 60초 간격으로 throttle — 잦은 쓰기 방지).
@@ -162,7 +195,9 @@ actor LocalUsageCache {
             claude: claudeCache,
             codex: codexCache,
             gemini: geminiCache,
-            codexParserVersion: Self.codexParserVersion)
+            grok: grokCache,
+            codexParserVersion: Self.codexParserVersion,
+            grokParserVersion: Self.grokParserVersion)
         if let data = try? JSONEncoder().encode(snap) {
             // JSON 은 zlib 로 크게 압축됨(수 MB → 수백 KB). 실패 시 평문 저장(로드가 양쪽 다 처리).
             let out = (try? (data as NSData).compressed(using: .zlib) as Data) ?? data

--- a/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
@@ -65,6 +65,38 @@ struct LocalGeminiProvider: UsageProvider {
     }
 }
 
+/// 로컬 로그 직접 파싱 기반 Grok CLI provider (공식 xAI Grok CLI).
+/// 세션이 ~/.grok/sessions/<id>/updates.jsonl 에 있을 때만 데이터가 잡힌다(없으면 스냅샷 미생성 → UI 미표시).
+struct LocalGrokProvider: UsageProvider {
+    let id = "grok"
+    let displayName = "Grok"
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let now = Date()
+        let entries = await LocalUsageCache.shared.grokEntries(modifiedSince: Calendar.current.startOfDay(for: now))
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey())
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let now = Date()
+        let monthStart = LocalUsageReader.startOfMonth(now)
+        let entries = await LocalUsageCache.shared.grokEntries(
+            modifiedSince: LocalUsageReader.enrichmentScanStart(now: now))
+        let fmt = LocalUsageReader.localDayFormatter()
+        var r = ProviderEnrichment()
+        // 블록(burn rate) 계산은 프로바이더 공통 — companion 리듬이 전 프로바이더를 따르게.
+        r.activeBlock = LocalUsageReader.activeBlock(entries: entries, now: now)
+        r.blocksOK = true
+        let weekStart = LocalUsageReader.startOfWeek(now)
+        r.weekTotal = LocalUsageReader.period(entries: entries, periodKey: fmt.string(from: weekStart),
+                                              fromDay: fmt.string(from: weekStart), toDay: fmt.string(from: now))
+        r.monthTotal = LocalUsageReader.period(entries: entries, periodKey: LocalUsageReader.monthKey(now),
+                                               fromDay: fmt.string(from: monthStart), toDay: fmt.string(from: now))
+        r.periodsOK = true
+        return r
+    }
+}
+
 /// 로컬 로그 직접 파싱 기반 Codex provider. (주간 = 일별 합산)
 struct LocalCodexProvider: UsageProvider {
     let id = "codex"

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -303,7 +303,11 @@ enum LocalUsageReader {
     ///
     /// 턴이 끝날 때마다 durable 로 append 되는 `sessionUpdate:"turn_completed"` 라인의 `usage`
     /// (= 그 프롬프트 한 턴의 사용량)만 읽는다. 라인 봉투는
-    /// `{"timestamp":…,"update":{"sessionId":…,"update":{…},"_meta":{…}}}`.
+    /// `{"timestamp":<초>,"method":"_x.ai/session/update","params":{"sessionId":…,"update":{…},"_meta":{…}}}`.
+    ///
+    /// 같은 파일의 다른 토큰 필드(`_meta.totalTokens`, auto-compact/subagent 진행 이벤트)는 *컨텍스트
+    /// 창 크기*라 사용량이 아니다 — 섞으면 합계가 크게 부풀어 오른다. `turn_completed` 의 `usage` 만 본다.
+    /// rewind 로 버려진 분기의 턴도 그대로 센다: 되돌려도 그 토큰은 이미 청구됐다(대화 재생과 다른 질문).
     ///
     /// 토큰 매핑 — `Entry.total == usage.totalTokens` 가 성립하게 맞춘다:
     /// - `inputTokens`(camelCase)는 **캐시 읽기를 포함한** 전체 프롬프트 →
@@ -313,12 +317,6 @@ enum LocalUsageReader {
     /// - `output = outputTokens` (reasoning 은 output 에 포함), `cacheWrite = 0`
     ///   (Grok 은 캐시 쓰기를 prompt 토큰에 접어 넣는다).
     static func parseGrokFile(_ url: URL, fmt: DateFormatter) -> [Entry] {
-        // 서브에이전트 세션의 토큰은 부모 턴 usage 에 이미 접혀 들어온다 → 여기서 또 세면 이중 집계.
-        // CLI 가 세션 목록에서 숨기는 것과 같은 판정(`session_kind` 접두사)을 쓴다.
-        // 알려진 한계: 부모 턴이 이미 끝난 뒤 완료된 서브에이전트는 세션 원장에만 접히므로(부모
-        // 턴에는 안 들어옴) 그만큼 과소집계된다. 매번 도는 이중집계보다 이쪽이 작아서 택한 쪽이고,
-        // 그 경우 CLI 는 부모 bill 에 usageIsIncomplete 를 세워 비용도 신뢰 대상에서 빠진다.
-        guard !grokSessionIsSubagent(url.deletingLastPathComponent()) else { return [] }
         guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
         var out: [Entry] = []
         for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
@@ -336,15 +334,37 @@ enum LocalUsageReader {
         let fmt = localDayFormatter()
         var entries: [Entry] = []
         for file in jsonlFiles(in: root ?? grokSessionsDir, modifiedSince: modifiedSince)
-        where file.lastPathComponent == grokUpdatesFileName {
+        where isGrokUsageFile(file) {
             entries.append(contentsOf: parseGrokFile(file, fmt: fmt))
         }
         // fork 세션이 부모 updates 를 복사해도 턴 id 가 같아 한 번만 남는다(전역 dedup).
         return dedupKeepMax(entries)
     }
 
-    /// `summary.json` 의 `session_kind` 가 서브에이전트 계열인가.
+    /// 집계 대상 파일인가 — 사용량이 담긴 `updates.jsonl` 이고, 서브에이전트 세션이 아닌 것.
+    ///
+    /// 서브에이전트 세션의 토큰은 부모 턴 usage 에 이미 접혀 들어오므로(RecordSubagentUsage) 여기서
+    /// 또 세면 이중 집계다. CLI 가 세션 목록에서 숨기는 것과 같은 판정(`session_kind` 접두사)을 쓴다.
+    ///
+    /// **파일 선택 단계에서 판정한다** — 파싱 결과 캐시(blob)는 `updates.jsonl` 의 mtime·size 로만
+    /// 무효화되는데 이 판정의 근거는 옆 파일(`summary.json`)이다. 파싱 안에서 걸러내면 "summary 가
+    /// 아직 session_kind 를 못 쓴 시점에 파싱된" 서브에이전트 세션이 blob 에 그대로 굳어 이중집계가
+    /// 영구화된다(파일이 더 안 바뀌므로 캐시가 계속 히트). 선택 단계는 매 새로고침 재평가돼 자연 복구된다.
+    ///
+    /// 알려진 한계: 부모 턴이 끝난 뒤 완료된 서브에이전트는 부모 프롬프트 원장이 아니라 세션 원장에만
+    /// 접히므로 그만큼 과소집계된다. 매 턴 도는 이중집계보다 작아서 택한 쪽이고, 그 경우 CLI 는 부모
+    /// bill 에 usageIsIncomplete 를 세워 비용도 신뢰 대상에서 빠진다.
+    static func isGrokUsageFile(_ url: URL) -> Bool {
+        guard url.lastPathComponent == grokUpdatesFileName else { return false }
+        return !grokSessionIsSubagent(url.deletingLastPathComponent())
+    }
+
+    /// `summary.json` 의 `session_kind` 가 서브에이전트 계열(subagent/subagent_fork/subagent_resume)인가.
+    /// 파일이 없거나 못 읽으면 사용자 세션으로 본다 — CLI 는 세션 생성 시 summary 를 먼저 쓰므로
+    /// 부재는 "턴이 아직 없는 새 세션"(= 셀 것도 없음)이다.
     private static func grokSessionIsSubagent(_ sessionDir: URL) -> Bool {
+        // `hidden` 은 쓰지 않는다 — 사용자가 직접 숨긴 정상 세션까지 빠져 과소집계가 된다.
+        // 서브에이전트는 생성 시점에 session_kind 가 반드시 찍히므로 이 신호만으로 충분하다.
         guard let data = try? Data(contentsOf: sessionDir.appendingPathComponent("summary.json")),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let kind = obj["session_kind"] as? String else { return false }
@@ -352,31 +372,53 @@ enum LocalUsageReader {
     }
 
     private static func parseGrokLine(_ line: String, fmt: DateFormatter) -> Entry? {
-        // 봉투 → 알림 → 업데이트 세 겹: {timestamp, update:{sessionId, update:{sessionUpdate,…}, _meta}}
+        // 디스크 라인은 봉투 → 알림 → 업데이트 세 겹이다:
+        //   {timestamp:<초>, method:"_x.ai/session/update", params:{sessionId, update:{sessionUpdate,…}, _meta}}
+        // `method` 없는 구형 라인은 알림 그 자체(봉투 없음)라 한 겹으로 받는다.
         guard let data = line.data(using: .utf8),
-              let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let notification = envelope["update"] as? [String: Any],
-              let update = notification["update"] as? [String: Any],
+              let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        let notification = (envelope["params"] as? [String: Any]) ?? envelope
+        guard let update = notification["update"] as? [String: Any],
               (update["sessionUpdate"] as? String) == "turn_completed",
               let usage = update["usage"] as? [String: Any] else { return nil }
         let meta = notification["_meta"] as? [String: Any]
-        // 재생으로 다시 append 된 라인은 같은 턴을 두 번 세게 만든다(id dedup 과 이중 방어).
+        // 재생 표시가 붙은 라인은 건너뛴다. 주 방어는 아래 턴 id dedup 이고 이건 보조다
+        // (재생은 대개 전송 경로에만 표시가 붙어 디스크엔 안 남는다).
         if boolValue(meta?["isReplay"]) { return nil }
-        // 턴 식별자에 세션 경로를 섞지 않는다 — fork 가 부모 updates 를 복사해도 같은 턴은 하나다.
-        guard let turnID = nonEmpty(update["prompt_id"] as? String)
-                ?? nonEmpty(meta?["promptId"] as? String)
-                ?? nonEmpty(meta?["eventId"] as? String),
+        // 턴 식별자는 `prompt_id` 뿐이다. 세션 경로를 섞지 않아 fork 가 부모 updates 를 복사해도
+        // 같은 턴이 하나로 접힌다(전역 유일한 uuid — 합성 턴은 접두사 붙은 uuid). `_meta.eventId`
+        // 같은 대체 키는 쓰지 않는다: 전역 유일성이 보장되지 않아 서로 다른 세션의 턴을 합쳐버릴 수 있다.
+        guard let turnID = nonEmpty(update["prompt_id"] as? String),
               let date = grokDate(envelope: envelope, meta: meta) else { return nil }
 
-        let output = intValue(usage["outputTokens"] ?? usage["output_tokens"])
-        let cacheRead = intValue(usage["cachedReadTokens"] ?? usage["cached_read_tokens"])
-        let input: Int
-        if let full = usage["inputTokens"] {
-            input = max(0, intValue(full) - cacheRead)   // 캐시 포함 전체 프롬프트 → 비캐시분만
+        // `null` 을 "값 있음"으로 착각하면 캐시분을 잘못 빼거나 토큰을 0으로 만든다 → intOrNil.
+        let output = intOrNil(usage["outputTokens"]) ?? intOrNil(usage["output_tokens"]) ?? 0
+        let reportedCacheRead = intOrNil(usage["cachedReadTokens"]) ?? intOrNil(usage["cached_read_tokens"]) ?? 0
+        let (input, cacheRead): (Int, Int)
+        if let full = intOrNil(usage["inputTokens"]) {
+            // 캐시 읽기는 프롬프트의 부분집합이라 전체보다 클 수 없다. clamp 로 identity 를 지킨다
+            // (max(0,·) 로 뭉개면 input+cacheRead 가 inputTokens 를 넘어 total 이 조용히 부풀었다).
+            let clamped = min(reportedCacheRead, full)
+            (input, cacheRead) = (full - clamped, clamped)
         } else {
-            input = intValue(usage["input_tokens"])      // 헤드리스 투영은 이미 캐시 제외
+            // 헤드리스 투영은 input_tokens 가 이미 캐시 제외값이다.
+            (input, cacheRead) = (intOrNil(usage["input_tokens"]) ?? 0, reportedCacheRead)
         }
-        guard input + output + cacheRead > 0 else { return nil }
+        // 소스가 말하는 total 과 어긋나면 남는 분을 output 에 귀속시켜 identity 를 맞춘다
+        // (모델별 행 합산 방식이 바뀌어 부분합이 어긋나도 합계는 소스를 따르게 — 다른 리더와 같은 규칙).
+        if let reportedTotal = intOrNil(usage["totalTokens"]) ?? intOrNil(usage["total_tokens"]) {
+            let parts = input + output + cacheRead
+            if reportedTotal > parts { return grokEntry(turnID: turnID, date: date, fmt: fmt, usage: usage,
+                                                        input: input, output: output + (reportedTotal - parts),
+                                                        cacheRead: cacheRead) }
+        }
+        return grokEntry(turnID: turnID, date: date, fmt: fmt, usage: usage,
+                         input: input, output: output, cacheRead: cacheRead)
+    }
+
+    private static func grokEntry(turnID: String, date: Date, fmt: DateFormatter, usage: [String: Any],
+                                  input: Int, output: Int, cacheRead: Int) -> Entry? {
+        guard input + output + cacheRead > 0 else { return nil }   // 0 토큰 턴(취소 등)은 기록하지 않는다
         return Entry(
             id: "grok|\(turnID)", date: date, localDay: fmt.string(from: date),
             model: grokModel(usage) ?? "grok",
@@ -387,11 +429,12 @@ enum LocalUsageReader {
     /// 표시용 모델명 — per-model 내역의 키에서 고른다. 토큰이 가장 많은 행이 대표(동수는 이름 순).
     /// 숫자는 항상 totals 로 집계한다(행 합계와 totals 가 어긋날 여지를 만들지 않는다).
     private static func grokModel(_ usage: [String: Any]) -> String? {
-        guard let byModel = (usage["modelUsage"] ?? usage["model_usage"]) as? [String: Any] else { return nil }
+        guard let byModel = (usage["modelUsage"] as? [String: Any])
+                ?? (usage["model_usage"] as? [String: Any]) else { return nil }
         var best: (model: String, total: Int)?
         for (model, raw) in byModel.sorted(by: { $0.key < $1.key }) {
             let fields = raw as? [String: Any] ?? [:]
-            let total = intValue(fields["totalTokens"] ?? fields["total_tokens"])
+            let total = intOrNil(fields["totalTokens"]) ?? intOrNil(fields["total_tokens"]) ?? 0
             if best == nil || total > best!.total { best = (model, total) }
         }
         return best.flatMap { nonEmpty($0.model) }
@@ -402,14 +445,22 @@ enum LocalUsageReader {
     private static func grokCost(_ usage: [String: Any]) -> Double? {
         if boolValue(usage["usageIsIncomplete"]) || boolValue(usage["usage_is_incomplete"]) { return nil }
         if boolValue(usage["costIsPartial"]) || boolValue(usage["cost_is_partial"]) { return nil }
-        let ticks = doubleValue(usage["costUsdTicks"] ?? usage["cost_usd_ticks"])
+        let ticks = doubleOrNil(usage["costUsdTicks"]) ?? doubleOrNil(usage["cost_usd_ticks"]) ?? 0
         return ticks > 0 ? ticks / 1e10 : nil
     }
 
+    /// 턴 시각은 `_meta.agentTimestampMs`(에이전트가 그 턴에 찍은 시각)를 **우선**한다.
+    /// 봉투 `timestamp` 는 *기록* 시각(Unix 초)이고 fork 가 부모 updates 를 복사할 때 새로 찍히므로,
+    /// 그것만 쓰면 포크된 세션의 과거 사용량이 전부 포크 시점 날짜로 몰린다(주·월·오늘 합계 왜곡).
+    /// `_meta` 는 복사 시 sessionId 만 교체되고 그대로 보존돼 원래 턴 시각을 지킨다.
     private static func grokDate(envelope: [String: Any], meta: [String: Any]?) -> Date? {
-        if let ts = envelope["timestamp"] as? String, let d = ISO8601Parser.date(from: ts) { return d }
-        let ms = doubleValue(meta?["agentTimestampMs"])
-        return ms > 0 ? Date(timeIntervalSince1970: ms / 1000) : nil
+        let ms = doubleOrNil(meta?["agentTimestampMs"]) ?? 0
+        if ms > 0 { return Date(timeIntervalSince1970: ms / 1000) }
+        let raw = doubleOrNil(envelope["timestamp"]) ?? 0
+        // 봉투는 초 단위지만, 밀리초로 오는 변형도 흡수한다(다른 로컬 리더와 같은 임계).
+        if raw > 0 { return Date(timeIntervalSince1970: raw >= 100_000_000_000 ? raw / 1_000 : raw) }
+        if let ts = envelope["timestamp"] as? String { return ISO8601Parser.date(from: ts) }
+        return nil
     }
 
     private static func codexModel(_ line: String) -> String? {
@@ -504,11 +555,18 @@ enum LocalUsageReader {
         return 0
     }
 
-    private static func doubleValue(_ v: Any?) -> Double {
-        if let d = v as? Double { return d }
-        if let i = v as? Int { return Double(i) }
-        if let n = v as? NSNumber { return n.doubleValue }
-        return 0
+    /// 숫자가 실제로 있을 때만 값을 준다. JSON `null`(=`NSNull`)·문자열·키 부재는 모두 nil —
+    /// `usage["x"] != nil` 로 존재를 판정하면 null 이 "값 있음"으로 통과해 0 으로 뭉개진다.
+    private static func doubleOrNil(_ v: Any?) -> Double? {
+        guard let n = v as? NSNumber, !(v is NSNull) else { return nil }
+        let d = n.doubleValue
+        return d.isFinite ? d : nil
+    }
+
+    private static func intOrNil(_ v: Any?) -> Int? {
+        guard let d = doubleOrNil(v) else { return nil }
+        guard d > 0 else { return 0 }                            // 음수 토큰은 없다
+        return d >= Double(Int.max) ? Int.max : Int(d)            // 비정상 큰 값에 트랩되지 않게
     }
 
     private static func boolValue(_ v: Any?) -> Bool {

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -284,6 +284,134 @@ enum LocalUsageReader {
         return entries
     }
 
+    // MARK: Grok 파싱
+
+    /// 세션 디렉토리에서 토큰이 담긴 유일한 파일. `chat_history.jsonl` 의 대화 아이템엔 usage 필드가
+    /// 없고 `events.jsonl` 은 턴 결과만 남기므로, 같이 스캔하면 빈 blob 으로 캐시만 불린다.
+    static let grokUpdatesFileName = "updates.jsonl"
+
+    /// Grok CLI 세션 루트. CLI 와 같은 규칙으로 `$GROK_HOME` 을 우선한다.
+    static var grokSessionsDir: URL {
+        if let home = ProcessInfo.processInfo.environment["GROK_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !home.isEmpty {
+            return URL(fileURLWithPath: home).appendingPathComponent("sessions")
+        }
+        return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".grok/sessions")
+    }
+
+    /// Grok CLI 세션 파일(`~/.grok/sessions/<id>/updates.jsonl`) 파싱.
+    ///
+    /// 턴이 끝날 때마다 durable 로 append 되는 `sessionUpdate:"turn_completed"` 라인의 `usage`
+    /// (= 그 프롬프트 한 턴의 사용량)만 읽는다. 라인 봉투는
+    /// `{"timestamp":…,"update":{"sessionId":…,"update":{…},"_meta":{…}}}`.
+    ///
+    /// 토큰 매핑 — `Entry.total == usage.totalTokens` 가 성립하게 맞춘다:
+    /// - `inputTokens`(camelCase)는 **캐시 읽기를 포함한** 전체 프롬프트 →
+    ///   `input = inputTokens − cachedReadTokens`, `cacheRead = cachedReadTokens`.
+    /// - `input_tokens`(snake_case)는 **이미 캐시 제외** → 그대로 input. 두 표기의 의미가 서로
+    ///   달라서 값 스펠링으로 분기한다(같은 값으로 취급하면 캐시분을 두 번 뺀다).
+    /// - `output = outputTokens` (reasoning 은 output 에 포함), `cacheWrite = 0`
+    ///   (Grok 은 캐시 쓰기를 prompt 토큰에 접어 넣는다).
+    static func parseGrokFile(_ url: URL, fmt: DateFormatter) -> [Entry] {
+        // 서브에이전트 세션의 토큰은 부모 턴 usage 에 이미 접혀 들어온다 → 여기서 또 세면 이중 집계.
+        // CLI 가 세션 목록에서 숨기는 것과 같은 판정(`session_kind` 접두사)을 쓴다.
+        // 알려진 한계: 부모 턴이 이미 끝난 뒤 완료된 서브에이전트는 세션 원장에만 접히므로(부모
+        // 턴에는 안 들어옴) 그만큼 과소집계된다. 매번 도는 이중집계보다 이쪽이 작아서 택한 쪽이고,
+        // 그 경우 CLI 는 부모 bill 에 usageIsIncomplete 를 세워 비용도 신뢰 대상에서 빠진다.
+        guard !grokSessionIsSubagent(url.deletingLastPathComponent()) else { return [] }
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+        var out: [Entry] = []
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            // updates.jsonl 은 스트리밍 청크까지 전부 라인으로 남는다(세션당 수만 라인) →
+            // JSON 파싱 전에 문자열로 걸러낸다.
+            guard line.contains("turn_completed") else { continue }
+            autoreleasepool {   // JSONSerialization 의 autoreleased 객체를 라인마다 배출
+                if let e = parseGrokLine(String(line), fmt: fmt) { out.append(e) }
+            }
+        }
+        return dedupKeepMax(out)
+    }
+
+    static func grokEntries(modifiedSince: Date, root: URL? = nil) -> [Entry] {
+        let fmt = localDayFormatter()
+        var entries: [Entry] = []
+        for file in jsonlFiles(in: root ?? grokSessionsDir, modifiedSince: modifiedSince)
+        where file.lastPathComponent == grokUpdatesFileName {
+            entries.append(contentsOf: parseGrokFile(file, fmt: fmt))
+        }
+        // fork 세션이 부모 updates 를 복사해도 턴 id 가 같아 한 번만 남는다(전역 dedup).
+        return dedupKeepMax(entries)
+    }
+
+    /// `summary.json` 의 `session_kind` 가 서브에이전트 계열인가.
+    private static func grokSessionIsSubagent(_ sessionDir: URL) -> Bool {
+        guard let data = try? Data(contentsOf: sessionDir.appendingPathComponent("summary.json")),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let kind = obj["session_kind"] as? String else { return false }
+        return kind.hasPrefix("subagent")
+    }
+
+    private static func parseGrokLine(_ line: String, fmt: DateFormatter) -> Entry? {
+        // 봉투 → 알림 → 업데이트 세 겹: {timestamp, update:{sessionId, update:{sessionUpdate,…}, _meta}}
+        guard let data = line.data(using: .utf8),
+              let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let notification = envelope["update"] as? [String: Any],
+              let update = notification["update"] as? [String: Any],
+              (update["sessionUpdate"] as? String) == "turn_completed",
+              let usage = update["usage"] as? [String: Any] else { return nil }
+        let meta = notification["_meta"] as? [String: Any]
+        // 재생으로 다시 append 된 라인은 같은 턴을 두 번 세게 만든다(id dedup 과 이중 방어).
+        if boolValue(meta?["isReplay"]) { return nil }
+        // 턴 식별자에 세션 경로를 섞지 않는다 — fork 가 부모 updates 를 복사해도 같은 턴은 하나다.
+        guard let turnID = nonEmpty(update["prompt_id"] as? String)
+                ?? nonEmpty(meta?["promptId"] as? String)
+                ?? nonEmpty(meta?["eventId"] as? String),
+              let date = grokDate(envelope: envelope, meta: meta) else { return nil }
+
+        let output = intValue(usage["outputTokens"] ?? usage["output_tokens"])
+        let cacheRead = intValue(usage["cachedReadTokens"] ?? usage["cached_read_tokens"])
+        let input: Int
+        if let full = usage["inputTokens"] {
+            input = max(0, intValue(full) - cacheRead)   // 캐시 포함 전체 프롬프트 → 비캐시분만
+        } else {
+            input = intValue(usage["input_tokens"])      // 헤드리스 투영은 이미 캐시 제외
+        }
+        guard input + output + cacheRead > 0 else { return nil }
+        return Entry(
+            id: "grok|\(turnID)", date: date, localDay: fmt.string(from: date),
+            model: grokModel(usage) ?? "grok",
+            input: input, output: output, cacheWrite: 0, cacheRead: cacheRead,
+            explicitCost: grokCost(usage))
+    }
+
+    /// 표시용 모델명 — per-model 내역의 키에서 고른다. 토큰이 가장 많은 행이 대표(동수는 이름 순).
+    /// 숫자는 항상 totals 로 집계한다(행 합계와 totals 가 어긋날 여지를 만들지 않는다).
+    private static func grokModel(_ usage: [String: Any]) -> String? {
+        guard let byModel = (usage["modelUsage"] ?? usage["model_usage"]) as? [String: Any] else { return nil }
+        var best: (model: String, total: Int)?
+        for (model, raw) in byModel.sorted(by: { $0.key < $1.key }) {
+            let fields = raw as? [String: Any] ?? [:]
+            let total = intValue(fields["totalTokens"] ?? fields["total_tokens"])
+            if best == nil || total > best!.total { best = (model, total) }
+        }
+        return best.flatMap { nonEmpty($0.model) }
+    }
+
+    /// 서버가 계산한 비용만 쓴다(1e10 ticks = $1). 부분합·불완전 집계 플래그가 서 있으면 버린다
+    /// (Grok 모델 단가표가 없으므로 추정 대신 0 — 금액 오표시를 만들지 않는다).
+    private static func grokCost(_ usage: [String: Any]) -> Double? {
+        if boolValue(usage["usageIsIncomplete"]) || boolValue(usage["usage_is_incomplete"]) { return nil }
+        if boolValue(usage["costIsPartial"]) || boolValue(usage["cost_is_partial"]) { return nil }
+        let ticks = doubleValue(usage["costUsdTicks"] ?? usage["cost_usd_ticks"])
+        return ticks > 0 ? ticks / 1e10 : nil
+    }
+
+    private static func grokDate(envelope: [String: Any], meta: [String: Any]?) -> Date? {
+        if let ts = envelope["timestamp"] as? String, let d = ISO8601Parser.date(from: ts) { return d }
+        let ms = doubleValue(meta?["agentTimestampMs"])
+        return ms > 0 ? Date(timeIntervalSince1970: ms / 1000) : nil
+    }
+
     private static func codexModel(_ line: String) -> String? {
         guard let data = line.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -374,5 +502,23 @@ enum LocalUsageReader {
         if let d = v as? Double { return Int(d) }
         if let n = v as? NSNumber { return n.intValue }
         return 0
+    }
+
+    private static func doubleValue(_ v: Any?) -> Double {
+        if let d = v as? Double { return d }
+        if let i = v as? Int { return Double(i) }
+        if let n = v as? NSNumber { return n.doubleValue }
+        return 0
+    }
+
+    private static func boolValue(_ v: Any?) -> Bool {
+        if let b = v as? Bool { return b }
+        if let n = v as? NSNumber { return n.boolValue }
+        return false
+    }
+
+    private static func nonEmpty(_ v: String?) -> String? {
+        guard let t = v?.trimmingCharacters(in: .whitespacesAndNewlines), !t.isEmpty else { return nil }
+        return t
     }
 }

--- a/Sources/PokeTokenBar/Core/ModelPricing.swift
+++ b/Sources/PokeTokenBar/Core/ModelPricing.swift
@@ -37,6 +37,9 @@ enum ModelPricing {
     static func rate(for model: String) -> ModelRate {
         if let r = table[model] { return r }
         let m = model.lowercased()
+        // Grok 은 서버가 보고한 비용(costUsdTicks)만 쓴다 — 단가표가 없으므로 0. 아래 패밀리 폴백보다
+        // 먼저 끊어야 `grok-codex-*`·`grok-4o-*` 류 이름이 GPT 단가로 잡혀 가짜 금액을 표시하지 않는다.
+        if m.hasPrefix("grok") { return .zero }
         if m.contains("opus")   { return .perMillion(5, 25, 6.25, 0.5) }
         if m.contains("sonnet") { return .perMillion(3, 15, 3.75, 0.3) }
         if m.contains("haiku")  { return .perMillion(1, 5, 1.25, 0.1) }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -295,8 +295,9 @@ final class UsageStore {
         return utils.max()
     }
 
-    /// 사탕 지급 대상 한도 창 — 세션급(≈5h)=1개, 주간급=5개, 전 프로바이더. Gemini 는 공식 한도
-    /// 신호가 없어 자연히 빠진다(창 목록에 없음). 지급 제외: Opus/Sonnet 주간·scoped·Codex 개인 spend
+    /// 사탕 지급 대상 한도 창 — 세션급(≈5h)=1개, 주간급=5개, 전 프로바이더. 공식 한도 신호가 없는
+    /// 프로바이더(Gemini·OpenCode·Hermes·Cursor·Grok)는 자연히 빠진다(창 목록에 없음).
+    /// 지급 제외: Opus/Sonnet 주간·scoped·Codex 개인 spend
     /// limit(헤드라인 창의 하위/중복 → 이중지급 방지). 알림(checkLimitAlerts)보다 좁은 지급 전용.
     var candyEligibleWindows: [CandyWindow] {
         let l = L(localizationLanguage)

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -360,6 +360,7 @@ final class UsageStore {
     init(providers: [any UsageProvider] = [
         LocalClaudeProvider(), LocalCodexProvider(), LocalGeminiProvider(),
         LocalOpenCodeProvider(), LocalHermesProvider(), LocalCursorProvider(),
+        LocalGrokProvider(),
     ],
          claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),

--- a/Tests/PokeTokenBarTests/GrokUsageTests.swift
+++ b/Tests/PokeTokenBarTests/GrokUsageTests.swift
@@ -1,0 +1,346 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// 오늘 사용량만 돌려주는 최소 스텁 — grok 단독 사용자 시나리오(프로바이더 무관 집계) 검증용.
+private struct GrokOnlyProvider: UsageProvider {
+    let id = "grok"
+    let displayName = "Grok"
+    let daily: DailyUsage?
+    let block: BlockUsage?
+
+    func fetchDaily() async throws -> DailyUsage? { daily }
+    func fetchEnrichment() async -> ProviderEnrichment {
+        var r = ProviderEnrichment()
+        r.activeBlock = block
+        r.blocksOK = true
+        r.weekTotal = PeriodUsage(period: "W", totalTokens: 9_000, totalCost: 0)
+        r.monthTotal = PeriodUsage(period: "M", totalTokens: 30_000, totalCost: 0)
+        r.periodsOK = true
+        return r
+    }
+}
+
+private struct NoLimitsForGrok: ClaudeLimitsProviding {
+    func fetch(allowKeychainPrompt: Bool) async throws -> LimitStatus { throw LimitsError.keychainInteractionNotAllowed }
+}
+private struct NoCodexLimitsForGrok: CodexLimitsProviding {
+    func fetch() async throws -> CodexRateLimitStatus? { nil }
+}
+private struct NoStatusForGrok: ProviderStatusProviding {
+    func fetch() async -> [String: ProviderStatus] { [:] }
+}
+
+/// 공식 xAI Grok CLI 세션 파싱 — `~/.grok/sessions/<id>/updates.jsonl` 의 `turn_completed.usage`.
+/// 스키마 근거는 grok-build 소스(`extensions/notification.rs` 의 SessionUpdate/PromptUsage serde 계약).
+final class GrokUsageTests: XCTestCase {
+    private var base: URL!
+    private var root: URL!          // = <base>/sessions
+    private var cacheFile: URL!
+
+    override func setUpWithError() throws {
+        base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ptb-grok-\(UUID().uuidString)")
+        root = base.appendingPathComponent("sessions")
+        cacheFile = base.appendingPathComponent("usage-cache.json")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: base)
+    }
+
+    // MARK: 픽스처
+
+    /// 스트리밍 청크 라인(토큰 없음) — 실제 updates.jsonl 대부분이 이 형태다.
+    private let chunkLine = """
+    {"timestamp":"2026-07-29T01:00:00.000Z","update":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}},"_meta":{"totalTokens":100,"eventId":"e0","agentTimestampMs":1785000000000,"chunkId":0}}}
+    """
+
+    /// 턴 종료 라인 — ACP durable wire(camelCase): inputTokens 는 캐시 읽기를 **포함**한다.
+    private func turnLine(
+        promptID: String,
+        input: Int = 41_203,
+        output: Int = 812,
+        cachedRead: Int = 38_400,
+        total: Int = 42_015,
+        costTicks: Int? = 12_000_000_000,
+        costIsPartial: Bool = false,
+        usageIsIncomplete: Bool = false,
+        model: String? = "grok-build-1",
+        timestamp: String? = "2026-07-29T01:00:10.000Z",
+        isReplay: Bool = false
+    ) -> String {
+        var usage: [String] = [
+            "\"inputTokens\":\(input)", "\"outputTokens\":\(output)", "\"totalTokens\":\(total)",
+            "\"cachedReadTokens\":\(cachedRead)", "\"reasoningTokens\":260", "\"modelCalls\":3",
+            "\"numTurns\":1",
+        ]
+        if let costTicks { usage.append("\"costUsdTicks\":\(costTicks)") }
+        if costIsPartial { usage.append("\"costIsPartial\":true") }
+        if usageIsIncomplete { usage.append("\"usageIsIncomplete\":true") }
+        if let model {
+            usage.append("""
+            "modelUsage":{"\(model)":{"inputTokens":\(input),"outputTokens":\(output),"totalTokens":\(total),"cachedReadTokens":\(cachedRead)}}
+            """)
+        }
+        var meta = ["\"totalTokens\":\(total)", "\"eventId\":\"ev-\(promptID)\"",
+                    "\"agentTimestampMs\":1785000010000", "\"promptId\":\"\(promptID)\""]
+        if isReplay { meta.append("\"isReplay\":true") }
+        let ts = timestamp.map { "\"timestamp\":\"\($0)\"," } ?? ""
+        return """
+        {\(ts)"update":{"sessionId":"s1","update":{"sessionUpdate":"turn_completed","prompt_id":"\(promptID)","stop_reason":"end_turn","usage":{\(usage.joined(separator: ","))}},"_meta":{\(meta.joined(separator: ","))}}}
+        """
+    }
+
+    @discardableResult
+    private func writeSession(_ id: String, lines: [String], sessionKind: String? = nil) throws -> URL {
+        let dir = root.appendingPathComponent(id)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let updates = dir.appendingPathComponent("updates.jsonl")
+        try lines.joined(separator: "\n").write(to: updates, atomically: true, encoding: .utf8)
+        var summary = "{\"session_summary\":\"x\""
+        if let sessionKind { summary += ",\"session_kind\":\"\(sessionKind)\"" }
+        summary += "}"
+        try summary.write(to: dir.appendingPathComponent("summary.json"), atomically: true, encoding: .utf8)
+        return updates
+    }
+
+    private func parse(_ url: URL) -> [LocalUsageReader.Entry] {
+        LocalUsageReader.parseGrokFile(url, fmt: LocalUsageReader.localDayFormatter())
+    }
+
+    // MARK: 토큰 매핑
+
+    /// camelCase(durable ACP wire) — inputTokens 는 캐시 포함이므로 캐시분을 빼야 하고,
+    /// Entry.total 은 usage.totalTokens 와 정확히 일치해야 한다.
+    func testTurnCompletedTokenMappingPreservesTotalIdentity() throws {
+        let url = try writeSession("s1", lines: [chunkLine, turnLine(promptID: "p-1")])
+        let entries = parse(url)
+        XCTAssertEqual(entries.count, 1, "청크 라인은 토큰이 없어 집계 대상이 아니다")
+        let e = try XCTUnwrap(entries.first)
+        XCTAssertEqual(e.input, 2_803, "input = inputTokens(41203) − cachedReadTokens(38400)")
+        XCTAssertEqual(e.cacheRead, 38_400)
+        XCTAssertEqual(e.output, 812, "reasoning 은 output 에 포함 — 따로 더하지 않는다")
+        XCTAssertEqual(e.cacheWrite, 0, "Grok 은 캐시 쓰기를 prompt 토큰에 접어 넣는다")
+        XCTAssertEqual(e.total, 42_015, "Entry.total == usage.totalTokens")
+        XCTAssertEqual(e.model, "grok-build-1")
+        XCTAssertEqual(try XCTUnwrap(e.explicitCost), 1.2, accuracy: 1e-9, "12e9 ticks = $1.2")
+    }
+
+    /// [트리거 브랜치] 헤드리스 투영(snake_case)의 `input_tokens` 는 **이미 캐시 제외**다.
+    /// camelCase 와 같은 값으로 취급하면 캐시분을 두 번 빼 input 이 60 → 20 으로 어긋난다.
+    func testHeadlessSnakeCaseInputIsNotCacheAdjustedAgain() throws {
+        let line = """
+        {"timestamp":"2026-07-29T02:00:00.000Z","update":{"sessionId":"s2","update":{"sessionUpdate":"turn_completed","prompt_id":"p-snake","stop_reason":"end_turn","usage":{"input_tokens":60,"output_tokens":10,"total_tokens":110,"cached_read_tokens":40}},"_meta":{"eventId":"ev-snake","agentTimestampMs":1785000020000}}}
+        """
+        let url = try writeSession("s2", lines: [line])
+        let e = try XCTUnwrap(parse(url).first)
+        XCTAssertEqual(e.input, 60, "snake_case input_tokens 는 캐시 제외값 — 다시 빼면 안 된다")
+        XCTAssertEqual(e.cacheRead, 40)
+        XCTAssertEqual(e.output, 10)
+        XCTAssertEqual(e.total, 110)
+    }
+
+    /// 여러 턴 합산 + 청크 라인 다수 무시.
+    func testMultipleTurnsAggregate() throws {
+        let url = try writeSession("s3", lines: [
+            chunkLine, turnLine(promptID: "p-1"), chunkLine,
+            turnLine(promptID: "p-2", input: 100, output: 20, cachedRead: 0, total: 120, costTicks: nil),
+        ])
+        let entries = parse(url)
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries.map(\.total).reduce(0, +), 42_015 + 120)
+        let day = try XCTUnwrap(entries.first?.localDay)
+        let daily = try XCTUnwrap(LocalUsageReader.daily(entries: entries, localDay: day))
+        XCTAssertEqual(daily.totalTokens, 42_015 + 120)
+        XCTAssertEqual(daily.totalCost, 1.2, accuracy: 1e-9, "비용은 서버가 준 ticks 만 — 두 번째 턴은 0")
+    }
+
+    // MARK: 이중 집계 방어
+
+    /// 재생(replay)으로 다시 append 된 턴 라인은 같은 턴을 두 번 세게 만든다.
+    func testReplayLineIsNotCountedTwice() throws {
+        let url = try writeSession("s4", lines: [
+            turnLine(promptID: "p-1"),
+            turnLine(promptID: "p-1", isReplay: true),
+        ])
+        let entries = parse(url)
+        XCTAssertEqual(entries.count, 1, "isReplay 라인은 건너뛴다")
+        XCTAssertEqual(entries.first?.total, 42_015)
+    }
+
+    /// [트리거 브랜치] fork 세션이 부모 updates 를 복사하면 같은 턴이 두 파일에 존재한다.
+    /// 턴 id 에 세션 경로를 섞지 않아야 전역 dedup 으로 한 번만 잡힌다.
+    func testForkedSessionCopyDoesNotDoubleCount() throws {
+        try writeSession("parent", lines: [turnLine(promptID: "p-1")])
+        try writeSession("child-fork", lines: [turnLine(promptID: "p-1")], sessionKind: "fork")
+        let entries = LocalUsageReader.grokEntries(modifiedSince: Date(timeIntervalSince1970: 0), root: root)
+        XCTAssertEqual(entries.count, 1, "같은 prompt_id 는 파일이 달라도 한 턴이다")
+        XCTAssertEqual(entries.first?.total, 42_015)
+    }
+
+    /// [트리거 브랜치] 서브에이전트 토큰은 부모 턴 usage 에 이미 접혀 들어온다(RecordSubagentUsage) →
+    /// 서브에이전트 세션을 또 집계하면 이중 계산. worktree/fork 등 사용자 세션은 유지해야 한다.
+    func testSubagentSessionsAreSkippedButUserSessionsKept() throws {
+        try writeSession("main", lines: [turnLine(promptID: "p-main")])
+        try writeSession("sub", lines: [turnLine(promptID: "p-sub")], sessionKind: "subagent")
+        try writeSession("sub2", lines: [turnLine(promptID: "p-sub2")], sessionKind: "subagent_fork")
+        try writeSession("wt", lines: [turnLine(promptID: "p-wt")], sessionKind: "worktree")
+
+        let entries = LocalUsageReader.grokEntries(modifiedSince: Date(timeIntervalSince1970: 0), root: root)
+        XCTAssertEqual(Set(entries.map(\.id)), Set(["grok|p-main", "grok|p-wt"]))
+    }
+
+    // MARK: 비용 신뢰 조건
+
+    /// 부분합·불완전 집계면 서버 비용을 버린다. Grok 단가표가 없으므로 결과 비용은 0(추정 금지).
+    func testUntrustworthyCostsAreDropped() throws {
+        let partial = try writeSession("cost-partial", lines: [
+            turnLine(promptID: "p-partial", costIsPartial: true)])
+        XCTAssertNil(parse(partial).first?.explicitCost, "costIsPartial → 신뢰 불가")
+
+        let incomplete = try writeSession("cost-incomplete", lines: [
+            turnLine(promptID: "p-incomplete", usageIsIncomplete: true)])
+        XCTAssertNil(parse(incomplete).first?.explicitCost, "usageIsIncomplete → 신뢰 불가")
+
+        let entries = parse(partial)
+        let day = try XCTUnwrap(entries.first?.localDay)
+        let daily = try XCTUnwrap(LocalUsageReader.daily(entries: entries, localDay: day))
+        XCTAssertEqual(daily.totalCost, 0, "단가표에 없는 모델 → 0 (금액 오표시 방지)")
+        XCTAssertEqual(ModelPricing.rate(for: "grok-build-1"), .zero)
+        XCTAssertEqual(ModelPricing.rate(for: "grok-4-fast"), .zero)
+    }
+
+    // MARK: 경계·폴백
+
+    /// 0 토큰 턴(취소 등)은 엔트리를 만들지 않는다 — `usage` 존재만으로 판정하지 않는다.
+    func testZeroUsageTurnProducesNoEntry() throws {
+        let url = try writeSession("zero", lines: [
+            turnLine(promptID: "p-zero", input: 0, output: 0, cachedRead: 0, total: 0, costTicks: nil)])
+        XCTAssertTrue(parse(url).isEmpty)
+    }
+
+    /// 봉투 timestamp 가 없으면 `_meta.agentTimestampMs` 로 폴백한다.
+    func testTimestampFallsBackToMetaAgentTimestamp() throws {
+        let url = try writeSession("ts", lines: [turnLine(promptID: "p-ts", timestamp: nil)])
+        let e = try XCTUnwrap(parse(url).first)
+        XCTAssertEqual(e.date.timeIntervalSince1970, 1_785_000_010, accuracy: 0.001)
+    }
+
+    /// modelUsage 가 없으면 totals 만으로 집계하고 모델명은 폴백.
+    func testMissingModelUsageFallsBackToGenericModel() throws {
+        let url = try writeSession("nomodel", lines: [turnLine(promptID: "p-nm", model: nil)])
+        let e = try XCTUnwrap(parse(url).first)
+        XCTAssertEqual(e.model, "grok")
+        XCTAssertEqual(e.total, 42_015)
+    }
+
+    /// turn_completed 가 없는 파일(청크만)은 조용히 0건 — JSON 파싱 전에 문자열로 걸러진다.
+    func testFileWithoutTurnCompletedYieldsNothing() throws {
+        let url = try writeSession("chunks", lines: [chunkLine, chunkLine, chunkLine])
+        XCTAssertTrue(parse(url).isEmpty)
+    }
+
+    /// 스케일 가드: 실제 updates.jsonl 은 스트리밍 청크가 대부분이라 세션당 수만 라인이 된다.
+    /// 문자열 prefilter 없이 라인마다 JSON 을 파싱하면 새로고침마다 이 비용을 문다.
+    func testLargeUpdatesFileStaysCheapAndAccurate() throws {
+        var lines: [String] = []
+        for turn in 0..<50 {
+            lines.append(contentsOf: Array(repeating: chunkLine, count: 400))
+            lines.append(turnLine(promptID: "p-\(turn)", input: 1_000, output: 100,
+                                  cachedRead: 400, total: 1_100, costTicks: nil))
+        }
+        let url = try writeSession("big", lines: lines)
+        let started = Date()
+        let entries = parse(url)
+        let elapsed = Date().timeIntervalSince(started)
+        XCTAssertEqual(entries.count, 50)
+        XCTAssertEqual(entries.map(\.total).reduce(0, +), 50 * 1_100)
+        XCTAssertLessThan(elapsed, 5, "20k 라인 파싱이 \(elapsed)s — prefilter 가 빠졌는지 확인")
+    }
+
+    // MARK: 캐시 경로
+
+    /// 캐시는 updates.jsonl 만 읽는다(chat_history/events 는 토큰이 없어 blob 만 부풀린다) + 스냅샷 라운드트립.
+    func testCacheReadsOnlyUpdatesFileAndPersists() async throws {
+        let dir = root.appendingPathComponent("s-cache")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try [chunkLine, turnLine(promptID: "p-1")].joined(separator: "\n")
+            .write(to: dir.appendingPathComponent("updates.jsonl"), atomically: true, encoding: .utf8)
+        // 같은 디렉토리의 다른 .jsonl — 파싱 대상이 아니어야 한다.
+        try turnLine(promptID: "p-should-not-count")
+            .write(to: dir.appendingPathComponent("chat_history.jsonl"), atomically: true, encoding: .utf8)
+        try turnLine(promptID: "p-events")
+            .write(to: dir.appendingPathComponent("events.jsonl"), atomically: true, encoding: .utf8)
+        try "{\"session_summary\":\"x\"}".write(
+            to: dir.appendingPathComponent("summary.json"), atomically: true, encoding: .utf8)
+
+        let entries = await LocalUsageCache(grokRoot: root, fileURL: cacheFile)
+            .grokEntries(modifiedSince: Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(entries.map(\.id), ["grok|p-1"])
+
+        // 두 번째 인스턴스는 디스크 스냅샷을 재사용해도 같은 결과여야 한다.
+        let again = await LocalUsageCache(grokRoot: root, fileURL: cacheFile)
+            .grokEntries(modifiedSince: Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(again.map(\.id), ["grok|p-1"])
+    }
+
+    // MARK: 등록·집계 패리티
+
+    /// Grok 만 쓰는 사용자도 오늘/주/월·번레이트·메뉴 표시가 모두 동작해야 한다
+    /// (과거 회귀: 특정 프로바이더에만 계산을 붙여 다른 프로바이더 전용 사용자가 idle 로 남았다).
+    @MainActor
+    func testGrokOnlyUserGetsAllAggregates() async throws {
+        let suite = "GrokUsageTests.parity.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let today = LocalUsageReader.todayKey()
+        // burnTier 임계는 1,000 tokens/min 초과 — 그 위 값으로 "관측됐다"를 검증한다.
+        let block = BlockUsage(id: "b", startTime: "", endTime: "", isActive: true,
+                               totalTokens: 50_000, costUSD: 0, tokensPerMinute: 5_000)
+        let store = UsageStore(
+            providers: [GrokOnlyProvider(
+                daily: DailyUsage(date: today, inputTokens: 1_000, outputTokens: 200,
+                                  cacheCreationTokens: 0, cacheReadTokens: 800,
+                                  totalTokens: 2_000, totalCost: 0.5),
+                block: block)],
+            claudeLimitsProvider: NoLimitsForGrok(),
+            codexLimitsProvider: NoCodexLimitsForGrok(),
+            statusProvider: NoStatusForGrok(),
+            autoRefresh: false,
+            defaults: defaults)
+
+        await store.refresh(scheduleEmptyRetry: false)
+
+        XCTAssertEqual(store.todayTotalTokens, 2_000)
+        XCTAssertEqual(store.weekTotalTokens, 9_000)
+        XCTAssertEqual(store.monthTotalTokens, 30_000)
+        XCTAssertEqual(store.snapshots.map(\.providerID), ["grok"])
+        XCTAssertEqual(store.burnTier, .normal, "번레이트가 Grok 블록을 관측해야 한다(idle 이면 미관측)")
+        XCTAssertFalse(store.menuTitle.isEmpty)
+        XCTAssertNil(store.lastErrorDescription)
+    }
+
+    /// 기본 레지스트리에 Grok 이 등록돼 있어야 팝오버 탭/집계에 나타난다.
+    @MainActor
+    func testDefaultRegistryIncludesGrok() {
+        let suite = "GrokUsageTests.registry.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = UsageStore(autoRefresh: false, defaults: defaults)
+        XCTAssertTrue(store.registeredProviderIDs.contains("grok"))
+    }
+
+    /// `$GROK_HOME` 이 설정돼 있으면 그 아래 sessions 를 본다(CLI 와 같은 규칙).
+    func testSessionsDirHonoursGrokHomeEnvironment() throws {
+        let expected: URL
+        if let home = ProcessInfo.processInfo.environment["GROK_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !home.isEmpty {
+            expected = URL(fileURLWithPath: home).appendingPathComponent("sessions")
+        } else {
+            expected = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".grok/sessions")
+        }
+        XCTAssertEqual(LocalUsageReader.grokSessionsDir.standardizedFileURL, expected.standardizedFileURL)
+        XCTAssertEqual(LocalUsageReader.grokSessionsDir.lastPathComponent, "sessions")
+    }
+}

--- a/Tests/PokeTokenBarTests/GrokUsageTests.swift
+++ b/Tests/PokeTokenBarTests/GrokUsageTests.swift
@@ -51,8 +51,10 @@ final class GrokUsageTests: XCTestCase {
     // MARK: 픽스처
 
     /// 스트리밍 청크 라인(토큰 없음) — 실제 updates.jsonl 대부분이 이 형태다.
+    /// 봉투는 실제 디스크 형식 그대로: `{timestamp:<초>, method, params:{sessionId, update, _meta}}`.
+    /// (`_meta.totalTokens` 는 컨텍스트 창 크기 — 사용량으로 세면 안 된다.)
     private let chunkLine = """
-    {"timestamp":"2026-07-29T01:00:00.000Z","update":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}},"_meta":{"totalTokens":100,"eventId":"e0","agentTimestampMs":1785000000000,"chunkId":0}}}
+    {"timestamp":1785000000,"method":"_x.ai/session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}},"_meta":{"totalTokens":100,"eventId":"e0","agentTimestampMs":1785000000000,"chunkId":0}}}
     """
 
     /// 턴 종료 라인 — ACP durable wire(camelCase): inputTokens 는 캐시 읽기를 **포함**한다.
@@ -66,7 +68,8 @@ final class GrokUsageTests: XCTestCase {
         costIsPartial: Bool = false,
         usageIsIncomplete: Bool = false,
         model: String? = "grok-build-1",
-        timestamp: String? = "2026-07-29T01:00:10.000Z",
+        envelopeSeconds: Int? = 1_785_000_010,
+        agentTimestampMs: Int? = 1_785_000_010_000,
         isReplay: Bool = false
     ) -> String {
         var usage: [String] = [
@@ -83,25 +86,37 @@ final class GrokUsageTests: XCTestCase {
             """)
         }
         var meta = ["\"totalTokens\":\(total)", "\"eventId\":\"ev-\(promptID)\"",
-                    "\"agentTimestampMs\":1785000010000", "\"promptId\":\"\(promptID)\""]
+                    "\"promptId\":\"\(promptID)\""]
+        if let agentTimestampMs { meta.append("\"agentTimestampMs\":\(agentTimestampMs)") }
         if isReplay { meta.append("\"isReplay\":true") }
-        let ts = timestamp.map { "\"timestamp\":\"\($0)\"," } ?? ""
+        let ts = envelopeSeconds.map { "\"timestamp\":\($0)," } ?? ""
         return """
-        {\(ts)"update":{"sessionId":"s1","update":{"sessionUpdate":"turn_completed","prompt_id":"\(promptID)","stop_reason":"end_turn","usage":{\(usage.joined(separator: ","))}},"_meta":{\(meta.joined(separator: ","))}}}
+        {\(ts)"method":"_x.ai/session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"turn_completed","prompt_id":"\(promptID)","stop_reason":"end_turn","usage":{\(usage.joined(separator: ","))}},"_meta":{\(meta.joined(separator: ","))}}}
         """
     }
 
+    /// 세션 디렉토리 하나를 만든다. 실제 레이아웃은 `sessions/<encoded-cwd>/<session-id>/` 라
+    /// 한 단계 더 깊다 — 스캔이 재귀인지까지 함께 확인하려고 같은 깊이로 쓴다.
     @discardableResult
-    private func writeSession(_ id: String, lines: [String], sessionKind: String? = nil) throws -> URL {
-        let dir = root.appendingPathComponent(id)
+    private func writeSession(_ id: String, lines: [String], sessionKind: String? = nil,
+                              summary: Bool = true, mtime: Date? = nil) throws -> URL {
+        let dir = root.appendingPathComponent("cwd-group/\(id)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let updates = dir.appendingPathComponent("updates.jsonl")
         try lines.joined(separator: "\n").write(to: updates, atomically: true, encoding: .utf8)
+        if summary { try writeSummary(id, sessionKind: sessionKind) }
+        if let mtime {
+            try FileManager.default.setAttributes([.modificationDate: mtime], ofItemAtPath: updates.path)
+        }
+        return updates
+    }
+
+    private func writeSummary(_ id: String, sessionKind: String? = nil) throws {
         var summary = "{\"session_summary\":\"x\""
         if let sessionKind { summary += ",\"session_kind\":\"\(sessionKind)\"" }
         summary += "}"
-        try summary.write(to: dir.appendingPathComponent("summary.json"), atomically: true, encoding: .utf8)
-        return updates
+        try summary.write(to: root.appendingPathComponent("cwd-group/\(id)/summary.json"),
+                          atomically: true, encoding: .utf8)
     }
 
     private func parse(_ url: URL) -> [LocalUsageReader.Entry] {
@@ -128,9 +143,11 @@ final class GrokUsageTests: XCTestCase {
 
     /// [트리거 브랜치] 헤드리스 투영(snake_case)의 `input_tokens` 는 **이미 캐시 제외**다.
     /// camelCase 와 같은 값으로 취급하면 캐시분을 두 번 빼 input 이 60 → 20 으로 어긋난다.
+    /// (디스크의 durable 라인은 camelCase 다. 이 형태는 헤드리스 결과 JSON 을 옮겨 적는 도구를
+    /// 대비한 방어 경로이므로, 의미가 반대인 두 스펠링이 섞여도 각각 맞게 읽히는지 고정한다.)
     func testHeadlessSnakeCaseInputIsNotCacheAdjustedAgain() throws {
         let line = """
-        {"timestamp":"2026-07-29T02:00:00.000Z","update":{"sessionId":"s2","update":{"sessionUpdate":"turn_completed","prompt_id":"p-snake","stop_reason":"end_turn","usage":{"input_tokens":60,"output_tokens":10,"total_tokens":110,"cached_read_tokens":40}},"_meta":{"eventId":"ev-snake","agentTimestampMs":1785000020000}}}
+        {"timestamp":1785000020,"method":"_x.ai/session/update","params":{"sessionId":"s2","update":{"sessionUpdate":"turn_completed","prompt_id":"p-snake","stop_reason":"end_turn","usage":{"input_tokens":60,"output_tokens":10,"total_tokens":110,"cached_read_tokens":40}},"_meta":{"eventId":"ev-snake","agentTimestampMs":1785000020000}}}
         """
         let url = try writeSession("s2", lines: [line])
         let e = try XCTUnwrap(parse(url).first)
@@ -216,8 +233,45 @@ final class GrokUsageTests: XCTestCase {
         let day = try XCTUnwrap(entries.first?.localDay)
         let daily = try XCTUnwrap(LocalUsageReader.daily(entries: entries, localDay: day))
         XCTAssertEqual(daily.totalCost, 0, "단가표에 없는 모델 → 0 (금액 오표시 방지)")
-        XCTAssertEqual(ModelPricing.rate(for: "grok-build-1"), .zero)
-        XCTAssertEqual(ModelPricing.rate(for: "grok-4-fast"), .zero)
+    }
+
+    /// [트리거 브랜치] Grok 이름은 패밀리 폴백에 걸리기 전에 0 으로 끊어야 한다 — `grok-codex-*`·
+    /// `grok-4o-*` 는 `codex`/`o4` 부분문자열에 걸려 GPT 단가($5/$30)로 가짜 금액을 만들 수 있다.
+    func testGrokNamesNeverInheritOtherFamilyPricing() {
+        for name in ["grok-build-1", "grok-4-fast", "grok-code-fast-1", "grok-codex-next", "grok-4o-mini"] {
+            XCTAssertEqual(ModelPricing.rate(for: name), .zero, "\(name) 단가는 0이어야 한다")
+        }
+        XCTAssertEqual(ModelPricing.cost(model: "grok-codex-next", input: 1_000_000, output: 1_000_000,
+                                         cacheWrite: 0, cacheRead: 0), 0)
+        // 다른 프로바이더의 폴백은 그대로 살아 있어야 한다(과잉 차단 방지).
+        XCTAssertEqual(ModelPricing.rate(for: "gpt-5.6-codex"), .perMillion(5, 30, 0, 0.5))
+    }
+
+    /// 프로바이더가 쓰는 것과 같은 집계 경로(블록·주·월)를 실제 파일로 검증한다.
+    /// (`LocalGrokProvider` 는 이 세 helper 를 그대로 호출한다 — 산술이 여기서 고정된다.)
+    func testBlockWeekMonthAggregatesFromRealFiles() throws {
+        let now = Date()
+        let recent = Int(now.addingTimeInterval(-600).timeIntervalSince1970)   // 10분 전 = 5h 블록 안
+        try writeSession("agg", lines: [
+            turnLine(promptID: "p-block", input: 1_000, output: 100, cachedRead: 0, total: 1_100,
+                     costTicks: nil, envelopeSeconds: recent, agentTimestampMs: recent * 1_000)])
+        let entries = LocalUsageReader.grokEntries(modifiedSince: epoch, root: root)
+        XCTAssertEqual(entries.count, 1)
+
+        let block = try XCTUnwrap(LocalUsageReader.activeBlock(entries: entries, now: now))
+        XCTAssertEqual(block.totalTokens, 1_100)
+        XCTAssertTrue(block.isActive)
+        let fmt = LocalUsageReader.localDayFormatter()
+        let weekStart = LocalUsageReader.startOfWeek(now)
+        let week = LocalUsageReader.period(entries: entries, periodKey: "W",
+                                          fromDay: fmt.string(from: weekStart), toDay: fmt.string(from: now))
+        XCTAssertEqual(week.totalTokens, 1_100)
+        let month = LocalUsageReader.period(entries: entries, periodKey: LocalUsageReader.monthKey(now),
+                                            fromDay: fmt.string(from: LocalUsageReader.startOfMonth(now)),
+                                            toDay: fmt.string(from: now))
+        XCTAssertEqual(month.totalTokens, 1_100)
+        XCTAssertEqual(LocalUsageReader.daily(entries: entries,
+                                              localDay: LocalUsageReader.todayKey())?.totalTokens, 1_100)
     }
 
     // MARK: 경계·폴백
@@ -229,11 +283,64 @@ final class GrokUsageTests: XCTestCase {
         XCTAssertTrue(parse(url).isEmpty)
     }
 
-    /// 봉투 timestamp 가 없으면 `_meta.agentTimestampMs` 로 폴백한다.
-    func testTimestampFallsBackToMetaAgentTimestamp() throws {
-        let url = try writeSession("ts", lines: [turnLine(promptID: "p-ts", timestamp: nil)])
+    /// [트리거 브랜치] 봉투 `timestamp` 는 *기록* 시각이고 fork 복사 때 새로 찍힌다 →
+    /// 그걸 우선하면 포크된 세션의 과거 사용량이 전부 포크 시점으로 재날짜화된다.
+    /// `_meta.agentTimestampMs`(턴 시각, 복사 시 보존)가 이겨야 한다.
+    func testAgentTimestampWinsOverEnvelopeWriteTime() throws {
+        let forkWriteTime = 1_785_600_000              // 원래 턴보다 약 6.9일 뒤
+        let url = try writeSession("forked", lines: [
+            turnLine(promptID: "p-old", envelopeSeconds: forkWriteTime,
+                     agentTimestampMs: 1_785_000_010_000)])
+        let e = try XCTUnwrap(parse(url).first)
+        XCTAssertEqual(e.date.timeIntervalSince1970, 1_785_000_010, accuracy: 0.001,
+                       "포크 기록 시각(\(forkWriteTime))이 아니라 턴 시각을 써야 한다")
+    }
+
+    /// `_meta.agentTimestampMs` 가 없으면 봉투 `timestamp`(Unix 초)로 폴백한다.
+    /// 봉투는 ISO 문자열이 아니라 숫자다 — 문자열로만 읽으면 모든 턴이 조용히 사라진다.
+    func testEnvelopeSecondsUsedWhenAgentTimestampMissing() throws {
+        let url = try writeSession("ts", lines: [
+            turnLine(promptID: "p-ts", envelopeSeconds: 1_785_000_010, agentTimestampMs: nil)])
         let e = try XCTUnwrap(parse(url).first)
         XCTAssertEqual(e.date.timeIntervalSince1970, 1_785_000_010, accuracy: 0.001)
+    }
+
+    /// [트리거 브랜치] JSON `null` 은 "값 있음"이 아니다. camelCase 키가 null 이면 snake_case 값을
+    /// 써야 하고, null 을 0 으로 읽어 캐시분을 빼면 입력 토큰이 통째로 사라진다.
+    func testNullTokenFieldsDoNotZeroTheTurn() throws {
+        let line = """
+        {"timestamp":1785000030,"method":"_x.ai/session/update","params":{"sessionId":"s5","update":{"sessionUpdate":"turn_completed","prompt_id":"p-null","stop_reason":"end_turn","usage":{"inputTokens":null,"input_tokens":60,"outputTokens":null,"output_tokens":10,"cachedReadTokens":40,"totalTokens":110}},"_meta":{"eventId":"ev-null","agentTimestampMs":1785000030000}}}
+        """
+        let url = try writeSession("nulls", lines: [line])
+        let e = try XCTUnwrap(parse(url).first)
+        XCTAssertEqual(e.input, 60, "inputTokens 가 null 이면 snake_case 값을 쓴다")
+        XCTAssertEqual(e.output, 10)
+        XCTAssertEqual(e.cacheRead, 40)
+        XCTAssertEqual(e.total, 110)
+    }
+
+    /// [트리거 브랜치] 캐시 읽기는 프롬프트의 부분집합이라 전체보다 클 수 없다. 어긋난 페이로드에서
+    /// `max(0, full − cache)` 로 뭉개면 input+cacheRead 가 프롬프트를 넘어 total 이 조용히 부푼다.
+    func testCacheReadIsClampedToPromptTotal() throws {
+        let url = try writeSession("clamp", lines: [
+            turnLine(promptID: "p-clamp", input: 1_000, output: 50, cachedRead: 1_200,
+                     total: 1_050, costTicks: nil)])
+        let e = try XCTUnwrap(parse(url).first)
+        XCTAssertEqual(e.input, 0)
+        XCTAssertEqual(e.cacheRead, 1_000, "캐시 읽기는 프롬프트 전체(1000)로 clamp")
+        XCTAssertEqual(e.total, 1_050, "소스가 말한 totalTokens 와 일치해야 한다")
+    }
+
+    /// 부분 필드 합이 소스의 `totalTokens` 보다 작으면 남는 분은 output 에 귀속시켜 합계를 소스에 맞춘다.
+    func testResidualAgainstReportedTotalGoesToOutput() throws {
+        let url = try writeSession("residual", lines: [
+            turnLine(promptID: "p-res", input: 500, output: 10, cachedRead: 100,
+                     total: 700, costTicks: nil)])
+        let e = try XCTUnwrap(parse(url).first)
+        XCTAssertEqual(e.total, 700)
+        XCTAssertEqual(e.input, 400)
+        XCTAssertEqual(e.cacheRead, 100)
+        XCTAssertEqual(e.output, 200, "10 + (700 − 510) 잔여분")
     }
 
     /// modelUsage 가 없으면 totals 만으로 집계하고 모델명은 폴백.
@@ -250,9 +357,11 @@ final class GrokUsageTests: XCTestCase {
         XCTAssertTrue(parse(url).isEmpty)
     }
 
-    /// 스케일 가드: 실제 updates.jsonl 은 스트리밍 청크가 대부분이라 세션당 수만 라인이 된다.
-    /// 문자열 prefilter 없이 라인마다 JSON 을 파싱하면 새로고침마다 이 비용을 문다.
-    func testLargeUpdatesFileStaysCheapAndAccurate() throws {
+    /// 스케일 정확성: 실제 updates.jsonl 은 스트리밍 청크가 대부분(세션당 수만 라인)이고 그 안엔
+    /// `_meta.totalTokens` 같은 *컨텍스트 창* 숫자가 라인마다 들어 있다. 2만 라인 중 턴 종료 50건만
+    /// 정확히 집계돼야 한다(청크의 토큰 필드가 새면 합계가 수십 배로 부푼다).
+    /// (벽시계 상한은 두지 않는다 — 실측상 prefilter 유무의 차이가 작아 상한이 통과의례가 된다.)
+    func testLargeUpdatesFileAggregatesOnlyTurnEndings() throws {
         var lines: [String] = []
         for turn in 0..<50 {
             lines.append(contentsOf: Array(repeating: chunkLine, count: 400))
@@ -260,38 +369,109 @@ final class GrokUsageTests: XCTestCase {
                                   cachedRead: 400, total: 1_100, costTicks: nil))
         }
         let url = try writeSession("big", lines: lines)
-        let started = Date()
         let entries = parse(url)
-        let elapsed = Date().timeIntervalSince(started)
         XCTAssertEqual(entries.count, 50)
         XCTAssertEqual(entries.map(\.total).reduce(0, +), 50 * 1_100)
-        XCTAssertLessThan(elapsed, 5, "20k 라인 파싱이 \(elapsed)s — prefilter 가 빠졌는지 확인")
     }
 
     // MARK: 캐시 경로
 
-    /// 캐시는 updates.jsonl 만 읽는다(chat_history/events 는 토큰이 없어 blob 만 부풀린다) + 스냅샷 라운드트립.
-    func testCacheReadsOnlyUpdatesFileAndPersists() async throws {
-        let dir = root.appendingPathComponent("s-cache")
+    private var epoch: Date { Date(timeIntervalSince1970: 0) }
+
+    /// 캐시는 updates.jsonl 만 읽는다 — 같은 디렉토리의 chat_history/events 는 토큰이 없고,
+    /// 파싱하면 없는 사용량이 잡히거나 빈 blob 이 스냅샷을 부풀린다.
+    func testCacheReadsOnlyTheUpdatesFile() async throws {
+        let dir = root.appendingPathComponent("cwd-group/s-cache")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         try [chunkLine, turnLine(promptID: "p-1")].joined(separator: "\n")
             .write(to: dir.appendingPathComponent("updates.jsonl"), atomically: true, encoding: .utf8)
-        // 같은 디렉토리의 다른 .jsonl — 파싱 대상이 아니어야 한다.
         try turnLine(promptID: "p-should-not-count")
             .write(to: dir.appendingPathComponent("chat_history.jsonl"), atomically: true, encoding: .utf8)
         try turnLine(promptID: "p-events")
             .write(to: dir.appendingPathComponent("events.jsonl"), atomically: true, encoding: .utf8)
-        try "{\"session_summary\":\"x\"}".write(
-            to: dir.appendingPathComponent("summary.json"), atomically: true, encoding: .utf8)
+        try writeSummary("s-cache")
 
-        let entries = await LocalUsageCache(grokRoot: root, fileURL: cacheFile)
-            .grokEntries(modifiedSince: Date(timeIntervalSince1970: 0))
+        let entries = await LocalUsageCache(grokRoot: root, fileURL: cacheFile).grokEntries(modifiedSince: epoch)
         XCTAssertEqual(entries.map(\.id), ["grok|p-1"])
+    }
 
-        // 두 번째 인스턴스는 디스크 스냅샷을 재사용해도 같은 결과여야 한다.
-        let again = await LocalUsageCache(grokRoot: root, fileURL: cacheFile)
-            .grokEntries(modifiedSince: Date(timeIntervalSince1970: 0))
-        XCTAssertEqual(again.map(\.id), ["grok|p-1"])
+    /// blob 재사용을 실제로 증명한다: mtime·size 를 유지한 채 내용만 바꿔치기하면 캐시 히트가
+    /// **옛 값**을 돌려줘야 한다(같은 결과가 나오는지만 보면 재파싱과 구분되지 않는다).
+    func testCacheHitReusesBlobForUnchangedFileStamp() async throws {
+        let stamp = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970) - 3_600)
+        let first = turnLine(promptID: "p-aaaa", input: 1_000, output: 100, cachedRead: 0,
+                             total: 1_100, costTicks: nil)
+        try writeSession("hit", lines: [first], mtime: stamp)
+        _ = await LocalUsageCache(grokRoot: root, fileURL: cacheFile).grokEntries(modifiedSince: epoch)
+
+        // 같은 길이·같은 mtime 으로 교체(id 만 다름) → 캐시를 쓰면 옛 id 가 그대로 나온다.
+        let swapped = turnLine(promptID: "p-bbbb", input: 1_000, output: 100, cachedRead: 0,
+                              total: 1_100, costTicks: nil)
+        XCTAssertEqual(swapped.count, first.count, "바꿔치기 라인은 길이가 같아야 캐시 키가 유지된다")
+        try writeSession("hit", lines: [swapped], mtime: stamp)
+
+        let cached = await LocalUsageCache(grokRoot: root, fileURL: cacheFile).grokEntries(modifiedSince: epoch)
+        XCTAssertEqual(cached.map(\.id), ["grok|p-aaaa"], "디스크 스냅샷을 재사용해야 한다")
+    }
+
+    /// 파서 버전이 바뀌면 Grok blob 만 버리고 재파싱한다(토큰 매핑 변경이 옛 캐시에 굳지 않게).
+    func testGrokParserVersionInvalidatesCachedBlobs() async throws {
+        let stamp = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970) - 3_600)
+        let first = turnLine(promptID: "p-aaaa", input: 1_000, output: 100, cachedRead: 0,
+                             total: 1_100, costTicks: nil)
+        try writeSession("ver", lines: [first], mtime: stamp)
+        _ = await LocalUsageCache(grokRoot: root, fileURL: cacheFile).grokEntries(modifiedSince: epoch)
+
+        try rewriteSnapshot { snapshot in snapshot["grokParserVersion"] = 0 }
+
+        let swapped = turnLine(promptID: "p-bbbb", input: 1_000, output: 100, cachedRead: 0,
+                              total: 1_100, costTicks: nil)
+        try writeSession("ver", lines: [swapped], mtime: stamp)
+        let entries = await LocalUsageCache(grokRoot: root, fileURL: cacheFile).grokEntries(modifiedSince: epoch)
+        XCTAssertEqual(entries.map(\.id), ["grok|p-bbbb"], "버전 불일치면 재파싱해야 한다")
+    }
+
+    /// grok 키가 없는 구버전 스냅샷도 로드된다 — 여기서 throw 하면 `ensureLoaded` 가 중단되고
+    /// Claude/Codex/Gemini 까지 전부 콜드 재파싱(수백 MB)에 빠진다.
+    func testSnapshotWithoutGrokKeysStillLoads() async throws {
+        let stamp = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970) - 3_600)
+        try writeSession("legacy", lines: [turnLine(promptID: "p-legacy")], mtime: stamp)
+        _ = await LocalUsageCache(grokRoot: root, fileURL: cacheFile).grokEntries(modifiedSince: epoch)
+
+        try rewriteSnapshot { snapshot in
+            snapshot.removeValue(forKey: "grok")
+            snapshot.removeValue(forKey: "grokParserVersion")
+        }
+
+        let entries = await LocalUsageCache(grokRoot: root, fileURL: cacheFile).grokEntries(modifiedSince: epoch)
+        XCTAssertEqual(entries.map(\.id), ["grok|p-legacy"], "구버전 스냅샷에서도 재파싱으로 복구돼야 한다")
+    }
+
+    /// [회귀] 서브에이전트 판정 근거(summary.json)는 캐시 키(updates.jsonl 의 mtime·size)와 다른
+    /// 파일이다. 판정을 파싱 안에서 하면 "summary 가 아직 session_kind 를 못 쓴" 시점의 결과가 blob 에
+    /// 굳어 이중집계가 영구화된다 — 파일 선택 단계 판정이면 다음 새로고침에 자연 복구된다.
+    func testLateWrittenSessionKindStopsCountingOnNextRefresh() async throws {
+        let stamp = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970) - 3_600)
+        try writeSession("sub-late", lines: [turnLine(promptID: "p-sub-late")],
+                         summary: false, mtime: stamp)
+        let cache = LocalUsageCache(grokRoot: root, fileURL: cacheFile)
+        let before = await cache.grokEntries(modifiedSince: epoch)
+        XCTAssertEqual(before.map(\.id), ["grok|p-sub-late"], "summary 없으면 사용자 세션으로 센다")
+
+        // 세션이 끝나며 summary 에 session_kind 가 찍힌다. updates.jsonl 은 더 안 바뀐다.
+        try writeSummary("sub-late", sessionKind: "subagent")
+
+        let after = await cache.grokEntries(modifiedSince: epoch)
+        XCTAssertTrue(after.isEmpty, "다음 새로고침엔 서브에이전트로 제외돼야 한다(부모 턴에 이미 포함)")
+    }
+
+    private func rewriteSnapshot(_ mutate: (inout [String: Any]) throws -> Void) throws {
+        let raw = try Data(contentsOf: cacheFile)
+        let plain = (try? (raw as NSData).decompressed(using: .zlib) as Data) ?? raw
+        var snapshot = try XCTUnwrap(JSONSerialization.jsonObject(with: plain) as? [String: Any])
+        try mutate(&snapshot)
+        let data = try JSONSerialization.data(withJSONObject: snapshot)
+        try ((data as NSData).compressed(using: .zlib) as Data).write(to: cacheFile, options: .atomic)
     }
 
     // MARK: 등록·집계 패리티

--- a/Tests/PokeTokenBarTests/GrokUsageTests.swift
+++ b/Tests/PokeTokenBarTests/GrokUsageTests.swift
@@ -330,6 +330,20 @@ final class GrokUsageTests: XCTestCase {
         XCTAssertTrue(store.registeredProviderIDs.contains("grok"))
     }
 
+    /// Grok 을 안 쓰는 사용자(세션 디렉토리 없음)에서 프로바이더는 조용히 비어야 한다 —
+    /// 던지면 refresh 전체가 에러로 물들고, 0 을 돌려주면 미사용 프로바이더 탭이 생긴다.
+    /// (스모크: 실제 경로가 없을 때의 경로만 확인한다 — 파싱·집계는 위 픽스처 테스트가 담당.)
+    func testProviderIsSilentWhenNoGrokDataExists() async throws {
+        guard !FileManager.default.fileExists(atPath: LocalUsageReader.grokSessionsDir.path) else {
+            throw XCTSkip("이 기기에 Grok 세션이 있어 '없을 때' 경로를 검증할 수 없다")
+        }
+        let daily = try await LocalGrokProvider().fetchDaily()
+        XCTAssertNil(daily, "세션 디렉토리가 없으면 스냅샷을 만들지 않아야 한다")
+        let enrichment = await LocalGrokProvider().fetchEnrichment()
+        XCTAssertNil(enrichment.activeBlock)
+        XCTAssertEqual(enrichment.weekTotal?.totalTokens, 0)
+    }
+
     /// `$GROK_HOME` 이 설정돼 있으면 그 아래 sessions 를 본다(CLI 와 같은 규칙).
     func testSessionsDirHonoursGrokHomeEnvironment() throws {
         let expected: URL

--- a/Tests/PokeTokenBarTests/GrokUsageTests.swift
+++ b/Tests/PokeTokenBarTests/GrokUsageTests.swift
@@ -158,14 +158,24 @@ final class GrokUsageTests: XCTestCase {
     // MARK: 이중 집계 방어
 
     /// 재생(replay)으로 다시 append 된 턴 라인은 같은 턴을 두 번 세게 만든다.
-    func testReplayLineIsNotCountedTwice() throws {
-        let url = try writeSession("s4", lines: [
+    /// 두 방어가 겹쳐 있어 각각을 따로 밟는다 — 같은 id 중복은 dedup 이, 그렇지 않은 재생 라인은
+    /// isReplay 판정이 막는다. (같은 id 로만 테스트하면 dedup 이 통과시켜 isReplay 분기가 미검증으로 남는다.)
+    func testReplayLinesAreNotCountedTwice() throws {
+        let deduped = try writeSession("s4", lines: [
             turnLine(promptID: "p-1"),
             turnLine(promptID: "p-1", isReplay: true),
         ])
-        let entries = parse(url)
-        XCTAssertEqual(entries.count, 1, "isReplay 라인은 건너뛴다")
-        XCTAssertEqual(entries.first?.total, 42_015)
+        let byID = parse(deduped)
+        XCTAssertEqual(byID.count, 1, "같은 턴 id 는 한 번만")
+        XCTAssertEqual(byID.first?.total, 42_015)
+
+        // isReplay 분기 단독: id 가 달라 dedup 이 못 막는 재생 라인.
+        let replayOnly = try writeSession("s4-replay", lines: [
+            turnLine(promptID: "p-live"),
+            turnLine(promptID: "p-replayed", isReplay: true),
+        ])
+        XCTAssertEqual(parse(replayOnly).map(\.id), ["grok|p-live"],
+                       "isReplay 라인은 id 가 달라도 집계 대상이 아니다")
     }
 
     /// [트리거 브랜치] fork 세션이 부모 updates 를 복사하면 같은 턴이 두 파일에 존재한다.
@@ -344,17 +354,20 @@ final class GrokUsageTests: XCTestCase {
         XCTAssertEqual(enrichment.weekTotal?.totalTokens, 0)
     }
 
-    /// `$GROK_HOME` 이 설정돼 있으면 그 아래 sessions 를 본다(CLI 와 같은 규칙).
-    func testSessionsDirHonoursGrokHomeEnvironment() throws {
-        let expected: URL
-        if let home = ProcessInfo.processInfo.environment["GROK_HOME"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines), !home.isEmpty {
-            expected = URL(fileURLWithPath: home).appendingPathComponent("sessions")
+    /// 세션 루트 기본값은 `~/.grok/sessions` — CLI 가 `$GROK_HOME` 없을 때 쓰는 경로와 같아야 한다.
+    /// (환경변수가 설정된 셸에서 돌면 그 경로가 진실이므로 기본값 검증은 건너뛴다.)
+    func testSessionsDirDefaultsToDotGrokUnderHome() throws {
+        let env = ProcessInfo.processInfo.environment["GROK_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let dir = LocalUsageReader.grokSessionsDir
+        if let env, !env.isEmpty {
+            XCTAssertTrue(dir.path.hasPrefix(URL(fileURLWithPath: env).path),
+                          "$GROK_HOME 가 설정되면 그 아래를 봐야 한다: \(dir.path)")
         } else {
-            expected = FileManager.default.homeDirectoryForCurrentUser
+            let home = FileManager.default.homeDirectoryForCurrentUser
                 .appendingPathComponent(".grok/sessions")
+            XCTAssertEqual(dir.standardizedFileURL.path, home.standardizedFileURL.path)
         }
-        XCTAssertEqual(LocalUsageReader.grokSessionsDir.standardizedFileURL, expected.standardizedFileURL)
-        XCTAssertEqual(LocalUsageReader.grokSessionsDir.lastPathComponent, "sessions")
+        XCTAssertEqual(dir.lastPathComponent, "sessions")
     }
 }

--- a/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
+++ b/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
@@ -133,7 +133,7 @@ final class LocalAdditionalUsageTests: XCTestCase {
 
         XCTAssertEqual(
             Set(store.registeredProviderIDs),
-            Set(["claude_code", "codex", "gemini", "opencode", "hermes", "cursor"]))
+            Set(["claude_code", "codex", "gemini", "opencode", "hermes", "cursor", "grok"]))
     }
 
     func testPrintRealOpenCodeAggregate() throws {

--- a/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
@@ -17,10 +17,11 @@ final class ProviderTabLayoutTests: XCTestCase {
                          weekTotal: nil, monthTotal: nil, fetchedAt: Date())
     }
 
-    /// 현재 등록된 6개 프로바이더의 표시 이름 — UsageStore.init 기본 배열과 같은 순서.
+    /// 현재 등록된 7개 프로바이더의 표시 이름 — UsageStore.init 기본 배열과 같은 순서.
     private var allProviders: [ProviderSnapshot] {
         [("claude_code", "Claude Code"), ("codex", "Codex"), ("gemini", "Gemini"),
-         ("opencode", "OpenCode"), ("hermes", "Hermes Agent"), ("cursor", "Cursor")]
+         ("opencode", "OpenCode"), ("hermes", "Hermes Agent"), ("cursor", "Cursor"),
+         ("grok", "Grok")]
             .map { snapshot($0.0, $0.1) }
     }
 
@@ -33,7 +34,7 @@ final class ProviderTabLayoutTests: XCTestCase {
         NSHostingController(rootView: view).sizeThatFits(in: CGSize(width: proposing, height: 600))
     }
 
-    /// 트리거 재현: 스크롤 없이 나열하면 6개 탭은 팝오버 콘텐츠 폭을 넘는다(= 버그 조건).
+    /// 트리거 재현: 스크롤 없이 나열하면 등록된 탭 전부는 팝오버 콘텐츠 폭을 넘는다(= 버그 조건).
     /// 넘치지 않으면 아래 단일 행 검증이 무의미해지므로 이 테스트가 먼저 실패해야 한다.
     func testAllProviderTabsExceedPopoverContentWidthWhenLaidOutInOneRow() {
         let natural = HStack(spacing: 6) {
@@ -46,17 +47,17 @@ final class ProviderTabLayoutTests: XCTestCase {
         }
         let w = rendered(natural, proposing: .greatestFiniteMagnitude).width
         XCTAssertGreaterThan(w, PopoverMetrics.contentWidth,
-                             "6개 탭은 한 줄로 펼치면 콘텐츠 폭을 넘어야 한다 — 안 넘으면 이 가드가 무의미하다")
+                             "\(allProviders.count)개 탭은 한 줄로 펼치면 콘텐츠 폭을 넘어야 한다 — 안 넘으면 이 가드가 무의미하다")
     }
 
-    /// 수정 후: 탭이 6개여도 탭 바는 한 행 높이를 유지한다(= 캡슐 텍스트가 접히지 않는다).
+    /// 수정 후: 탭이 다 붙어도 탭 바는 한 행 높이를 유지한다(= 캡슐 텍스트가 접히지 않는다).
     /// 기준선은 탭 2개짜리 바 — 넘치지 않는 대조군이다.
     func testProviderTabBarStaysSingleRowWithAllProviders() {
         let baseline = rendered(bar(Array(allProviders.prefix(2))),
                                 proposing: PopoverMetrics.contentWidth).height
         let full = rendered(bar(allProviders), proposing: PopoverMetrics.contentWidth).height
         XCTAssertEqual(full, baseline, accuracy: 0.5,
-                       "6개 탭 바 높이 \(full) 가 2개 기준선 \(baseline) 을 넘으면 캡슐 텍스트가 접힌 것이다")
+                       "\(allProviders.count)개 탭 바 높이 \(full) 가 2개 기준선 \(baseline) 을 넘으면 캡슐 텍스트가 접힌 것이다")
     }
 
     /// 탭 바 자체는 주어진 폭 안에 머문다(넘친 자식이 부모 VStack 을 부풀려 팝오버를 자르지 않게).


### PR DESCRIPTION
Adds the official xAI Grok CLI as the seventh usage provider, following the extension contract in `CLAUDE.md`: one `UsageProvider` implementation plus one registration in `UsageStore.init`. No provider-specific branch is added to any shared path.

## Where the usage lives

`~/.grok/sessions/<encoded-cwd>/<session-id>/updates.jsonl` — every turn appends a durable line
`{"timestamp":<unix seconds>,"method":"_x.ai/session/update","params":{"sessionId":…,"update":{"sessionUpdate":"turn_completed",…,"usage":{…}},"_meta":{…}}}`
whose `usage` is that prompt's ledger. `$GROK_HOME` is honoured the same way the CLI resolves its home.

Turn dates come from `_meta.agentTimestampMs`, not the envelope timestamp: forking copies the parent's updates file and re-stamps every envelope with the copy time, which would re-date a forked session's whole history to the fork moment. `_meta` survives the copy (only `sessionId` is rewritten).

Other candidates were ruled out by reading the upstream source (`xai-org/grok-build`, SOURCE_REV `6372e41`):

| Candidate | Verdict |
|---|---|
| `chat_history.jsonl` | conversation items carry no usage and no timestamp — `usage` lives on the runtime response type, not the persisted item |
| `events.jsonl` | `turn_ended` records an outcome and cancellation reason only |
| turn trace metadata | has the token counts, but it is an artifact uploaded to remote telemetry, not a local usage log |
| in-memory `UsageLedger` | never serialized to disk |

## Token mapping

Keeps the identity every other provider keeps — `Entry.total` equals the source's own total.

| Grok field | Entry |
|---|---|
| `inputTokens − cachedReadTokens` | `input` |
| `cachedReadTokens` | `cacheRead` |
| — | `cacheWrite = 0` (cache writes are folded into the prompt server-side) |
| `outputTokens` | `output` (reasoning already included) |
| `modelUsage` key | `model` (numbers always come from totals) |
| `costUsdTicks / 1e10` | `explicitCost`, only when trustworthy |

`inputTokens` (camelCase, the durable wire) includes cache reads; `input_tokens` (snake_case, the headless projection) already excludes them. The parser branches on the spelling — treating them as aliases would subtract the cache twice.

Cost is dropped when `costIsPartial` or `usageIsIncomplete` is set. There is no rate table for Grok models, so an untrustworthy bill reads as $0 rather than an estimate.

## Double counting

Two paths would have inflated totals; both are closed and both have a regression test that reproduces the trigger:

- **Forks.** Forking copies the parent's updates file, so the same turn exists in two session directories. Turn ids are therefore session-independent (`grok|<prompt_id>`) and dedup globally. `prompt_id` is a uuid — v4 for interactive prompts, a prefixed v7 for synthetic ones (`task-completed-…`) — so it is globally unique but must not be parsed as a v4; it is only ever used as an opaque key.
- **Subagents.** Subagent usage is folded into the parent prompt's ledger, so a subagent session's own `turn_completed` lines would count it again. Those sessions are skipped by the same `session_kind` prefix test the CLI uses to hide them. Known limitation, recorded in the code: a subagent that finishes after its parent turn ends folds into the session ledger only, so those tokens are missed — smaller than counting every subagent twice, and the CLI marks that parent bill `usageIsIncomplete`, which also drops its cost.

Replayed appends (`_meta.isReplay`) are skipped as a second layer.

## Not included

- **No official-limit row.** The CLI exposes no local quota numbers — only a subscription tier name, and an error string when the balance runs out. `/usage` is an interactive, tier-gated TUI command, not a headless one.
- **No status row.** `status.x.ai/api/v2/summary.json` returns HTTP 403, so there is no statuspage component to read.
- **No new screenshot.** The change adds no surface of its own; the existing provider tab bar gains one capsule when Grok data is present.
- **Community CLIs** (`@vibe-kit/grok-cli` and friends) are out of scope. The maintenance forks of the official CLI share this layout and are covered as-is.

## Tests

`GrokUsageTests` (27 cases), all on real-format fixtures:

- **Mapping** — the `Entry.total == usage.totalTokens` identity, the snake_case (headless) semantics branch, the cache-read clamp when `cachedReadTokens` exceeds the prompt, the residual reconciliation against the reported total, JSON `null` fields not zeroing a turn, zero-usage turns producing nothing, the model fallback.
- **Dates** — `_meta.agentTimestampMs` beating a fork's re-stamped envelope time, and the integer-seconds envelope fallback when the meta timestamp is absent.
- **Double counting** — fork copies collapsing to one turn, replayed lines skipped with a distinct id (so the guard is exercised rather than shadowed by dedup), subagent sessions skipped while worktree/fork sessions are kept, and a late-written `session_kind` taking effect on the next refresh instead of freezing in the blob cache.
- **Cost** — the three trust cases, and Grok names never inheriting GPT/Claude family pricing.
- **Cache** — reuse proven by swapping file content behind an unchanged mtime/size, parser-version invalidation, a snapshot missing the `grok` keys still loading, and `updates.jsonl`-only scoping.
- **Aggregation** — block/week/month/today over real files, plus a Grok-only user reaching every aggregate and a non-idle burn tier, so the old "one provider gets the maths" regression cannot come back.
- **Scale** — 20k lines of streaming chunks yielding exactly the 50 turn endings (the chunk lines carry `_meta.totalTokens`, a context-window number that must never leak into spend).

Updated: the provider tab overflow guard (now 7 tabs, trigger still reproduced) and the registry assertion.

`swift build` (debug and release) and `swift test` pass — 415 tests, 0 failures, 5 skipped (the `PTB_PARITY=1` smoke tests).

## Verification status

Grok CLI is not installed on this machine, so the format was established from the upstream writer and reader rather than from a capture: `SessionUpdateEnvelope` (`session/storage/mod.rs`) for the envelope and integer timestamp, the `turn_completed` serde contract tests for the tag and field spellings, `record_subagent_usage` for the parent fold, and `copy_session_data_sync` for the fork copy and its re-stamped envelope. An independent verification pass over those sources refuted three of my initial assumptions — the envelope wrapper key, the timestamp type, and that `prompt_id` is always a v4 UUID — and each is fixed or accounted for in the last commit.

Still worth doing before this is advertised: run one real Grok session and diff the popover numbers against it.

## Follow-ups

- The landing page (`gh-pages`) already carries the corresponding chip and i18n updates as a local commit; it is intentionally unpushed so it publishes with the release that ships this.
- Ship in the next weekly release train as a minor, not an immediate patch.
