### PR TITLE
fix: ignore sprite loads that finish after their subject is gone

### DIFF
--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -39,6 +39,38 @@ struct ItemIconView: View {
     }
 }
 
+/// SpriteView 가 그리는 주체(정적 이미지 + 그 이미지가 어느 종의 것인지)의 전이 규칙.
+///
+/// SwiftUI `.task` 는 호스트 없이 돌릴 수 없어 규칙만 순수 값 전이로 빼 둔다(`frameDelay` 와 같은 방식).
+/// 여기 담긴 규칙은 둘 다 "화면에 남은 픽셀이 지금 주체의 것인가"를 지킨다.
+struct SpriteSubject: Equatable {
+    var image: NSImage?
+    /// image 가 어느 speciesID 것인지. nil = 알(또는 로드된 개체 없음).
+    var loadedID: Int?
+
+    /// 주체가 알로 바뀌었다(졸업·새 알). 이전 **개체**의 이미지는 다른 주체의 픽셀이라 버린다.
+    /// 이미 알이던 경우(loadedID == nil)엔 손대지 않는다 — 시드된 알 이미지를 지워 🥚 글리프로 깜빡이게 하지 않기 위해.
+    func becomingEgg(cachedEgg: NSImage?) -> SpriteSubject {
+        guard loadedID != nil else { return self }
+        return SpriteSubject(image: cachedEgg, loadedID: nil)
+    }
+
+    /// 로드된 정적 스프라이트를 반영한 결과. **취소된 로드는 nil — 상태를 아예 건드리지 않는다.**
+    /// 취소는 곧 주체가 바뀌었다는 뜻이고, 협조적 취소라 continuation 은 그대로 실행되므로 후속 `.task`
+    /// 가 이미 새 주체로 잡아 둔 상태를 뒤늦게 덮어쓸 수 있다. 그러면 알 위에 옛 개체가 되살아나고
+    /// (#135 와 같은 증상), 실패한 로드가 `loadedID` 만 남기면 다음에 그 종이 다시 활성일 때
+    /// "이미 로드됨"으로 판단해 🥚 글리프가 고정된다.
+    /// (nil 로 돌려주는 이유: 같은 값을 되쓰면 @State 무효화가 한 번 더 돌아 항상 떠 있는 펫에 불필요한 재렌더가 생긴다.)
+    func applyingLoad(_ image: NSImage?, for id: Int, cancelled: Bool) -> SpriteSubject? {
+        cancelled ? nil : SpriteSubject(image: image, loadedID: id)
+    }
+
+    /// 로드된 알 스프라이트를 반영한 결과(같은 이유로 취소면 nil). 알은 종이 없으므로 loadedID 는 그대로.
+    func applyingEgg(_ image: NSImage?, cancelled: Bool) -> SpriteSubject? {
+        cancelled ? nil : SpriteSubject(image: image, loadedID: loadedID)
+    }
+}
+
 /// 스프라이트 1개(런타임 로드 + 캐시). 없으면 알 글리프. bob 으로 가벼운 상하 움직임.
 /// animated=true 면 Gen-V GIF 프레임을 순환(미지원/오프라인이면 정적+bob 으로 폴백).
 struct SpriteView: View {
@@ -75,6 +107,25 @@ struct SpriteView: View {
     /// 프레임 지속(초) = max(원본 delay, 하한). 순수·테스트용 — fps 상한 회귀 가드.
     static func frameDelay(base: TimeInterval, floor: TimeInterval) -> TimeInterval { max(base, floor) }
 
+    /// 디코드된 GIF 프레임 중 실제로 재생할 것 — 취소됐거나 2프레임 미만이면 빈 배열(정적 폴백).
+    /// 취소 검사가 여기 있는 이유: `frames` 는 body 에서 `img` 보다 먼저 그려지므로, 취소된 로드가
+    /// 뒤늦게 대입되면 새 주체(알) 위에 옛 개체의 GIF 가 정지 상태로 올라온다.
+    static func framesToApply(_ decoded: [(image: NSImage, delay: TimeInterval)],
+                              cancelled: Bool) -> [(image: NSImage, delay: TimeInterval)] {
+        (cancelled || decoded.count < 2) ? [] : decoded
+    }
+
+    /// 현재 그리는 주체(순수 전이 입력).
+    private var subject: SpriteSubject { SpriteSubject(image: img, loadedID: loadedID) }
+
+    /// 전이 결과를 @State 로 되돌린다(State 세터는 nonmutating). 값이 그대로면 쓰지 않는다 —
+    /// @State 는 같은 값을 써도 무효화가 돌아, 항상 떠 있는 펫에 불필요한 재렌더가 생긴다.
+    private func apply(_ next: SpriteSubject) {
+        guard next != subject else { return }
+        img = next.image
+        loadedID = next.loadedID
+    }
+
     var body: some View {
         Group {
             if !frames.isEmpty {
@@ -99,15 +150,17 @@ struct SpriteView: View {
                 // 알 상태 — 정적 알 스프라이트 로드(애니메이션 알은 없음). 실패/오프라인이면 body 가 🥚 폴백.
                 // 종 → 알(졸업·새 알)이면 이전 개체 이미지를 버려야 한다 — img 는 뷰 identity 가 살아있는 동안
                 // 유지되고 플로팅 펫 패널은 졸업 때 재생성되지 않아, 안 버리면 옛 포켓몬이 계속 떠 있다.
-                if loadedID != nil { img = SpriteLoader.cachedEggImage() }
-                loadedID = nil
-                if img == nil { img = await SpriteLoader.eggImage() }
+                apply(subject.becomingEgg(cachedEgg: SpriteLoader.cachedEggImage()))
+                if img == nil {
+                    let egg = await SpriteLoader.eggImage()
+                    if let next = subject.applyingEgg(egg, cancelled: Task.isCancelled) { apply(next) }
+                }
                 return
             }
             // 정적 스프라이트 먼저(즉시 표시 + 폴백 보장). 캐시 시드로 이미 같은 id 면 재요청 생략(플래시 방지)
             if loadedID != id {
-                img = await SpriteLoader.image(speciesID: id, animated: false, shiny: shiny)
-                loadedID = id
+                let loaded = await SpriteLoader.image(speciesID: id, animated: false, shiny: shiny)
+                if let next = subject.applyingLoad(loaded, for: id, cancelled: Task.isCancelled) { apply(next) }
             }
             guard animated else { return }
             // animated GIF 시도(shiny 미제공 종은 일반 GIF 폴백) → 프레임 2개 이상이면 순환 루프
@@ -116,9 +169,10 @@ struct SpriteView: View {
                 gifData = await SpriteStore.shared.data(speciesID: id, animated: true, shiny: false)
             }
             guard let data = gifData else { return }
-            let raw = GIFDecoder.frames(from: data)
-            guard raw.count > 1 else { return }   // 단일 프레임/디코드 실패 → 정적 폴백
-            frames = raw
+            // 단일 프레임/디코드 실패 → 정적 폴백. 취소됐으면 아예 반영하지 않는다(빈 배열이라 아래서 종료).
+            let ready = Self.framesToApply(GIFDecoder.frames(from: data), cancelled: Task.isCancelled)
+            guard !ready.isEmpty else { return }
+            frames = ready
             // delay 기반 프레임 advance. .task 취소 시(speciesID 변경/뷰 소멸) 루프 종료 — 누수 없음
             while !Task.isCancelled {
                 let delay = Self.frameDelay(base: frames[frameIndex % frames.count].delay, floor: minFrameDelay)

--- a/Tests/PokeTokenBarTests/SpriteSubjectTests.swift
+++ b/Tests/PokeTokenBarTests/SpriteSubjectTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+import AppKit
+@testable import PokeTokenBar
+
+// SpriteView 가 그리는 주체의 전이 규칙.
+//
+// 두 가지를 잠근다:
+//  1) 주체가 알로 바뀌면 이전 개체의 픽셀을 버린다 (#135 — 졸업·Fresh Egg 후에도 옛 포켓몬이 떠 있던 회귀).
+//  2) **취소된 로드는 어떤 상태도 건드리지 않는다.** Swift 의 취소는 협조적이라 `.task(id:)` 가 취소돼도
+//     await 뒤 코드는 계속 실행된다 — 후속 task 가 이미 새 주체로 잡아 둔 상태를 뒤늦게 덮어쓸 수 있다.
+//
+// SwiftUI `.task` 자체는 호스트 없이 돌릴 수 없어 규칙을 순수 전이로 빼서 검증한다(frameDelay 와 같은 방식).
+// 아래 동시성 테스트는 그 "뒤늦게 도착하는 continuation" 순서를 게이트로 **강제**해 재현한다.
+
+/// 테스트가 재개 시점을 쥐는 게이트 — 로드가 await 에서 멈춰 있는 구간을 결정적으로 만든다.
+/// (UsageStoreTests 의 GatedUsageProvider 와 같은 방식.)
+private actor LoadGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func wait() async {
+        if released { return }
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+            if released { c.resume() } else { continuation = c }
+        }
+    }
+
+    func release() {
+        released = true
+        let c = continuation
+        continuation = nil
+        c?.resume()
+    }
+}
+
+/// @State 대신 전이 결과를 담아 두는 상자 — Task 클로저에서 안전하게 갱신하기 위해.
+@MainActor
+private final class SubjectBox {
+    var subject: SpriteSubject
+    var frames: [(image: NSImage, delay: TimeInterval)] = []
+    var sawCancellation = false
+    init(_ subject: SpriteSubject) { self.subject = subject }
+}
+
+@MainActor
+final class SpriteSubjectTests: XCTestCase {
+
+    private func image(_ side: CGFloat) -> NSImage { NSImage(size: NSSize(width: side, height: side)) }
+    private func frame(_ img: NSImage, _ delay: TimeInterval = 0.1) -> (image: NSImage, delay: TimeInterval) {
+        (image: img, delay: delay)
+    }
+
+    // MARK: 주체가 알로 바뀔 때 (#135)
+
+    /// 졸업·Fresh Egg — 이전 개체의 픽셀은 다른 주체의 것이라 버리고 알로 교체한다.
+    func testBecomingEggDropsPreviousSpeciesPixels() {
+        let species = image(4), egg = image(2)
+        let next = SpriteSubject(image: species, loadedID: 25).becomingEgg(cachedEgg: egg)
+        XCTAssertTrue(next.image === egg, "옛 개체 이미지가 남으면 플로팅 펫이 졸업 후에도 그 포켓몬을 그린다")
+        XCTAssertNil(next.loadedID)
+    }
+
+    /// 알 이미지가 아직 캐시에 없으면(콜드) 옛 개체를 남기는 대신 글리프로 떨어뜨린다.
+    func testBecomingEggWithColdCacheClearsToGlyph() {
+        let next = SpriteSubject(image: image(4), loadedID: 25).becomingEgg(cachedEgg: nil)
+        XCTAssertNil(next.image, "캐시가 없다고 옛 개체를 남기면 안 된다 — 🥚 글리프가 옳다")
+        XCTAssertNil(next.loadedID)
+    }
+
+    /// 이미 알이던 주체는 건드리지 않는다 — 시드된 알 이미지를 지우면 글리프로 한 번 깜빡인다.
+    func testBecomingEggLeavesAnExistingEggAlone() {
+        let egg = image(2)
+        let next = SpriteSubject(image: egg, loadedID: nil).becomingEgg(cachedEgg: nil)
+        XCTAssertTrue(next.image === egg)
+        XCTAssertNil(next.loadedID)
+    }
+
+    // MARK: 취소된 로드 (이 PR)
+
+    /// [트리거] 취소된 정적 로드는 이미지도 loadedID 도 건드리지 않는다.
+    /// 반영하면 (a) 알 위에 옛 개체가 되살아나고 (b) loadedID 가 오염돼 다음에 그 종이 활성일 때
+    /// "이미 로드됨"으로 판단해 살아있는 포켓몬 자리에 🥚 글리프가 고정된다.
+    func testCancelledLoadLeavesSubjectUntouched() {
+        let species = image(4)
+        XCTAssertNil(SpriteSubject(image: image(2), loadedID: nil).applyingLoad(species, for: 26, cancelled: true),
+                     "취소된 로드는 상태를 아예 건드리면 안 된다 — 이미지 복원과 loadedID 오염이 여기서 갈린다")
+    }
+
+    /// 취소되지 않은 로드는 그대로 반영한다(가드가 과잉 차단하지 않는지).
+    func testAcceptedLoadUpdatesImageAndID() throws {
+        let species = image(4)
+        let next = try XCTUnwrap(SpriteSubject(image: nil, loadedID: nil)
+            .applyingLoad(species, for: 26, cancelled: false))
+        XCTAssertTrue(next.image === species)
+        XCTAssertEqual(next.loadedID, 26)
+    }
+
+    /// 로드 실패(오프라인)는 기존 동작대로 "시도했음"을 남긴다 — 같은 id 재요청 폭주 방지.
+    func testFailedButNotCancelledLoadStillMarksTheAttempt() throws {
+        let next = try XCTUnwrap(SpriteSubject(image: image(4), loadedID: 25)
+            .applyingLoad(nil, for: 26, cancelled: false))
+        XCTAssertNil(next.image)
+        XCTAssertEqual(next.loadedID, 26)
+    }
+
+    /// 알 이미지 로드도 같은 규칙 — 취소면 무시, 아니면 반영하되 loadedID 는 알(nil) 그대로.
+    func testEggImageAppliesOnlyWhenNotCancelled() throws {
+        let egg = image(2)
+        XCTAssertNil(SpriteSubject(image: nil, loadedID: nil).applyingEgg(egg, cancelled: true))
+
+        let applied = try XCTUnwrap(SpriteSubject(image: nil, loadedID: nil).applyingEgg(egg, cancelled: false))
+        XCTAssertTrue(applied.image === egg)
+        XCTAssertNil(applied.loadedID)
+    }
+
+    // MARK: GIF 프레임
+
+    /// [트리거] 취소된 GIF 는 반영하지 않는다 — body 가 frames 를 img 보다 먼저 그리므로,
+    /// 뒤늦게 대입되면 알 위에 옛 개체의 프레임이 정지 상태로 올라온다(#135 와 같은 증상).
+    func testFramesDroppedWhenCancelled() {
+        let decoded = [frame(image(4)), frame(image(4))]
+        XCTAssertTrue(SpriteView.framesToApply(decoded, cancelled: true).isEmpty)
+    }
+
+    /// 2프레임 미만은 애니메이션이 아니다 → 정적 폴백(기존 규칙 보존).
+    func testSingleFrameFallsBackToStatic() {
+        XCTAssertTrue(SpriteView.framesToApply([frame(image(4))], cancelled: false).isEmpty)
+        XCTAssertTrue(SpriteView.framesToApply([], cancelled: false).isEmpty)
+    }
+
+    func testMultiFrameAcceptedWhenNotCancelled() {
+        let first = image(4), second = image(4)
+        let ready = SpriteView.framesToApply([frame(first), frame(second)], cancelled: false)
+        XCTAssertEqual(ready.count, 2)
+        XCTAssertTrue(ready.first?.image === first)
+    }
+
+    // MARK: 실제 취소 순서 재현 (회귀 트리거)
+
+    /// [회귀] 취소된 task 의 continuation 이 **후속 task 뒤에** 도착하는 순서를 게이트로 강제한다.
+    /// 이 순서가 실재하지 않으면 위 가드는 무의미하므로, 취소가 관측됐다는 사실까지 함께 확인한다.
+    func testCancelledLoadArrivingLateCannotRestorePreviousSubject() async {
+        let gate = LoadGate()
+        let species = image(4), egg = image(2)
+        let box = SubjectBox(SpriteSubject(image: species, loadedID: 25))   // 25 를 띄우던 펫
+
+        // 26 으로 바뀌어 스프라이트를 받는 중(await 에서 정지).
+        let load = Task { @MainActor in
+            await gate.wait()
+            box.sawCancellation = Task.isCancelled
+            if let next = box.subject.applyingLoad(species, for: 26, cancelled: Task.isCancelled) {
+                box.subject = next
+            }
+        }
+
+        // 그 사이 졸업 → .task 취소 + 후속 task 가 알 상태를 확정.
+        load.cancel()
+        box.subject = box.subject.becomingEgg(cachedEgg: egg)
+        XCTAssertTrue(box.subject.image === egg, "사전 조건: 알 전환은 이미 반영돼 있어야 한다")
+
+        // 이제 멈춰 있던 로드가 재개된다.
+        await gate.release()
+        _ = await load.value
+
+        XCTAssertTrue(box.sawCancellation,
+                      "취소된 task 의 await 뒤 코드는 계속 실행된다 — 이 전제가 깨지면 이 가드는 불필요하다")
+        XCTAssertTrue(box.subject.image === egg, "뒤늦은 로드가 알을 덮어썼다 — #135 가 그대로 재발한다")
+        XCTAssertNil(box.subject.loadedID, "뒤늦은 로드가 loadedID 를 오염시켰다")
+
+        // 대조군: 가드가 없으면(=취소를 안 보면) 옛 개체가 되살아난다 — 가드가 실제로 일하는지.
+        let unguarded = SpriteSubject(image: egg, loadedID: nil).applyingLoad(species, for: 26, cancelled: false)
+        XCTAssertTrue(unguarded?.image === species)
+        XCTAssertEqual(unguarded?.loadedID, 26)
+    }
+
+    /// [회귀] 같은 순서를 GIF 경로로 — 취소된 디코드 결과가 뒤늦게 도착해도 프레임은 비어 있어야 한다.
+    func testCancelledFramesArrivingLateCannotResurrectPreviousSpecies() async {
+        let gate = LoadGate()
+        let box = SubjectBox(SpriteSubject(image: image(4), loadedID: 25))
+        box.frames = [frame(image(4)), frame(image(4))]   // 25 의 GIF 재생 중
+
+        let decode = Task { @MainActor in
+            await gate.wait()
+            box.sawCancellation = Task.isCancelled
+            box.frames = SpriteView.framesToApply([self.frame(self.image(4)), self.frame(self.image(4))],
+                                                  cancelled: Task.isCancelled)
+        }
+
+        decode.cancel()
+        box.frames = []                                   // 후속 task 진입 시 프레임 초기화
+        box.subject = box.subject.becomingEgg(cachedEgg: image(2))
+
+        await gate.release()
+        _ = await decode.value
+
+        XCTAssertTrue(box.sawCancellation)
+        XCTAssertTrue(box.frames.isEmpty,
+                      "취소된 GIF 가 되살아나면 알 위에 옛 포켓몬이 정지 프레임으로 그려진다")
+        XCTAssertNil(box.subject.loadedID)
+    }
+}


### PR DESCRIPTION
Follow-up to #136, which fixed the deterministic way the floating pet kept a graduated Pokémon on screen. This closes the second path to the same picture. It is a pre-existing defect — #136 neither caused it nor made it worse — which is why it is a separate PR.

## The path that is still open

Cancellation in Swift is cooperative: when `.task(id:)` restarts because the subject changed, the old task's code *after* its `await` still runs. If it resumes after the replacement task has already settled the new subject, it overwrites it.

Three writes sat after an await with no check:

| Write | What a late arrival does |
|---|---|
| `frames` | `body` draws `frames` before `img`, so the previous Pokémon's GIF lands back on top of the egg — frozen, because the advance loop exits immediately on `Task.isCancelled`. This is the picture #135 described. |
| `img` / `loadedID` (species) | A cancelled load returns nil and still stamps `loadedID = id`. The image is gone but the id claims it is loaded, so the next time that species is active the view skips the fetch and a live Pokémon renders as the 🥚 glyph until the hosting tree is rebuilt. |
| `img` (egg) | Repaints an egg over a species that has since hatched. |

The window is real rather than theoretical: the GIF path takes it whenever the sprite is already in the memory or disk cache, which is the steady state for a pet that has been showing that species — exactly the moment a graduation happens.

## The fix

One rule in all three places: **a load that lost its subject must not touch the view's state.**

It lives in `SpriteSubject` (`becomingEgg`, `applyingLoad`, `applyingEgg`) and `SpriteView.framesToApply`. Discarded results come back as `nil` / `[]` rather than as the current value, so they cost no `@State` write — writing the same value back invalidates the always-on pet for nothing, which is the discipline the rest of this file already follows.

The transitions are pure values because SwiftUI's `.task` cannot run without a host; this is the same shape as `SpriteView.frameDelay`, which `FloatingPetEnergyTests` already locks.

## Tests

`SpriteSubjectTests`, 12 cases:

- **The rules** — cancelled static load, cancelled egg load and cancelled GIF are all ignored; the non-cancelled equivalents still apply (the guards do not over-block); a failed-but-not-cancelled load still records the attempt, so offline retries do not loop; single-frame GIFs still fall back to static.
- **The ordering** — two regression tests force the late arrival with a gated actor: the load parks on a gate, the subject becomes an egg, the gate opens, and the resumed result must not restore the species. Both assert that `Task.isCancelled` was actually observed inside the resumed continuation, so if that premise ever stops holding the tests say so instead of passing quietly. Each ends with a control showing that the same call *without* the cancellation check does restore the old subject.
- **#136's rule** — the egg transition had no regression test; it is the same state machine, so it is covered here (drops the previous species' pixels, falls to the glyph on a cold egg cache, leaves an existing egg alone).

Removing any of the three guards fails six of these tests. `swift build` (debug and release) and `swift test` pass — 427 tests, 0 failures, 5 skipped (the `PTB_PARITY=1` smoke tests).

## Deliberately not in this PR

`ItemIconView` has the same shape (`.task(id:)` plus a `guard img == nil` that keeps the previous item's icon), but nothing can currently trigger it: both lists key their rows by the item itself (`BagView` by `\.kind`, `ShopView` by `\.self`), so a row's `kind` never changes in place. Left alone rather than changed blind.
