### PR TITLE
fix: keep companion progress moving after usage snapshot drops

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -504,7 +504,14 @@ struct CompanionState: Codable, Sendable {
     var eggTier: Rarity?
     // 알 상태에서 미리 롤해둔 부화 종(프리패칭) — 부화 순간 네트워크 딜레이 제거. 재시작에도 유지.
     var pendingHatchID: Int?
-    var claimedTodayTokens = 0
+    /// 오늘 사용량 적립 기준값 — 프로바이더별로 독립 관리한다.
+    ///
+    /// `nil`은 aggregate `claimedTodayTokens`만 가지고 있던 구버전 세이브가 아직 첫 유효
+    /// snapshot을 기준으로 seed되지 않았다는 뜻이다. 첫 update에서 현재 프로바이더 값을
+    /// 기준값으로만 저장하고, 과거 사용량은 소급 지급하지 않는다. 빈 map은 이미 seed된 뒤
+    /// 오늘 보고한 프로바이더가 없는 정상 상태와 구분되어야 하므로 `nil`과 별도로 유지한다.
+    /// 키는 `UsageProvider.id`를 그대로 사용한다.
+    var claimedTodayTokensByProvider: [String: Int]? = nil
     var lastDate = ""
     // 현재 포켓몬(없으면 알)
     var active: MonState?
@@ -534,7 +541,15 @@ struct CompanionState: Codable, Sendable {
         // 모르는 rawValue 는 nil(보증 없음)로 강등 — 관대 디코딩의 안전한 방향(있지도 않은 보증을 만들지 않는다).
         eggTier            = c.lenientOptional(Rarity.self, forKey: .eggTier)
         pendingHatchID     = c.lenientOptional(Int.self, forKey: .pendingHatchID)
-        claimedTodayTokens = c.lenient(Int.self, forKey: .claimedTodayTokens, default: 0)
+        if c.contains(.claimedTodayTokensByProvider) {
+            claimedTodayTokensByProvider = c.lenient([String: Int].self,
+                                                      forKey: .claimedTodayTokensByProvider,
+                                                      default: [:])
+        } else {
+            // 구버전의 aggregate claimedTodayTokens 키는 의도적으로 읽지 않는다. 프로바이더별
+            // 분해가 불가능하므로 다음 CompanionStore.update에서 현재 snapshot을 기준점으로 seed한다.
+            claimedTodayTokensByProvider = nil
+        }
         lastDate           = c.lenient(String.self, forKey: .lastDate, default: "")
         // active 손상(빈 pathIDs 등) → 알로 폴백하되 도감·인벤토리는 보존.
         active             = c.lenientOptional(MonState.self, forKey: .active)

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -226,8 +226,9 @@ final class CompanionStore {
 
     // MARK: 갱신 (AppDelegate 가 UsageStore 값으로 호출)
 
-    func update(todayTokens: Int, todayDate: String, monthTotal: Int,
+    func update(todayTokensByProvider: [String: Int], todayDate: String, monthTotal: Int,
                 burnTier: BurnTier, limitWarning: Bool, hasUsageData: Bool) {
+        let todayTokens = todayTokensByProvider.values.reduce(0, +)
         if !state.installBaselineSet {
             // 설치 기준선 — 실제 데이터가 도착한 시점의 today 를 baseline 으로(이전 사용량 미카운트).
             // 데이터 도착 전(기동 직후 빈 새로고침)에는 잡지 않는다.
@@ -241,32 +242,55 @@ final class CompanionStore {
                 return
             }
             state.installBaselineSet = true
-            state.claimedTodayTokens = todayTokens
+            state.claimedTodayTokensByProvider = todayTokensByProvider
             state.lastDate = todayDate
             save()
         } else {
-            if todayDate != state.lastDate { state.lastDate = todayDate; state.claimedTodayTokens = 0 }
-            if todayTokens < state.claimedTodayTokens, hasUsageData {
-                // todayTokens 는 append-only 서버 카운터가 아니라 로컬 로그를 매번 재집계한 스냅샷이다.
-                // Codex 세션 재생/중복 제거/파일 갱신으로 기존 값보다 낮아질 수 있으므로, 유효한
-                // 낮은 스냅샷은 새 기준점으로 삼는다. 그래야 그 다음 관측값의 양의 증가분이
-                // high-water mark 뒤에 영구히 막히지 않고 알/포켓몬 성장에 반영된다.
-                //
-                // hasUsageData == false 인 0 또는 빈 스냅샷은 조회 실패·일시적 데이터 공백일 수 있다.
-                // 이를 기준점으로 채택하면 다음 정상 조회 때 당일 전체가 새 사용량으로 중복 지급되므로
-                // 기준을 유지한다.
-                let previous = state.claimedTodayTokens
-                state.claimedTodayTokens = todayTokens
-                AppLog.write("companion usage regression date=\(todayDate) previous=\(previous) current=\(todayTokens) drop=\(previous - todayTokens) — rebased daily ledger")
-            }
-            if todayTokens > state.claimedTodayTokens {
-                let delta = todayTokens - state.claimedTodayTokens
-                state.claimedTodayTokens = todayTokens
-                state.usedSinceInstall += delta
-                if state.active == nil {
-                    state.eggUsage += delta   // 알 인큐베이션 누적
+            // `today == nil` carrier만 남거나 파싱이 실패한 refresh는 현재 map이 비어 있을 수
+            // 있다. 그런 관측으로 날짜·ledger를 움직이면 다음 정상 snapshot을 당일 전체 신규
+            // 사용량으로 오인할 수 있으므로, 유효한 사용량이 있는 refresh만 ledger를 갱신한다.
+            if hasUsageData {
+                let dateChanged = todayDate != state.lastDate
+                if dateChanged {
+                    // 일자별 snapshot은 서로 비교할 수 없다. 새 날짜의 첫 관측은 프로바이더별
+                    // 기준점으로 seed하고, 그 이전 날짜의 사용량을 새 날짜로 이월하지 않는다.
+                    state.lastDate = todayDate
+                    state.claimedTodayTokensByProvider = todayTokensByProvider
+                } else if state.claimedTodayTokensByProvider == nil {
+                    // 구버전 세이브에는 aggregate high-water mark만 있어 프로바이더별로 분해할 수 없다.
+                    // 첫 유효 관측을 새 장부의 기준점으로만 저장해 과거 사용량을 소급 지급하지 않는다.
+                    state.claimedTodayTokensByProvider = todayTokensByProvider
+                    AppLog.write("companion provider ledger seeded date=\(todayDate) providers=\(todayTokensByProvider.keys.sorted().joined(separator: ","))")
                 } else {
-                    applyUsage(delta)
+                    var ledger = state.claimedTodayTokensByProvider ?? [:]
+                    var delta = 0
+                    for (providerID, current) in todayTokensByProvider {
+                        guard let previous = ledger[providerID] else {
+                            // 새로 관측된 프로바이더의 과거 로그를 소급하지 않는다. 이후 refresh부터
+                            // 해당 프로바이더의 증가분을 추적할 수 있도록 현재 값을 seed한다.
+                            ledger[providerID] = current
+                            continue
+                        }
+                        if current < previous {
+                            // 전체 합계가 아니라 해당 프로바이더의 line만 rebase한다. 다른 프로바이더가
+                            // 이번 refresh에서 보고하지 않았거나 carrier snapshot만 남은 경우에는 map에
+                            // line 자체가 없으므로 기존 기준값을 건드리지 않는다.
+                            ledger[providerID] = current
+                            AppLog.write("companion usage regression provider=\(providerID) date=\(todayDate) previous=\(previous) current=\(current) drop=\(previous - current) — rebased provider ledger")
+                            continue
+                        }
+                        delta += current - previous
+                        ledger[providerID] = current
+                    }
+                    state.claimedTodayTokensByProvider = ledger
+                    if delta > 0 {
+                        state.usedSinceInstall += delta
+                        if state.active == nil {
+                            state.eggUsage += delta   // 알 인큐베이션 누적
+                        } else {
+                            applyUsage(delta)
+                        }
+                    }
                 }
             }
         }
@@ -302,7 +326,7 @@ final class CompanionStore {
 
     /// 토큰 증분을 현재 포켓몬에 적용 — 임계 도달 시 진화/졸업.
     /// 라인 미로딩(재시작 직후·오프라인)이어도 사용량은 항상 적립한다 — 여기서 드롭하면
-    /// claimedTodayTokens 는 이미 전진해 델타가 영구 유실된다. 진화 판정만 라인 로드 후로 미룬다.
+    /// 프로바이더별 ledger 는 이미 전진해 델타가 영구 유실된다. 진화 판정만 라인 로드 후로 미룬다.
     func applyUsage(_ delta: Int) {
         guard state.active != nil else { return }
         state.active!.usedAtStage += delta
@@ -978,11 +1002,12 @@ final class CompanionStore {
     /// 검증된 세이브를 이 기기에 적용 — 기존 상태 백업 → 기기 기준 재정렬 → 저장 → 라인 재로딩.
     /// 백업을 못 남기면 **적용하지 않고** throw 한다 — 확인창이 "직전 상태가 남는다"고 약속하므로,
     /// 그 약속을 못 지키는 채로 덮어쓰면 사용자는 되돌릴 수단 없이 진행을 잃는다.
-    func applySave(_ envelope: SaveEnvelope, todayTokens: Int, todayDate: String, hasUsageData: Bool) throws {
+    func applySave(_ envelope: SaveEnvelope, todayTokensByProvider: [String: Int], todayDate: String,
+                   hasUsageData: Bool) throws {
         try backupStateBeforeImport()
         state = SaveTransfer.rebasedForThisDevice(envelope.state,
                                                   current: state,
-                                                  todayTokens: todayTokens,
+                                                  todayTokensByProvider: todayTokensByProvider,
                                                   todayDate: todayDate,
                                                   hasUsageData: hasUsageData)
         // 이전 개체 기준으로 진행 중이던 비동기·연출을 전부 무효화한다. activeGeneration 을 올리지

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -229,10 +229,14 @@ final class CompanionStore {
     func update(todayTokensByProvider: [String: Int], todayDate: String, monthTotal: Int,
                 burnTier: BurnTier, limitWarning: Bool, hasUsageData: Bool) {
         let todayTokens = todayTokensByProvider.values.reduce(0, +)
+        // `hasUsageData`는 표시용 snapshot 존재 여부이고, 이 map은 오늘 날짜가 확인된
+        // provider 데이터만 담는다. stale snapshot이나 today == nil carrier만 있는 refresh는
+        // ledger의 기준점을 움직일 수 있는 관측으로 취급하지 않는다.
+        let hasCurrentProviderData = hasUsageData && !todayTokensByProvider.isEmpty
         if !state.installBaselineSet {
             // 설치 기준선 — 실제 데이터가 도착한 시점의 today 를 baseline 으로(이전 사용량 미카운트).
             // 데이터 도착 전(기동 직후 빈 새로고침)에는 잡지 않는다.
-            guard hasUsageData else {
+            guard hasCurrentProviderData else {
                 // 세이브 불러오기가 baseline 판정을 이 경로에 넘겼을 수 있다(SaveTransfer.rebasedForThisDevice).
                 // 그 경우 개체는 이미 들어와 있으므로 알로 표시하면 안 되고, 진화 라인 로드도 계속 재시도해야
                 // 한다 — 새 Mac 은 AI CLI 를 처음 쓸 때까지 hasUsageData 가 false 라 여기서 막히면 그날 내내
@@ -249,18 +253,29 @@ final class CompanionStore {
             // `today == nil` carrier만 남거나 파싱이 실패한 refresh는 현재 map이 비어 있을 수
             // 있다. 그런 관측으로 날짜·ledger를 움직이면 다음 정상 snapshot을 당일 전체 신규
             // 사용량으로 오인할 수 있으므로, 유효한 사용량이 있는 refresh만 ledger를 갱신한다.
-            if hasUsageData {
+            if hasCurrentProviderData {
                 let dateChanged = todayDate != state.lastDate
-                if dateChanged {
-                    // 일자별 snapshot은 서로 비교할 수 없다. 새 날짜의 첫 관측은 프로바이더별
-                    // 기준점으로 seed하고, 그 이전 날짜의 사용량을 새 날짜로 이월하지 않는다.
-                    state.lastDate = todayDate
-                    state.claimedTodayTokensByProvider = todayTokensByProvider
-                } else if state.claimedTodayTokensByProvider == nil {
+                if state.claimedTodayTokensByProvider == nil {
                     // 구버전 세이브에는 aggregate high-water mark만 있어 프로바이더별로 분해할 수 없다.
                     // 첫 유효 관측을 새 장부의 기준점으로만 저장해 과거 사용량을 소급 지급하지 않는다.
                     state.claimedTodayTokensByProvider = todayTokensByProvider
+                    state.lastDate = todayDate
                     AppLog.write("companion provider ledger seeded date=\(todayDate) providers=\(todayTokensByProvider.keys.sorted().joined(separator: ","))")
+                } else if dateChanged {
+                    // 일자별 snapshot은 서로 비교할 수 없다. 새 날짜에는 이전 날짜의 ledger를
+                    // 기준으로 삼지 않고, 현재 날짜의 누적값 전체를 새 날짜 사용량으로 적립한다.
+                    // 단, 위의 nil migration 경로는 구버전 aggregate를 분해할 수 없으므로 seed만 한다.
+                    state.lastDate = todayDate
+                    state.claimedTodayTokensByProvider = todayTokensByProvider
+                    let delta = todayTokensByProvider.values.reduce(0, +)
+                    if delta > 0 {
+                        state.usedSinceInstall += delta
+                        if state.active == nil {
+                            state.eggUsage += delta
+                        } else {
+                            applyUsage(delta)
+                        }
+                    }
                 } else {
                     var ledger = state.claimedTodayTokensByProvider ?? [:]
                     var delta = 0

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -265,8 +265,20 @@ final class CompanionStore {
                     // 일자별 snapshot은 서로 비교할 수 없다. 새 날짜에는 이전 날짜의 ledger를
                     // 기준으로 삼지 않고, 현재 날짜의 누적값 전체를 새 날짜 사용량으로 적립한다.
                     // 단, 위의 nil migration 경로는 구버전 aggregate를 분해할 수 없으므로 seed만 한다.
+                    //
+                    // 이전 날짜에 이미 알려진 provider가 첫 새로고침에서 빠질 수 있다(오늘 데이터
+                    // 없음, stale 응답, 일시 실패). 그 provider를 아예 ledger에서 제거하면 같은
+                    // 날짜에 복구될 때 현재 누적값을 "이미 적립한 값"으로 seed해 사용량이 누락된다.
+                    // 이전 날짜의 숫자는 비교에 사용할 수 없으므로, 알려진 provider의 새 날짜 기준을
+                    // 0으로 열어 둔다. 이후 복구된 현재 날짜 값은 그 날짜의 실제 사용량으로 적립되고,
+                    // 같은 날짜의 부분 응답에서는 이 기준을 그대로 보존한다.
                     state.lastDate = todayDate
-                    state.claimedTodayTokensByProvider = todayTokensByProvider
+                    var newLedger = Dictionary(uniqueKeysWithValues:
+                        state.claimedTodayTokensByProvider!.keys.map { ($0, 0) })
+                    for (providerID, current) in todayTokensByProvider {
+                        newLedger[providerID] = current
+                    }
+                    state.claimedTodayTokensByProvider = newLedger
                     let delta = todayTokensByProvider.values.reduce(0, +)
                     if delta > 0 {
                         state.usedSinceInstall += delta

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -246,6 +246,19 @@ final class CompanionStore {
             save()
         } else {
             if todayDate != state.lastDate { state.lastDate = todayDate; state.claimedTodayTokens = 0 }
+            if todayTokens < state.claimedTodayTokens, hasUsageData {
+                // todayTokens 는 append-only 서버 카운터가 아니라 로컬 로그를 매번 재집계한 스냅샷이다.
+                // Codex 세션 재생/중복 제거/파일 갱신으로 기존 값보다 낮아질 수 있으므로, 유효한
+                // 낮은 스냅샷은 새 기준점으로 삼는다. 그래야 그 다음 관측값의 양의 증가분이
+                // high-water mark 뒤에 영구히 막히지 않고 알/포켓몬 성장에 반영된다.
+                //
+                // hasUsageData == false 인 0 또는 빈 스냅샷은 조회 실패·일시적 데이터 공백일 수 있다.
+                // 이를 기준점으로 채택하면 다음 정상 조회 때 당일 전체가 새 사용량으로 중복 지급되므로
+                // 기준을 유지한다.
+                let previous = state.claimedTodayTokens
+                state.claimedTodayTokens = todayTokens
+                AppLog.write("companion usage regression date=\(todayDate) previous=\(previous) current=\(todayTokens) drop=\(previous - todayTokens) — rebased daily ledger")
+            }
             if todayTokens > state.claimedTodayTokens {
                 let delta = todayTokens - state.claimedTodayTokens
                 state.claimedTodayTokens = todayTokens

--- a/Sources/PokeTokenBar/Core/SaveTransfer.swift
+++ b/Sources/PokeTokenBar/Core/SaveTransfer.swift
@@ -145,7 +145,9 @@ enum SaveTransfer {
         s.usedSinceInstall = clampToken(s.usedSinceInstall)
         s.spentTokens = clampToken(s.spentTokens)
         s.eggUsage = clampToken(s.eggUsage)
-        s.claimedTodayTokens = clampToken(s.claimedTodayTokens)
+        s.claimedTodayTokensByProvider = s.claimedTodayTokensByProvider?.reduce(into: [:]) { result, entry in
+            result[entry.key] = clampToken(entry.value)
+        }
         // 알 보증은 "지금 품고 있는 알"에만 붙는 값이라 활성 포켓몬과 공존할 수 없다. 손편집·구버전
         // 조합으로 둘 다 들어오면 그 보증이 다음 알로 새어 영구 프리미엄이 되므로 여기서 떨군다.
         // 그 보증으로 미리 뽑아둔 종(pendingHatchID)도 함께 버린다 — 보증만 지우면 졸업 후 받는 **무료**
@@ -172,9 +174,9 @@ enum SaveTransfer {
     /// `CompanionState` 의 필드는 이전 관점에서 세 부류다.
     ///  - **진행**: 어느 기기에서든 참(`usedSinceInstall`·`dex`·`inventory`·`active`·`eggUsage`·`eggTier`…)
     ///    → 그대로. 알 보증(`eggTier`)은 산 물건이지 이 기기의 장부가 아니라 기기를 옮겨도 따라간다.
-    ///  - **로컬 장부**: *그 기기가* 어디까지 적립했나(`claimedTodayTokens`·`lastDate`·`installBaselineSet`)
+    ///  - **로컬 장부**: *그 기기가* 어디까지 적립했나(`claimedTodayTokensByProvider`·`lastDate`·`installBaselineSet`)
     ///    → 새 기기 기준으로 다시 잡는다. 그대로 들여오면 옛 기기의 오늘 총량이 문턱이 되어
-    ///    `CompanionStore.update` 의 `todayTokens > claimedTodayTokens` 게이트가 이전 당일 내내 거짓이 되고,
+    ///    `CompanionStore.update` 의 프로바이더별 증분 게이트가 이전 당일 내내 거짓이 되고,
     ///    새 기기 사용분이 조용히 안 잡힌다(자정에 저절로 낫기 때문에 버그로 안 보인다).
     ///  - **기기 환경설정**: 진행이 아니라 이 기기에서 보는 방식(`language`) → **현재 기기 값을 지킨다**.
     ///    일본어 Mac 의 세이브가 영어 Mac 의 UI 언어를 바꾸면 안 된다.
@@ -184,7 +186,7 @@ enum SaveTransfer {
     /// 사라져 같은 창에서 사탕이 재지급된다(보존만으로는 이 역방향을 못 막는다).
     static func rebasedForThisDevice(_ imported: CompanionState,
                                      current: CompanionState,
-                                     todayTokens: Int,
+                                     todayTokensByProvider: [String: Int],
                                      todayDate: String,
                                      hasUsageData: Bool) -> CompanionState {
         var state = imported
@@ -194,13 +196,13 @@ enum SaveTransfer {
         if hasUsageData {
             // 신규 설치와 같은 규칙: 불러온 시점 이전의 이 기기 사용량은 소급 적립하지 않는다.
             state.installBaselineSet = true
-            state.claimedTodayTokens = todayTokens
+            state.claimedTodayTokensByProvider = todayTokensByProvider
             state.lastDate = todayDate
         } else {
             // 아직 이 기기의 오늘 사용량을 모른다(파싱 전·프로바이더 없음). 여기서 0 으로 잡으면
             // 첫 파싱 때 하루치가 통째로 델타가 된다 → baseline 판정을 신규 설치 경로에 넘긴다.
             state.installBaselineSet = false
-            state.claimedTodayTokens = 0
+            state.claimedTodayTokensByProvider = nil
             state.lastDate = ""
         }
         return state

--- a/Sources/PokeTokenBar/Core/SaveTransfer.swift
+++ b/Sources/PokeTokenBar/Core/SaveTransfer.swift
@@ -193,14 +193,17 @@ enum SaveTransfer {
         state.language = current.language
         state.candyGrantTier = mergedGrantTier(imported.candyGrantTier, current.candyGrantTier)
         state.candyFeatureSeeded = imported.candyFeatureSeeded || current.candyFeatureSeeded
-        if hasUsageData {
+        let hasCurrentProviderData = hasUsageData && !todayTokensByProvider.isEmpty
+        if hasCurrentProviderData {
             // 신규 설치와 같은 규칙: 불러온 시점 이전의 이 기기 사용량은 소급 적립하지 않는다.
             state.installBaselineSet = true
             state.claimedTodayTokensByProvider = todayTokensByProvider
             state.lastDate = todayDate
         } else {
-            // 아직 이 기기의 오늘 사용량을 모른다(파싱 전·프로바이더 없음). 여기서 0 으로 잡으면
-            // 첫 파싱 때 하루치가 통째로 델타가 된다 → baseline 판정을 신규 설치 경로에 넘긴다.
+            // 아직 이 기기의 오늘 사용량을 모른다(파싱 전·프로바이더 없음·stale snapshot만 존재).
+            // `hasUsageData`는 snapshot 존재 여부일 뿐 오늘 날짜 데이터의 존재를 보장하지 않는다.
+            // 여기서 빈 map을 이미 seed된 장부로 저장하면 첫 정상 snapshot이 "새 provider"로
+            // 취급되어 그 시점까지의 하루치가 조용히 누락된다 → baseline 판정을 신규 설치 경로에 넘긴다.
             state.installBaselineSet = false
             state.claimedTodayTokensByProvider = nil
             state.lastDate = ""

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -543,6 +543,9 @@ final class UsageStore {
 
             let today: DailyUsage?
             if let fetched = dailyByID[provider.id] {
+                if let previous = prevToday, fetched.totalTokens < previous.totalTokens {
+                    AppLog.write("usage regression provider=\(provider.id) date=\(fetched.date) previous=\(previous.totalTokens) current=\(fetched.totalTokens) drop=\(previous.totalTokens - fetched.totalTokens) — provider returned lower daily snapshot")
+                }
                 today = fetched
             } else if failedIDs.contains(provider.id) {
                 today = prevToday   // 실패 → 오늘자 이전 값 유지

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -148,6 +148,22 @@ final class UsageStore {
         return snapshots.reduce(0) { $0 + ($1.today?.date == todayKey ? $1.todayTotalTokens : 0) }
     }
 
+    /// 오늘 사용량을 프로바이더 고유 ID별로 제공한다.
+    ///
+    /// companion 적립 장부는 전체 합계가 아니라 이 map을 기준으로 한다. `today == nil`인
+    /// carrier snapshot이나 오늘이 아닌 snapshot은 map에서 제외한다. 그러면 프로바이더가
+    /// 이번 refresh에서 보고하지 않은 경우에는 해당 프로바이더의 기존 장부를 건드리지 않고,
+    /// 실제 오늘 수치가 있는 프로바이더만 증분 계산에 참여한다.
+    /// 키는 `UsageProvider.id`를 그대로 사용하며, 프로바이더 등록/식별자 정책은
+    /// `docs/reference/provider-extension.md`를 따른다.
+    var todayTokensByProvider: [String: Int] {
+        let todayKey = LocalUsageReader.todayKey()
+        return snapshots.reduce(into: [:]) { result, snapshot in
+            guard let today = snapshot.today, today.date == todayKey else { return }
+            result[snapshot.providerID] = today.totalTokens
+        }
+    }
+
     /// 사용량 데이터(스냅샷)가 하나라도 있는가 — companion sleep 판정용
     var hasUsageData: Bool { !snapshots.isEmpty }
 

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -163,7 +163,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// UsageStore 값 → CompanionStore (사용량 적립 + 표시 상태). 매 관찰 변경 시 호출.
     private func updateCompanion() {
         companion.update(
-            todayTokens: store.todayTotalTokens,
+            todayTokensByProvider: store.todayTokensByProvider,
             todayDate: LocalUsageReader.todayKey(),
             monthTotal: store.monthTotalTokens,
             burnTier: store.burnTier,

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -522,7 +522,7 @@ struct SettingsView: View {
 
         do {
             try companion.applySave(envelope,
-                                    todayTokens: store.todayTotalTokens,
+                                    todayTokensByProvider: store.todayTokensByProvider,
                                     todayDate: LocalUsageReader.todayKey(),
                                     hasUsageData: store.hasUsageData)
         } catch {

--- a/Tests/PokeTokenBarTests/CompanionDisplayStateTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionDisplayStateTests.swift
@@ -32,42 +32,42 @@ final class CompanionDisplayStateTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-disp-\(UUID().uuidString).json")
         let s = CompanionStore(provider: StubProvider(value: dline(base: 1)),
                                clock: { dNow }, fileURL: url, rng: SeededRNG(seed: 1))
-        s.update(todayTokens: 0, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: false)
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: false)
         XCTAssertEqual(s.displayState, .egg)
     }
 
     func testLevelUpDuringEventWindow() async {
         let (s, _) = await hatchedStore()
         // 이벤트 윈도우가 살아있는 동안(시계 미전진) → levelUp 유지
-        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 100], todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.displayState, .levelUp)
     }
 
     func testWorkingAfterEventExpires() async {
         let (s, clock) = await hatchedStore()
         clock.now = dNow.addingTimeInterval(60)   // 이벤트 만료
-        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 100], todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.displayState, .working)
     }
 
     func testFocusOnHighBurn() async {
         let (s, clock) = await hatchedStore()
         clock.now = dNow.addingTimeInterval(60)
-        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .blazing, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 100], todayDate: "d", monthTotal: 0, burnTier: .blazing, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.displayState, .focus)
     }
 
     func testTiredWhenLimitWarning() async {
         let (s, clock) = await hatchedStore()
         clock.now = dNow.addingTimeInterval(60)
-        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: true, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 100], todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: true, hasUsageData: true)
         XCTAssertEqual(s.displayState, .tired)
     }
 
     func testSleepWhenZeroUsageToday() async {
         let (s, clock) = await hatchedStore()
         clock.now = dNow.addingTimeInterval(60)
-        s.update(todayTokens: 0, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.displayState, .sleep)
     }
 
@@ -78,19 +78,19 @@ final class CompanionDisplayStateTests: XCTestCase {
         let (s, clock) = await hatchedStore()
         clock.now = dNow.addingTimeInterval(60)   // 부화 창 만료 — 이후엔 진화 이벤트만 남게
         // 기준선 설정(첫 update 는 baseline 만 잡고 delta 는 적용 안 함).
-        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 100], todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: false, hasUsageData: true)
         // stage0 임계 도달 → 정확히 1회 진화(1→2). justEvolvedTo 설정 + 이벤트 창 갱신(clock+4).
         s.applyUsage(PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0))
         XCTAssertEqual(s.state.active?.stageIndex, 1)
         let evolvedName = s.justEvolvedTo
         XCTAssertNotNil(evolvedName, "진화 직후 진화 문구가 설정돼야 함")
         // 창이 살아있는 동안 추가 update()(delta 0)가 와도 진화 문구·levelUp 이 유지돼야 한다.
-        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 100], todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.justEvolvedTo, evolvedName, "이벤트 창 도중 진화 문구가 nil 로 밀리면 안 됨(#4)")
         XCTAssertEqual(s.displayState, .levelUp)
         // 창 만료 후 update → 진화 문구 정리 + 일반 상태 복귀.
         clock.now = dNow.addingTimeInterval(70)
-        s.update(todayTokens: 100, todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 100], todayDate: "d", monthTotal: 0, burnTier: .normal, limitWarning: false, hasUsageData: true)
         XCTAssertNil(s.justEvolvedTo, "창 만료 시 진화 문구가 정리돼야 함")
         XCTAssertEqual(s.displayState, .working)
     }
@@ -106,9 +106,9 @@ final class CompanionDisplayStateTests: XCTestCase {
         XCTAssertEqual(s.eggTokensToHatch, PokemonBalance.eggHatchThreshold)
 
         // 임계의 40% 사용
-        s.update(todayTokens: 0, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         let part = PokemonBalance.eggHatchThreshold * 2 / 5
-        s.update(todayTokens: part, todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": part], todayDate: "d", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.eggProgress, 0.4, accuracy: 0.001)
         XCTAssertEqual(s.eggTokensToHatch, PokemonBalance.eggHatchThreshold - part)
         XCTAssertTrue(s.eggStarted)

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -302,19 +302,19 @@ final class CompanionStoreTests: XCTestCase {
     func testInstallBaselineExcludesPreInstallUsage() {
         let s = store(linear3)
         // 데이터 도착 전 → baseline 미설정
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: false)
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: false)
         XCTAssertFalse(s.state.installBaselineSet)
         // 첫 실데이터 → baseline = 그 시점 today(이전 사용량 미카운트)
-        s.update(todayTokens: 48_000_000, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 48_000_000], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertTrue(s.state.installBaselineSet)
         XCTAssertEqual(s.state.usedSinceInstall, 0)
         // 이후 증가분만 누적
-        s.update(todayTokens: 148_000_000, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 148_000_000], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.state.usedSinceInstall, 100_000_000)
     }
 
     /// [회귀] 로컬 사용량 재집계가 기존 값보다 낮아진 뒤에도, 새 기준점 이후의 증가분은 알에 반영한다.
-    /// 예전에는 claimedTodayTokens 를 high-water mark 로만 유지해 감소 후 증가가 영구히 무시됐다.
+    /// 예전에는 aggregate high-water mark 로만 유지해 감소 후 증가가 영구히 무시됐다.
     func testUsageIncreaseAfterValidDropContinuesEggProgress() {
         let s = store(linear3)
         base(s)
@@ -324,7 +324,7 @@ final class CompanionStoreTests: XCTestCase {
         // 유효한 낮은 스냅샷: 이 자체는 토큰 사용량으로 지급하지 않고 기준점만 재설정한다.
         use(s, 40)
         XCTAssertEqual(s.state.eggUsage, 200)
-        XCTAssertEqual(s.state.claimedTodayTokens, 40)
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider?["test"], 40)
 
         // 새 기준점 이후의 증가분만 반영한다.
         use(s, 75)
@@ -341,18 +341,80 @@ final class CompanionStoreTests: XCTestCase {
 
         use(s, 0, hasUsageData: false) // 빈 스냅샷/조회 공백
         XCTAssertEqual(s.state.eggUsage, 200)
-        XCTAssertEqual(s.state.claimedTodayTokens, 200)
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider?["test"], 200)
 
         use(s, 250)
         XCTAssertEqual(s.state.eggUsage, 250)
         XCTAssertEqual(s.state.usedSinceInstall, 250)
     }
 
+    /// [회귀] 프로바이더 하나가 일시적으로 snapshot을 내놓지 않아도 다른 프로바이더의
+    /// 증가분만 적립하고, 사라졌던 프로바이더가 복구될 때 과거 사용량을 중복 지급하지 않는다.
+    func testProviderLedgerDoesNotRecreditMissingProviderAfterPartialSnapshotLoss() {
+        let s = store(linear3)
+        useMap(s, ["claude_code": 0, "codex": 0])
+        useMap(s, ["claude_code": 1_000, "codex": 500])
+        XCTAssertEqual(s.state.usedSinceInstall, 1_500)
+
+        // codex today == nil인 carrier snapshot은 map에서 빠진다. codex line은 그대로 보존한다.
+        useMap(s, ["claude_code": 1_000], hasUsageData: true)
+        XCTAssertEqual(s.state.usedSinceInstall, 1_500)
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider,
+                       ["claude_code": 1_000, "codex": 500])
+
+        // 복구된 codex의 기존 500을 다시 지급하지 않고 이후 증가분만 지급한다.
+        useMap(s, ["claude_code": 1_000, "codex": 500])
+        XCTAssertEqual(s.state.usedSinceInstall, 1_500)
+        useMap(s, ["claude_code": 1_000, "codex": 700])
+        XCTAssertEqual(s.state.usedSinceInstall, 1_700)
+    }
+
+    /// [회귀] carrier만 남아 오늘 map이 비어도 프로바이더별 ledger를 0으로 낮추지 않는다.
+    /// 정상 snapshot 복구 뒤에는 복구 시점 이후 증가분만 적립한다.
+    func testCarrierWithoutTodayDataDoesNotRebaseProviderLedger() {
+        let s = store(linear3)
+        useMap(s, ["codex": 0])
+        useMap(s, ["codex": 2_000])
+        XCTAssertEqual(s.state.usedSinceInstall, 2_000)
+
+        useMap(s, [:], hasUsageData: false)
+        XCTAssertEqual(s.state.usedSinceInstall, 2_000)
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider, ["codex": 2_000])
+
+        useMap(s, ["codex": 2_200])
+        XCTAssertEqual(s.state.usedSinceInstall, 2_200)
+    }
+
+    /// [마이그레이션] aggregate high-water mark만 가진 구버전 세이브는 값을 프로바이더별로
+    /// 추정하지 않고 첫 유효 snapshot을 seed한다. 이후 증가분은 새 ledger로 정상 적립한다.
+    func testLegacyAggregateLedgerSeedsProviderMapWithoutRetrospectiveCredit() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
+        let legacy = #"{"installBaselineSet":true,"usedSinceInstall":10000,"claimedTodayTokens":9000,"lastDate":"d1"}"#
+        try Data(legacy.utf8).write(to: url)
+
+        let s = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow }, fileURL: url,
+                               rng: SeededRNG(seed: 7))
+        XCTAssertNil(s.state.claimedTodayTokensByProvider)
+
+        s.update(todayTokensByProvider: ["codex": 500], todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.state.usedSinceInstall, 10_000)
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider, ["codex": 500])
+
+        s.update(todayTokensByProvider: ["codex": 700], todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.state.usedSinceInstall, 10_200)
+    }
+
     private func base(_ s: CompanionStore) {
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
     }
     private func use(_ s: CompanionStore, _ today: Int, hasUsageData: Bool = true) {
-        s.update(todayTokens: today, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: hasUsageData)
+        s.update(todayTokensByProvider: ["test": today], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: hasUsageData)
+    }
+    private func useMap(_ s: CompanionStore, _ todayTokensByProvider: [String: Int], hasUsageData: Bool = true) {
+        s.update(todayTokensByProvider: todayTokensByProvider, todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: hasUsageData)
     }
 
     func testEggDoesNotHatchBelowThreshold() async {
@@ -481,6 +543,7 @@ final class CompanionStoreTests: XCTestCase {
         let state = try JSONDecoder().decode(CompanionState.self, from: Data(json.utf8))
         XCTAssertEqual(state.eggUsage, 0)
         XCTAssertEqual(state.usedSinceInstall, 5)
+        XCTAssertNil(state.claimedTodayTokensByProvider)
     }
 
     func testEvolvesThroughLineAndGraduatesWithFullChain() async {
@@ -633,7 +696,7 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(opposing.next() % 2, 1, "a reroll would select the opposite branch (3)")
         let rng = CountingRNG(seed: 1)
         let s2 = CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: rng)
-        s2.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+        s2.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0,
                   burnTier: .idle, limitWarning: false, hasUsageData: true)
         let loaded = await waitUntil { s2.currentLine != nil }
         XCTAssertTrue(loaded, "line should load before evolution")
@@ -655,7 +718,7 @@ final class CompanionStoreTests: XCTestCase {
         let rng = CountingRNG(seed: 7)
         let s = CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: rng)
 
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         let loaded = await waitUntil { s.currentLine != nil }
         XCTAssertTrue(loaded, "line should load legacy state")
@@ -668,7 +731,7 @@ final class CompanionStoreTests: XCTestCase {
 
         let reloadRNG = CountingRNG(seed: 1)
         let reloaded = CompanionStore(provider: StubProvider(value: line), clock: { fixedNow }, fileURL: url, rng: reloadRNG)
-        reloaded.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+        reloaded.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0,
                         burnTier: .idle, limitWarning: false, hasUsageData: true)
         let reloadedLine = await waitUntil { reloaded.currentLine != nil }
         XCTAssertTrue(reloadedLine)
@@ -682,7 +745,7 @@ final class CompanionStoreTests: XCTestCase {
         try Data(saved.utf8).write(to: url)
         let s = CompanionStore(provider: StubProvider(value: wurmpleLine), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 9))
 
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         let loaded = await waitUntil { s.currentLine != nil }
         XCTAssertTrue(loaded)
@@ -700,7 +763,7 @@ final class CompanionStoreTests: XCTestCase {
         try Data(saved.utf8).write(to: url)
         let s = CompanionStore(provider: StubProvider(value: wurmpleLine), clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 9))
 
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         let loaded = await waitUntil { s.currentLine != nil }
         XCTAssertTrue(loaded)
@@ -721,7 +784,7 @@ final class CompanionStoreTests: XCTestCase {
         let rng = CountingRNG(seed: 9)
         let s = CompanionStore(provider: StubProvider(value: wurmpleLine), clock: { fixedNow }, fileURL: url, rng: rng)
 
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         let loaded = await waitUntil { s.currentLine != nil }
         XCTAssertTrue(loaded)
@@ -738,7 +801,7 @@ final class CompanionStoreTests: XCTestCase {
         let provider = SuspendedLineProvider(value: linear3)
         let s = CompanionStore(provider: provider, clock: { fixedNow }, fileURL: url, rng: SeededRNG(seed: 7))
 
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         let suspensionDeadline = Date().addingTimeInterval(1)
         while !(await provider.isSuspended()), Date() < suspensionDeadline {
@@ -920,6 +983,7 @@ final class CompanionIdentityTests: XCTestCase {
         XCTAssertEqual(s.active?.plannedPathIDs, [1])
         XCTAssertEqual(s.active?.isShiny, false)
         XCTAssertNil(s.active?.nature)
+        XCTAssertNil(s.claimedTodayTokensByProvider, "구버전 aggregate ledger는 프로바이더별 값으로 추정하지 않는다")
         XCTAssertEqual(s.dex[0].isShiny, false)
         XCTAssertNil(s.dex[0].nature)
         // 재인코딩 후 재디코딩도 안정적(라운드트립)
@@ -975,7 +1039,7 @@ final class CompanionIdentityTests: XCTestCase {
         // 1차 스토어: 부화 후 저장
         let s1 = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow },
                                 fileURL: url, rng: SeededRNG(seed: 5))
-        s1.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s1.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         await s1.hatch(baseID: 1)
         XCTAssertNotNil(s1.state.active)
 
@@ -989,7 +1053,7 @@ final class CompanionIdentityTests: XCTestCase {
         XCTAssertEqual(s2.state.active?.usedAtStage, 300_000_000, "라인 미로딩 중 델타가 유실되면 안 된다")
         XCTAssertEqual(s2.state.active?.stageIndex, 0)
         // update → loadCurrentLine 완료 시 적립분으로 진화 판정(드레인)
-        s2.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s2.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         for _ in 0..<50 where s2.currentLine == nil { await Task.yield() }
         XCTAssertNotNil(s2.currentLine)
         XCTAssertEqual(s2.state.active?.stageIndex, 1, "라인 로드 후 적립분으로 진화해야 한다")
@@ -1006,7 +1070,7 @@ final class CompanionIdentityTests: XCTestCase {
         let s = CompanionStore(provider: StubProvider(value: supportedLine), clock: { fixedNow },
                                fileURL: url, rng: SeededRNG(seed: 5))
 
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         for _ in 0..<50 where s.currentLine == nil { await Task.yield() }
 
@@ -1031,9 +1095,9 @@ final class CompanionIdentityTests: XCTestCase {
         guard let seed else { return XCTFail("shiny 시드 탐색 실패") }
 
         let s = store(linear3, seed: seed)
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         // 알 임계(5M) + stage0 임계(125M) 초과 → 부화 즉시 1회 진화하는 이월
-        s.update(todayTokens: 135_000_000, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 135_000_000], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         await s.hatchIfNeeded()
         XCTAssertEqual(s.state.active?.isShiny, true)
         XCTAssertEqual(s.state.active?.stageIndex, 1, "이월로 1회 진화했어야 함")
@@ -1043,9 +1107,9 @@ final class CompanionIdentityTests: XCTestCase {
     /// [회귀] 이월이 졸업 총량을 넘어 부화 즉시 졸업한 극단 케이스 — hatch 연출은 생략(이미 도감행).
     func testHatchCelebrationSkippedOnInstantGraduate() async {
         let s = store(noEvo, seed: 11)
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         // 알 임계 + 졸업 총량(750M) 초과
-        s.update(todayTokens: 800_000_000, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 800_000_000], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         await s.hatchIfNeeded()
         XCTAssertNil(s.state.active, "즉시 졸업")
         XCTAssertEqual(s.state.dex.count, 1)
@@ -1142,11 +1206,11 @@ final class CompanionIdentityTests: XCTestCase {
         st.lastDate = "d1"
         let s = samplerStore(p, seed: 5, preloadState: st)
         // 임계 미만 사용 → 부화는 안 되지만 프리패칭은 돌아야 한다
-        s.update(todayTokens: 1_000, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 1_000], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         for _ in 0..<50 where s.state.pendingHatchID == nil { await Task.yield() }
         XCTAssertEqual(s.state.pendingHatchID, 77, "알 상태에서 종이 미리 롤/저장돼야 한다")
         // 임계 도달 → 부화는 pending 그대로 (추가 선택 롤 없음: shiny/nature 만 소비)
-        s.update(todayTokens: 6_000_000, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 6_000_000], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         await s.hatchIfNeeded()
         XCTAssertEqual(s.state.active?.baseID, 77)
         XCTAssertNil(s.state.pendingHatchID, "부화 후 pending 은 비워져야 한다")
@@ -1159,7 +1223,7 @@ final class CompanionIdentityTests: XCTestCase {
         p.index = [BaseSpecies(id: 88, captureRate: 255)]
         p.failAll = true
         let s = samplerStore(p, seed: 9, preloadState: eggReadyState())
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         for _ in 0..<10 { await Task.yield() }        // 프리패치 시도 소진(실패)
         XCTAssertNil(s.state.pendingHatchID)
         await s.hatchIfNeeded()                        // 여전히 오프라인 → 알 유지

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -385,6 +385,38 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(s.state.usedSinceInstall, 2_200)
     }
 
+    /// [회귀] 날짜가 바뀌면 이전 날짜의 provider별 기준값과 비교하지 않고,
+    /// 새 날짜에 이미 사용한 누적값 전체를 적립한 뒤 이후 증가분을 이어서 적립한다.
+    func testDateRolloverCreditsCurrentDayUsage() {
+        let s = store(linear3)
+        useMap(s, ["codex": 0], date: "d1")
+        useMap(s, ["codex": 200], date: "d1")
+        XCTAssertEqual(s.state.usedSinceInstall, 200)
+
+        useMap(s, ["codex": 100], date: "d2")
+        XCTAssertEqual(s.state.usedSinceInstall, 300)
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider, ["codex": 100])
+
+        useMap(s, ["codex": 150], date: "d2")
+        XCTAssertEqual(s.state.usedSinceInstall, 350)
+    }
+
+    /// [회귀] stale snapshot처럼 오늘 provider map이 비어 있는 refresh는 날짜 경계를 소비하지
+    /// 않는다. 다음 유효한 새 날짜 snapshot이 들어오면 그 시점의 오늘 사용량을 적립한다.
+    func testStaleSnapshotDoesNotConsumeDateBoundary() {
+        let s = store(linear3)
+        useMap(s, ["codex": 0], date: "d1")
+        useMap(s, ["codex": 200], date: "d1")
+
+        useMap(s, [:], date: "d2", hasUsageData: true)
+        XCTAssertEqual(s.state.usedSinceInstall, 200)
+        XCTAssertEqual(s.state.lastDate, "d1")
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider, ["codex": 200])
+
+        useMap(s, ["codex": 100], date: "d2")
+        XCTAssertEqual(s.state.usedSinceInstall, 300)
+    }
+
     /// [마이그레이션] aggregate high-water mark만 가진 구버전 세이브는 값을 프로바이더별로
     /// 추정하지 않고 첫 유효 snapshot을 seed한다. 이후 증가분은 새 ledger로 정상 적립한다.
     func testLegacyAggregateLedgerSeedsProviderMapWithoutRetrospectiveCredit() throws {
@@ -412,8 +444,9 @@ final class CompanionStoreTests: XCTestCase {
     private func use(_ s: CompanionStore, _ today: Int, hasUsageData: Bool = true) {
         s.update(todayTokensByProvider: ["test": today], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: hasUsageData)
     }
-    private func useMap(_ s: CompanionStore, _ todayTokensByProvider: [String: Int], hasUsageData: Bool = true) {
-        s.update(todayTokensByProvider: todayTokensByProvider, todayDate: "d1", monthTotal: 0,
+    private func useMap(_ s: CompanionStore, _ todayTokensByProvider: [String: Int], date: String = "d1",
+                        hasUsageData: Bool = true) {
+        s.update(todayTokensByProvider: todayTokensByProvider, todayDate: date, monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: hasUsageData)
     }
 

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -401,6 +401,30 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(s.state.usedSinceInstall, 350)
     }
 
+    /// [회귀] 날짜 경계의 첫 refresh에서 provider 하나가 빠져도, 같은 날 복구된 현재 사용량을
+    /// 누락하지 않는다. 이전 날짜의 ledger 값은 새 날짜와 비교할 수 없으므로 복구 provider의
+    /// 새 날짜 기준은 0으로 열고, 그 날 처음 확인된 누적값을 적립한다.
+    func testLateProviderRecoveryAfterDateRolloverCreditsCurrentDayUsage() {
+        let s = store(linear3)
+        useMap(s, ["claude_code": 0, "codex": 0], date: "d1")
+        useMap(s, ["claude_code": 1_000, "codex": 500], date: "d1")
+        XCTAssertEqual(s.state.usedSinceInstall, 1_500)
+
+        // 날짜가 바뀐 첫 응답에는 codex가 빠졌다. Claude의 d2 사용량만 먼저 적립한다.
+        useMap(s, ["claude_code": 100], date: "d2")
+        XCTAssertEqual(s.state.usedSinceInstall, 1_600)
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider,
+                       ["claude_code": 100, "codex": 0])
+
+        // 같은 날 codex가 복구되면 d2의 현재 누적값 전체가 적립되어야 한다.
+        useMap(s, ["claude_code": 100, "codex": 700], date: "d2")
+        XCTAssertEqual(s.state.usedSinceInstall, 2_300)
+
+        // 이후에는 복구 시점 기준의 증가분만 적립한다.
+        useMap(s, ["claude_code": 100, "codex": 900], date: "d2")
+        XCTAssertEqual(s.state.usedSinceInstall, 2_500)
+    }
+
     /// [회귀] stale snapshot처럼 오늘 provider map이 비어 있는 refresh는 날짜 경계를 소비하지
     /// 않는다. 다음 유효한 새 날짜 snapshot이 들어오면 그 시점의 오늘 사용량을 적립한다.
     func testStaleSnapshotDoesNotConsumeDateBoundary() {

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -313,11 +313,46 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(s.state.usedSinceInstall, 100_000_000)
     }
 
+    /// [회귀] 로컬 사용량 재집계가 기존 값보다 낮아진 뒤에도, 새 기준점 이후의 증가분은 알에 반영한다.
+    /// 예전에는 claimedTodayTokens 를 high-water mark 로만 유지해 감소 후 증가가 영구히 무시됐다.
+    func testUsageIncreaseAfterValidDropContinuesEggProgress() {
+        let s = store(linear3)
+        base(s)
+        use(s, 200)
+        XCTAssertEqual(s.state.eggUsage, 200)
+
+        // 유효한 낮은 스냅샷: 이 자체는 토큰 사용량으로 지급하지 않고 기준점만 재설정한다.
+        use(s, 40)
+        XCTAssertEqual(s.state.eggUsage, 200)
+        XCTAssertEqual(s.state.claimedTodayTokens, 40)
+
+        // 새 기준점 이후의 증가분만 반영한다.
+        use(s, 75)
+        XCTAssertEqual(s.state.eggUsage, 235)
+        XCTAssertEqual(s.state.usedSinceInstall, 235)
+    }
+
+    /// [회귀] 데이터 공백/조회 실패로 today=0 이 들어와도 당일 기준점을 0으로 낮추지 않는다.
+    /// 다음 정상 조회 때 당일 전체를 중복 지급하면 안 된다.
+    func testEmptyUsageSnapshotDoesNotRebaseDailyLedger() {
+        let s = store(linear3)
+        base(s)
+        use(s, 200)
+
+        use(s, 0, hasUsageData: false) // 빈 스냅샷/조회 공백
+        XCTAssertEqual(s.state.eggUsage, 200)
+        XCTAssertEqual(s.state.claimedTodayTokens, 200)
+
+        use(s, 250)
+        XCTAssertEqual(s.state.eggUsage, 250)
+        XCTAssertEqual(s.state.usedSinceInstall, 250)
+    }
+
     private func base(_ s: CompanionStore) {
         s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
     }
-    private func use(_ s: CompanionStore, _ today: Int) {
-        s.update(todayTokens: today, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+    private func use(_ s: CompanionStore, _ today: Int, hasUsageData: Bool = true) {
+        s.update(todayTokens: today, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: hasUsageData)
     }
 
     func testEggDoesNotHatchBelowThreshold() async {

--- a/Tests/PokeTokenBarTests/DittoTests.swift
+++ b/Tests/PokeTokenBarTests/DittoTests.swift
@@ -100,7 +100,7 @@ final class DittoRevealTests: XCTestCase {
 
     /// update → loadCurrentLine → applyUsage(0) → (임계 초과 시) revealDitto 비동기 체인을 드레인.
     private func drainReveal(_ s: CompanionStore) async {
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
         for _ in 0..<200 where !(s.state.active?.dittoRevealed ?? false) { await Task.yield() }
     }
 
@@ -179,7 +179,7 @@ final class DittoRevealTests: XCTestCase {
         let s = CompanionStore(provider: provider, clock: { dNow }, fileURL: url,
                                rng: SeededRNG(seed: selectedSeed), dittoDisguiseRollingEnabled: true)
 
-        s.update(todayTokens: 0, todayDate: "d1", monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         let deadline = Date().addingTimeInterval(1)
         while !(await provider.isSuspended()), Date() < deadline {

--- a/Tests/PokeTokenBarTests/ModelLogicTests.swift
+++ b/Tests/PokeTokenBarTests/ModelLogicTests.swift
@@ -256,7 +256,7 @@ final class StatePersistenceLogicTests: XCTestCase {
         st.installBaselineSet = true
         st.usedSinceInstall = 42
         st.eggUsage = 1234
-        st.claimedTodayTokens = 7
+        st.claimedTodayTokensByProvider = ["test": 7]
         st.lastDate = "2026-06-27"
         st.collectedFinals = ["1:3", "10:12"]
         st.language = .ja
@@ -268,6 +268,7 @@ final class StatePersistenceLogicTests: XCTestCase {
         XCTAssertEqual(back.installBaselineSet, true)
         XCTAssertEqual(back.usedSinceInstall, 42)
         XCTAssertEqual(back.eggUsage, 1234)
+        XCTAssertEqual(back.claimedTodayTokensByProvider, ["test": 7])
         XCTAssertEqual(back.lastDate, "2026-06-27")
         XCTAssertEqual(back.collectedFinals, ["1:3", "10:12"])
         XCTAssertEqual(back.language, .ja)

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -52,7 +52,7 @@ final class StorePerformanceTests: XCTestCase {
         measure {
             for _ in 0..<500 {
                 token += 100
-                s.update(todayTokens: token, todayDate: "d", monthTotal: 0,
+                s.update(todayTokensByProvider: ["test": token], todayDate: "d", monthTotal: 0,
                          burnTier: .normal, limitWarning: false, hasUsageData: true)
             }
         }

--- a/Tests/PokeTokenBarTests/PremiumEggTests.swift
+++ b/Tests/PokeTokenBarTests/PremiumEggTests.swift
@@ -376,7 +376,7 @@ final class PremiumEggTests: XCTestCase {
         imported.eggTier = .uncommon
         imported.usedSinceInstall = 1_000_000
         let rebased = SaveTransfer.rebasedForThisDevice(imported, current: CompanionState(),
-                                                        todayTokens: 0, todayDate: "d", hasUsageData: true)
+                                                        todayTokensByProvider: ["test": 0], todayDate: "d", hasUsageData: true)
         XCTAssertEqual(rebased.eggTier, .uncommon)
     }
 

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -85,7 +85,7 @@ final class SaveTransferTests: XCTestCase {
         s.installBaselineSet = true
         s.usedSinceInstall = 8_000_000_000
         s.spentTokens = 3_500_000_000
-        s.claimedTodayTokens = 56_800_000
+        s.claimedTodayTokensByProvider = ["test": 56_800_000]
         s.lastDate = today
         s.inventory = ["rareCandy": 2]
         s.collectedFinals = ["1-3"]
@@ -166,7 +166,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [회귀] 이전 당일에 새 Mac 에서 쓴 토큰이 조용히 누락되던 결함.
     ///
-    /// `claimedTodayTokens` 는 "이 기기가 오늘 어디까지 적립했나"인데 옛 기기 값(56.8M)이 그대로
+    /// `claimedTodayTokensByProvider` 는 "이 기기가 프로바이더별로 오늘 어디까지 적립했나"인데 옛 기기 값(56.8M)이 그대로
     /// 따라오면 `update` 의 `todayTokens > claimedTodayTokens` 게이트가 하루 종일 거짓이 된다.
     /// 대조군(재정렬 없음)을 같이 돌려 트리거 브랜치를 실제로 밟는지 확인한다.
     func testTransferDayTokensStillCountAfterRebase() throws {
@@ -180,7 +180,7 @@ final class SaveTransferTests: XCTestCase {
         try JSONEncoder().encode(imported).write(to: rawURL)
         let raw = store(at: rawURL)
         let rawBefore = raw.state.usedSinceInstall
-        raw.update(todayTokens: newMacTodayLater, todayDate: today, monthTotal: 0,
+        raw.update(todayTokensByProvider: ["test": newMacTodayLater], todayDate: today, monthTotal: 0,
                    burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(raw.state.usedSinceInstall - rawBefore, 0,
                        "재현 실패 — 이 대조군이 0 이 아니면 결함 조건이 바뀐 것이므로 테스트가 무의미해진다")
@@ -191,14 +191,14 @@ final class SaveTransferTests: XCTestCase {
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
         let envelope = try SaveTransfer.decode(data)
-        try s.applySave(envelope, todayTokens: newMacTodaySoFar, todayDate: today, hasUsageData: true)
+        try s.applySave(envelope, todayTokensByProvider: ["test": newMacTodaySoFar], todayDate: today, hasUsageData: true)
 
-        XCTAssertEqual(s.state.claimedTodayTokens, newMacTodaySoFar)
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider?["test"], newMacTodaySoFar)
         XCTAssertEqual(s.state.lastDate, today)
         XCTAssertTrue(s.state.installBaselineSet)
 
         let before = s.state.usedSinceInstall
-        s.update(todayTokens: newMacTodayLater, todayDate: today, monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": newMacTodayLater], todayDate: today, monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.state.usedSinceInstall - before, newMacTodayLater - newMacTodaySoFar,
                        "이전 당일에도 새 Mac 에서 쓴 증분이 적립돼야 한다")
@@ -212,19 +212,19 @@ final class SaveTransferTests: XCTestCase {
         let s = store(at: url)
         let data = try SaveTransfer.encode(state: oldMacState(today: today), appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        try s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: false)
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: ["test": 0], todayDate: today, hasUsageData: false)
 
         XCTAssertFalse(s.state.installBaselineSet)
 
         // 데이터가 도착하는 첫 틱은 baseline 만 잡고 적립하지 않는다.
         let before = s.state.usedSinceInstall
-        s.update(todayTokens: 40_000_000, todayDate: today, monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 40_000_000], todayDate: today, monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.state.usedSinceInstall, before, "도착 시점의 하루치를 소급 적립하지 않는다")
-        XCTAssertEqual(s.state.claimedTodayTokens, 40_000_000)
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider?["test"], 40_000_000)
 
         // 그 다음부터는 정상 적립.
-        s.update(todayTokens: 41_000_000, todayDate: today, monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 41_000_000], todayDate: today, monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertEqual(s.state.usedSinceInstall - before, 1_000_000)
     }
@@ -242,7 +242,7 @@ final class SaveTransferTests: XCTestCase {
         let s = store(at: url)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1, todayDate: today, hasUsageData: true)
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: ["test": 1], todayDate: today, hasUsageData: true)
 
         XCTAssertEqual(s.state.usedSinceInstall, 8_000_000_000)
         XCTAssertEqual(s.state.spentTokens, 3_500_000_000)
@@ -268,7 +268,7 @@ final class SaveTransferTests: XCTestCase {
 
         let data = try SaveTransfer.encode(state: oldMacState(today: today), appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        try s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: true)
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: ["test": 0], todayDate: today, hasUsageData: true)
 
         let backup = url.deletingLastPathComponent()
             .appendingPathComponent(SaveTransfer.backupFileName(date: transferNow))
@@ -296,7 +296,7 @@ final class SaveTransferTests: XCTestCase {
                                    stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: ["test": 1],
                     todayDate: "2026-08-03", hasUsageData: true)
 
         await release.fire()
@@ -335,7 +335,7 @@ final class SaveTransferTests: XCTestCase {
                                    stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: ["test": 1],
                     todayDate: "2026-08-03", hasUsageData: true)
 
         await release.fire()
@@ -367,7 +367,7 @@ final class SaveTransferTests: XCTestCase {
                                    stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: ["test": 1],
                     todayDate: "2026-08-03", hasUsageData: true)
         XCTAssertNil(s.currentLine, "전제: 부화 락에 막혀 라인이 아직 없다")
 
@@ -394,10 +394,10 @@ final class SaveTransferTests: XCTestCase {
                                    stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        try s.applySave(try SaveTransfer.decode(data), todayTokens: 0, todayDate: today, hasUsageData: false)
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: ["test": 0], todayDate: today, hasUsageData: false)
         XCTAssertFalse(s.state.installBaselineSet, "전제: baseline 판정을 미룬 상태")
 
-        s.update(todayTokens: 0, todayDate: today, monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 0], todayDate: today, monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: false)
         XCTAssertNotNil(s.state.active, "개체는 그대로 있어야 한다")
         XCTAssertEqual(s.displayState, .idle, "개체가 있는데 알로 표시하면 안 된다")
@@ -405,7 +405,7 @@ final class SaveTransferTests: XCTestCase {
         // 알 상태에서 같은 경로를 타면 여전히 알이어야 한다(반대 방향 고정).
         let eggURL = tempURL("stillegg")
         let e = store(at: eggURL)
-        e.update(todayTokens: 0, todayDate: today, monthTotal: 0,
+        e.update(todayTokensByProvider: ["test": 0], todayDate: today, monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: false)
         XCTAssertEqual(e.displayState, .egg)
     }
@@ -420,7 +420,7 @@ final class SaveTransferTests: XCTestCase {
         evil.usedSinceInstall = Int.max
         evil.spentTokens = Int.min
         evil.eggUsage = Int.max
-        evil.claimedTodayTokens = -42
+        evil.claimedTodayTokensByProvider = ["test": -42]
         evil.active = MonState(baseID: 1, pathIDs: [1], plannedPathIDs: [1],
                                stageIndex: Int.max, usedAtStage: Int.max, rarity: .common,
                                totalForms: Int.max)
@@ -433,7 +433,7 @@ final class SaveTransferTests: XCTestCase {
         XCTAssertEqual(s.usedSinceInstall, SaveTransfer.maxTokenValue)
         XCTAssertEqual(s.spentTokens, 0, "음수는 0 으로")
         XCTAssertEqual(s.eggUsage, SaveTransfer.maxTokenValue)
-        XCTAssertEqual(s.claimedTodayTokens, 0)
+        XCTAssertEqual(s.claimedTodayTokensByProvider?["test"], 0)
         XCTAssertEqual(s.active?.usedAtStage, SaveTransfer.maxTokenValue)
         XCTAssertEqual(s.active?.totalForms, 12)
         XCTAssertEqual(s.active?.stageIndex, 0, "pathIDs 범위를 넘지 않아야 한다")
@@ -441,9 +441,9 @@ final class SaveTransferTests: XCTestCase {
         // 정규화된 값으로 실제 산술 경로를 태워 트랩이 안 나는지 확인한다.
         let url = tempURL("clamped")
         let store = store(at: url)
-        try store.applySave(envelope, todayTokens: 0, todayDate: "2026-08-03", hasUsageData: true)
+        try store.applySave(envelope, todayTokensByProvider: ["test": 0], todayDate: "2026-08-03", hasUsageData: true)
         XCTAssertGreaterThanOrEqual(store.availableTokens, 0)
-        store.update(todayTokens: 1_000, todayDate: "2026-08-03", monthTotal: 0,
+        store.update(todayTokensByProvider: ["test": 1_000], todayDate: "2026-08-03", monthTotal: 0,
                      burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertLessThanOrEqual(store.state.usedSinceInstall, SaveTransfer.maxTokenValue + 1_000)
     }
@@ -463,11 +463,11 @@ final class SaveTransferTests: XCTestCase {
         XCTAssertEqual(s.state.usedSinceInstall, SaveTransfer.maxTokenValue)
         XCTAssertEqual(s.state.spentTokens, 0)
         XCTAssertEqual(s.state.eggUsage, SaveTransfer.maxTokenValue)
-        XCTAssertEqual(s.state.claimedTodayTokens, 0)
+        XCTAssertNil(s.state.claimedTodayTokensByProvider, "구버전 aggregate field는 프로바이더별 ledger로 추정하지 않는다")
 
         // 정규화된 값으로 실제 산술 경로를 태워 트랩이 안 나는지 확인(이 줄이 예전엔 SIGTRAP).
         XCTAssertGreaterThanOrEqual(s.availableTokens, 0)
-        s.update(todayTokens: 1_000, todayDate: "2026-08-03", monthTotal: 0,
+        s.update(todayTokensByProvider: ["test": 1_000], todayDate: "2026-08-03", monthTotal: 0,
                  burnTier: .idle, limitWarning: false, hasUsageData: true)
         XCTAssertLessThanOrEqual(s.state.usedSinceInstall, SaveTransfer.maxTokenValue + 1_000)
     }
@@ -480,7 +480,7 @@ final class SaveTransferTests: XCTestCase {
         // eggTier(알 등급 보증) = 진행 — 산 물건이지 이 기기의 장부가 아니라 기기를 옮겨도 따라간다.
         let progress: Set<String> = ["usedSinceInstall", "spentTokens", "eggUsage", "eggTier",
                                      "pendingHatchID", "active", "dex", "collectedFinals", "inventory"]
-        let deviceLedger: Set<String> = ["installBaselineSet", "claimedTodayTokens", "lastDate"]
+        let deviceLedger: Set<String> = ["installBaselineSet", "claimedTodayTokensByProvider", "lastDate"]
         let accountLedger: Set<String> = ["candyGrantTier", "candyFeatureSeeded"]
         let devicePreference: Set<String> = ["language"]
 
@@ -508,7 +508,7 @@ final class SaveTransferTests: XCTestCase {
         imported.language = .ja
         let data = try SaveTransfer.encode(state: imported, appVersion: "2.5.0",
                                            deviceName: "JA Mac", now: transferNow)
-        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: ["test": 1],
                         todayDate: today, hasUsageData: true)
 
         XCTAssertEqual(s.language, .en, "불러온 세이브의 언어가 이 기기 설정을 덮으면 안 된다")
@@ -531,7 +531,7 @@ final class SaveTransferTests: XCTestCase {
         older.candyGrantTier = ["weekly|B": 50, "five_hour|C": 100]
         let data = try SaveTransfer.encode(state: older, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
-        try s.applySave(try SaveTransfer.decode(data), todayTokens: 1,
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: ["test": 1],
                         todayDate: today, hasUsageData: true)
 
         XCTAssertEqual(s.state.candyGrantTier["five_hour|A"], 100, "이 기기가 이미 지급한 창이 사라지면 재지급된다")
@@ -561,7 +561,7 @@ final class SaveTransferTests: XCTestCase {
         let data = try SaveTransfer.encode(state: oldMacState(today: today), appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
         let envelope = try SaveTransfer.decode(data)
-        XCTAssertThrowsError(try s.applySave(envelope, todayTokens: 1, todayDate: today, hasUsageData: true)) {
+        XCTAssertThrowsError(try s.applySave(envelope, todayTokensByProvider: ["test": 1], todayDate: today, hasUsageData: true)) {
             XCTAssertEqual($0 as? SaveTransferError, .backupFailed)
         }
         XCTAssertEqual(s.state.usedSinceInstall, 123_456_789, "중단했으면 진행이 그대로여야 한다")
@@ -584,13 +584,13 @@ final class SaveTransferTests: XCTestCase {
         var first = oldMacState(today: today); first.usedSinceInstall = 222
         try s.applySave(try SaveTransfer.decode(
             try SaveTransfer.encode(state: first, appVersion: "2.5.0", deviceName: "A", now: transferNow)),
-                        todayTokens: 1, todayDate: today, hasUsageData: true)
+                        todayTokensByProvider: ["test": 1], todayDate: today, hasUsageData: true)
 
         clock.now = transferNow.addingTimeInterval(60)   // 다음 백업은 다른 슬롯
         var second = oldMacState(today: today); second.usedSinceInstall = 333
         try s.applySave(try SaveTransfer.decode(
             try SaveTransfer.encode(state: second, appVersion: "2.5.0", deviceName: "B", now: transferNow)),
-                        todayTokens: 1, todayDate: today, hasUsageData: true)
+                        todayTokensByProvider: ["test": 1], todayDate: today, hasUsageData: true)
 
         let dir = url.deletingLastPathComponent()
         let backups = try FileManager.default.contentsOfDirectory(atPath: dir.path)
@@ -622,14 +622,14 @@ final class SaveTransferTests: XCTestCase {
         let a = store(at: tempURL("dispA"))
         try a.applySave(try SaveTransfer.decode(
             try SaveTransfer.encode(state: withMon, appVersion: "2.5.0", deviceName: "A", now: transferNow)),
-                        todayTokens: 1, todayDate: today, hasUsageData: true)
+                        todayTokensByProvider: ["test": 1], todayDate: today, hasUsageData: true)
         XCTAssertEqual(a.displayState, .idle)
 
         let eggOnly = oldMacState(today: today)   // active == nil
         let b = store(at: tempURL("dispB"))
         try b.applySave(try SaveTransfer.decode(
             try SaveTransfer.encode(state: eggOnly, appVersion: "2.5.0", deviceName: "B", now: transferNow)),
-                        todayTokens: 1, todayDate: today, hasUsageData: true)
+                        todayTokensByProvider: ["test": 1], todayDate: today, hasUsageData: true)
         XCTAssertEqual(b.displayState, .egg)
     }
 

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -229,6 +229,37 @@ final class SaveTransferTests: XCTestCase {
         XCTAssertEqual(s.state.usedSinceInstall - before, 1_000_000)
     }
 
+    /// [회귀] stale snapshot만 남아 `hasUsageData`는 true인데 오늘 map은 비어 있는 상태로
+    /// 세이브를 불러와도, 빈 provider ledger를 유효한 기준점으로 저장하면 안 된다.
+    /// 첫 정상 snapshot은 baseline으로만 잡고, 그 이후 증가분부터 적립해야 한다.
+    func testImportWithStaleOnlyUsageDefersBaselineInsteadOfSeedingEmptyLedger() throws {
+        let today = "2026-08-03"
+        let url = tempURL("stale-only")
+        let s = store(at: url)
+        let data = try SaveTransfer.encode(state: oldMacState(today: today), appVersion: "2.5.0",
+                                           deviceName: "Old Mac", now: transferNow)
+
+        // snapshots가 stale이거나 carrier만 남은 상태: 표시용 hasUsageData는 true지만
+        // 오늘 날짜가 확인된 provider 데이터는 없다.
+        try s.applySave(try SaveTransfer.decode(data), todayTokensByProvider: [:], todayDate: today,
+                        hasUsageData: true)
+
+        XCTAssertFalse(s.state.installBaselineSet)
+        XCTAssertNil(s.state.claimedTodayTokensByProvider)
+        XCTAssertEqual(s.state.lastDate, "")
+
+        let before = s.state.usedSinceInstall
+        s.update(todayTokensByProvider: ["test": 40_000_000], todayDate: today, monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.state.usedSinceInstall, before, "첫 정상 snapshot은 baseline만 설정해야 한다")
+        XCTAssertEqual(s.state.claimedTodayTokensByProvider?["test"], 40_000_000)
+
+        s.update(todayTokensByProvider: ["test": 41_000_000], todayDate: today, monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        XCTAssertEqual(s.state.usedSinceInstall - before, 1_000_000,
+                       "빈 ledger로 import해도 이후 증가분은 정상 적립돼야 한다")
+    }
+
     // MARK: 진행 보존 · 가드레일
 
     func testImportKeepsProgressAndCandyGrantLedger() throws {

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -603,6 +603,33 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(store.todayTokensByProvider, ["claude_code": 100_000_000])
     }
 
+    /// [회귀] 한 provider의 성공 응답이 today=nil이 된 partial snapshot에서도 다른 provider의
+    /// 당일 값은 유지하고, 빠졌던 provider가 실제 refresh 결과에 복귀하면 다시 map에 포함한다.
+    /// CompanionStore가 이 map을 소비할 때 provider별 ledger line을 보존할 수 있도록 하는 경계 테스트다.
+    func testRefreshPreservesProviderIdentityAcrossPartialSnapshotLossAndRecovery() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code",
+                                       daily: todayDaily(1_000))
+        let codex = FakeUsageProvider(id: "codex", displayName: "Codex", daily: todayDaily(500))
+        let store = makeStore(providers: [claude, codex])
+
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.todayTokensByProvider,
+                       ["claude_code": 1_000, "codex": 500])
+
+        // 성공했지만 오늘 데이터가 없는 응답은 해당 provider snapshot을 제거한다.
+        codex.daily = nil
+        claude.daily = todayDaily(1_200)
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.todayTokensByProvider, ["claude_code": 1_200])
+        XCTAssertEqual(store.snapshots.map(\.providerID), ["claude_code"])
+
+        // 복구된 provider는 같은 provider ID로 map에 돌아온다.
+        codex.daily = todayDaily(700)
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertEqual(store.todayTokensByProvider,
+                       ["claude_code": 1_200, "codex": 700])
+    }
+
     func testProviderFailureKeepsPreviousTodayValue() async {
         let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(100_000_000))
         let store = makeStore(providers: [claude])

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -572,6 +572,9 @@ final class UsageStoreTests: XCTestCase {
         let store = makeStore(providers: [claude, codex])
         await store.refresh(scheduleEmptyRetry: false)
         XCTAssertEqual(store.todayTotalTokens, 150_000_000)
+        XCTAssertEqual(store.todayTokensByProvider,
+                       ["claude_code": 100_000_000, "codex": 50_000_000])
+        XCTAssertEqual(store.todayTokensByProvider.values.reduce(0, +), store.todayTotalTokens)
         XCTAssertNotNil(store.lastUpdated)
         XCTAssertNil(store.lastErrorDescription)
     }
@@ -585,6 +588,7 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertTrue(store.hasUsageData)
         XCTAssertEqual(store.snapshots.count, 1)        // claude 는 today nil → 스냅샷 미생성
         XCTAssertEqual(store.snapshots.first?.providerID, "codex")
+        XCTAssertEqual(store.todayTokensByProvider, ["codex": 50_000_000])
     }
 
     func testStaleDatedSnapshotExcludedFromTodayTotal() async {
@@ -596,6 +600,7 @@ final class UsageStoreTests: XCTestCase {
         let store = makeStore(providers: [claude, codex])
         await store.refresh(scheduleEmptyRetry: false)
         XCTAssertEqual(store.todayTotalTokens, 100_000_000)   // codex 999 제외
+        XCTAssertEqual(store.todayTokensByProvider, ["claude_code": 100_000_000])
     }
 
     func testProviderFailureKeepsPreviousTodayValue() async {


### PR DESCRIPTION
## Summary

- Rebase the companion's daily usage ledger when a valid usage snapshot decreases.
- Continue crediting only positive usage deltas observed after the new baseline.
- Preserve the previous baseline when usage data is empty or unavailable.
- Add regression logging and tests for drop-and-recovery scenarios.

## Root cause

The companion ledger treated `todayTokens` as a monotonic counter and only processed values greater than `claimedTodayTokens`. Codex daily usage is recalculated from local rollout files and can decrease after replay, deduplication, or file updates. Once the snapshot dropped below the previous high-water mark, later usage was ignored and egg progress stopped.

## Behavior change

A valid lower snapshot becomes the new daily baseline without subtracting existing progress. Subsequent increases are credited from that baseline. Empty or unavailable usage data does not rebase the ledger, preventing a temporary zero from crediting the entire day again.

## Validation

- Local `swift build` passed with Xcode 26.6.
- Local `./scripts/test-gate.sh` passed: 519 tests executed, 7 skipped, 0 failures.
- Local logic-core line coverage passed: 89.29% (75% threshold).
- GitHub Actions `build-test` passed on `macos-15`.
- GitHub Actions `secret-scan` passed.
