### PR TITLE
fix: stop the Grok aggregate test from failing just after midnight

### DIFF
--- a/Tests/PokeTokenBarTests/GrokUsageTests.swift
+++ b/Tests/PokeTokenBarTests/GrokUsageTests.swift
@@ -251,7 +251,12 @@ final class GrokUsageTests: XCTestCase {
     /// (`LocalGrokProvider` 는 이 세 helper 를 그대로 호출한다 — 산술이 여기서 고정된다.)
     func testBlockWeekMonthAggregatesFromRealFiles() throws {
         let now = Date()
-        let recent = Int(now.addingTimeInterval(-600).timeIntervalSince1970)   // 10분 전 = 5h 블록 안
+        // 10분 전 = 5h 블록 안. 단 로컬 자정 직후 10분 안에 돌면 그 시각이 **어제**가 되어, 마지막
+        // `todayKey()` 일별 단언이 nil 로 깨진다(프로덕션은 정상 — 엔트리를 제 날짜에 넣을 뿐이다).
+        // 실측: TZ=UTC 로 00:00~00:10 사이에 실행하면 재현. 오늘 안으로 클램프해 벽시계 의존을 없앤다.
+        let tenMinutesAgo = now.addingTimeInterval(-600)
+        let recent = Int(max(tenMinutesAgo, Calendar.current.startOfDay(for: now).addingTimeInterval(1))
+                            .timeIntervalSince1970)
         try writeSession("agg", lines: [
             turnLine(promptID: "p-block", input: 1_000, output: 100, cachedRead: 0, total: 1_100,
                      costTicks: nil, envelopeSeconds: recent, agentTimestampMs: recent * 1_000)])


### PR DESCRIPTION
## What

`GrokUsageTests.testBlockWeekMonthAggregatesFromRealFiles` fails when it runs within ten minutes of local midnight.

The fixture writes a turn at `now - 600s`, and the final assertion looks that entry up under `LocalUsageReader.todayKey()`. Inside that window those are two different days, so the daily lookup returns `nil`:

```
XCTAssertEqual failed: ("nil") is not equal to ("Optional(1100)")
```

Production behaviour is correct — the reader files the entry under its own local day. The wrong assumption is the test's: that "ten minutes ago" is still today.

## How it showed up

CI runs in UTC and a run happened to start 46 seconds after midnight. Reproduced locally with `TZ=UTC` inside the same window, and reproduced on `main` at `1af297e` as well, so it predates every branch currently open — it will keep blocking whichever PR happens to push during that window.

## Fix

Clamp the fixture timestamp into today. It stays inside the active 5-hour block in the normal case (the expression is a no-op then), so the block/week/month assertions are untouched and `todayKey()` keeps doing real work rather than being weakened to the entry's own day.

## Verification

Checked in the failing window itself rather than waiting for it to pass:

- `TZ=UTC` at 00:05 UTC — passes (same condition that failed at 00:00:46)
- local timezone (UTC+9) — passes
- full suite in both timezones — 427 tests, 0 failures
