### PR TITLE
fix: floating pet keeps the graduated Pokémon's sprite after a new egg is issued

### DIFF
--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -97,8 +97,11 @@ struct SpriteView: View {
             frameIndex = 0
             guard let id = speciesID else {
                 // 알 상태 — 정적 알 스프라이트 로드(애니메이션 알은 없음). 실패/오프라인이면 body 가 🥚 폴백.
-                if img == nil { img = await SpriteLoader.eggImage() }
+                // 종 → 알(졸업·새 알)이면 이전 개체 이미지를 버려야 한다 — img 는 뷰 identity 가 살아있는 동안
+                // 유지되고 플로팅 펫 패널은 졸업 때 재생성되지 않아, 안 버리면 옛 포켓몬이 계속 떠 있다.
+                if loadedID != nil { img = SpriteLoader.cachedEggImage() }
                 loadedID = nil
+                if img == nil { img = await SpriteLoader.eggImage() }
                 return
             }
             // 정적 스프라이트 먼저(즉시 표시 + 폴백 보장). 캐시 시드로 이미 같은 id 면 재요청 생략(플래시 방지)


### PR DESCRIPTION
## Summary

When a Pokémon graduates and is replaced by a fresh Token Egg, the floating desktop pet keeps drawing
the graduated Pokémon — frozen, no animation — while the popover correctly shows the new egg. This
makes `SpriteView` drop a cached sprite that belongs to a different subject, so both surfaces switch
to the egg the moment there is no active Pokémon. Closes #135.

### Root cause

`SpriteView` caches its loaded sprite in `@State private var img`, which survives every body update
for as long as the view keeps its identity. `.task(id:)` restarts when `speciesID` changes, but the
egg branch only fetched the egg sprite when nothing was loaded yet:

```swift
guard let id = speciesID else {
    if img == nil { img = await SpriteLoader.eggImage() }   // never true — img holds the old species
    loadedID = nil
    return
}
```

On `25 → nil` the task restarts and clears `frames` — the GIF frames only — the `img == nil` guard is
false, so the egg is never loaded, and `body` falls through to `else if let img` and draws the
previous species' static image. With `frames` gone, it sits there frozen.

The popover escaped this by accident: `popoverDidClose` sets `contentViewController = nil` for idle
CPU, so the next open builds a fresh `SpriteView` whose `init` seeds `SpriteLoader.cachedEggImage()`
for `speciesID == nil`. `FloatingPetController.show()` only replaces its hosting view when
`contentView == nil` or the animation flag flips, so the pet's `SpriteView` — and its stale `img` —
outlive graduation. The popover shows the same stale sprite if it happens to be open on the Home tab
when a Pokémon graduates, until a tab switch or a reopen.

Two entry points reach the identical `state.active = nil` transition: `CompanionStore.graduate()` and
`CompanionStore.buyFreshEgg()` (Shop → Fresh Egg), the latter reproducing it on demand.

### Fix

One line: when the subject becomes the egg and an image for some species is still loaded, replace it
with `SpriteLoader.cachedEggImage()` before awaiting.

```swift
if loadedID != nil { img = SpriteLoader.cachedEggImage() }
loadedID = nil
if img == nil { img = await SpriteLoader.eggImage() }
```

`cachedEggImage()` is synchronous and memoised, so the swap is instant in practice; a cold cache falls
back to the `🥚` glyph for the length of one `await eggImage()`, exactly as a freshly built view
already did.

Species → species is deliberately left as it was — the previous image stays on screen while the next
one loads. Clearing `img` on every subject change would have been the smaller diff, but it flashes the
`🥚` glyph mid-evolution: the new species' sprite is by definition not in the cache yet, so there is
nothing to show synchronously. That asymmetry is the point of the fix. An egg is a *different
subject*, so keeping the old pixels is wrong; an evolution is *the same individual's next form*, so
keeping them until the new sprite arrives is the better of two imperfect frames.

`loadedID` stays an `Int?`. Folding `shiny` into the cache key was considered and dropped: the only
in-place shiny change is the Ditto reveal, which changes `speciesID` too, so the key would carry a
distinction nothing can currently trigger.

An earlier draft wrapped the check in a `canKeepImage(loadedID:for:)` predicate so a unit test could
assert it. That was dropped: the predicate was `loadedID == speciesID` and the tests over it asserted
`==`, which cannot fail while the defect — the call site forgetting to drop the image — stays
possible. It read as coverage without being any.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

Only the sprite shown after a graduation or a Fresh Egg reroll changes; nothing about layout, size or
animation timing moves.

| Before | After |
| ------ | ----- |
| The floating pet keeps the graduated Pokémon and freezes on its static sprite — the animated frames are gone, the subject is not. It clears only on hide/re-show, display sleep, a Low Power Mode toggle, or a relaunch. | The floating pet switches to the egg sprite as soon as there is no active Pokémon, matching the popover. |

<img width="792" height="322" alt="pr-before-after" src="https://github.com/user-attachments/assets/2ec52817-2ecc-4b46-8335-f84c1cf94fb3" />


Note the frozen sprite in "before" is the *static* PNG, not the last GIF frame: `.task(id:)` does clear
`frames`, which is why the pet stops animating — it just never replaces the image underneath.

- **Evolution** is unchanged — the current sprite stays until the next form's sprite has loaded, no
  intermediate egg glyph.
- **Hatching** is unchanged — the egg image is already dropped by the existing `loadedID != id` path.
- **Popover, Pokédex rows, Shop and Bag icons** render exactly as before.

## Testing

No new test. The defect lives in `@State` mutation inside `.task`, which cannot be exercised in xctest
without a SwiftUI host — the same limitation the floating pet's energy guards already carry — and a
hosted test would have to hit the sprite cache or the network to have an image to go stale. The state
side of the transition is already covered: `CompanionTests.testEvolvesThroughLineAndGraduatesWithFullChain`
and `testNewEggAfterGraduationReincubates` assert `state.active == nil` after graduation, and
`FreshEggTests.testBuyFreshEggDiscardsWithoutDexOrProbabilityImpact` does the same for the reroll. What
was missing was never a store assertion; it was the view reacting to it.

`swift build` clean; `swift test` — all 415 tests pass (5 skipped), unchanged from `main`.

Also verified in a real build, since the call site is exactly what the tests cannot reach. Both a
pre-fix and a post-fix bundle were run against an isolated state directory (`PTB_STATE_DIR`) holding
an active Pokémon and a funded wallet, with the floating pet enabled. Before the fix the pet keeps
the previous Pokémon after the state goes to the egg, and stops animating; after the fix it swaps to
the egg sprite within the same refresh, with no intermediate `🥚` glyph. Evolution and hatching were
re-checked in the same build and are visually unchanged.

The transition itself was fired by calling the shipped `buyFreshEgg()` from a launch-time timer in
the QA bundles (a local, uncommitted hook): a second instance gets no menu-bar status item on a full
menu bar, so the Shop UI is unreachable and the button press cannot be scripted. The state
transition, the panel lifecycle and the view stack are the real ones — only the tap that starts it is
synthetic.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] Tests were added or updated for this change — see **Testing** for why, and for the manual
      before/after that stands in for it
