### PR TITLE
feat: add save export/import for moving between Macs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,13 @@
 - **JSON `null` 은 "값 있음"이 아니다.** `obj["x"] != nil` 은 `NSNull` 에도 참이라 `intValue` 가 0 을 돌려주고,
   그 0 으로 캐시분을 빼면 토큰이 통째로 사라진다. 숫자 필드는 `NSNull`·문자열·부재를 모두 nil 로 만드는
   추출기(`intOrNil`/`doubleOrNil`)로 읽고, 대체 스펠링 폴백은 그 nil 로 판단한다.
+- **비동기 완료가 "그 사이 교체된 대상"에 착지하지 않게 하라 — 상태를 통째로 바꾸는 경로를 새로 만들면
+  진행 중인 await 를 전수 점검한다.** 이 레포가 세 번 겪은 부류다(#136·#138 스프라이트, 그리고 세이브
+  불러오기 중 부화). `isHatching` 같은 중복 실행 락은 *같은 작업의 재진입*만 막을 뿐, await 창에서 상태가
+  **다른 주체로 교체되는 것**은 못 막는다. 방어는 두 형태 중 하나로 통일한다: ① `activeGeneration` 을
+  진입 시 캡처하고 mutation 직전 재검사(`hatchCore`·`revealDitto`·`loadCurrentLine`) ② 대상을 id 로 다시
+  찾아 없으면 무시(`dexChainNames` 의 `firstIndex(where: id)`). 회귀 가드는 sleep 이 아니라 신호(actor +
+  continuation)로 await 지점을 정확히 잡아 재현한다 — `testImportDuringHatchDiscardsTheHatch`.
 - **상태 파일을 옮기거나 합칠 땐 "진행"과 "이 기기 장부"를 먼저 분류하라.** 같은 파일에 살아도 성격이
   다르다 — `usedSinceInstall`·`dex`·`inventory`·`candyGrantTier` 는 어느 기기에서든 참인 **진행**이고,
   `claimedTodayTokens`·`lastDate`·`installBaselineSet` 은 *그 기기가* 어디까지 적립했나를 적은 **로컬

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,20 @@
   진입 시 캡처하고 mutation 직전 재검사(`hatchCore`·`revealDitto`·`loadCurrentLine`) ② 대상을 id 로 다시
   찾아 없으면 무시(`dexChainNames` 의 `firstIndex(where: id)`). 회귀 가드는 sleep 이 아니라 신호(actor +
   continuation)로 await 지점을 정확히 잡아 재현한다 — `testImportDuringHatchDiscardsTheHatch`.
+  **세대는 호출 체인에서 *가장 이른* await 앞에서 캡처하라 — 안쪽 함수에서 캡처하면 가드가 자동 통과한다.**
+  딥리뷰 실측: `hatchCore` 에만 가드를 넣었더니 `hatchIfNeeded` 의 `chooseBase()` 창에 들어온 교체를 못
+  막았다. `hatchCore` 는 *교체 이후*의 세대를 캡처하므로 `activeGeneration == generation` 이 항상 참이 된다
+  (출발할 때 봐야 할 시계를 도착해서 보는 격). 가드를 넣을 땐 그 함수 위의 await 까지 거슬러 확인하고,
+  회귀 테스트도 **그 await 를 실제로 지나는 진입점**으로 써라 — `hatch(baseID:)` 경로 테스트는
+  `chooseBase()` 를 안 지나 통과하면서 아무것도 지키지 않았다(`testImportDuringSpeciesRollDiscardsTheHatch`).
+- **관대 디코딩(`lenient`/`Lossy`)을 유지하려면 신뢰경계의 값 범위 검증이 짝으로 와야 한다.** 관대 디코딩은
+  "한 필드가 깨져도 도감을 안 날린다"를 얻는 대신 "말이 안 되는 값도 통과시킨다"를 떠안는다. 자기 앱이 쓴
+  파일만 읽을 땐 무해하지만, **외부 파일을 읽는 경로가 생기는 순간 그 트레이드오프가 라이브가 된다** —
+  `Int.max` 같은 값이 그대로 저장되면 이후 산술이 Swift 오버플로 트랩으로 프로세스를 죽이고, 재기동해도
+  같은 파일을 읽어 다시 죽는다(`load()` 의 `.corrupt` 복구는 디코드가 *성공*하므로 발동 안 함 → 파일을
+  손으로 지우기 전까지 앱 사용 불가). 방어는 다운스트림 산술 지점마다가 아니라 **값이 들어오는 경계 한
+  곳**에서(`SaveTransfer.sanitized`). 자르는 대상은 산술에 쓰이는 수치뿐 — 도감·인벤토리 *항목*은 잘라내면
+  데이터 손실이다. (딥리뷰 2026-08-03: SIGTRAP 재현.)
 - **상태 파일을 옮기거나 합칠 땐 "진행"과 "이 기기 장부"를 먼저 분류하라.** 같은 파일에 살아도 성격이
   다르다 — `usedSinceInstall`·`dex`·`inventory`·`candyGrantTier` 는 어느 기기에서든 참인 **진행**이고,
   `claimedTodayTokens`·`lastDate`·`installBaselineSet` 은 *그 기기가* 어디까지 적립했나를 적은 **로컬

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,3 +165,13 @@
 - **JSON `null` 은 "값 있음"이 아니다.** `obj["x"] != nil` 은 `NSNull` 에도 참이라 `intValue` 가 0 을 돌려주고,
   그 0 으로 캐시분을 빼면 토큰이 통째로 사라진다. 숫자 필드는 `NSNull`·문자열·부재를 모두 nil 로 만드는
   추출기(`intOrNil`/`doubleOrNil`)로 읽고, 대체 스펠링 폴백은 그 nil 로 판단한다.
+- **상태 파일을 옮기거나 합칠 땐 "진행"과 "이 기기 장부"를 먼저 분류하라.** 같은 파일에 살아도 성격이
+  다르다 — `usedSinceInstall`·`dex`·`inventory`·`candyGrantTier` 는 어느 기기에서든 참인 **진행**이고,
+  `claimedTodayTokens`·`lastDate`·`installBaselineSet` 은 *그 기기가* 어디까지 적립했나를 적은 **로컬
+  장부**다. 장부를 그대로 들여오면 옛 기기의 오늘 최고치가 문턱이 되어 `update` 의
+  `todayTokens > claimedTodayTokens` 게이트가 이전 당일 내내 거짓 → 새 기기 사용분이 조용히 안 잡힌다
+  (자정에 저절로 낫기 때문에 버그로 안 보인다). 반대로 계정 전역 근거로 만들어진 원장(`candyGrantTier`
+  — 한도 창 key)은 **버리면** 같은 창에서 재지급된다. 이전·병합 경로를 만들 땐 필드를 전수로 이 두 부류에
+  넣어 보고, 로컬 장부만 새 기기 기준으로 다시 잡는다(`SaveTransfer.rebasedForThisDevice`). 회귀 가드:
+  `testTransferDayTokensStillCountAfterRebase` — 재정렬 없는 대조군을 같이 돌려 결함 조건이 살아 있는지도
+  함께 확인한다(테스트가 트리거 브랜치를 실제로 밟는지 보증).

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -231,7 +231,15 @@ final class CompanionStore {
         if !state.installBaselineSet {
             // 설치 기준선 — 실제 데이터가 도착한 시점의 today 를 baseline 으로(이전 사용량 미카운트).
             // 데이터 도착 전(기동 직후 빈 새로고침)에는 잡지 않는다.
-            guard hasUsageData else { displayState = .egg; return }
+            guard hasUsageData else {
+                // 세이브 불러오기가 baseline 판정을 이 경로에 넘겼을 수 있다(SaveTransfer.rebasedForThisDevice).
+                // 그 경우 개체는 이미 들어와 있으므로 알로 표시하면 안 되고, 진화 라인 로드도 계속 재시도해야
+                // 한다 — 새 Mac 은 AI CLI 를 처음 쓸 때까지 hasUsageData 가 false 라 여기서 막히면 그날 내내
+                // 알로 보인다(재시작해도 동일).
+                displayState = state.active == nil ? .egg : .idle
+                kickLineLoadIfNeeded()
+                return
+            }
             state.installBaselineSet = true
             state.claimedTodayTokens = todayTokens
             state.lastDate = todayDate
@@ -635,6 +643,7 @@ final class CompanionStore {
         // 내렸다가(hatch 자체 가드 통과용) hatch 를 호출해, 그 await 창에서 다른 update 틱이
         // 두 번째 종을 롤하는 경합이 있었다. hatchCore 는 isHatching 을 재검사하지 않으므로
         // 여기서 소유한 락 하나로 롤·부화가 원자적으로 보호된다.
+        let generation = activeGeneration
         isHatching = true
         defer { isHatching = false }
         // 프리패칭된 종이 있으면 그대로 사용(라인·스프라이트 예열됨 → 딜레이 ~0), 없으면 지금 롤.
@@ -645,8 +654,25 @@ final class CompanionStore {
             base = await chooseBase()
         }
         guard let base else { return }   // 네트워크 불안정 → 알 유지, 다음 update 틱에 재시도
+        // 세대 검사는 **여기서** 해야 한다. `chooseBase()` 대기 창에서 상태가 통째로 교체되면
+        // (세이브 불러오기) 그 뒤에 진입하는 hatchCore 는 *교체 이후*의 세대를 캡처해 자기 가드가
+        // 무조건 통과한다 — 옛 롤 결과가 불러온 개체를 덮어쓰고 save() 로 디스크에 박힌다.
+        guard activeGeneration == generation, state.active == nil else {
+            AppLog.write("hatch: discarded before core — subject replaced during species roll")
+            kickLineLoadIfNeeded()
+            return
+        }
         state.pendingHatchID = nil
         await hatchCore(baseID: base)
+    }
+
+    /// 부화가 폐기된 뒤 남은 개체(대개 방금 불러온 개체)의 진화 라인을 다시 로드한다.
+    /// `loadCurrentLine` 은 `!isHatching` 을 요구하므로 부화 중에 걸린 로드는 조용히 실패한다 —
+    /// 아무도 재시도하지 않으면 다음 update 틱(기본 120초)까지 이름이 "Token Egg" 로 남는다.
+    /// Task 본문은 현재 동기 실행(= defer 로 isHatching 해제)이 끝난 뒤 돌므로 락이 이미 풀려 있다.
+    private func kickLineLoadIfNeeded() {
+        guard state.active != nil, currentLine == nil else { return }
+        Task { await loadCurrentLine() }
     }
 
     // MARK: 알 프리패칭
@@ -711,6 +737,7 @@ final class CompanionStore {
         // (loadCurrentLine·revealDitto 와 같은 세대 가드 — isHatching 락은 같은 앱 내 중복 부화만 막는다.)
         guard activeGeneration == generation else {
             AppLog.write("hatch: discarded — active subject replaced during line fetch")
+            kickLineLoadIfNeeded()
             return
         }
         currentLine = line

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -701,8 +701,16 @@ final class CompanionStore {
 
     /// 실제 부화 로직 — isHatching 락은 호출자(hatch / hatchIfNeeded)가 소유·해제한다.
     private func hatchCore(baseID: Int) async {
+        let generation = activeGeneration
         guard let line = try? await provider.line(baseSpeciesID: baseID) else {
             AppLog.write("hatch: line fetch failed for base \(baseID) — egg kept, retry next tick")
+            return
+        }
+        // 라인 fetch 창(네트워크) 동안 활성 개체가 교체됐으면 이 부화 결과를 폐기한다. 세이브 불러오기가
+        // 그 창에 들어오면, 여기서 멈추지 않는 한 갓 부화한 개체가 방금 불러온 개체를 덮어쓴다.
+        // (loadCurrentLine·revealDitto 와 같은 세대 가드 — isHatching 락은 같은 앱 내 중복 부화만 막는다.)
+        guard activeGeneration == generation else {
+            AppLog.write("hatch: discarded — active subject replaced during line fetch")
             return
         }
         currentLine = line

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -685,12 +685,15 @@ final class CompanionStore {
     /// 전부 성공하면 부화 순간 네트워크 0. 실패 지점부터 다음 update 틱에 이어서 재시도.
     private func ensureEggPrefetch() async {
         guard state.active == nil, !isHatching, !prefetchInFlight else { return }
+        let generation = activeGeneration
         prefetchInFlight = true
         defer { prefetchInFlight = false }
 
         if state.pendingHatchID == nil {
             guard let id = await chooseBase() else { return }   // 오프라인 → 다음 틱 재시도
-            guard state.active == nil else { return }           // await 사이 부화 완료 케이스 방어
+            // await 사이에 부화가 끝났거나(active != nil) 상태가 통째로 교체됐으면(세이브 불러오기)
+            // 이 롤을 버린다 — 안 그러면 불러온 알의 pre-roll 을 남의 롤로 덮어쓴다.
+            guard state.active == nil, activeGeneration == generation else { return }
             state.pendingHatchID = id
             save()
         }
@@ -897,22 +900,22 @@ final class CompanionStore {
     /// 덮어쓰기 확인에 쓸 "이 기기의 현재 진행" 요약.
     var transferSummary: SaveSummary { SaveSummary(state: state) }
 
+    /// 저장 패널에 채울 기본 파일명. 봉투의 `exportedAt` 과 **같은 시계**에서 뽑는다 — 뷰가 따로
+    /// `Date()` 를 부르면 파일명 날짜와 내용의 날짜가 갈릴 수 있다(자정 경계).
+    var suggestedExportFileName: String { SaveTransfer.suggestedFileName(date: clock()) }
+
     /// 내보내기 페이로드. 파일 쓰기는 호출자(UI)가 사용자가 고른 위치에 수행한다.
     func exportedSaveData(appVersion: String, deviceName: String) throws -> Data {
         try SaveTransfer.encode(state: state, appVersion: appVersion, deviceName: deviceName, now: clock())
     }
 
-    /// 적용 전 검증 — 확인 다이얼로그에 들여올 내용을 먼저 보여주기 위해 분리했다.
-    /// (파일을 고르자마자 덮어쓰지 않는다.)
-    static func inspectSave(_ data: Data) throws -> (summary: SaveSummary, envelope: SaveEnvelope) {
-        let envelope = try SaveTransfer.decode(data)
-        return (SaveSummary(state: envelope.state), envelope)
-    }
-
     /// 검증된 세이브를 이 기기에 적용 — 기존 상태 백업 → 기기 기준 재정렬 → 저장 → 라인 재로딩.
-    func applySave(_ envelope: SaveEnvelope, todayTokens: Int, todayDate: String, hasUsageData: Bool) {
-        backupStateBeforeImport()
+    /// 백업을 못 남기면 **적용하지 않고** throw 한다 — 확인창이 "직전 상태가 남는다"고 약속하므로,
+    /// 그 약속을 못 지키는 채로 덮어쓰면 사용자는 되돌릴 수단 없이 진행을 잃는다.
+    func applySave(_ envelope: SaveEnvelope, todayTokens: Int, todayDate: String, hasUsageData: Bool) throws {
+        try backupStateBeforeImport()
         state = SaveTransfer.rebasedForThisDevice(envelope.state,
+                                                  current: state,
                                                   todayTokens: todayTokens,
                                                   todayDate: todayDate,
                                                   hasUsageData: hasUsageData)
@@ -925,18 +928,42 @@ final class CompanionStore {
         justGraduated = nil
         eventUntil = nil
         celebration = nil
+        // 이전 개체 기준의 1회성 피드백(사탕 +XP·민트 성격)도 비운다 — 안 비우면 불러온 직후 남의
+        // 개체에 대한 "+XP" 가 새 개체 위에 떠오른다.
+        candyFeedbackAmount = 0
+        mintFeedbackNature = nil
         displayState = state.active != nil ? .idle : .egg
         save()
         if state.active != nil { Task { await loadCurrentLine() } }
         AppLog.write("save imported from \(envelope.sourceDevice): dex=\(state.dex.count) lifetime=\(state.usedSinceInstall)")
     }
 
-    /// 덮어쓰기 직전 현재 상태를 옆에 남긴다 — 잘못 불러왔을 때 손으로 되돌릴 수단.
-    /// 한 슬롯만 유지(불러오기마다 갱신)한다 — 무한 증식보다 "직전 상태 하나"가 실제로 쓸모 있다.
-    private func backupStateBeforeImport() {
-        guard let data = try? JSONEncoder().encode(state) else { return }
-        let backup = fileURL.deletingPathExtension().appendingPathExtension("pre-import.json")
-        try? data.write(to: backup, options: .atomic)
+    /// 덮어쓰기 직전 현재 상태를 옆에 남긴다 — 잘못 불러왔을 때 되돌릴 수단.
+    /// 슬롯을 하나만 쓰면 두 번째 불러오기가 **원본**을 덮어써, "잘못 불러왔으니 되돌린다"는 바로 그
+    /// 상황에서 되돌릴 대상이 사라진다. 불러올 때마다 새 슬롯을 쓰고 오래된 것부터 정리한다.
+    @discardableResult
+    private func backupStateBeforeImport() throws -> URL {
+        guard let data = try? JSONEncoder().encode(state) else { throw SaveTransferError.backupFailed }
+        let dir = fileURL.deletingLastPathComponent()
+        let backup = dir.appendingPathComponent(SaveTransfer.backupFileName(date: clock()))
+        do {
+            try data.write(to: backup, options: .atomic)
+        } catch {
+            AppLog.write("save import aborted — backup write failed: \(error)")
+            throw SaveTransferError.backupFailed
+        }
+        pruneImportBackups(in: dir)
+        return backup
+    }
+
+    /// 최근 N 개만 남기고 오래된 백업을 지운다. 파일명이 `yyyy-MM-dd-HHmmss` 라 사전순 = 시간순이다.
+    private func pruneImportBackups(in dir: URL) {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { return }
+        let backups = names.filter { $0.hasPrefix(SaveTransfer.backupFilePrefix) }.sorted()
+        guard backups.count > SaveTransfer.backupsToKeep else { return }
+        for stale in backups.dropLast(SaveTransfer.backupsToKeep) {
+            try? FileManager.default.removeItem(at: dir.appendingPathComponent(stale))
+        }
     }
 
     // MARK: 영속

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -951,7 +951,10 @@ final class CompanionStore {
             AppLog.write("companion state decode failed — original backed up to \(backup.lastPathComponent), starting fresh")
             return
         }
-        state = s
+        // 불러오기 경계와 같은 정규화를 디스크에서 읽을 때도 건다. 불러오기만 막으면 **이미 저장된**
+        // 극단값은 그대로 남아, 앱이 매 기동마다 같은 값을 읽어 산술 트랩으로 죽는 상태를 못 벗어난다
+        // (디코드는 *성공*하므로 위의 .corrupt 복구도 발동하지 않는다). 여기서 걸면 자가 복구된다.
+        state = SaveTransfer.sanitized(s)
     }
     private func save() {
         guard let data = try? JSONEncoder().encode(state) else { return }

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -857,6 +857,53 @@ final class CompanionStore {
         }
     }
 
+    // MARK: 세이브 이전 (기기 교체)
+
+    /// 덮어쓰기 확인에 쓸 "이 기기의 현재 진행" 요약.
+    var transferSummary: SaveSummary { SaveSummary(state: state) }
+
+    /// 내보내기 페이로드. 파일 쓰기는 호출자(UI)가 사용자가 고른 위치에 수행한다.
+    func exportedSaveData(appVersion: String, deviceName: String) throws -> Data {
+        try SaveTransfer.encode(state: state, appVersion: appVersion, deviceName: deviceName, now: clock())
+    }
+
+    /// 적용 전 검증 — 확인 다이얼로그에 들여올 내용을 먼저 보여주기 위해 분리했다.
+    /// (파일을 고르자마자 덮어쓰지 않는다.)
+    static func inspectSave(_ data: Data) throws -> (summary: SaveSummary, envelope: SaveEnvelope) {
+        let envelope = try SaveTransfer.decode(data)
+        return (SaveSummary(state: envelope.state), envelope)
+    }
+
+    /// 검증된 세이브를 이 기기에 적용 — 기존 상태 백업 → 기기 기준 재정렬 → 저장 → 라인 재로딩.
+    func applySave(_ envelope: SaveEnvelope, todayTokens: Int, todayDate: String, hasUsageData: Bool) {
+        backupStateBeforeImport()
+        state = SaveTransfer.rebasedForThisDevice(envelope.state,
+                                                  todayTokens: todayTokens,
+                                                  todayDate: todayDate,
+                                                  hasUsageData: hasUsageData)
+        // 이전 개체 기준으로 진행 중이던 비동기·연출을 전부 무효화한다. activeGeneration 을 올리지
+        // 않으면 먼저 떠 있던 라인 로드가 완료되며 새로 불러온 개체를 덮어쓴다.
+        activeGeneration += 1
+        currentLine = nil
+        prefetchedLineID = nil
+        justEvolvedTo = nil
+        justGraduated = nil
+        eventUntil = nil
+        celebration = nil
+        displayState = state.active != nil ? .idle : .egg
+        save()
+        if state.active != nil { Task { await loadCurrentLine() } }
+        AppLog.write("save imported from \(envelope.sourceDevice): dex=\(state.dex.count) lifetime=\(state.usedSinceInstall)")
+    }
+
+    /// 덮어쓰기 직전 현재 상태를 옆에 남긴다 — 잘못 불러왔을 때 손으로 되돌릴 수단.
+    /// 한 슬롯만 유지(불러오기마다 갱신)한다 — 무한 증식보다 "직전 상태 하나"가 실제로 쓸모 있다.
+    private func backupStateBeforeImport() {
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        let backup = fileURL.deletingPathExtension().appendingPathExtension("pre-import.json")
+        try? data.write(to: backup, options: .atomic)
+    }
+
     // MARK: 영속
     private func load() {
         guard let data = try? Data(contentsOf: fileURL) else { return }   // 파일 없음 = 신규 설치

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -148,6 +148,67 @@ struct L {
     var aggregationNote: String { t("토큰 집계 기준: totalTokens (input + output + cache, 로컬 날짜)", "Token basis: totalTokens (input + output + cache, local date)", "集計基準: totalTokens (input + output + cache, ローカル日付)") }
     var close: String { t("닫기", "Close", "閉じる") }
 
+    // MARK: 세이브 이전 (설정 → 백업 & 이전)
+    var transferSectionTitle: String { t("백업 & 이전", "Backup & Transfer", "バックアップと移行") }
+    var exportSaveLabel: String { t("세이브 내보내기", "Export save", "セーブを書き出す") }
+    var exportSaveHint: String {
+        t("도감·누적 토큰·현재 포켓몬을 파일 하나로 저장해요",
+          "Saves your Pokédex, lifetime tokens, and current Pokémon as one file",
+          "図鑑・累計トークン・現在のポケモンを1つのファイルに保存します")
+    }
+    var exportSaveButton: String { t("내보내기…", "Export…", "書き出す…") }
+    var importSaveLabel: String { t("세이브 불러오기", "Import save", "セーブを読み込む") }
+    var importSaveHint: String {
+        t("다른 Mac에서 내보낸 파일을 골라 이 Mac으로 이어서 키워요",
+          "Pick a file exported from another Mac and continue here",
+          "他のMacから書き出したファイルを選んでこのMacで続けます")
+    }
+    var importSaveButton: String { t("불러오기…", "Import…", "読み込む…") }
+    func exportSaveDone(_ fileName: String) -> String {
+        t("저장했어요 — \(fileName)", "Saved — \(fileName)", "保存しました — \(fileName)")
+    }
+    var importConfirmTitle: String {
+        t("이 Mac의 진행을 대체할까요?", "Replace this Mac's progress?", "このMacの進行を置き換えますか？")
+    }
+    /// 무엇이 사라지는지 수치로 적는다 — 일반적인 "정말 진행할까요?" 보다 판단에 실제로 쓸모 있다.
+    func importConfirmBody(incomingDex: Int, incomingTokens: String,
+                           currentDex: Int, currentTokens: String) -> String {
+        t("""
+          불러올 세이브: 도감 \(incomingDex)마리 · 누적 \(incomingTokens)
+          현재 이 Mac: 도감 \(currentDex)마리 · 누적 \(currentTokens)
+
+          이 Mac의 현재 진행은 대체되며, 직전 상태는 companion-state.pre-import.json 으로 남습니다.
+          """,
+          """
+          Incoming save: \(incomingDex) in Pokédex · \(incomingTokens) lifetime
+          This Mac now: \(currentDex) in Pokédex · \(currentTokens) lifetime
+
+          This Mac's current progress is replaced. The previous state is kept as companion-state.pre-import.json.
+          """,
+          """
+          読み込むセーブ: 図鑑 \(incomingDex)匹 · 累計 \(incomingTokens)
+          現在のこのMac: 図鑑 \(currentDex)匹 · 累計 \(currentTokens)
+
+          このMacの現在の進行は置き換えられます。直前の状態は companion-state.pre-import.json に残ります。
+          """)
+    }
+    var importConfirmReplace: String { t("대체", "Replace", "置き換える") }
+    func importSaveDone(dex: Int, tokens: String) -> String {
+        t("불러왔어요 — 도감 \(dex)마리 · 누적 \(tokens)",
+          "Imported — \(dex) in Pokédex · \(tokens) lifetime",
+          "読み込みました — 図鑑 \(dex)匹 · 累計 \(tokens)")
+    }
+    var importErrorNotSaveFile: String {
+        t("PokeTokenBar 세이브 파일이 아니에요.",
+          "That isn't a PokeTokenBar save file.",
+          "PokeTokenBar のセーブファイルではありません。")
+    }
+    var importErrorNewerSchema: String {
+        t("더 새로운 버전에서 만든 세이브예요 — 앱을 업데이트한 뒤 다시 시도해 주세요.",
+          "This save was made by a newer version — update the app and try again.",
+          "より新しいバージョンで作成されたセーブです — アプリを更新してから再試行してください。")
+    }
+
     // MARK: 문제점 알리기 (설정 → 메일 리포트)
     var reportProblem: String { t("문제점 알리기", "Report a problem", "問題を報告") }
     var showLogFile: String { t("로그 파일 보기", "Show log file", "ログファイルを表示") }

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -152,9 +152,9 @@ struct L {
     var transferSectionTitle: String { t("백업 & 이전", "Backup & Transfer", "バックアップと移行") }
     var exportSaveLabel: String { t("세이브 내보내기", "Export save", "セーブを書き出す") }
     var exportSaveHint: String {
-        t("도감·누적 토큰·현재 포켓몬을 파일 하나로 저장해요",
-          "Saves your Pokédex, lifetime tokens, and current Pokémon as one file",
-          "図鑑・累計トークン・現在のポケモンを1つのファイルに保存します")
+        t("도감·누적 토큰·가방·현재 포켓몬을 파일 하나로 저장해요",
+          "Saves your Pokédex, lifetime tokens, Bag, and current Pokémon as one file",
+          "図鑑・累計トークン・バッグ・現在のポケモンを1つのファイルに保存します")
     }
     var exportSaveButton: String { t("내보내기…", "Export…", "書き出す…") }
     var importSaveLabel: String { t("세이브 불러오기", "Import save", "セーブを読み込む") }
@@ -164,32 +164,35 @@ struct L {
           "他のMacから書き出したファイルを選んでこのMacで続けます")
     }
     var importSaveButton: String { t("불러오기…", "Import…", "読み込む…") }
-    func exportSaveDone(_ fileName: String) -> String {
-        t("저장했어요 — \(fileName)", "Saved — \(fileName)", "保存しました — \(fileName)")
-    }
     var importConfirmTitle: String {
         t("이 Mac의 진행을 대체할까요?", "Replace this Mac's progress?", "このMacの進行を置き換えますか？")
     }
     /// 무엇이 사라지는지 수치로 적는다 — 일반적인 "정말 진행할까요?" 보다 판단에 실제로 쓸모 있다.
+    /// 내보낸 시각·출처 기기를 함께 보여주는 이유: 도감 수가 같으면 3주 전 세이브도 문구가 똑같아,
+    /// 오래된 파일을 되돌리는 상황을 사용자가 알아챌 단서가 없다.
     func importConfirmBody(incomingDex: Int, incomingTokens: String,
+                           exportedAt: String, sourceDevice: String,
                            currentDex: Int, currentTokens: String) -> String {
         t("""
           불러올 세이브: 도감 \(incomingDex)마리 · 누적 \(incomingTokens)
+          내보낸 시각: \(exportedAt) · \(sourceDevice)
           현재 이 Mac: 도감 \(currentDex)마리 · 누적 \(currentTokens)
 
-          이 Mac의 현재 진행은 대체되며, 직전 상태는 companion-state.pre-import.json 으로 남습니다.
+          이 Mac의 현재 진행은 대체됩니다. 직전 상태는 상태 폴더에 백업으로 남습니다(최근 5개).
           """,
           """
           Incoming save: \(incomingDex) in Pokédex · \(incomingTokens) lifetime
+          Exported: \(exportedAt) · \(sourceDevice)
           This Mac now: \(currentDex) in Pokédex · \(currentTokens) lifetime
 
-          This Mac's current progress is replaced. The previous state is kept as companion-state.pre-import.json.
+          This Mac's current progress is replaced. The previous state is kept as a backup in the state folder (last 5).
           """,
           """
           読み込むセーブ: 図鑑 \(incomingDex)匹 · 累計 \(incomingTokens)
+          書き出し日時: \(exportedAt) · \(sourceDevice)
           現在のこのMac: 図鑑 \(currentDex)匹 · 累計 \(currentTokens)
 
-          このMacの現在の進行は置き換えられます。直前の状態は companion-state.pre-import.json に残ります。
+          このMacの現在の進行は置き換えられます。直前の状態は状態フォルダにバックアップとして残ります（最新5件）。
           """)
     }
     var importConfirmReplace: String { t("대체", "Replace", "置き換える") }
@@ -213,10 +216,23 @@ struct L {
     /// couldn't be completed…" 같은 원문이 그대로 노출된다(조용한 품질 저하).
     func importErrorMessage(_ error: Error) -> String {
         switch error {
-        case SaveTransferError.notASaveFile: return importErrorNotSaveFile
-        case SaveTransferError.newerSchema:  return importErrorNewerSchema
+        case SaveTransferError.notASaveFile:  return importErrorNotSaveFile
+        case SaveTransferError.newerSchema:   return importErrorNewerSchema
+        case SaveTransferError.fileTooLarge:  return importErrorTooLarge
+        case SaveTransferError.backupFailed:  return importErrorBackupFailed
         default: return error.localizedDescription
         }
+    }
+    var importErrorTooLarge: String {
+        t("세이브 파일이라기엔 너무 커요 — 다른 파일을 고른 것 같아요.",
+          "That file is too large to be a save — it looks like the wrong file.",
+          "セーブファイルにしては大きすぎます — 別のファイルを選んだようです。")
+    }
+    /// 백업을 못 남기면 불러오기를 중단한다 — 되돌릴 수단 없이 진행을 대체하지 않기 위해서다.
+    var importErrorBackupFailed: String {
+        t("현재 상태를 백업하지 못해 불러오기를 중단했어요 — 진행은 그대로예요. 디스크 여유 공간을 확인해 주세요.",
+          "Import stopped because the current state couldn't be backed up — your progress is untouched. Check free disk space.",
+          "現在の状態をバックアップできなかったため読み込みを中止しました — 進行はそのままです。ディスクの空き容量を確認してください。")
     }
 
     // MARK: 문제점 알리기 (설정 → 메일 리포트)

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -208,6 +208,16 @@ struct L {
           "This save was made by a newer version — update the app and try again.",
           "より新しいバージョンで作成されたセーブです — アプリを更新してから再試行してください。")
     }
+    /// 불러오기 실패 사유 → 사용자 문구. 뷰가 아니라 여기 두는 이유는 이 매핑이 테스트 가능해야 하기
+    /// 때문이다 — 매핑이 어긋나면 `SaveTransferError` 는 LocalizedError 가 아니라서 "The operation
+    /// couldn't be completed…" 같은 원문이 그대로 노출된다(조용한 품질 저하).
+    func importErrorMessage(_ error: Error) -> String {
+        switch error {
+        case SaveTransferError.notASaveFile: return importErrorNotSaveFile
+        case SaveTransferError.newerSchema:  return importErrorNewerSchema
+        default: return error.localizedDescription
+        }
+    }
 
     // MARK: 문제점 알리기 (설정 → 메일 리포트)
     var reportProblem: String { t("문제점 알리기", "Report a problem", "問題を報告") }

--- a/Sources/PokeTokenBar/Core/SaveTransfer.swift
+++ b/Sources/PokeTokenBar/Core/SaveTransfer.swift
@@ -19,19 +19,23 @@ struct SaveEnvelope: Codable, Sendable {
     var state: CompanionState
 }
 
+/// 봉투의 앞부분만 읽는 최소 구조 — 본문(`state`)이 상위 스키마라 못 읽히더라도 "새 버전 세이브"임을
+/// 알아보고 정확한 안내를 하기 위해서다. 이게 없으면 상위 스키마 파일이 "세이브 파일이 아니에요"로
+/// 뜬다(사용자는 앱을 업데이트하면 된다는 걸 모른다).
+private struct SaveHeader: Decodable {
+    let format: String
+    let schema: Int
+}
+
 /// 덮어쓰기 확인에 쓰는 요약 — "무엇이 대체되는지"를 수치로 보여주기 위한 값.
 /// (경고문에 대상을 구체적으로 적는 것이 일반적인 "정말 진행할까요?" 보다 사용자에게 유용하다.)
 struct SaveSummary: Equatable, Sendable {
     var dexCount: Int
     var lifetimeTokens: Int
 
-    init(dexCount: Int, lifetimeTokens: Int) {
-        self.dexCount = dexCount
-        self.lifetimeTokens = lifetimeTokens
-    }
-
     init(state: CompanionState) {
-        self.init(dexCount: state.dex.count, lifetimeTokens: state.usedSinceInstall)
+        dexCount = state.dex.count
+        lifetimeTokens = state.usedSinceInstall
     }
 }
 
@@ -40,16 +44,56 @@ enum SaveTransferError: Error, Equatable {
     case notASaveFile
     /// 이 빌드보다 새 스키마 — 상위 버전에서 만든 세이브.
     case newerSchema(found: Int, supported: Int)
+    /// 세이브로 보기엔 과하게 큰 파일 — 파싱이 메인스레드를 오래 잡는다.
+    case fileTooLarge(bytes: Int, limit: Int)
+    /// 덮어쓰기 전 백업을 못 남겼다 — 확인창이 약속한 복구 수단이 없으므로 불러오기를 중단한다.
+    case backupFailed
+}
+
+/// 불러오기 확인창의 버튼 배치 규칙. AppKit 밖으로 빼둔 이유는 이 규칙이 **데이터 손실과 직결**되는데
+/// `NSAlert` 구성은 XCTest 에서 도달할 수 없기 때문이다 — 두 줄이 뒤바뀌면 Return 한 키로 이 Mac 의
+/// 진행이 대체되는데 잡을 자동 테스트가 없었다.
+enum ImportConfirmPolicy {
+    static let replaceButtonIndex = 0
+    static let cancelButtonIndex = 1
+
+    /// 기본 버튼(Return)은 **취소**여야 한다. 파괴적 동작을 기본으로 두지 않는다.
+    static func keyEquivalent(forButtonAt index: Int) -> String {
+        index == cancelButtonIndex ? "\r" : ""
+    }
 }
 
 enum SaveTransfer {
+    /// 세이브 파일 크기 상한. 정상 세이브는 수 KB 이고 도감이 가득 차도 수백 KB 를 넘지 않는다.
+    /// 상한이 없으면 거대한 JSON 이 메인스레드 파싱을 수 초간 잡는다(실측: 39MB → 약 1.8초 정지).
+    static let maxFileBytes = 8 * 1024 * 1024
+
+    /// 세이브에 들어올 수 있는 수치의 상한 — 실사용(수십억)의 10만 배라 정상 진행을 자르지 않으면서,
+    /// 이 값끼리 더하고 빼도 Int64 범위 안에 머문다.
+    static let maxTokenValue = 1_000_000_000_000_000
+
     /// 내보내기 파일명 — 날짜가 들어가야 여러 번 내보내도 덮어쓰지 않는다.
     static func suggestedFileName(date: Date) -> String {
+        "PokeTokenBar-Save-\(dayStamp(date)).json"
+    }
+
+    /// 백업 파일명 — 불러올 때마다 새 슬롯. 하나만 유지하면 두 번째 불러오기가 **원본**을 덮어써,
+    /// "잘못 불러왔으니 되돌린다"는 바로 그 상황에서 되돌릴 대상이 사라진다.
+    static func backupFileName(date: Date) -> String {
+        "companion-state.pre-import-\(secondStamp(date)).json"
+    }
+    static let backupFilePrefix = "companion-state.pre-import-"
+    /// 유지할 백업 개수 — 오래된 것부터 지운다.
+    static let backupsToKeep = 5
+
+    private static func stamp(_ date: Date, _ format: String) -> String {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
-        f.dateFormat = "yyyy-MM-dd"
-        return "PokeTokenBar-Save-\(f.string(from: date)).json"
+        f.dateFormat = format
+        return f.string(from: date)
     }
+    private static func dayStamp(_ date: Date) -> String { stamp(date, "yyyy-MM-dd") }
+    private static func secondStamp(_ date: Date) -> String { stamp(date, "yyyy-MM-dd-HHmmss") }
 
     static func encode(state: CompanionState, appVersion: String, deviceName: String, now: Date) throws -> Data {
         let envelope = SaveEnvelope(format: SaveEnvelope.formatID,
@@ -66,22 +110,25 @@ enum SaveTransfer {
     }
 
     static func decode(_ data: Data) throws -> SaveEnvelope {
+        guard data.count <= maxFileBytes else {
+            throw SaveTransferError.fileTooLarge(bytes: data.count, limit: maxFileBytes)
+        }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        guard var envelope = try? decoder.decode(SaveEnvelope.self, from: data),
-              envelope.format == SaveEnvelope.formatID else {
+        // 헤더를 먼저 읽는다 — 본문이 상위 스키마라 못 읽혀도 "새 버전 세이브"로 정확히 안내하기 위해.
+        guard let header = try? decoder.decode(SaveHeader.self, from: data),
+              header.format == SaveEnvelope.formatID else {
             throw SaveTransferError.notASaveFile
         }
-        guard envelope.schema <= SaveEnvelope.schemaVersion else {
-            throw SaveTransferError.newerSchema(found: envelope.schema, supported: SaveEnvelope.schemaVersion)
+        guard header.schema <= SaveEnvelope.schemaVersion else {
+            throw SaveTransferError.newerSchema(found: header.schema, supported: SaveEnvelope.schemaVersion)
+        }
+        guard var envelope = try? decoder.decode(SaveEnvelope.self, from: data) else {
+            throw SaveTransferError.notASaveFile   // 같은 스키마인데 못 읽힘 = 손상
         }
         envelope.state = sanitized(envelope.state)
         return envelope
     }
-
-    /// 세이브에 들어올 수 있는 수치의 상한 — 실사용(수십억)의 10만 배라 정상 진행을 자르지 않으면서,
-    /// 이 값끼리 더하고 빼도 Int64 범위 안에 머문다.
-    static let maxTokenValue = 1_000_000_000_000_000
 
     /// 신뢰경계 값 정규화 — 세이브는 **앱 밖에서** 온다(손편집·전송 중 손상·다른 빌드).
     ///
@@ -111,17 +158,27 @@ enum SaveTransfer {
 
     /// 다른 기기에서 온 상태를 **이 기기 기준으로 재정렬**한다.
     ///
-    /// `claimedTodayTokens` 는 진행이 아니라 "이 기기가 오늘 어디까지 적립했나"라는 기기 로컬 장부다.
-    /// 그대로 들여오면 옛 기기의 오늘 총량이 문턱이 되어, `CompanionStore.update` 의
-    /// `todayTokens > claimedTodayTokens` 게이트가 이전 당일 내내 거짓이 된다 — 새 기기에서 쓴
-    /// 토큰이 성장·잔액에 조용히 안 잡힌다(다음 날 00시에 저절로 낫기 때문에 버그로 안 보인다).
+    /// `CompanionState` 의 필드는 이전 관점에서 세 부류다.
+    ///  - **진행**: 어느 기기에서든 참(`usedSinceInstall`·`dex`·`inventory`·`active`·`eggUsage`…) → 그대로.
+    ///  - **로컬 장부**: *그 기기가* 어디까지 적립했나(`claimedTodayTokens`·`lastDate`·`installBaselineSet`)
+    ///    → 새 기기 기준으로 다시 잡는다. 그대로 들여오면 옛 기기의 오늘 총량이 문턱이 되어
+    ///    `CompanionStore.update` 의 `todayTokens > claimedTodayTokens` 게이트가 이전 당일 내내 거짓이 되고,
+    ///    새 기기 사용분이 조용히 안 잡힌다(자정에 저절로 낫기 때문에 버그로 안 보인다).
+    ///  - **기기 환경설정**: 진행이 아니라 이 기기에서 보는 방식(`language`) → **현재 기기 값을 지킨다**.
+    ///    일본어 Mac 의 세이브가 영어 Mac 의 UI 언어를 바꾸면 안 된다.
     ///
-    /// 진행(도감·누적·인벤토리·현재 개체·사탕 지급 원장)은 전부 보존하고 이 장부만 다시 잡는다.
+    /// 계정 전역 원장(`candyGrantTier`)은 교체가 아니라 **key 별 max 병합**이다. 한도 창 key 는 계정
+    /// 단위라 두 기기가 같은 창을 본다 — 더 오래된 세이브로 통째 교체하면 이미 지급한 창의 기록이
+    /// 사라져 같은 창에서 사탕이 재지급된다(보존만으로는 이 역방향을 못 막는다).
     static func rebasedForThisDevice(_ imported: CompanionState,
+                                     current: CompanionState,
                                      todayTokens: Int,
                                      todayDate: String,
                                      hasUsageData: Bool) -> CompanionState {
         var state = imported
+        state.language = current.language
+        state.candyGrantTier = mergedGrantTier(imported.candyGrantTier, current.candyGrantTier)
+        state.candyFeatureSeeded = imported.candyFeatureSeeded || current.candyFeatureSeeded
         if hasUsageData {
             // 신규 설치와 같은 규칙: 불러온 시점 이전의 이 기기 사용량은 소급 적립하지 않는다.
             state.installBaselineSet = true
@@ -135,5 +192,10 @@ enum SaveTransfer {
             state.lastDate = ""
         }
         return state
+    }
+
+    /// 창 key 별로 더 높은 tier 를 남긴다 — 어느 쪽에서든 이미 지급했으면 지급한 것으로 본다.
+    static func mergedGrantTier(_ a: [String: Int], _ b: [String: Int]) -> [String: Int] {
+        a.merging(b) { max($0, $1) }
     }
 }

--- a/Sources/PokeTokenBar/Core/SaveTransfer.swift
+++ b/Sources/PokeTokenBar/Core/SaveTransfer.swift
@@ -68,14 +68,45 @@ enum SaveTransfer {
     static func decode(_ data: Data) throws -> SaveEnvelope {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        guard let envelope = try? decoder.decode(SaveEnvelope.self, from: data),
+        guard var envelope = try? decoder.decode(SaveEnvelope.self, from: data),
               envelope.format == SaveEnvelope.formatID else {
             throw SaveTransferError.notASaveFile
         }
         guard envelope.schema <= SaveEnvelope.schemaVersion else {
             throw SaveTransferError.newerSchema(found: envelope.schema, supported: SaveEnvelope.schemaVersion)
         }
+        envelope.state = sanitized(envelope.state)
         return envelope
+    }
+
+    /// 세이브에 들어올 수 있는 수치의 상한 — 실사용(수십억)의 10만 배라 정상 진행을 자르지 않으면서,
+    /// 이 값끼리 더하고 빼도 Int64 범위 안에 머문다.
+    static let maxTokenValue = 1_000_000_000_000_000
+
+    /// 신뢰경계 값 정규화 — 세이브는 **앱 밖에서** 온다(손편집·전송 중 손상·다른 빌드).
+    ///
+    /// `CompanionState` 의 디코딩은 의도적으로 관대해서(한 필드가 깨져도 도감을 안 날리려고) 말이 안 되는
+    /// 값도 통과시킨다. 그 값이 그대로 저장되면 이후 산술이 Swift 오버플로 트랩으로 **프로세스를 죽이고,
+    /// 재기동해도 같은 파일을 읽어 다시 죽는다** — 사용자가 파일을 손으로 지우기 전까지 앱을 못 쓴다
+    /// (`load()` 의 `.corrupt` 자동복구는 디코드가 *성공*하므로 발동하지 않는다).
+    ///
+    /// 다운스트림 산술 지점마다 막으면 새 지점이 생길 때마다 재발하므로, 값이 **들어오는 경계 한 곳**에서
+    /// 정규화한다. 대상은 실제로 산술에 쓰이는 필드뿐이다 — 도감·인벤토리 항목은 잘라내지 않는다(데이터 손실).
+    static func sanitized(_ state: CompanionState) -> CompanionState {
+        func clampToken(_ v: Int) -> Int { min(max(0, v), maxTokenValue) }
+        var s = state
+        s.usedSinceInstall = clampToken(s.usedSinceInstall)
+        s.spentTokens = clampToken(s.spentTokens)
+        s.eggUsage = clampToken(s.eggUsage)
+        s.claimedTodayTokens = clampToken(s.claimedTodayTokens)
+        if var active = s.active {
+            active.usedAtStage = clampToken(active.usedAtStage)
+            // totalForms 는 `kk * (kk + 1)` 형태로 쓰여(PokemonBalance.phaseThreshold) 큰 값이 그 자체로 트랩이다.
+            active.totalForms = min(max(1, active.totalForms), 12)
+            active.stageIndex = min(max(0, active.stageIndex), max(0, active.pathIDs.count - 1))
+            s.active = active
+        }
+        return s
     }
 
     /// 다른 기기에서 온 상태를 **이 기기 기준으로 재정렬**한다.

--- a/Sources/PokeTokenBar/Core/SaveTransfer.swift
+++ b/Sources/PokeTokenBar/Core/SaveTransfer.swift
@@ -24,18 +24,14 @@ struct SaveEnvelope: Codable, Sendable {
 struct SaveSummary: Equatable, Sendable {
     var dexCount: Int
     var lifetimeTokens: Int
-    var hasActive: Bool
 
-    init(dexCount: Int, lifetimeTokens: Int, hasActive: Bool) {
+    init(dexCount: Int, lifetimeTokens: Int) {
         self.dexCount = dexCount
         self.lifetimeTokens = lifetimeTokens
-        self.hasActive = hasActive
     }
 
     init(state: CompanionState) {
-        self.init(dexCount: state.dex.count,
-                  lifetimeTokens: state.usedSinceInstall,
-                  hasActive: state.active != nil)
+        self.init(dexCount: state.dex.count, lifetimeTokens: state.usedSinceInstall)
     }
 }
 

--- a/Sources/PokeTokenBar/Core/SaveTransfer.swift
+++ b/Sources/PokeTokenBar/Core/SaveTransfer.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// 기기 교체용 세이브 이전 — 상태를 봉투에 담아 내보내고, 다른 기기에서 들여온다.
+///
+/// `CompanionState` 를 그대로 파일로 쓰지 않고 봉투로 감싸는 이유: 상태 디코딩이 의도적으로
+/// 관대해서(`lenient*` — 한 필드가 깨져도 도감 전체를 날리지 않으려고) **아무 JSON 이나 넣어도
+/// 전 필드가 기본값으로 흡수되며 "성공"한다.** 봉투 없이는 남의 JSON 을 골라도 불러오기가
+/// 성공한 뒤 도감이 빈 상태가 되어, 사용자에겐 "앱이 내 진행을 지웠다"로 보인다.
+/// 봉투의 `format`/`schema` 는 관대 디코딩 대상이 아니라(기본값 없음) 이 오인을 먼저 차단한다.
+struct SaveEnvelope: Codable, Sendable {
+    static let formatID = "poketokenbar.save"
+    static let schemaVersion = 1
+
+    var format: String
+    var schema: Int
+    var appVersion: String
+    var exportedAt: Date
+    var sourceDevice: String
+    var state: CompanionState
+}
+
+/// 덮어쓰기 확인에 쓰는 요약 — "무엇이 대체되는지"를 수치로 보여주기 위한 값.
+/// (경고문에 대상을 구체적으로 적는 것이 일반적인 "정말 진행할까요?" 보다 사용자에게 유용하다.)
+struct SaveSummary: Equatable, Sendable {
+    var dexCount: Int
+    var lifetimeTokens: Int
+    var hasActive: Bool
+
+    init(dexCount: Int, lifetimeTokens: Int, hasActive: Bool) {
+        self.dexCount = dexCount
+        self.lifetimeTokens = lifetimeTokens
+        self.hasActive = hasActive
+    }
+
+    init(state: CompanionState) {
+        self.init(dexCount: state.dex.count,
+                  lifetimeTokens: state.usedSinceInstall,
+                  hasActive: state.active != nil)
+    }
+}
+
+enum SaveTransferError: Error, Equatable {
+    /// 봉투가 아니거나 다른 앱의 JSON.
+    case notASaveFile
+    /// 이 빌드보다 새 스키마 — 상위 버전에서 만든 세이브.
+    case newerSchema(found: Int, supported: Int)
+}
+
+enum SaveTransfer {
+    /// 내보내기 파일명 — 날짜가 들어가야 여러 번 내보내도 덮어쓰지 않는다.
+    static func suggestedFileName(date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return "PokeTokenBar-Save-\(f.string(from: date)).json"
+    }
+
+    static func encode(state: CompanionState, appVersion: String, deviceName: String, now: Date) throws -> Data {
+        let envelope = SaveEnvelope(format: SaveEnvelope.formatID,
+                                    schema: SaveEnvelope.schemaVersion,
+                                    appVersion: appVersion,
+                                    exportedAt: now,
+                                    sourceDevice: deviceName,
+                                    state: state)
+        let encoder = JSONEncoder()
+        // 사람이 열어봤을 때 읽히도록(무엇이 옮겨가는지 확인 가능) — 4KB 라 크기는 무의미.
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(envelope)
+    }
+
+    static func decode(_ data: Data) throws -> SaveEnvelope {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let envelope = try? decoder.decode(SaveEnvelope.self, from: data),
+              envelope.format == SaveEnvelope.formatID else {
+            throw SaveTransferError.notASaveFile
+        }
+        guard envelope.schema <= SaveEnvelope.schemaVersion else {
+            throw SaveTransferError.newerSchema(found: envelope.schema, supported: SaveEnvelope.schemaVersion)
+        }
+        return envelope
+    }
+
+    /// 다른 기기에서 온 상태를 **이 기기 기준으로 재정렬**한다.
+    ///
+    /// `claimedTodayTokens` 는 진행이 아니라 "이 기기가 오늘 어디까지 적립했나"라는 기기 로컬 장부다.
+    /// 그대로 들여오면 옛 기기의 오늘 총량이 문턱이 되어, `CompanionStore.update` 의
+    /// `todayTokens > claimedTodayTokens` 게이트가 이전 당일 내내 거짓이 된다 — 새 기기에서 쓴
+    /// 토큰이 성장·잔액에 조용히 안 잡힌다(다음 날 00시에 저절로 낫기 때문에 버그로 안 보인다).
+    ///
+    /// 진행(도감·누적·인벤토리·현재 개체·사탕 지급 원장)은 전부 보존하고 이 장부만 다시 잡는다.
+    static func rebasedForThisDevice(_ imported: CompanionState,
+                                     todayTokens: Int,
+                                     todayDate: String,
+                                     hasUsageData: Bool) -> CompanionState {
+        var state = imported
+        if hasUsageData {
+            // 신규 설치와 같은 규칙: 불러온 시점 이전의 이 기기 사용량은 소급 적립하지 않는다.
+            state.installBaselineSet = true
+            state.claimedTodayTokens = todayTokens
+            state.lastDate = todayDate
+        } else {
+            // 아직 이 기기의 오늘 사용량을 모른다(파싱 전·프로바이더 없음). 여기서 0 으로 잡으면
+            // 첫 파싱 때 하루치가 통째로 델타가 된다 → baseline 판정을 신규 설치 경로에 넘긴다.
+            state.installBaselineSet = false
+            state.claimedTodayTokens = 0
+            state.lastDate = ""
+        }
+        return state
+    }
+}

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -446,6 +446,12 @@ struct SettingsView: View {
     // 결과를 인라인 텍스트로 못 보여주는 이유: 팝오버가 `.transient` 라 파일 선택창이 키 윈도우가 되는
     // 순간 닫히고, popoverDidClose 가 호스팅 컨트롤러를 해제해 이 뷰(@State 포함)가 사라진다.
     // → 성공은 Finder 노출(로그 파일 보기와 같은 방식), 그 외는 알림창으로 알린다.
+    //
+    // 활성화는 `activate(ignoringOtherApps: true)` 여야 한다 — 이 앱은 LSUIElement 라 백그라운드에서
+    // `NSApp.activate()`(협조적 활성화)가 무시된다. 실측: activate() 는 isActive=false 로 최전면이 안 바뀌고
+    // (패널이 다른 창 뒤에 떠 사용자가 못 찾는다), ignoringOtherApps 만 전면화된다.
+    // `NSRunningApplication.current.activate(.activateAllWindows)` 도 같은 이유로 실패한다.
+    // 레포의 다른 활성화 지점(PokeTokenBarApp·FloatingPetPanel)도 같은 형태다 — 통일해서 유지할 것.
 
     private func exportSave() {
         let panel = NSSavePanel()
@@ -453,7 +459,7 @@ struct SettingsView: View {
         panel.nameFieldStringValue = SaveTransfer.suggestedFileName(date: Date())
         panel.allowedContentTypes = [.json]
         panel.canCreateDirectories = true
-        NSApp.activate()
+        NSApp.activate(ignoringOtherApps: true)
         guard panel.runModal() == .OK, let url = panel.url else { return }
         do {
             let data = try companion.exportedSaveData(appVersion: Self.appVersion, deviceName: Self.deviceName)
@@ -470,7 +476,7 @@ struct SettingsView: View {
         panel.allowedContentTypes = [.json]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
-        NSApp.activate()
+        NSApp.activate(ignoringOtherApps: true)
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
         let incoming: SaveSummary
@@ -480,7 +486,7 @@ struct SettingsView: View {
             incoming = parsed.summary
             envelope = parsed.envelope
         } catch {
-            presentAlert(title: l.importSaveLabel, message: importErrorText(error), style: .warning)
+            presentAlert(title: l.importSaveLabel, message: l.importErrorMessage(error), style: .warning)
             return
         }
 
@@ -496,6 +502,9 @@ struct SettingsView: View {
             currentTokens: TokenFormatter.compact(current.lifetimeTokens))
         confirm.addButton(withTitle: l.importConfirmReplace)
         confirm.addButton(withTitle: l.cancel)
+        // 파괴적 동작을 기본 버튼으로 두지 않는다 — 그대로 두면 Return 한 번에 이 Mac 의 진행이 대체된다.
+        confirm.buttons[0].keyEquivalent = ""
+        confirm.buttons[1].keyEquivalent = "\r"
         guard confirm.runModal() == .alertFirstButtonReturn else { return }
 
         companion.applySave(envelope,
@@ -508,21 +517,13 @@ struct SettingsView: View {
                      style: .informational)
     }
 
-    private func importErrorText(_ error: Error) -> String {
-        switch error {
-        case SaveTransferError.notASaveFile: return l.importErrorNotSaveFile
-        case SaveTransferError.newerSchema:  return l.importErrorNewerSchema
-        default: return error.localizedDescription
-        }
-    }
-
     private func presentAlert(title: String, message: String, style: NSAlert.Style) {
         let alert = NSAlert()
         alert.alertStyle = style
         alert.messageText = title
         alert.informativeText = message
         alert.addButton(withTitle: l.close)
-        NSApp.activate()
+        NSApp.activate(ignoringOtherApps: true)
         alert.runModal()
     }
 }

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @Environment(UsageStore.self) private var store
@@ -12,10 +13,14 @@ struct SettingsView: View {
     @State private var advancedExpanded = false
     @State private var isCheckingUpdate = false
     @State private var didCheckUpdate = false
-
     private var l: L { companion.l }
 
     private var isBundledApp: Bool { AppEnv.isBundledApp }
+
+    /// 세이브 봉투에 남길 출처 표기 — 어느 Mac에서 내보낸 파일인지 나중에 알아보기 위한 것.
+    private static var deviceName: String {
+        Host.current().localizedName ?? ProcessInfo.processInfo.hostName
+    }
 
     /// 현재 앱 버전 — 업데이트 적용 여부 확인용으로 설정창 하단에 표기.
     private static var appVersion: String {
@@ -36,6 +41,7 @@ struct SettingsView: View {
                     floatingPetGroup(store)
                     notificationsGroup(store)
                     updateGroup(store)
+                    transferGroup(store)
                     advancedGroup(store)
                     aboutSupportGroup
                 }
@@ -259,6 +265,32 @@ struct SettingsView: View {
         }
     }
 
+    /// 백업 & 이전 — 새 Mac으로 옮길 때 쓰는 세이브 파일 내보내기/불러오기.
+    /// 사용자가 상태 파일 경로를 직접 찾아다니지 않도록, 저장 위치와 불러올 파일 모두 표준
+    /// 파일 선택창으로 고르게 한다.
+    @ViewBuilder
+    private func transferGroup(_ store: UsageStore) -> some View {
+        settingsSection(l.transferSectionTitle) {
+            groupRow {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(l.exportSaveLabel)
+                    Text(l.exportSaveHint).font(.caption2).foregroundStyle(.tertiary)
+                }
+                Spacer()
+                Button(l.exportSaveButton) { exportSave() }
+            }
+            Divider()
+            groupRow {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(l.importSaveLabel)
+                    Text(l.importSaveHint).font(.caption2).foregroundStyle(.tertiary)
+                }
+                Spacer()
+                Button(l.importSaveButton) { importSave(store) }
+            }
+        }
+    }
+
     @ViewBuilder
     private func advancedGroup(_ store: UsageStore) -> some View {
         @Bindable var store = store
@@ -407,5 +439,90 @@ struct SettingsView: View {
             return
         }
         reportError = nil
+    }
+
+    // MARK: 세이브 이전
+    //
+    // 결과를 인라인 텍스트로 못 보여주는 이유: 팝오버가 `.transient` 라 파일 선택창이 키 윈도우가 되는
+    // 순간 닫히고, popoverDidClose 가 호스팅 컨트롤러를 해제해 이 뷰(@State 포함)가 사라진다.
+    // → 성공은 Finder 노출(로그 파일 보기와 같은 방식), 그 외는 알림창으로 알린다.
+
+    private func exportSave() {
+        let panel = NSSavePanel()
+        panel.title = l.exportSaveLabel
+        panel.nameFieldStringValue = SaveTransfer.suggestedFileName(date: Date())
+        panel.allowedContentTypes = [.json]
+        panel.canCreateDirectories = true
+        NSApp.activate()
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            let data = try companion.exportedSaveData(appVersion: Self.appVersion, deviceName: Self.deviceName)
+            try data.write(to: url, options: .atomic)
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        } catch {
+            presentAlert(title: l.exportSaveLabel, message: error.localizedDescription, style: .warning)
+        }
+    }
+
+    private func importSave(_ store: UsageStore) {
+        let panel = NSOpenPanel()
+        panel.title = l.importSaveLabel
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        NSApp.activate()
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        let incoming: SaveSummary
+        let envelope: SaveEnvelope
+        do {
+            let parsed = try CompanionStore.inspectSave(try Data(contentsOf: url))
+            incoming = parsed.summary
+            envelope = parsed.envelope
+        } catch {
+            presentAlert(title: l.importSaveLabel, message: importErrorText(error), style: .warning)
+            return
+        }
+
+        // 고른 즉시 덮어쓰지 않는다 — 무엇이 대체되는지 수치로 보여주고 한 번 더 확인받는다.
+        let current = companion.transferSummary
+        let confirm = NSAlert()
+        confirm.alertStyle = .warning
+        confirm.messageText = l.importConfirmTitle
+        confirm.informativeText = l.importConfirmBody(
+            incomingDex: incoming.dexCount,
+            incomingTokens: TokenFormatter.compact(incoming.lifetimeTokens),
+            currentDex: current.dexCount,
+            currentTokens: TokenFormatter.compact(current.lifetimeTokens))
+        confirm.addButton(withTitle: l.importConfirmReplace)
+        confirm.addButton(withTitle: l.cancel)
+        guard confirm.runModal() == .alertFirstButtonReturn else { return }
+
+        companion.applySave(envelope,
+                            todayTokens: store.todayTotalTokens,
+                            todayDate: LocalUsageReader.todayKey(),
+                            hasUsageData: store.hasUsageData)
+        presentAlert(title: l.importSaveLabel,
+                     message: l.importSaveDone(dex: incoming.dexCount,
+                                               tokens: TokenFormatter.compact(incoming.lifetimeTokens)),
+                     style: .informational)
+    }
+
+    private func importErrorText(_ error: Error) -> String {
+        switch error {
+        case SaveTransferError.notASaveFile: return l.importErrorNotSaveFile
+        case SaveTransferError.newerSchema:  return l.importErrorNewerSchema
+        default: return error.localizedDescription
+        }
+    }
+
+    private func presentAlert(title: String, message: String, style: NSAlert.Style) {
+        let alert = NSAlert()
+        alert.alertStyle = style
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButton(withTitle: l.close)
+        NSApp.activate()
+        alert.runModal()
     }
 }

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -456,7 +456,7 @@ struct SettingsView: View {
     private func exportSave() {
         let panel = NSSavePanel()
         panel.title = l.exportSaveLabel
-        panel.nameFieldStringValue = SaveTransfer.suggestedFileName(date: Date())
+        panel.nameFieldStringValue = companion.suggestedExportFileName
         panel.allowedContentTypes = [.json]
         panel.canCreateDirectories = true
         NSApp.activate(ignoringOtherApps: true)
@@ -479,16 +479,14 @@ struct SettingsView: View {
         NSApp.activate(ignoringOtherApps: true)
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
-        let incoming: SaveSummary
         let envelope: SaveEnvelope
         do {
-            let parsed = try CompanionStore.inspectSave(try Data(contentsOf: url))
-            incoming = parsed.summary
-            envelope = parsed.envelope
+            envelope = try SaveTransfer.decode(try Data(contentsOf: url))
         } catch {
             presentAlert(title: l.importSaveLabel, message: l.importErrorMessage(error), style: .warning)
             return
         }
+        let incoming = SaveSummary(state: envelope.state)
 
         // 고른 즉시 덮어쓰지 않는다 — 무엇이 대체되는지 수치로 보여주고 한 번 더 확인받는다.
         let current = companion.transferSummary
@@ -498,23 +496,41 @@ struct SettingsView: View {
         confirm.informativeText = l.importConfirmBody(
             incomingDex: incoming.dexCount,
             incomingTokens: TokenFormatter.compact(incoming.lifetimeTokens),
+            exportedAt: Self.exportedAtText(envelope.exportedAt),
+            sourceDevice: envelope.sourceDevice,
             currentDex: current.dexCount,
             currentTokens: TokenFormatter.compact(current.lifetimeTokens))
         confirm.addButton(withTitle: l.importConfirmReplace)
         confirm.addButton(withTitle: l.cancel)
-        // 파괴적 동작을 기본 버튼으로 두지 않는다 — 그대로 두면 Return 한 번에 이 Mac 의 진행이 대체된다.
-        confirm.buttons[0].keyEquivalent = ""
-        confirm.buttons[1].keyEquivalent = "\r"
+        // 파괴적 동작을 기본 버튼으로 두지 않는다(Return 한 번에 진행이 대체되지 않게).
+        // 규칙 자체는 ImportConfirmPolicy 에 있고 여기선 적용만 한다 — NSAlert 구성은 테스트 불가라
+        // 순서가 뒤바뀌어도 잡을 자동 경로가 없기 때문이다.
+        for (index, button) in confirm.buttons.enumerated() {
+            button.keyEquivalent = ImportConfirmPolicy.keyEquivalent(forButtonAt: index)
+        }
         guard confirm.runModal() == .alertFirstButtonReturn else { return }
 
-        companion.applySave(envelope,
-                            todayTokens: store.todayTotalTokens,
-                            todayDate: LocalUsageReader.todayKey(),
-                            hasUsageData: store.hasUsageData)
+        do {
+            try companion.applySave(envelope,
+                                    todayTokens: store.todayTotalTokens,
+                                    todayDate: LocalUsageReader.todayKey(),
+                                    hasUsageData: store.hasUsageData)
+        } catch {
+            presentAlert(title: l.importSaveLabel, message: l.importErrorMessage(error), style: .warning)
+            return
+        }
         presentAlert(title: l.importSaveLabel,
                      message: l.importSaveDone(dex: incoming.dexCount,
                                                tokens: TokenFormatter.compact(incoming.lifetimeTokens)),
                      style: .informational)
+    }
+
+    /// 확인창에 보일 내보낸 시각 — 사용자 로케일 기준 짧은 표기.
+    private static func exportedAtText(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return f.string(from: date)
     }
 
     private func presentAlert(title: String, message: String, style: NSAlert.Style) {

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+@testable import PokeTokenBar
+
+// MARK: 스텁 (이 파일 전용 — 다른 테스트 파일의 스텁은 file-private)
+
+private enum TransferStubError: Error { case unavailable }
+
+/// 세이브 이전 테스트는 진화 라인을 필요로 하지 않는다 — 사용량 적립은 라인 미로딩에서도
+/// 동작해야 하기 때문(CompanionStore.applyUsage 주석). 전부 실패시켜 그 경로를 강제한다.
+private struct OfflineProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine { throw TransferStubError.unavailable }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { throw TransferStubError.unavailable }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { throw TransferStubError.unavailable }
+}
+
+private let transferNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+@MainActor
+final class SaveTransferTests: XCTestCase {
+
+    private func tempURL(_ tag: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("ptb-\(tag)-\(UUID().uuidString).json")
+    }
+
+    private func store(at url: URL) -> CompanionStore {
+        CompanionStore(provider: OfflineProvider(), clock: { transferNow }, fileURL: url)
+    }
+
+    /// 옛 기기에서 내보낸 것과 같은 모양의 상태 — 오늘 이미 56.8M 을 적립해 둔 시점.
+    private func oldMacState(today: String) -> CompanionState {
+        var s = CompanionState()
+        s.installBaselineSet = true
+        s.usedSinceInstall = 8_000_000_000
+        s.spentTokens = 3_500_000_000
+        s.claimedTodayTokens = 56_800_000
+        s.lastDate = today
+        s.inventory = ["rareCandy": 2]
+        s.collectedFinals = ["1-3"]
+        s.dex = [DexEntry(baseID: 1, finalID: 3, chainOrder: [1, 2, 3], rarity: .common, caughtAt: transferNow)]
+        return s
+    }
+
+    // MARK: 봉투
+
+    func testRoundTripPreservesProgress() throws {
+        let original = oldMacState(today: "2026-08-03")
+        let data = try SaveTransfer.encode(state: original, appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        let envelope = try SaveTransfer.decode(data)
+
+        XCTAssertEqual(envelope.format, SaveEnvelope.formatID)
+        XCTAssertEqual(envelope.sourceDevice, "Old Mac")
+        XCTAssertEqual(envelope.state.usedSinceInstall, original.usedSinceInstall)
+        XCTAssertEqual(envelope.state.spentTokens, original.spentTokens)
+        XCTAssertEqual(envelope.state.inventory, original.inventory)
+        XCTAssertEqual(envelope.state.dex.count, 1)
+        XCTAssertEqual(envelope.state.collectedFinals, original.collectedFinals)
+    }
+
+    /// [핵심] 봉투가 없으면 `CompanionState` 의 관대 디코딩이 아무 JSON 이나 빈 상태로 흡수해
+    /// "불러오기 성공 → 도감이 사라짐"이 된다. 포맷 id 로 먼저 거른다.
+    func testForeignJSONIsRejectedRatherThanImportedAsEmptyState() throws {
+        // 관대 디코딩이면 통째로 통과해 버릴 모양의 JSON.
+        let foreign = Data(#"{"some":"other app","dex":123}"#.utf8)
+        XCTAssertThrowsError(try SaveTransfer.decode(foreign)) { error in
+            XCTAssertEqual(error as? SaveTransferError, .notASaveFile)
+        }
+
+        // 상태만 담긴(봉투 없는) 예전식 파일도 세이브로 인정하지 않는다.
+        let bare = try JSONEncoder().encode(oldMacState(today: "2026-08-03"))
+        XCTAssertThrowsError(try SaveTransfer.decode(bare)) { error in
+            XCTAssertEqual(error as? SaveTransferError, .notASaveFile)
+        }
+    }
+
+    func testNewerSchemaIsRejected() throws {
+        var data = try SaveTransfer.encode(state: CompanionState(), appVersion: "2.5.0",
+                                           deviceName: "Future Mac", now: transferNow)
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        json["schema"] = SaveEnvelope.schemaVersion + 1
+        data = try JSONSerialization.data(withJSONObject: json)
+
+        XCTAssertThrowsError(try SaveTransfer.decode(data)) { error in
+            XCTAssertEqual(error as? SaveTransferError,
+                           .newerSchema(found: SaveEnvelope.schemaVersion + 1,
+                                        supported: SaveEnvelope.schemaVersion))
+        }
+    }
+
+    // MARK: 기기 기준 재정렬 (회귀)
+
+    /// [회귀] 이전 당일에 새 Mac 에서 쓴 토큰이 조용히 누락되던 결함.
+    ///
+    /// `claimedTodayTokens` 는 "이 기기가 오늘 어디까지 적립했나"인데 옛 기기 값(56.8M)이 그대로
+    /// 따라오면 `update` 의 `todayTokens > claimedTodayTokens` 게이트가 하루 종일 거짓이 된다.
+    /// 대조군(재정렬 없음)을 같이 돌려 트리거 브랜치를 실제로 밟는지 확인한다.
+    func testTransferDayTokensStillCountAfterRebase() throws {
+        let today = "2026-08-03"
+        let imported = oldMacState(today: today)
+        let newMacTodaySoFar = 5_000_000
+        let newMacTodayLater = 8_000_000
+
+        // 대조군: 재정렬 없이 그대로 들여온 경우 — 델타가 적립되지 않아야 한다(결함 재현).
+        let rawURL = tempURL("raw")
+        try JSONEncoder().encode(imported).write(to: rawURL)
+        let raw = store(at: rawURL)
+        let rawBefore = raw.state.usedSinceInstall
+        raw.update(todayTokens: newMacTodayLater, todayDate: today, monthTotal: 0,
+                   burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(raw.state.usedSinceInstall - rawBefore, 0,
+                       "재현 실패 — 이 대조군이 0 이 아니면 결함 조건이 바뀐 것이므로 테스트가 무의미해진다")
+
+        // 실제 경로: 불러오기 시점의 이 기기 오늘 사용량으로 장부를 다시 잡는다.
+        let url = tempURL("rebased")
+        let s = store(at: url)
+        let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        let envelope = try SaveTransfer.decode(data)
+        s.applySave(envelope, todayTokens: newMacTodaySoFar, todayDate: today, hasUsageData: true)
+
+        XCTAssertEqual(s.state.claimedTodayTokens, newMacTodaySoFar)
+        XCTAssertEqual(s.state.lastDate, today)
+        XCTAssertTrue(s.state.installBaselineSet)
+
+        let before = s.state.usedSinceInstall
+        s.update(todayTokens: newMacTodayLater, todayDate: today, monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.state.usedSinceInstall - before, newMacTodayLater - newMacTodaySoFar,
+                       "이전 당일에도 새 Mac 에서 쓴 증분이 적립돼야 한다")
+    }
+
+    /// 불러올 때 이 기기의 오늘 사용량을 아직 모르면(파싱 전·프로바이더 없음) baseline 판정을
+    /// 신규 설치 경로에 넘긴다 — 여기서 0 으로 잡으면 첫 파싱 때 하루치가 통째로 델타가 된다.
+    func testImportWithoutUsageDataDefersBaselineInsteadOfCreditingWholeDay() throws {
+        let today = "2026-08-03"
+        let url = tempURL("nodata")
+        let s = store(at: url)
+        let data = try SaveTransfer.encode(state: oldMacState(today: today), appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: false)
+
+        XCTAssertFalse(s.state.installBaselineSet)
+
+        // 데이터가 도착하는 첫 틱은 baseline 만 잡고 적립하지 않는다.
+        let before = s.state.usedSinceInstall
+        s.update(todayTokens: 40_000_000, todayDate: today, monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.state.usedSinceInstall, before, "도착 시점의 하루치를 소급 적립하지 않는다")
+        XCTAssertEqual(s.state.claimedTodayTokens, 40_000_000)
+
+        // 그 다음부터는 정상 적립.
+        s.update(todayTokens: 41_000_000, todayDate: today, monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.state.usedSinceInstall - before, 1_000_000)
+    }
+
+    // MARK: 진행 보존 · 가드레일
+
+    func testImportKeepsProgressAndCandyGrantLedger() throws {
+        let today = "2026-08-03"
+        var imported = oldMacState(today: today)
+        // 한도는 계정 전역이라 같은 창 key 가 새 기기에서도 유효하다 — 원장을 버리면 사탕이 중복 지급된다.
+        imported.candyGrantTier = ["five_hour|2026-08-03T00:00:00Z": 100]
+        imported.candyFeatureSeeded = true
+
+        let url = tempURL("progress")
+        let s = store(at: url)
+        let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        s.applySave(try SaveTransfer.decode(data), todayTokens: 1, todayDate: today, hasUsageData: true)
+
+        XCTAssertEqual(s.state.usedSinceInstall, 8_000_000_000)
+        XCTAssertEqual(s.state.spentTokens, 3_500_000_000)
+        XCTAssertEqual(s.state.dex.count, 1)
+        XCTAssertEqual(s.state.inventory["rareCandy"], 2)
+        XCTAssertEqual(s.state.candyGrantTier["five_hour|2026-08-03T00:00:00Z"], 100,
+                       "사탕 지급 원장 보존 — 버리면 같은 창에서 재지급된다")
+        XCTAssertTrue(s.state.candyFeatureSeeded)
+    }
+
+    /// 덮어쓰기 전 직전 상태를 남긴다 — 잘못 불러왔을 때 손으로 되돌릴 수단.
+    func testPreviousStateIsBackedUpBeforeOverwrite() throws {
+        let today = "2026-08-03"
+        let url = tempURL("backup")
+
+        var mine = CompanionState()
+        mine.installBaselineSet = true
+        mine.usedSinceInstall = 123_456_789
+        try JSONEncoder().encode(mine).write(to: url)
+
+        let s = store(at: url)
+        XCTAssertEqual(s.state.usedSinceInstall, 123_456_789)
+
+        let data = try SaveTransfer.encode(state: oldMacState(today: today), appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: true)
+
+        let backup = url.deletingPathExtension().appendingPathExtension("pre-import.json")
+        let restored = try JSONDecoder().decode(CompanionState.self, from: Data(contentsOf: backup))
+        XCTAssertEqual(restored.usedSinceInstall, 123_456_789, "덮어쓰기 전 상태가 그대로 남아야 한다")
+        XCTAssertEqual(s.state.usedSinceInstall, 8_000_000_000)
+    }
+
+    func testSuggestedFileNameCarriesDate() {
+        // 2026-08-03 12:00 UTC — 정오라 표준시대가 달라도 날짜 경계를 넘지 않는다(파일명은 로컬 날짜).
+        let name = SaveTransfer.suggestedFileName(date: Date(timeIntervalSince1970: 1_785_758_400))
+        XCTAssertTrue(name.hasPrefix("PokeTokenBar-Save-"))
+        XCTAssertTrue(name.hasSuffix(".json"))
+        XCTAssertTrue(name.contains("2026-08-03"), "실제 이름: \(name)")
+    }
+}

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -27,6 +27,21 @@ private actor TransferSignal {
     }
 }
 
+/// **종 롤**(`baseSpeciesIndex`)에서 멈추는 provider — `hatchIfNeeded` 의 첫 await 창을 재현한다.
+/// 라인 fetch 창(`GatedProvider`)과는 다른 지점이라 별도 스텁이 필요하다.
+private struct GatedIndexProvider: PokeProviding {
+    let entered: TransferSignal
+    let release: TransferSignal
+    let result: EvoLine
+    func line(baseSpeciesID: Int) async throws -> EvoLine { result }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] {
+        await entered.fire()
+        await release.wait()
+        return [BaseSpecies(id: 1, captureRate: 255)]
+    }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { nil }
+}
+
 /// 라인 fetch 에서 멈춰 있다가 신호를 받고 반환하는 provider — 부화 중 상태 교체를 재현한다.
 private struct GatedProvider: PokeProviding {
     let entered: TransferSignal
@@ -96,6 +111,28 @@ final class SaveTransferTests: XCTestCase {
         // 상태만 담긴(봉투 없는) 예전식 파일도 세이브로 인정하지 않는다.
         let bare = try JSONEncoder().encode(oldMacState(today: "2026-08-03"))
         XCTAssertThrowsError(try SaveTransfer.decode(bare)) { error in
+            XCTAssertEqual(error as? SaveTransferError, .notASaveFile)
+        }
+    }
+
+    /// [회귀·딥리뷰 H4] `decode` 는 "디코딩 실패 **또는** format 불일치"라는 `A || B` 게이트인데,
+    /// 기존 두 케이스는 모두 필수 키 누락이라 A 로만 통과했다 — `format` 비교를 통째로 삭제해도
+    /// 전체 스위트가 그대로 통과했다(뮤테이션으로 확인). 여기서 **B 단독**을 고정한다:
+    /// 6개 필드가 전부 유효하고 `format` 값만 다른 완전한 봉투.
+    func testValidEnvelopeWithWrongFormatIDIsRejected() throws {
+        let data = try SaveTransfer.encode(state: oldMacState(today: "2026-08-03"),
+                                           appVersion: "2.5.0", deviceName: "Other App", now: transferNow)
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["format"] as? String, SaveEnvelope.formatID, "전제: 원본은 유효한 포맷")
+        json["format"] = "someotherapp.save"
+        let patched = try JSONSerialization.data(withJSONObject: json)
+
+        // 디코딩 자체는 성공해야 한다 — 그래야 B 분기(포맷 값 비교)만 단독으로 검증된다.
+        let decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
+        XCTAssertNotNil(try? decoder.decode(SaveEnvelope.self, from: patched),
+                        "전제: 필드 구조는 유효 — 여기서 nil 이면 A 분기로 새어 테스트가 무의미해진다")
+
+        XCTAssertThrowsError(try SaveTransfer.decode(patched)) { error in
             XCTAssertEqual(error as? SaveTransferError, .notASaveFile)
         }
     }
@@ -255,6 +292,110 @@ final class SaveTransferTests: XCTestCase {
 
         XCTAssertEqual(s.state.active?.baseID, 403, "뒤늦게 끝난 부화가 불러온 개체를 덮어쓰면 안 된다")
         XCTAssertEqual(s.state.dex.count, imported.dex.count, "도감도 부화 경로에 밀려나면 안 된다")
+    }
+
+    /// [회귀·딥리뷰 B1] 부화의 **첫** await(`chooseBase`) 창에 불러오기가 들어오면, 그 뒤 진입하는
+    /// `hatchCore` 는 *교체 이후*의 세대를 캡처해 자기 가드가 무조건 통과한다 — 옛 롤 결과가 불러온
+    /// 개체를 덮어쓰고 디스크에 박혔다. 위의 `testImportDuringHatchDiscardsTheHatch` 는 `hatch(baseID:)`
+    /// 경로라 이 브랜치를 지나지 않는다(통과하면서 아무것도 지키지 않던 상태).
+    func testImportDuringSpeciesRollDiscardsTheHatch() async throws {
+        let entered = TransferSignal()
+        let release = TransferSignal()
+        let evo = EvoLine(baseID: 1, tree: EvoNode(speciesID: 1, children: []), rarity: .common,
+                          names: [1: ["en": "P1", "ko": "포1", "ja": "ポ1"]])
+        let url = tempURL("rollrace")
+
+        // 알 상태 + 부화 임계 도달 + pre-roll 없음 → `chooseBase()` 로 들어간다.
+        var egg = CompanionState()
+        egg.installBaselineSet = true
+        egg.eggUsage = PokemonBalance.eggHatchThreshold
+        try JSONEncoder().encode(egg).write(to: url)
+
+        let s = CompanionStore(provider: GatedIndexProvider(entered: entered, release: release, result: evo),
+                               clock: { transferNow }, fileURL: url)
+        XCTAssertNil(s.state.active, "전제: 알 상태에서 시작")
+
+        let hatching = Task { await s.hatchIfNeeded() }
+        await entered.wait()   // 종 롤이 인덱스 대기 지점에 도달
+
+        var imported = oldMacState(today: "2026-08-03")
+        imported.active = MonState(baseID: 403, pathIDs: [403], plannedPathIDs: [403],
+                                   stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
+        let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+                    todayDate: "2026-08-03", hasUsageData: true)
+
+        await release.fire()
+        await hatching.value
+
+        XCTAssertEqual(s.state.active?.baseID, 403, "종 롤 대기 중 들어온 불러오기를 부화가 덮어쓰면 안 된다")
+        XCTAssertEqual(s.state.dex.count, imported.dex.count)
+    }
+
+    /// [회귀·딥리뷰 H1] 새 Mac 에서 AI CLI 를 아직 안 쓴 시점(hasUsageData=false)에 불러오면,
+    /// 개체가 있는데도 알로 표시되고 진화 라인 로드 재시도가 도달 불가였다.
+    func testImportedCompanionIsNotShownAsEggBeforeUsageArrives() throws {
+        let today = "2026-08-03"
+        let url = tempURL("noegg")
+        let s = store(at: url)
+        var imported = oldMacState(today: today)
+        imported.active = MonState(baseID: 403, pathIDs: [403], plannedPathIDs: [403],
+                                   stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
+        let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: false)
+        XCTAssertFalse(s.state.installBaselineSet, "전제: baseline 판정을 미룬 상태")
+
+        s.update(todayTokens: 0, todayDate: today, monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: false)
+        XCTAssertNotNil(s.state.active, "개체는 그대로 있어야 한다")
+        XCTAssertEqual(s.displayState, .idle, "개체가 있는데 알로 표시하면 안 된다")
+
+        // 알 상태에서 같은 경로를 타면 여전히 알이어야 한다(반대 방향 고정).
+        let eggURL = tempURL("stillegg")
+        let e = store(at: eggURL)
+        e.update(todayTokens: 0, todayDate: today, monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: false)
+        XCTAssertEqual(e.displayState, .egg)
+    }
+
+    // MARK: 신뢰경계 값 정규화 (딥리뷰 H2)
+
+    /// [회귀·딥리뷰 H2] 극단값 세이브가 그대로 저장되면 이후 산술이 오버플로 트랩으로 프로세스를 죽이고,
+    /// 재기동해도 같은 파일을 읽어 다시 죽는다(수동 삭제 전까지 복구 불가).
+    func testExtremeValuesAreClampedAtTheTrustBoundary() throws {
+        var evil = CompanionState()
+        evil.installBaselineSet = true
+        evil.usedSinceInstall = Int.max
+        evil.spentTokens = Int.min
+        evil.eggUsage = Int.max
+        evil.claimedTodayTokens = -42
+        evil.active = MonState(baseID: 1, pathIDs: [1], plannedPathIDs: [1],
+                               stageIndex: Int.max, usedAtStage: Int.max, rarity: .common,
+                               totalForms: Int.max)
+
+        let data = try SaveTransfer.encode(state: evil, appVersion: "2.5.0",
+                                           deviceName: "Corrupt", now: transferNow)
+        let envelope = try SaveTransfer.decode(data)
+        let s = envelope.state
+
+        XCTAssertEqual(s.usedSinceInstall, SaveTransfer.maxTokenValue)
+        XCTAssertEqual(s.spentTokens, 0, "음수는 0 으로")
+        XCTAssertEqual(s.eggUsage, SaveTransfer.maxTokenValue)
+        XCTAssertEqual(s.claimedTodayTokens, 0)
+        XCTAssertEqual(s.active?.usedAtStage, SaveTransfer.maxTokenValue)
+        XCTAssertEqual(s.active?.totalForms, 12)
+        XCTAssertEqual(s.active?.stageIndex, 0, "pathIDs 범위를 넘지 않아야 한다")
+
+        // 정규화된 값으로 실제 산술 경로를 태워 트랩이 안 나는지 확인한다.
+        let url = tempURL("clamped")
+        let store = store(at: url)
+        store.applySave(envelope, todayTokens: 0, todayDate: "2026-08-03", hasUsageData: true)
+        XCTAssertGreaterThanOrEqual(store.availableTokens, 0)
+        store.update(todayTokens: 1_000, todayDate: "2026-08-03", monthTotal: 0,
+                     burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertLessThanOrEqual(store.state.usedSinceInstall, SaveTransfer.maxTokenValue + 1_000)
     }
 
     // MARK: 오류 문구 매핑

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -15,6 +15,13 @@ private struct OfflineProvider: PokeProviding {
 
 private let transferNow = Date(timeIntervalSince1970: 1_700_000_000)
 
+/// 시각을 앞으로 밀 수 있는 주입 시계 — 백업 슬롯이 불러오기마다 갈리는지 보려면 두 번의
+/// `applySave` 가 서로 다른 초를 봐야 한다.
+private final class MutableClock: @unchecked Sendable {
+    var now: Date
+    init(_ now: Date) { self.now = now }
+}
+
 /// 비동기 경합 테스트용 1회성 신호 — 부화가 네트워크 대기에 들어간 순간을 정확히 잡기 위해
 /// sleep 대신 쓴다(타이밍 의존 = flaky).
 private actor TransferSignal {
@@ -59,9 +66,13 @@ private struct GatedProvider: PokeProviding {
 @MainActor
 final class SaveTransferTests: XCTestCase {
 
+    /// 테스트마다 **전용 디렉토리**를 준다. 불러오기 백업은 상태 파일 이름이 아니라 시각으로 이름이
+    /// 정해지므로, 공유 임시 디렉토리를 쓰면 고정 시계를 쓰는 테스트들끼리 같은 백업 파일명을 놓고 충돌한다.
     private func tempURL(_ tag: String) -> URL {
-        FileManager.default.temporaryDirectory
-            .appendingPathComponent("ptb-\(tag)-\(UUID().uuidString).json")
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ptb-\(tag)-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("companion-state.json")
     }
 
     private func store(at url: URL) -> CompanionStore {
@@ -180,7 +191,7 @@ final class SaveTransferTests: XCTestCase {
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
         let envelope = try SaveTransfer.decode(data)
-        s.applySave(envelope, todayTokens: newMacTodaySoFar, todayDate: today, hasUsageData: true)
+        try s.applySave(envelope, todayTokens: newMacTodaySoFar, todayDate: today, hasUsageData: true)
 
         XCTAssertEqual(s.state.claimedTodayTokens, newMacTodaySoFar)
         XCTAssertEqual(s.state.lastDate, today)
@@ -201,7 +212,7 @@ final class SaveTransferTests: XCTestCase {
         let s = store(at: url)
         let data = try SaveTransfer.encode(state: oldMacState(today: today), appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: false)
+        try s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: false)
 
         XCTAssertFalse(s.state.installBaselineSet)
 
@@ -231,7 +242,7 @@ final class SaveTransferTests: XCTestCase {
         let s = store(at: url)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        s.applySave(try SaveTransfer.decode(data), todayTokens: 1, todayDate: today, hasUsageData: true)
+        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1, todayDate: today, hasUsageData: true)
 
         XCTAssertEqual(s.state.usedSinceInstall, 8_000_000_000)
         XCTAssertEqual(s.state.spentTokens, 3_500_000_000)
@@ -257,9 +268,10 @@ final class SaveTransferTests: XCTestCase {
 
         let data = try SaveTransfer.encode(state: oldMacState(today: today), appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: true)
+        try s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: true)
 
-        let backup = url.deletingPathExtension().appendingPathExtension("pre-import.json")
+        let backup = url.deletingLastPathComponent()
+            .appendingPathComponent(SaveTransfer.backupFileName(date: transferNow))
         let restored = try JSONDecoder().decode(CompanionState.self, from: Data(contentsOf: backup))
         XCTAssertEqual(restored.usedSinceInstall, 123_456_789, "덮어쓰기 전 상태가 그대로 남아야 한다")
         XCTAssertEqual(s.state.usedSinceInstall, 8_000_000_000)
@@ -284,7 +296,7 @@ final class SaveTransferTests: XCTestCase {
                                    stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
                     todayDate: "2026-08-03", hasUsageData: true)
 
         await release.fire()
@@ -323,7 +335,7 @@ final class SaveTransferTests: XCTestCase {
                                    stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
                     todayDate: "2026-08-03", hasUsageData: true)
 
         await release.fire()
@@ -355,7 +367,7 @@ final class SaveTransferTests: XCTestCase {
                                    stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
                     todayDate: "2026-08-03", hasUsageData: true)
         XCTAssertNil(s.currentLine, "전제: 부화 락에 막혀 라인이 아직 없다")
 
@@ -382,7 +394,7 @@ final class SaveTransferTests: XCTestCase {
                                    stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: false)
+        try s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: false)
         XCTAssertFalse(s.state.installBaselineSet, "전제: baseline 판정을 미룬 상태")
 
         s.update(todayTokens: 0, todayDate: today, monthTotal: 0,
@@ -429,7 +441,7 @@ final class SaveTransferTests: XCTestCase {
         // 정규화된 값으로 실제 산술 경로를 태워 트랩이 안 나는지 확인한다.
         let url = tempURL("clamped")
         let store = store(at: url)
-        store.applySave(envelope, todayTokens: 0, todayDate: "2026-08-03", hasUsageData: true)
+        try store.applySave(envelope, todayTokens: 0, todayDate: "2026-08-03", hasUsageData: true)
         XCTAssertGreaterThanOrEqual(store.availableTokens, 0)
         store.update(todayTokens: 1_000, todayDate: "2026-08-03", monthTotal: 0,
                      burnTier: .idle, limitWarning: false, hasUsageData: true)
@@ -458,6 +470,187 @@ final class SaveTransferTests: XCTestCase {
         s.update(todayTokens: 1_000, todayDate: "2026-08-03", monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertLessThanOrEqual(s.state.usedSinceInstall, SaveTransfer.maxTokenValue + 1_000)
+    }
+
+    // MARK: 필드 부류 (딥리뷰 M-c·M-e·M-g)
+
+    /// [딥리뷰 M-g] 이전 시 필드 분류가 산문 규약뿐이라, 새 필드가 추가되면 아무 판단 없이 "진행"으로
+    /// 딸려 들어간다(`language` 가 실제로 그랬다). 필드 목록을 테스트로 고정해 **분류를 강제**한다.
+    func testEveryCompanionStateFieldIsClassifiedForTransfer() {
+        let progress: Set<String> = ["usedSinceInstall", "spentTokens", "eggUsage", "pendingHatchID",
+                                     "active", "dex", "collectedFinals", "inventory"]
+        let deviceLedger: Set<String> = ["installBaselineSet", "claimedTodayTokens", "lastDate"]
+        let accountLedger: Set<String> = ["candyGrantTier", "candyFeatureSeeded"]
+        let devicePreference: Set<String> = ["language"]
+
+        let classified = progress.union(deviceLedger).union(accountLedger).union(devicePreference)
+        let actual = Set(Mirror(reflecting: CompanionState()).children.compactMap(\.label))
+        XCTAssertEqual(actual, classified, """
+            CompanionState 필드가 바뀌었다. 세이브 이전에서 이 필드가 무엇인지 정하고 목록을 갱신하라 —
+            진행(그대로) / 로컬 장부(새 기기 기준 재설정) / 계정 원장(병합) / 기기 환경설정(현재 값 유지).
+            """)
+    }
+
+    /// [딥리뷰 M-c] `language` 는 진행이 아니라 이 기기에서 보는 방식이다. 일본어 Mac 의 세이브가
+    /// 영어 Mac 의 UI 언어를 조용히 바꾸면 안 된다.
+    func testImportKeepsThisDevicesLanguage() throws {
+        let today = "2026-08-03"
+        let url = tempURL("lang")
+        var mine = CompanionState()
+        mine.installBaselineSet = true
+        mine.language = .en
+        try JSONEncoder().encode(mine).write(to: url)
+        let s = store(at: url)
+        XCTAssertEqual(s.language, .en)
+
+        var imported = oldMacState(today: today)
+        imported.language = .ja
+        let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
+                                           deviceName: "JA Mac", now: transferNow)
+        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+                        todayDate: today, hasUsageData: true)
+
+        XCTAssertEqual(s.language, .en, "불러온 세이브의 언어가 이 기기 설정을 덮으면 안 된다")
+        XCTAssertEqual(s.state.dex.count, imported.dex.count, "진행은 그대로 들어와야 한다")
+    }
+
+    /// [딥리뷰 M-e] 사탕 지급 원장은 계정 전역(한도 창 key)이라 통째 교체하면 안 된다.
+    /// **더 오래된** 세이브를 불러오면 이미 지급한 창의 기록이 사라져 같은 창에서 재지급된다.
+    func testCandyGrantLedgerMergesInsteadOfBeingReplacedByAnOlderSave() throws {
+        let today = "2026-08-03"
+        let url = tempURL("candy")
+        var mine = CompanionState()
+        mine.installBaselineSet = true
+        mine.candyGrantTier = ["five_hour|A": 100, "weekly|B": 80]
+        try JSONEncoder().encode(mine).write(to: url)
+        let s = store(at: url)
+
+        // 옛 세이브: A 창을 아직 못 봤고, B 는 더 낮은 tier 에서 찍혔다.
+        var older = oldMacState(today: today)
+        older.candyGrantTier = ["weekly|B": 50, "five_hour|C": 100]
+        let data = try SaveTransfer.encode(state: older, appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+                        todayDate: today, hasUsageData: true)
+
+        XCTAssertEqual(s.state.candyGrantTier["five_hour|A"], 100, "이 기기가 이미 지급한 창이 사라지면 재지급된다")
+        XCTAssertEqual(s.state.candyGrantTier["weekly|B"], 80, "같은 창은 더 높은 tier 를 남긴다")
+        XCTAssertEqual(s.state.candyGrantTier["five_hour|C"], 100, "세이브 쪽 창도 들어와야 한다")
+    }
+
+    // MARK: 백업 가드레일 (딥리뷰 M-a·M-b)
+
+    /// [딥리뷰 M-a] 확인창은 3개 언어로 "직전 상태가 남는다"고 약속한다. 백업을 못 남기면 그 약속을
+    /// 못 지키는 것이므로 **덮어쓰지 않고 중단**해야 한다(예전엔 `try?` 로 삼키고 그냥 진행했다).
+    func testImportAbortsWhenBackupCannotBeWritten() throws {
+        let today = "2026-08-03"
+        let url = tempURL("nobackup")
+        var mine = CompanionState()
+        mine.installBaselineSet = true
+        mine.usedSinceInstall = 123_456_789
+        try JSONEncoder().encode(mine).write(to: url)
+        let s = store(at: url)
+
+        // 백업이 쓰일 자리를 디렉토리로 막아 쓰기를 실패시킨다.
+        let blocked = url.deletingLastPathComponent()
+            .appendingPathComponent(SaveTransfer.backupFileName(date: transferNow))
+        try FileManager.default.createDirectory(at: blocked, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: blocked) }
+
+        let data = try SaveTransfer.encode(state: oldMacState(today: today), appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        let envelope = try SaveTransfer.decode(data)
+        XCTAssertThrowsError(try s.applySave(envelope, todayTokens: 1, todayDate: today, hasUsageData: true)) {
+            XCTAssertEqual($0 as? SaveTransferError, .backupFailed)
+        }
+        XCTAssertEqual(s.state.usedSinceInstall, 123_456_789, "중단했으면 진행이 그대로여야 한다")
+        XCTAssertTrue(s.state.dex.isEmpty)
+    }
+
+    /// [딥리뷰 M-b] 백업 슬롯이 하나면 두 번째 불러오기가 **원본**을 덮어써, 되돌리려는 바로 그
+    /// 순간 되돌릴 대상이 사라진다. 불러올 때마다 새 슬롯이어야 한다.
+    func testSecondImportDoesNotDestroyTheOriginalBackup() throws {
+        let today = "2026-08-03"
+        let url = tempURL("twoimports")
+        var original = CompanionState()
+        original.installBaselineSet = true
+        original.usedSinceInstall = 111
+        try JSONEncoder().encode(original).write(to: url)
+
+        let clock = MutableClock(transferNow)
+        let s = CompanionStore(provider: OfflineProvider(), clock: { clock.now }, fileURL: url)
+
+        var first = oldMacState(today: today); first.usedSinceInstall = 222
+        try s.applySave(try SaveTransfer.decode(
+            try SaveTransfer.encode(state: first, appVersion: "2.5.0", deviceName: "A", now: transferNow)),
+                        todayTokens: 1, todayDate: today, hasUsageData: true)
+
+        clock.now = transferNow.addingTimeInterval(60)   // 다음 백업은 다른 슬롯
+        var second = oldMacState(today: today); second.usedSinceInstall = 333
+        try s.applySave(try SaveTransfer.decode(
+            try SaveTransfer.encode(state: second, appVersion: "2.5.0", deviceName: "B", now: transferNow)),
+                        todayTokens: 1, todayDate: today, hasUsageData: true)
+
+        let dir = url.deletingLastPathComponent()
+        let backups = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            .filter { $0.hasPrefix(SaveTransfer.backupFilePrefix) }.sorted()
+        XCTAssertEqual(backups.count, 2, "불러오기마다 새 슬롯이어야 한다")
+        let oldest = try JSONDecoder().decode(
+            CompanionState.self, from: Data(contentsOf: dir.appendingPathComponent(backups[0])))
+        XCTAssertEqual(oldest.usedSinceInstall, 111, "가장 오래된 백업이 원본이어야 한다")
+        for name in backups { try? FileManager.default.removeItem(at: dir.appendingPathComponent(name)) }
+    }
+
+    // MARK: 확인창 정책 · 표시 상태 (딥리뷰 M-f·M-h)
+
+    /// [딥리뷰 M-f] 파괴적 버튼이 기본이면 Return 한 키로 진행이 대체된다. `NSAlert` 구성은 XCTest 에서
+    /// 도달 불가라 규칙만 순수 함수로 빼 고정한다.
+    func testCancelIsTheDefaultButtonOnTheImportConfirmation() {
+        XCTAssertEqual(ImportConfirmPolicy.keyEquivalent(forButtonAt: ImportConfirmPolicy.cancelButtonIndex), "\r")
+        XCTAssertEqual(ImportConfirmPolicy.keyEquivalent(forButtonAt: ImportConfirmPolicy.replaceButtonIndex), "",
+                       "대체(파괴적) 버튼이 기본이면 안 된다")
+    }
+
+    /// [딥리뷰 M-h] `applySave` 가 정하는 표시 상태가 어떤 테스트에서도 단언되지 않아, 삼항을 뒤집어도
+    /// 통과했다.
+    func testApplySaveSetsDisplayStateFromWhetherACompanionCameIn() throws {
+        let today = "2026-08-03"
+        var withMon = oldMacState(today: today)
+        withMon.active = MonState(baseID: 403, pathIDs: [403], plannedPathIDs: [403],
+                                  stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
+        let a = store(at: tempURL("dispA"))
+        try a.applySave(try SaveTransfer.decode(
+            try SaveTransfer.encode(state: withMon, appVersion: "2.5.0", deviceName: "A", now: transferNow)),
+                        todayTokens: 1, todayDate: today, hasUsageData: true)
+        XCTAssertEqual(a.displayState, .idle)
+
+        let eggOnly = oldMacState(today: today)   // active == nil
+        let b = store(at: tempURL("dispB"))
+        try b.applySave(try SaveTransfer.decode(
+            try SaveTransfer.encode(state: eggOnly, appVersion: "2.5.0", deviceName: "B", now: transferNow)),
+                        todayTokens: 1, todayDate: today, hasUsageData: true)
+        XCTAssertEqual(b.displayState, .egg)
+    }
+
+    // MARK: 파일 경계 (딥리뷰 LOW)
+
+    /// 거대한 JSON 은 메인스레드 파싱을 수 초간 잡는다(실측 39MB ≈ 1.8초). 세이브는 수 KB 라 상한이 안전하다.
+    func testOversizedFileIsRejectedBeforeParsing() {
+        let huge = Data(count: SaveTransfer.maxFileBytes + 1)
+        XCTAssertThrowsError(try SaveTransfer.decode(huge)) { error in
+            XCTAssertEqual(error as? SaveTransferError,
+                           .fileTooLarge(bytes: SaveTransfer.maxFileBytes + 1, limit: SaveTransfer.maxFileBytes))
+        }
+    }
+
+    /// 상위 스키마 세이브는 본문 모양이 달라 전체 디코드가 실패할 수 있다. 그래도 "세이브 파일이
+    /// 아니에요"가 아니라 "앱을 업데이트하라"로 안내해야 한다 — 헤더를 먼저 읽는 이유다.
+    func testNewerSchemaIsReportedEvenWhenTheBodyIsUnreadable() throws {
+        let json = #"{"format":"poketokenbar.save","schema":99,"whatever":{"unknown":true}}"#
+        XCTAssertThrowsError(try SaveTransfer.decode(Data(json.utf8))) { error in
+            XCTAssertEqual(error as? SaveTransferError,
+                           .newerSchema(found: 99, supported: SaveEnvelope.schemaVersion))
+        }
     }
 
     // MARK: 오류 문구 매핑

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -333,6 +333,44 @@ final class SaveTransferTests: XCTestCase {
         XCTAssertEqual(s.state.dex.count, imported.dex.count)
     }
 
+    /// [회귀·딥리뷰 H3] 부화가 폐기된 뒤 불러온 개체의 진화 라인이 다시 로드돼야 한다.
+    /// `applySave` 가 띄우는 로드는 `loadCurrentLine` 의 `!isHatching` 가드에 막혀 조용히 실패하는데,
+    /// 아무도 재시도하지 않으면 다음 update 틱(기본 120초)까지 이름이 "Token Egg" 로 남았다.
+    /// 위 두 경합 테스트는 `state.active`·`dex` 만 단언해 이 경로를 통과시킨다.
+    func testImportDuringHatchStillLoadsTheImportedLine() async throws {
+        let entered = TransferSignal()
+        let release = TransferSignal()
+        // 불러올 개체(403)의 라인을 제공하는 provider — 부화용 라인 fetch 에서 한 번 멈춘다.
+        let evo = EvoLine(baseID: 403, tree: EvoNode(speciesID: 403, children: []), rarity: .common,
+                          names: [403: ["en": "Shinx", "ko": "꼬링크", "ja": "コリンク"]])
+        let url = tempURL("linereload")
+        let s = CompanionStore(provider: GatedProvider(entered: entered, release: release, result: evo),
+                               clock: { transferNow }, fileURL: url)
+
+        let hatching = Task { await s.hatch(baseID: 1) }
+        await entered.wait()
+
+        var imported = oldMacState(today: "2026-08-03")
+        imported.active = MonState(baseID: 403, pathIDs: [403], plannedPathIDs: [403],
+                                   stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
+        let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+                    todayDate: "2026-08-03", hasUsageData: true)
+        XCTAssertNil(s.currentLine, "전제: 부화 락에 막혀 라인이 아직 없다")
+
+        await release.fire()
+        await hatching.value
+
+        // 폐기 후 재점화된 로드가 끝날 때까지 양보(sleep 아님 — 이벤트 루프만 돌린다).
+        var spins = 0
+        while s.currentLine == nil, spins < 500 { await Task.yield(); spins += 1 }
+
+        XCTAssertNotNil(s.currentLine, "부화가 폐기됐으면 불러온 개체의 라인을 다시 로드해야 한다")
+        XCTAssertEqual(s.currentLine?.baseID, 403)
+        XCTAssertNotEqual(s.displayName, "Token Egg", "이름이 알 표기로 남으면 안 된다")
+    }
+
     /// [회귀·딥리뷰 H1] 새 Mac 에서 AI CLI 를 아직 안 쓴 시점(hasUsageData=false)에 불러오면,
     /// 개체가 있는데도 알로 표시되고 진화 라인 로드 재시도가 도달 불가였다.
     func testImportedCompanionIsNotShownAsEggBeforeUsageArrives() throws {
@@ -396,6 +434,30 @@ final class SaveTransferTests: XCTestCase {
         store.update(todayTokens: 1_000, todayDate: "2026-08-03", monthTotal: 0,
                      burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertLessThanOrEqual(store.state.usedSinceInstall, SaveTransfer.maxTokenValue + 1_000)
+    }
+
+    /// [회귀·딥리뷰 H2 후속] 불러오기 경계만 막으면 **이미 디스크에 있는** 극단값은 남아, 매 기동마다
+    /// 같은 값을 읽어 산술 트랩으로 죽는 상태를 벗어나지 못한다(디코드가 성공하므로 `.corrupt` 복구도
+    /// 발동 안 함). 상태 파일을 읽는 경로에서도 같은 정규화가 걸려야 자가 복구된다.
+    func testCorruptStateOnDiskIsClampedOnLoadNotJustOnImport() throws {
+        let url = tempURL("diskclamp")
+        // 앱이 아니라 손편집·이전 버전이 남긴 것처럼 극단값을 직접 파일에 심는다.
+        let json = #"{"installBaselineSet":true,"usedSinceInstall":9223372036854775807,"#
+            + #""spentTokens":-9223372036854775808,"eggUsage":9223372036854775807,"#
+            + #""claimedTodayTokens":-1,"lastDate":"2026-08-03"}"#
+        try Data(json.utf8).write(to: url)
+
+        let s = store(at: url)
+        XCTAssertEqual(s.state.usedSinceInstall, SaveTransfer.maxTokenValue)
+        XCTAssertEqual(s.state.spentTokens, 0)
+        XCTAssertEqual(s.state.eggUsage, SaveTransfer.maxTokenValue)
+        XCTAssertEqual(s.state.claimedTodayTokens, 0)
+
+        // 정규화된 값으로 실제 산술 경로를 태워 트랩이 안 나는지 확인(이 줄이 예전엔 SIGTRAP).
+        XCTAssertGreaterThanOrEqual(s.availableTokens, 0)
+        s.update(todayTokens: 1_000, todayDate: "2026-08-03", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertLessThanOrEqual(s.state.usedSinceInstall, SaveTransfer.maxTokenValue + 1_000)
     }
 
     // MARK: 오류 문구 매핑

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -15,6 +15,32 @@ private struct OfflineProvider: PokeProviding {
 
 private let transferNow = Date(timeIntervalSince1970: 1_700_000_000)
 
+/// 비동기 경합 테스트용 1회성 신호 — 부화가 네트워크 대기에 들어간 순간을 정확히 잡기 위해
+/// sleep 대신 쓴다(타이밍 의존 = flaky).
+private actor TransferSignal {
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var fired = false
+    func fire() { fired = true; waiters.forEach { $0.resume() }; waiters.removeAll() }
+    func wait() async {
+        if fired { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+/// 라인 fetch 에서 멈춰 있다가 신호를 받고 반환하는 provider — 부화 중 상태 교체를 재현한다.
+private struct GatedProvider: PokeProviding {
+    let entered: TransferSignal
+    let release: TransferSignal
+    let result: EvoLine
+    func line(baseSpeciesID: Int) async throws -> EvoLine {
+        await entered.fire()
+        await release.wait()
+        return result
+    }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { throw TransferStubError.unavailable }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { throw TransferStubError.unavailable }
+}
+
 @MainActor
 final class SaveTransferTests: XCTestCase {
 
@@ -200,6 +226,56 @@ final class SaveTransferTests: XCTestCase {
         let restored = try JSONDecoder().decode(CompanionState.self, from: Data(contentsOf: backup))
         XCTAssertEqual(restored.usedSinceInstall, 123_456_789, "덮어쓰기 전 상태가 그대로 남아야 한다")
         XCTAssertEqual(s.state.usedSinceInstall, 8_000_000_000)
+    }
+
+    /// [회귀] 불러오기가 진행 중인 부화의 네트워크 대기 창에 들어오면, 뒤늦게 끝난 부화가 방금 불러온
+    /// 개체를 덮어썼다. `isHatching` 락은 같은 앱 안의 중복 부화만 막을 뿐 상태 통째 교체는 못 막는다.
+    func testImportDuringHatchDiscardsTheHatch() async throws {
+        let entered = TransferSignal()
+        let release = TransferSignal()
+        let evo = EvoLine(baseID: 1, tree: EvoNode(speciesID: 1, children: []), rarity: .common,
+                          names: [1: ["en": "P1", "ko": "포1", "ja": "ポ1"]])
+        let url = tempURL("hatchrace")
+        let s = CompanionStore(provider: GatedProvider(entered: entered, release: release, result: evo),
+                               clock: { transferNow }, fileURL: url)
+
+        let hatching = Task { await s.hatch(baseID: 1) }
+        await entered.wait()   // 부화가 라인 fetch(네트워크) 대기 지점에 도달
+
+        var imported = oldMacState(today: "2026-08-03")
+        imported.active = MonState(baseID: 403, pathIDs: [403], plannedPathIDs: [403],
+                                   stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
+        let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+        s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+                    todayDate: "2026-08-03", hasUsageData: true)
+
+        await release.fire()
+        await hatching.value
+
+        XCTAssertEqual(s.state.active?.baseID, 403, "뒤늦게 끝난 부화가 불러온 개체를 덮어쓰면 안 된다")
+        XCTAssertEqual(s.state.dex.count, imported.dex.count, "도감도 부화 경로에 밀려나면 안 된다")
+    }
+
+    // MARK: 오류 문구 매핑
+
+    /// 매핑이 어긋나면 `SaveTransferError` 는 LocalizedError 가 아니라 "The operation couldn't be
+    /// completed. (PokeTokenBar.SaveTransferError error 0.)" 가 그대로 사용자에게 뜬다.
+    func testImportErrorMessagesAreLocalizedNotRawSwiftText() {
+        for lang in [AppLanguage.ko, .en, .ja] {
+            let l = L(lang)
+            let notSave = l.importErrorMessage(SaveTransferError.notASaveFile)
+            let newer = l.importErrorMessage(SaveTransferError.newerSchema(found: 2, supported: 1))
+            XCTAssertEqual(notSave, l.importErrorNotSaveFile, "\(lang)")
+            XCTAssertEqual(newer, l.importErrorNewerSchema, "\(lang)")
+            for message in [notSave, newer] {
+                XCTAssertFalse(message.contains("SaveTransferError"), "원문 노출: \(message)")
+                XCTAssertFalse(message.contains("couldn't be completed"), "원문 노출: \(message)")
+            }
+        }
+        // 그 외 오류는 시스템 문구로 폴백(파일 읽기 실패 등).
+        let other = NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoSuchFileError)
+        XCTAssertEqual(L(.en).importErrorMessage(other), other.localizedDescription)
     }
 
     func testSuggestedFileNameCarriesDate() {


### PR DESCRIPTION
## Why

Moving to a new Mac currently means finding `~/Library/Application Support/PokeTokenBar/` and copying a file by hand — and doing that silently loses a day of progress (see below). This adds a first-class way to carry a save across machines.

Only `companion-state.json` (~4 KB) is durable state. `usage-cache.json` is keyed by the local log files' `(path, mtime, size)` and is meaningless on another machine, and `sprites/` + `base-index.json` are re-downloadable caches. So the save is just that one file, wrapped in an envelope.

## The defect this fixes

`claimedTodayTokens` is a **per-machine** high-water mark of today's parsed usage, not progress. `CompanionStore.update` only credits growth when today's total passes it:

```swift
if todayTokens > state.claimedTodayTokens {
    let delta = todayTokens - state.claimedTodayTokens
    ...
    state.usedSinceInstall += delta
}
```

Carry the source Mac's value over — by copying the file, or by letting Migration Assistant move the home folder — and that gate stays false for the rest of the transfer day. Tokens spent on the new Mac stop counting toward growth and shop balance until midnight rolls `claimedTodayTokens` back to 0. Nothing errors; the companion just appears to stop growing.

Import now rebases that field to this Mac's current usage, so the transfer day counts normally. If today's usage isn't known yet (parse hasn't finished, or no provider is installed), baseline selection is handed back to the existing fresh-install path instead of being duplicated — setting it to 0 there would credit a whole day in one delta on first parse.

Existing tests never covered this because they all start from `installBaselineSet == false`; there was no case for "a baseline that arrived from another machine". `testTransferDayTokensStillCountAfterRebase` pins the trigger branch and runs an un-rebased control alongside, so the test fails loudly if the defect condition ever stops reproducing.

## UI

New **Backup & Transfer** section in Settings, between Update and Advanced (localized en/ko/ja).

- **Export save** → `NSSavePanel`, default name `PokeTokenBar-Save-YYYY-MM-DD.json`, user picks the folder. On success the file is revealed in Finder, matching how "Show log file" already gives feedback.
- **Import save** → `NSOpenPanel` for file selection, then a confirmation alert that names what is about to be replaced in numbers (incoming Pokédex count and lifetime tokens vs. this Mac's), plus where the previous state is kept. Cancel is the default button — Return must not destroy progress.
- Errors and the import result are shown as alerts, not inline text. The popover is `.transient` and `popoverDidClose` releases the hosting controller, so the settings view — and its `@State` — is gone the moment a panel becomes key. Inline status would never be visible.

## Design notes

- **Why an envelope, not the bare state.** `CompanionState.init(from:)` is deliberately lenient so one corrupt field can't wipe the Pokédex. The side effect is that *any* JSON decodes successfully as an empty state. Without a `format`/`schema` check, picking the wrong file would look like the app erased everything. The envelope's own fields have no defaults, so foreign JSON is rejected before it can be applied.
- **Candy grant ledger carries over.** Official limits are account-scoped, so the same window keys apply on the new Mac. Dropping `candyGrantTier` would re-grant Rare Candy for windows already paid out on the source machine.
- **Previous state is kept** as `companion-state.pre-import.json` before any overwrite, one slot, refreshed on each import.
- **Import invalidates in-flight async work** by bumping `activeGeneration` and clearing `currentLine` / prefetch / celebration state.
- **Panels use `activate(ignoringOtherApps:)`.** `NSApp.activate()` is cooperative activation and is ignored for an `LSUIElement` app in the background, so the panel would sit behind other windows. Measured: `activate()` leaves `isActive` false and the frontmost app unchanged; `NSRunningApplication.current.activate(.activateAllWindows)` fails identically. The rest of the repo already used the working form.

## Async-replacement hazard found while testing

`hatchCore` mutates `state.active` after awaiting the evolution-line fetch. `isHatching` only guards a second hatch in the same process — not the whole state being swapped underneath. Importing inside that network window let the finished hatch overwrite the just-imported companion. It now captures `activeGeneration` on entry and discards the hatch if the subject changed, matching `loadCurrentLine` / `revealDitto`.

A sweep of the other async paths found `dexChainNames` already safe (it re-finds the entry by `id`) and `ensureEggPrefetch` already re-checking `state.active`. This is the third time this class has bitten the repo (#136, #138 were the sprite variants), so it's now written down in `CLAUDE.md`.

## Tests

11 new cases in `SaveTransferTests`, full suite at 437 passing:

- transfer-day regression, with an un-rebased control
- import landing during a hatch (signal-driven, not sleep-based, so the await point is hit deterministically) — verified to fail without the generation guard
- deferred baseline when usage data isn't available yet
- foreign JSON and bare-state JSON both rejected instead of importing as empty
- newer schema rejected
- round-trip preserves dex / counters / inventory / collected finals
- candy ledger and progress preserved across import
- previous state backed up before overwrite
- import-error messages localized in all three languages (a mismatched mapping would surface raw Swift error text, since `SaveTransferError` is not a `LocalizedError`)
- suggested filename carries the local date

## Verification

`swift build` and `swift test` pass (437 tests, 0 failures).

Driven in a real build as two instances with isolated state (`PTB_STATE_DIR`), one seeded as the source Mac and one empty: the Backup & Transfer section renders, Export opens the save panel with the correct default filename, and the full export → file → import → rebase chain was then run against the state files those instances actually produced. Source 9 Pokédex / 8.78B lifetime landed intact on the target, `claimedTodayTokens` rebased to the target's own 396.1M instead of inheriting the source's 900M, the pre-import backup was written, and a subsequent +5M was credited normally.

## Follow-up

This is a `feat:` commit touching `Sources/PokeTokenBar/UI/`, so `release.sh`'s new-feature asset gate will hard-fail the next release until `assets/` gains a new screenshot for this section. README (en/ko/ja) and the landing page need the same treatment at release time.
