### PR TITLE
feat: find Claude usage logs outside the default project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,15 @@ build/
 *.cer
 *.certSigningRequest
 
-# Personal dev notes (kept locally, not published)
-docs/
+# Personal dev notes (kept locally, not published).
+# docs/reference/ is the exception: published agent/contributor reference docs.
+# (Must ignore docs/* rather than docs/ — git cannot re-include inside an excluded directory.)
+docs/*
+!docs/reference/
 
 # Agent worktrees / local state
 .claude/
 .worktrees/
+
+# Local-only review-gate opt-out (not published)
+.no-review-gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # PokeTokenBar — Claude 프로젝트 지침
 
+이 파일은 **매 세션 전문이 로드된다.** 그래서 여기엔 *항상 적용되는 규칙*만 둔다.
+길고 상황별인 절차는 `docs/reference/` 로 내리고 아래 인덱스에서 "언제 읽는가"로 가리킨다.
+새 규칙을 더할 때도 같은 기준으로 배치한다 — 항상 적용이면 여기, 특정 작업 때만이면 참조 문서.
+
+## 참조 문서 (필요할 때 읽는다)
+
+| 문서 | 언제 읽나 |
+|---|---|
+| `docs/reference/release-workflow.md` | 버전을 배포할 때, `release.sh` 게이트에 막혔을 때, UI 변경으로 스크린샷·랜딩을 갱신할 때 |
+| `docs/reference/provider-extension.md` | 새 사용량 소스·버전매니저·로그 루트를 추가할 때, 프로바이더 분기를 리뷰할 때 |
+| `docs/reference/defect-log.md` | 결함·회귀를 고치는 중(부류 스윕 근거), 동시성·캐시·외부 로그 포맷·상시 애니메이션·세이브 이전을 건드릴 때 |
+
+각 문서의 frontmatter(`summary`/`read_when`)가 그 문서의 적용 범위를 다시 명시한다.
+
 ## 기여 언어 규약 (오픈소스 대비 — English first)
 
 외부 컨트리뷰션을 받을 수 있도록 이 저장소는 **영어를 first language** 로 한다.
@@ -14,58 +28,29 @@
 ## 릴리스 (자연어 트리거)
 
 사용자가 **버전 배포를 자연어로 요청**하면 — 예: "배포해줘", "릴리스 올려줘", "패치 배포",
-"2.1.1 배포", "release", "다음 버전 내줘" — 한 줄 명령을 시키지 말고 아래를 직접 수행한다.
+"2.1.1 배포", "release", "다음 버전 내줘" — 한 줄 명령을 시키지 말고 직접 수행한다.
 
-1. **문서·이미지 갱신 (매 릴리스 필수 — "할까요?" 묻지 말고 무조건 한다).** `./scripts/release.sh
-   --check-only` 로 경고 확인 후 아래를 모두 반영한다.
-   - **README.md/ko/ja**: 기능 목록·how-it-works·스크린샷 참조.
-   - **랜딩(gh-pages orphan 브랜치) — 필수.** `git worktree add /tmp/ptb-ghpages gh-pages` → `index.html`
-     기능 카드(f#) + i18n 사전(en/ko/ja 동시·키 정합) 갱신 → 커밋 → `git push origin gh-pages` →
-     `git worktree remove`. (Pages 자동 재빌드. 커밋은 gh-pages log 모방 = `landing:` 프리픽스.)
-   - **스크린샷(`assets/`)**: UI(`Sources/PokeTokenBar/UI/`) 변경 시 재생성. 기존 방식 = **HTML 렌더**
-     (팝오버 라이브 캡처 아님) — Chrome `--headless --screenshot --force-device-scale-factor=2` 로 다크
-     팝오버를 720px PNG 로 그린다. 애니 GIF(home)는 프레임 합성 후 `gifsicle -O3 --lossy` 로 최적화
-     (PIL 재인코딩 단독은 용량 팽창 주의). 언어별 이미지(`settings.png`/`-ko`/`-ja` 등) 각 README 참조.
-   - homebrew-tap cask caveat.
-   - **함정:** `release.sh` 문서검토는 *커밋된* 상태를 비교 → 스크린샷을 스테이징만 하면 경고 프롬프트가
-     여전히 뜬다. 미리 커밋하거나 프롬프트에 `y`(스테이징분이 release.sh line 93-94 에서 릴리스 커밋에 함께 담김). (`RELEASE.md` 체크리스트)
-   - **신규 기능 = 신규 에셋 (하드 게이트, 프롬프트로 못 넘김).** 직전 태그 이후 `Sources/**/UI/` 를 건드린
-     `feat:` 커밋이 있는데 `assets/` 에 **새로 추가된** 파일이 없으면 `release.sh` 가 중단한다
-     (**예외 없음** — 통과시키려면 에셋을 만들거나 커밋 타입을 바꿔야 한다). 기존 staleness 검사는 "에셋이 하나라도 바뀌었나"만
-     보기 때문에 **기존 스크린샷만 다시 그려도 통과**한다 — 2.5.0 에서 플로팅 펫이 이미지 없이 나간 경로가
-     정확히 이것이다(`settings.png` 를 갱신해 둔 탓에 조용히 통과). 갱신(stale)과 커버리지(신규)는 다른 질문이다.
-2. **버전 결정** (2026-07-03 확정 규칙): 사용자가 말한 **단어가 곧 세그먼트 지정 명령**이다 —
-   릴리스에 기능이 포함돼 있어도 변경 내용으로 재해석하지 않는다.
-   - "**패치**(해줘)" → x.y.**Z+1** / "**마이너**" → x.**Y+1**.0 / "**메이저**" → **X+1**.0.0
-   - 버전을 직접 명시하면("2.4.1 배포") 그 값 그대로.
-   - 세그먼트 지정 없이 "배포/릴리스"만 말하면: 변경 성격 기준으로 제안 후 확인받고 진행.
-3. **릴리스 노트 작성** 후 실행 (반드시 `main` 브랜치에서):
-   ```bash
-   # 직전 릴리스 이후 변경을 요약해 노트 파일 작성
-   PTB_NOTES_FILE=/tmp/ptb-notes.md ./scripts/release.sh <version>
-   ```
-   스크립트가 test-gate → 문서검토 → 범프 → 빌드검증 → 커밋·push → GitHub Release → cask → Pages 를 순서대로 수행.
-4. **검증**: 완료 후 `brew upgrade --cask poke-token-bar` 로 실제 업그레이드 동작 확인.
+**버전 결정** (2026-07-03 확정 규칙): 사용자가 말한 **단어가 곧 세그먼트 지정 명령**이다 —
+릴리스에 기능이 포함돼 있어도 변경 내용으로 재해석하지 않는다.
+
+- "**패치**(해줘)" → x.y.**Z+1** / "**마이너**" → x.**Y+1**.0 / "**메이저**" → **X+1**.0.0
+- 버전을 직접 명시하면("2.4.1 배포") 그 값 그대로.
+- 세그먼트 지정 없이 "배포/릴리스"만 말하면: 변경 성격 기준으로 제안 후 확인받고 진행.
+
+**문서·스크린샷·랜딩 갱신은 매 릴리스 필수다 — "할까요?" 묻지 말고 무조건 한다.**
+실행 절차·에셋 게이트·함정은 `docs/reference/release-workflow.md`, 체크리스트는 `RELEASE.md`.
 
 릴리스는 외부 공개(비가역)이므로 실행 직전 **적용할 버전과 노트 요약을 한 번 보여준 뒤** 진행한다.
-세부 절차·체크리스트는 `RELEASE.md` 참고.
 
-## 확장 규약 (새 프로바이더/툴 추가 시 — 리뷰에서 위반 확인)
+## 확장 규약 (새 프로바이더/툴 추가 시)
 
-새 AI CLI(사용량 소스)·버전매니저를 더할 때 특정 플랫폼에 종속된 분기를 만들지 않는다.
-아래는 절차이며, 코드 리뷰 시 이 규약 위반을 결함으로 본다.
+특정 플랫폼에 종속된 분기를 만들지 않는다. 손댈 지점은 정해져 있다 — 사용량 소스는
+`UsageProvider` 구현체 + `UsageStore.init` 의 `providers:` 배열, 버전매니저는
+`BinaryLocator.commonToolDirectories()`, 로그 루트는 프로바이더별 루트 목록(예:
+`LocalUsageReader.claudeProjectRoots`). 범용 경로(오늘/주/월 합계·burn·companion)에
+`== "claude_code"` 류 리터럴 분기를 넣는 건 금지.
 
-- **사용량 소스 추가** = `UsageProvider` 프로토콜(`Core/UsageProvider.swift`) 구현체 1개 작성 +
-  `UsageStore.init` 의 기본 `providers:` 배열(`Core/UsageStore.swift`)에 등록. 이 두 곳이 유일한 손댈 지점.
-- **범용 동작은 프로바이더 무관하게 집계**: 오늘/주/월 합계·burn tier·companion 리듬은 전 프로바이더
-  합산이어야 한다(`snapshots` reduce). 한 프로바이더에만 계산을 붙이지 마라(과거 회귀: burn 이 Claude
-  블록만 관측 → Codex/Gemini 전용 사용자 companion 이 항상 idle). 패리티 테스트가 이를 강제한다
-  (`UsageStoreTests` 의 "unknown provider" 계열).
-- **프로바이더 고유 동작만 `providerID` 로 명시 분기**: 공식 한도(Claude=HTTP·Codex=프로세스),
-  5h forecast·"현재 블록" 행처럼 *특정 프로바이더에만 존재하는* 기능만 id 로 조건 분기한다.
-  범용 경로에 `== "claude_code"` 류 리터럴 분기를 추가하는 건 금지.
-- **버전매니저/설치경로 추가** = `BinaryLocator.commonToolDirectories()` 한 곳에만 추가한다
-  (탐색·자식 프로세스 PATH 보강이 이 단일 소스를 공유).
+전체 규약과 리뷰 기준은 `docs/reference/provider-extension.md`.
 
 ## 결함 대응 프로토콜 (잘못·회귀·공백·결함이 드러날 때마다 매번)
 
@@ -75,124 +60,10 @@
 1. **근본원인 (5-whys — 테스트·리뷰 공백까지).** 증상 → 직접원인 → **"테스트/리뷰가 있었는데 왜
    못 걸렀나"** 를 반드시 답한다. 대개 테스트가 결함 트리거와 *다른 경로*로 통과해 false confidence 를 준다.
 2. **부류 스윕.** 같은 부류(같은 API 오용·같은 패턴)를 코드베이스 전수 grep·검증. 하나만 고치고 끝내지 않는다.
+   축적된 부류 목록이 `docs/reference/defect-log.md` 다 — 스윕 전에 그 문서를 먼저 훑는다.
 3. **회귀 테스트 — 트리거 브랜치를 검증.** 결함을 유발하는 *바로 그 조건/브랜치*를 재현한다.
    `A || B` 게이트면 **B 단독**(A=false, B=true)도 검증. (활성 블록이 있는 케이스로만 테스트해서
-   주/월-only 경로를 못 밟은 게 #56 회귀의 원인.)
-4. **영구 캡처 (기억이 아니라 메커니즘).** 재발 방지는 테스트·게이트·CLAUDE.md·스크립트 중 *기계로
-   막을 수 있는* 형태로 남긴다. 릴리스 관련이면 `release.sh` 게이트, 절차면 이 문서.
-
-**축적된 구체 규칙:**
-- **옵셔널 tautology.** 옵셔널 필드라도 *생산자가 항상 채우면* `x != nil` 은 항상 참이다. "값이 있나"는
-  의미값으로 검사한다(예: `totalTokens > 0`, 또는 진짜 nil 가능한 필드 `activeBlock`). — weekTotal 회귀(#56).
-- **UI 변경 → 스크린샷 stale** 은 `release.sh` 가 자동 경고(§릴리스 1) — 통과의례화 방지.
-- **앱 소유 keychain 항목 금지.** 앱이 만든 keychain 항목은 코드서명(cdhash)이 바뀔 때마다(로컬 재빌드·
-  실사용자 매 업그레이드) 항목 ACL 이 안 맞아 접근 허용 프롬프트를 유발한다 — **no-UI 쿼리로도 이 ACL
-  프롬프트는 억제 안 됨**(#58). 토큰류는 인메모리 캐시 + 파일(`~/.claude/.credentials.json`) 재취득으로
-  처리하고, 앱 전용 keychain 캐시 항목을 새로 만들지 말 것.
-- **자동 폴링은 Claude 키체인을 절대 읽지 마라(키체인 읽기는 사용자 동작 전용).** no-UI 쿼리
-  (`kSecUseAuthenticationUIFail`/`LAContext`)는 '인증' 프롬프트만 억제할 뿐 **잠긴·미승인 login 키체인의
-  '암호 입력' 다이얼로그는 못 막는다** — 실측: 캐시 만료 폴 도중 `SecItemCopyMatching` 이 13초간 블록하며
-  팝업(토큰 만료 시점마다 하루 몇 회, 아침 등). self-signed 앱은 '항상 허용' 승인도 불안정. → 타이머 경로
-  `fetch(allowKeychainPrompt: false)` 는 캐시+파일만 쓰고 키체인은 건드리지 않는다(`OAuthLimitsProvider`
-  의 `guard allowKeychainPrompt` 가 키체인 읽기 앞에 위치). 키체인 읽기는 명시적 사용자 버튼
-  (설정 갱신·팝오버 `claudeLimitsRefreshRow`, `refreshLimitTokenFromKeychain`)에서만. 캐시 토큰이 살아있는
-  동안은 자동 폴이 그 토큰으로 한도를 계속 갱신하고, 만료되면 stale 표시 후 사용자가 갱신한다. 회귀 가드:
-  `testAutoRefreshUsesNoPromptPathManualUsesPromptPath`. (완전 근절은 Developer ID notarization 으로
-  '항상 허용' 승인을 안정화하는 것뿐 — 신뢰된 서명 신원이라야 ACL 승인이 지속된다. 미도입.)
-- **휘발성 필드를 dedup/identity 키에 쓰지 마라.** 매 fetch/refresh 마다 값이 변하는 필드(예: rolling
-  한도 창의 `resets_at`)를 알림 중복방지 키에 넣으면 매번 새 키가 되어 dedup 이 무력화된다 — 주간 한도
-  알림이 80·81·84…갱신마다 반복되던 회귀. 임계값 알림은 **엣지 트리거**(직전 tier 보다 높아진 순간만
-  발화, 경고선 아래로 내려가면 재무장)로 구현하고, 판정은 부수효과(실 알림 전송·`.app` 번들 가드)와
-  분리한 **순수 함수**(`UsageStore.evaluateLimitAlerts`)로 테스트한다 — 번들 가드 때문에 실 발화 경로는
-  xctest 에서 조기 return 되어 커버 불가였던 게 무테스트의 원인.
-- **컴팩트 표시는 오늘 사용한 프로바이더만.** 메뉴바(`menuLines`) 등 좁은 표시에서 한도·상태를 보일 땐
-  `snapshots` 의 오늘 토큰>0 으로 게이트한다 — 설치만 되고 오늘 안 쓴 프로바이더(Codex 등)를 노출하지
-  마라(#56 "미사용 프로바이더 탭" 계열의 표시 버전). 팝오버 상세 뷰는 전체 노출 유지(의도된 상세). 함정:
-  Claude 한도(OAuth)·Codex 한도(프로세스)는 *설치/인증만 돼 있으면 오늘 사용과 무관하게 값이 존재*하므로
-  `limits != nil`/`codexLimits != nil` 만으로 표시하면 미사용 프로바이더가 샌다.
-- **다중 토글 UI 레이아웃은 조합표 전수로.** 토글/입력이 여러 개인 표시 레이아웃을 바꿀 때, 사용자
-  지시가 여러 메시지에 걸쳐 진화하면 각 지시를 **전체 대체가 아니라 특정 조합(행)에 대한 제약**으로
-  누적한다. 구현 전 **모든 토글 조합 → 기대 출력 표**를 만들어 누적 지시와 대조·확인하고, 각 조합을
-  테스트로 고정한다(`testMenuLinesAllCombinations` 처럼). — 회귀: "토큰+비용 세로로"(2개 활성 케이스
-  지시)를 전역 규칙으로 오해해 "3줄 금지"(3개 활성 케이스 제약)를 깨고 3줄을 만든 사례. 두 지시는 서로
-  다른 조합에 관한 것이라 **둘 다 성립**해야 했다(2개→세로, 3개→토큰·비용 한 줄+한도 아랫줄). 최신
-  지시가 이전 제약과 충돌해 보이면 조합별로 재조정하고, 못 풀면 조합표로 되물어라.
-- **메뉴바(상태아이템) stale dim 금지.** 시간 기반 stale(=`isStale`)로 `appearsDisabled` 를 켜면
-  슬립/런치 직후 refresh 완료 전 몇 초간 메뉴바가 회색이 돼 '고장/비활성'으로 오인된다(사용자 반복 지적,
-  `&& lastUpdated != nil` 로 런치만 막는 건 슬립-후 stale 을 못 막음). '오래됨' 신호는 팝오버에서만.
-- **메뉴바 상태아이템 = idle CPU 저격수 (두 규칙 필수).** 실측: 라이브 앱 idle ~14% CPU → 수정 후 ~2%.
-  ① **`statusItem.button.image` 대입은 반드시 `setDisableActions` 트랜잭션 안에서** (`AppDelegate.setStatusImage`).
-  레이어 백드 `NSStatusBarButton` 은 이미지 대입마다 `NSStatusItemScene` 암묵적 전환 애니메이션
-  (`updateSettings:transition:` → `NSAnimationContext runAnimationGroup:`)을 돌려 상태바를 재합성한다 —
-  5fps 스프라이트 루프면 이 전환이 CPU를 먹는다. `CATransaction.begin()/setDisableActions(true)/commit()` 로
-  즉시 반영해 전환을 없앤다(애니메이션은 유지). ② **`.transient` NSPopover 는 `contentViewController` 를
-  평생 보유**해 닫혀도 `NSHostingView` 트리가 상주하며 매 디스플레이 사이클 재레이아웃된다(특히
-  `Text(_, style:.relative)` 가 `requestUpdate` 로 self-invalidation → `StackLayout.placeChildren` 폭주). 위
-  전환 CA 커밋이 이 레이아웃을 flush해 둘이 곱해진다. → `NSPopoverDelegate.popoverDidClose` 에서
-  `contentViewController = nil`, 열 때 재생성(`buildPopoverContent`). ③ 메뉴 애니는 팝오버 열림 중 정지
-  (`menuShouldAnimate` 에 `!popover.isShown`) — 팝오버 SpriteView가 이미 애니메이션하고, 트래킹 중 상태아이콘
-  리드로우는 WindowServer 부하(데스크톱 비컨볼) 위험. **status-item 전용 앱은 occlusion 이 실제로 잘 안
-  떠서**(앱이 status item 표시 중엔 occluded 안 됨) occlusion 게이팅은 보조 — 슬립/열림 게이팅이 실질 방어.
-  검증 함정: bare/`open -n` 보조 인스턴스는 애니메이션이 안 돌아 14%를 **재현 못 함** → 실측은 설치된
-  primary 앱 교체로만. **배터리(idle wakeup) 차원:** CPU% 낮아도 button.image 대입마다 레이어 dirty →
-  CA 커밋 → WindowServer 디스플레이 사이클 왕복이 wakeup을 증폭한다(실측 ~47 wakeup/s). `setStatusImage`
-  diff-gate(동일 프레임 객체 재대입 스킵 — 애니 프레임은 서로 다른 객체라 정상 통과) + GIF fps 하한 0.4s(≈2.5fps)
-  + `Timer.tolerance` 0.5(코얼레싱)로 ~5 wakeup/s(−89%), 애니메이션 유지. 배터리-vs-AC/thermal 적응·CADisplayLink
-  전환은 1인 로컬 노트북 기준 수확체감으로 판정, 미도입(필요 시 Agent Team 계획 참조). (Agent Team 조사 + 실측, 2026-07-22.)
-- **항상 뜬 애니메이션 표면은 메뉴바와 같은 idle 규율을 공유한다.** 플로팅 펫(`FloatingPetPanel`)처럼 상시
-  표시되는 두 번째 GIF 표면을 더할 땐 메뉴바 규율을 그대로 상속해야 회귀(#102 후속)를 안 만든다: ① GIF fps
-  하한(`SpriteView(minFrameDelay:)` — 펫은 `FloatingPetView.frameFloor` 0.4s≈2.5fps, 팝오버 등 *일시적* 표시는
-  0=네이티브) + `Task.sleep(for:tolerance:)` 코얼레싱, ② 저전력 모드 정적화(`FloatingPetController.shouldAnimate(lowPower:)`
-  — `NSProcessInfoPowerStateDidChange` 관찰 후 콘텐츠 재구성), ③ 숨김/슬립 시 `contentView=nil` 로 프레임 루프 정지
-  (팝오버 `popoverDidClose` 패턴). 회귀 가드: `FloatingPetEnergyTests`(fps 하한 clamp·`frameFloor>0`·팝오버 불변·
-  low-power 정적화 순수 판정 — SwiftUI `.task` 타이밍 자체는 호스트 없이 xctest 불가라 순수 경로만 잠금). occlusion 게이팅은
-  all-spaces/`.floating` 펫이 실제로 거의 안 가려져 메뉴바와 동일 수확체감으로 미도입. (#102 리뷰 지적 반영, 2026-07-22.)
-- **외부 로그 포맷은 *상위 소스의 writer* 로 검증한다 — 내 픽스처는 증거가 아니다.** 새 프로바이더 파서를
-  쓸 때 "이렇게 생겼을 것"으로 픽스처를 만들면 파서와 픽스처가 같은 오해를 공유해 테스트가 전부 통과하면서
-  실사용은 0 을 표시한다(#133: 봉투 래퍼 키를 `update` 로 봤으나 실제는 `params`, `timestamp` 는 ISO 문자열이
-  아니라 Unix `u64` 초 — 실제 라인은 한 건도 안 잡혔다). 순서: ① 업스트림에서 *쓰는* 코드(직렬화 구조체·serde
-  계약 테스트)를 열어 키·타입·의미를 확정 ② 그 계약으로 픽스처 작성 ③ 가능하면 실파일 1건 캡처. 특히
-  **같은 스펠링이 표면마다 의미가 다를 수 있다**(Grok `inputTokens`=캐시 포함 durable wire vs `input_tokens`=캐시
-  제외 헤드리스 투영) — 별칭으로 합치면 캐시분을 두 번 빼거나 두 번 더한다.
-- **사용량 소스의 "복사·재기록" 경로를 먼저 찾아라 (이중집계·재날짜화).** 세션 fork·재생·서브에이전트는 같은
-  지출을 여러 파일에 남기거나 시각을 다시 찍는다. 규칙: ① dedup 키는 *턴 자체* 의 전역 유일 id(파일·세션 경로를
-  섞지 마라 — 복사본이 별건이 된다) ② 시각은 *기록* 시각이 아니라 *턴* 시각(fork 는 봉투 timestamp 를 새로
-  찍는다 → 주/월 합계가 포크 시점으로 몰린다) ③ 부모에 접혀 들어오는 자식(서브에이전트) 세션은 제외.
-- **파일 밖 상태에 의존하는 판정을 파싱 캐시 안에서 하지 마라.** `LocalUsageCache` blob 은 그 파일의
-  `(path, mtime, size)` 로만 무효화된다. 옆 파일(예: Grok `summary.json` 의 `session_kind`)로 결정되는
-  포함·제외를 파서 안에서 하면, 근거가 나중에 바뀌어도 파일이 안 바뀌어 판정이 영구히 굳는다. 그런 판정은
-  파일 선택 단계(`collect(include:)`)에 둬 매 새로고침 재평가되게 한다.
-- **JSON `null` 은 "값 있음"이 아니다.** `obj["x"] != nil` 은 `NSNull` 에도 참이라 `intValue` 가 0 을 돌려주고,
-  그 0 으로 캐시분을 빼면 토큰이 통째로 사라진다. 숫자 필드는 `NSNull`·문자열·부재를 모두 nil 로 만드는
-  추출기(`intOrNil`/`doubleOrNil`)로 읽고, 대체 스펠링 폴백은 그 nil 로 판단한다.
-- **비동기 완료가 "그 사이 교체된 대상"에 착지하지 않게 하라 — 상태를 통째로 바꾸는 경로를 새로 만들면
-  진행 중인 await 를 전수 점검한다.** 이 레포가 세 번 겪은 부류다(#136·#138 스프라이트, 그리고 세이브
-  불러오기 중 부화). `isHatching` 같은 중복 실행 락은 *같은 작업의 재진입*만 막을 뿐, await 창에서 상태가
-  **다른 주체로 교체되는 것**은 못 막는다. 방어는 두 형태 중 하나로 통일한다: ① `activeGeneration` 을
-  진입 시 캡처하고 mutation 직전 재검사(`hatchCore`·`revealDitto`·`loadCurrentLine`) ② 대상을 id 로 다시
-  찾아 없으면 무시(`dexChainNames` 의 `firstIndex(where: id)`). 회귀 가드는 sleep 이 아니라 신호(actor +
-  continuation)로 await 지점을 정확히 잡아 재현한다 — `testImportDuringHatchDiscardsTheHatch`.
-  **세대는 호출 체인에서 *가장 이른* await 앞에서 캡처하라 — 안쪽 함수에서 캡처하면 가드가 자동 통과한다.**
-  딥리뷰 실측: `hatchCore` 에만 가드를 넣었더니 `hatchIfNeeded` 의 `chooseBase()` 창에 들어온 교체를 못
-  막았다. `hatchCore` 는 *교체 이후*의 세대를 캡처하므로 `activeGeneration == generation` 이 항상 참이 된다
-  (출발할 때 봐야 할 시계를 도착해서 보는 격). 가드를 넣을 땐 그 함수 위의 await 까지 거슬러 확인하고,
-  회귀 테스트도 **그 await 를 실제로 지나는 진입점**으로 써라 — `hatch(baseID:)` 경로 테스트는
-  `chooseBase()` 를 안 지나 통과하면서 아무것도 지키지 않았다(`testImportDuringSpeciesRollDiscardsTheHatch`).
-- **관대 디코딩(`lenient`/`Lossy`)을 유지하려면 신뢰경계의 값 범위 검증이 짝으로 와야 한다.** 관대 디코딩은
-  "한 필드가 깨져도 도감을 안 날린다"를 얻는 대신 "말이 안 되는 값도 통과시킨다"를 떠안는다. 자기 앱이 쓴
-  파일만 읽을 땐 무해하지만, **외부 파일을 읽는 경로가 생기는 순간 그 트레이드오프가 라이브가 된다** —
-  `Int.max` 같은 값이 그대로 저장되면 이후 산술이 Swift 오버플로 트랩으로 프로세스를 죽이고, 재기동해도
-  같은 파일을 읽어 다시 죽는다(`load()` 의 `.corrupt` 복구는 디코드가 *성공*하므로 발동 안 함 → 파일을
-  손으로 지우기 전까지 앱 사용 불가). 방어는 다운스트림 산술 지점마다가 아니라 **값이 들어오는 경계 한
-  곳**에서(`SaveTransfer.sanitized`). 자르는 대상은 산술에 쓰이는 수치뿐 — 도감·인벤토리 *항목*은 잘라내면
-  데이터 손실이다. (딥리뷰 2026-08-03: SIGTRAP 재현.)
-- **상태 파일을 옮기거나 합칠 땐 "진행"과 "이 기기 장부"를 먼저 분류하라.** 같은 파일에 살아도 성격이
-  다르다 — `usedSinceInstall`·`dex`·`inventory`·`candyGrantTier` 는 어느 기기에서든 참인 **진행**이고,
-  `claimedTodayTokens`·`lastDate`·`installBaselineSet` 은 *그 기기가* 어디까지 적립했나를 적은 **로컬
-  장부**다. 장부를 그대로 들여오면 옛 기기의 오늘 최고치가 문턱이 되어 `update` 의
-  `todayTokens > claimedTodayTokens` 게이트가 이전 당일 내내 거짓 → 새 기기 사용분이 조용히 안 잡힌다
-  (자정에 저절로 낫기 때문에 버그로 안 보인다). 반대로 계정 전역 근거로 만들어진 원장(`candyGrantTier`
-  — 한도 창 key)은 **버리면** 같은 창에서 재지급된다. 이전·병합 경로를 만들 땐 필드를 전수로 이 두 부류에
-  넣어 보고, 로컬 장부만 새 기기 기준으로 다시 잡는다(`SaveTransfer.rebasedForThisDevice`). 회귀 가드:
-  `testTransferDayTokensStillCountAfterRebase` — 재정렬 없는 대조군을 같이 돌려 결함 조건이 살아 있는지도
-  함께 확인한다(테스트가 트리거 브랜치를 실제로 밟는지 보증).
+   주/월-only 경로를 못 밟은 게 #56 회귀의 원인.) 새 가드는 **결함을 일부러 주입해 실패하는지**
+   한 번 확인한다 — 통과만 보면 아무것도 안 지키는 테스트를 구별할 수 없다.
+4. **영구 캡처 (기억이 아니라 메커니즘).** 재발 방지는 테스트·게이트·`docs/reference/defect-log.md`·
+   스크립트 중 *기계로 막을 수 있는* 형태로 남긴다. 릴리스 관련이면 `release.sh` 게이트, 절차면 문서.

--- a/Sources/PokeTokenBar/Core/BinaryLocator.swift
+++ b/Sources/PokeTokenBar/Core/BinaryLocator.swift
@@ -96,36 +96,84 @@ enum BinaryLocator {
     /// 사용자 로그인 셸을 인터랙티브+로그인으로 띄워 `command -v <binary>` 결과를 받는다.
     /// 인터랙티브 프로파일이 stdout 에 noise(neofetch 등)를 찍을 수 있어 마커로 감싸 추출한다.
     private static func shellResolve(_ binary: String) -> String? {
+        // binary 를 위치 인자($1)로 전달 — 문자열 보간 금지(향후 호출자가 외부 입력을 넘겨도 주입 불가).
+        guard let path = shellMarkedValue(
+            script: #"printf '<<<BIN:%s:BIN>>>' "$(command -v "$1" 2>/dev/null)""#,
+            argument: binary, label: "\(binary) shell resolve"),
+            FileManager.default.isExecutableFile(atPath: path)
+        else { return nil }
+        return path
+    }
+
+    /// 로그인+인터랙티브 셸을 띄워 마커로 감싼 값 하나를 받는다(`shellResolve`·`shellEnvironmentValue` 공용).
+    ///
+    /// stdout 은 프로세스 종료를 기다리기 **전에** 백그라운드로 드레인한다. 인터랙티브 프로파일이
+    /// 파이프 버퍼(64KB)를 넘게 찍으면 자식이 write 에서 막혀 영영 종료하지 않고, 종료를 먼저 기다리는
+    /// 구조에서는 타임아웃까지 통째로 날린 뒤 nil 을 돌려준다.
+    private static func shellMarkedValue(script: String, argument: String, label: String) -> String? {
         let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         guard FileManager.default.isExecutableFile(atPath: shell) else { return nil }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shell)
-        // binary 를 위치 인자($1)로 전달 — 문자열 보간 금지(향후 호출자가 외부 입력을 넘겨도 주입 불가).
-        process.arguments = ["-ilc", #"printf '<<<BIN:%s:BIN>>>' "$(command -v "$1" 2>/dev/null)""#, "sh", binary]
+        process.arguments = ["-ilc", script, "sh", argument]
         process.standardInput = FileHandle.nullDevice
         let output = Pipe()
         process.standardOutput = output
         process.standardError = FileHandle.nullDevice
 
         do { try process.run() } catch {
-            AppLog.write("\(binary) shell resolve spawn failed: \(error.localizedDescription)")
+            AppLog.write("\(label) spawn failed: \(error.localizedDescription)")
             return nil
         }
+
+        final class DataBox: @unchecked Sendable { var data = Data() }
+        let box = DataBox()
+        let drained = DispatchSemaphore(value: 0)
+        let handle = output.fileHandleForReading
+        DispatchQueue.global().async {
+            box.data = handle.readDataToEndOfFile()
+            drained.signal()
+        }
+
         let deadline = Date().addingTimeInterval(8)
         while process.isRunning && Date() < deadline { Thread.sleep(forTimeInterval: 0.05) }
         if process.isRunning {
             process.terminate()
-            AppLog.write("\(binary) shell resolve timed out")
+            try? handle.close()            // 리더 스레드 해제 — 안 닫으면 영구 블록된 채 남는다.
+            AppLog.write("\(label) timed out")
             return nil
         }
-        let data = output.fileHandleForReading.readDataToEndOfFile()
-        guard let raw = String(data: data, encoding: .utf8),
-              let path = parseMarkedPath(raw),
-              FileManager.default.isExecutableFile(atPath: path) else {
+        // 드레인은 **남은 예산 전체**를 준다. 셸이 종료해도 rc 가 띄운 백그라운드 잡(zsh-async·zinit turbo
+        // 등)이 stdout write end 를 계속 쥐고 있으면 EOF 가 늦게 온다 — 여기에 짧은 별도 상한을 두면
+        // 종료를 무한정 기다리던 이전 동작에서 값을 얻던 사용자가 nil 을 받는다(실측 회귀).
+        let remaining = max(0, deadline.timeIntervalSinceNow)
+        guard drained.wait(timeout: .now() + remaining) == .success else {
+            try? handle.close()
+            AppLog.write("\(label) output drain timed out")
             return nil
         }
-        return path
+        guard let raw = String(data: box.data, encoding: .utf8),
+              let value = parseMarkedPath(raw)
+        else { return nil }
+        return value
+    }
+
+    /// 로그인 셸에서 환경변수 하나를 읽는다. Finder/launchd 로 뜬 `.app` 은 셸 환경(`~/.zshrc` 의
+    /// export)을 상속하지 않아, 프로세스 환경만 보면 사용자가 설정한 값이 앱에서만 안 보인다.
+    /// PATH 해석(`shellResolve`)과 같은 수법이며, 셸을 띄우는 비용이 있으므로 호출자가 결과를 캐시해야 한다.
+    static func shellEnvironmentValue(_ name: String) -> String? {
+        // 변수명은 ASCII 대문자·숫자·밑줄만 허용 — 셸 주입 방지.
+        // `isUppercase`/`isNumber` 는 유니코드 기준이라 `Σ`·키릴 `А`·`٣` 도 통과한다. 셸 메타문자는
+        // 아니라 실제 주입은 안 되지만, 가드가 선언한 범위와 실제 허용 범위를 일치시킨다.
+        guard !name.isEmpty,
+              name.allSatisfy({ $0.isASCII && ($0.isUppercase || $0.isNumber || $0 == "_") })
+        else { return nil }
+        // 변수명은 위치 인자($1)로 넘기고 `eval` 은 그 이름의 값만 전개한다. 전개 결과는 재파싱되지
+        // 않으므로 값에 셸 메타문자가 있어도 그대로 돌아온다(실측 확인).
+        return shellMarkedValue(
+            script: #"printf '<<<BIN:%s:BIN>>>' "$(eval printf '%s' \"\$$1\" 2>/dev/null)""#,
+            argument: name, label: "\(name) shell env lookup")
     }
 
     /// `<<<BIN:/path/to/tool:BIN>>>` 에서 경로만 추출. 프로파일 noise 무시.

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -93,11 +93,20 @@ actor LocalUsageCache {
     /// throwing probe 를 쓴다 — 읽기 실패(throw)와 "metadata 없음"(`nil`)은 인덱스에 남길지가 다르다.
     private let codexProbe: @Sendable (URL) throws -> String?
 
-    init(claudeRoot: URL? = nil, codexRoot: URL? = nil, geminiRoot: URL? = nil, grokRoot: URL? = nil,
+    /// 다중 루트 시임. `claudeRoot` 단일 지정과 배타적이며, 프로덕션의 다중 루트 순회 브랜치를
+    /// 테스트가 실제로 밟게 하려고 둔다(단일 루트만 주면 루프가 1회로 단락돼 그 브랜치가 안 덮인다).
+    private let claudeRoots: [URL]?
+
+    init(claudeRoot: URL? = nil, claudeRoots: [URL]? = nil,
+         codexRoot: URL? = nil, geminiRoot: URL? = nil, grokRoot: URL? = nil,
          fileURL: URL? = nil, now: @escaping @Sendable () -> Date = Date.init,
          codexProbe: @escaping @Sendable (URL) throws -> String? = {
              try LocalUsageReader.probeCodexRolloutSessionID(at: $0)
          }) {
+        // 둘 다 주는 호출은 없다(프로덕션은 둘 다 nil, 테스트는 하나씩). precondition 으로 막지 않는 이유는
+        // 릴리스 빌드에서도 살아 있어, 잘못 써도 결과가 "테스트가 엉뚱한 루트를 본다"에 그치는 실수를
+        // 앱 종료로 키우기 때문이다. 우선순위는 claudeRoots.
+        self.claudeRoots = claudeRoots
         self.claudeRoot = claudeRoot
         self.codexRoot = codexRoot
         self.geminiRoot = geminiRoot
@@ -117,8 +126,15 @@ actor LocalUsageCache {
     func claudeEntries(modifiedSince: Date) -> [LocalUsageReader.Entry] {
         ensureLoaded()
         let fmt = LocalUsageReader.localDayFormatter()
-        let all = collect(root: claudeRoot ?? LocalUsageReader.claudeProjectsDir, since: modifiedSince, cache: &claudeCache) {
-            LocalUsageReader.parseClaudeFile($0, fmt: fmt)
+        // 루트가 여럿이다(CLI 기본 위치 + CLAUDE_CONFIG_DIR + Claude Desktop 임베디드 세션).
+        // blob 캐시 키가 절대경로라 루트가 늘어도 캐시는 그대로 재사용되고, 같은 턴이 여러 루트에
+        // 복사돼 있어도 전역 dedup 이 한 번만 센다.
+        let roots = claudeRoots ?? claudeRoot.map { [$0] } ?? LocalUsageReader.claudeProjectRoots
+        var all: [LocalUsageReader.Entry] = []
+        for root in roots {
+            all += collect(root: root, since: modifiedSince, cache: &claudeCache) {
+                LocalUsageReader.parseClaudeFile($0, fmt: fmt)
+            }
         }
         saveIfNeeded()
         return LocalUsageReader.dedupKeepMax(all)

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -44,8 +44,167 @@ enum LocalUsageReader {
 
     // MARK: 경로
 
+    /// CLI 기본 위치의 홈 기준 상대 경로 — `claudeProjectsDir` 와 루트 목록이 같은 문자열을 공유한다
+    /// (양쪽에 리터럴을 따로 쓰면 한쪽만 바뀌어도 테스트가 못 잡는다).
+    static let defaultRelativeProjectsPath = ".claude/projects"
+    static let configRelativeProjectsPath = ".config/claude/projects"
+
     static var claudeProjectsDir: URL {
-        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude/projects")
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(defaultRelativeProjectsPath)
+    }
+
+    /// Claude 사용 로그(`<root>/**/*.jsonl`)가 있을 수 있는 **모든** projects 루트.
+    /// 새 위치를 지원할 땐 이 한 곳에만 추가한다 — 스캔·캐시·테스트가 이 단일 소스를 공유한다.
+    ///
+    /// - `CLAUDE_CONFIG_DIR`: 사용자가 설정 위치를 옮긴 경우. 콤마로 여러 개를 줄 수 있고 각각 `<값>/projects`.
+    /// - `~/.config/claude/projects`, `~/.claude/projects`: CLI 기본 위치(전자는 XDG 스타일 설치).
+    /// - Claude Desktop 임베디드 세션: 세션 디렉터리마다 CLI 와 같은 모양의 `.claude/projects` 를 갖는다.
+    ///   Desktop 으로 일한 사용량이 여기에만 남으므로 빼면 조용히 누락된다.
+    /// 계산에 파일시스템 탐색 + (GUI 앱에선) 로그인 셸 조회가 들어가는데 새로고침은 분 단위로 돈다.
+    /// 루트 구성은 Desktop 세션이 새로 생길 때만 바뀌므로 TTL 캐시로 재계산을 접는다.
+    static var claudeProjectRoots: [URL] { rootsCache.roots() }
+
+    /// 테스트·진단용 — 캐시를 무시하고 지금 상태로 계산한다.
+    static func computeClaudeProjectRoots(
+        configDirValue: String? = shellAwareClaudeConfigDir(),
+        home: URL = FileManager.default.homeDirectoryForCurrentUser) -> [URL]
+    {
+        var roots: [URL] = []
+        if let raw = configDirValue {
+            for part in raw.split(separator: ",") {
+                let path = part.trimmingCharacters(in: .whitespaces)
+                guard !path.isEmpty else { continue }
+                roots.append(URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+                    .appendingPathComponent("projects"))
+            }
+        }
+        roots.append(home.appendingPathComponent(Self.configRelativeProjectsPath))
+        roots.append(home.appendingPathComponent(Self.defaultRelativeProjectsPath))
+
+        let desktop = home.appendingPathComponent("Library/Application Support/Claude")
+        for store in ["local-agent-mode-sessions", "claude-code-sessions"] {
+            roots.append(contentsOf: embeddedClaudeProjectRoots(under: desktop.appendingPathComponent(store)))
+        }
+        return normalizedRoots(roots)
+    }
+
+    /// `CLAUDE_CONFIG_DIR` 값. Finder/launchd 로 뜬 `.app` 은 셸 환경을 상속하지 않으므로
+    /// 프로세스 환경에 없으면 로그인 셸에 한 번 물어본다(`BinaryLocator` 가 PATH 에 쓰는 것과 같은 수법).
+    /// 이 조회가 없으면 설정 위치를 옮긴 사용자는 앱에서만 0 토큰을 보고, CLI·테스트에서는 정상이라
+    /// 재현이 안 된다.
+    /// 셸 조회는 프로세스 생애 1회만 한다 — 환경변수는 앱이 도는 동안 바뀌지 않는데, 루트 캐시의
+    /// TTL 에 묶으면 값을 안 쓰는 대다수 사용자까지 갱신마다 셸 spawn(실측 ~0.44s) 비용을 문다.
+    /// 못 찾은 결과(nil)도 함께 캐시해 재시도를 막는다. `static let` 은 lazy + once 라 이 자체가 캐시다.
+    static func shellAwareClaudeConfigDir() -> String? { cachedShellConfigDir }
+
+    private static let cachedShellConfigDir: String? = {
+        if let v = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"], !v.isEmpty { return v }
+        return BinaryLocator.shellEnvironmentValue("CLAUDE_CONFIG_DIR")
+    }()
+
+    private static let rootsCache = RootsCache()
+
+    final class RootsCache: @unchecked Sendable {
+        private let lock = NSLock()
+        private var cached: [URL]?
+        private var computedAt: Date?
+        /// 새 Desktop 세션이 생겨도 이 시간 안에는 반영된다. 새로고침 주기(분 단위)보다 넉넉히 길게.
+        private let ttl: TimeInterval = 300
+
+        /// 락은 캐시 필드 접근에만 쥔다. 계산은 락 **밖에서** 한다 — 첫 호출은 로그인 셸 spawn(최대 8초
+        /// 대기)과 파일시스템 탐색을 포함하는데, 그 동안 락을 쥐면 동시 호출자가 통째로 막힌다
+        /// (`UsageStore` 는 프로바이더를 taskGroup 으로 병렬 fetch 한다). 결과가 idempotent 하므로
+        /// 경합 시 중복 계산이 나는 편이 블로킹보다 낫다.
+        func roots() -> [URL] {
+            lock.lock()
+            let hit = (cached, computedAt)
+            lock.unlock()
+            if let cached = hit.0, let at = hit.1, Date().timeIntervalSince(at) < ttl { return cached }
+
+            let fresh = computeClaudeProjectRoots()
+            lock.lock()
+            cached = fresh
+            computedAt = Date()
+            lock.unlock()
+            return fresh
+        }
+    }
+
+    /// Claude Desktop 임베디드 세션 스토어에서 `.claude/projects` 디렉터리를 찾는다.
+    /// 세션 경로는 `<store>/<uuid>/<uuid>/local_<uuid>/.claude/projects` 처럼 UUID 단계가 여러 겹이라
+    /// 고정 경로로는 못 잡고 탐색해야 한다. `.claude` 는 hidden 이므로 `skipsHiddenFiles` 를 쓰면 안 된다.
+    /// 탐색 중 내려가지 않는 디렉터리. **패키지·VCS 내부처럼 사용자 작업 트리가 아닌 것만** 넣는다.
+    ///
+    /// 이름 기반 가지치기는 *조상* 이름 하나로 그 아래 전부를 잘라내므로, 정당한 작업 디렉터리 이름을
+    /// 넣으면 원래 막으려던 "조용한 0건"을 그대로 재생산한다. 실측: 세션 레이아웃에 `uploads`·`outputs`
+    /// 가 실제로 존재하고(`local_<uuid>/uploads`, `/outputs`) 그 아래에서 돌린 Claude 세션은 정당한
+    /// 루트다. `build`·`target` 역시 흔한 프로젝트 이름이라 뺐다. 폭 제어의 주 수단은 깊이 상한이고,
+    /// 이 목록은 보조다. 가드: `testEmbeddedRootsFindRootsUnderWorkDirectoryNames`.
+    private static let rootScanSkippedDirectories: Set<String> =
+        ["node_modules", ".git", "venv", ".venv"]
+
+    /// 기본 깊이 7의 근거(실측): 세션 기본 루트는 깊이 5(`<uuid>/<uuid>/local_<uuid>/.claude/projects`),
+    /// 세션 작업 디렉터리 아래 저장소(`outputs/myrepo/.claude/projects`)는 깊이 7이다. 6 이면 후자를 놓치고,
+    /// 8·9 로 올려도 방문 수는 그대로였다(100 고정) — 폭은 깊이가 아니라 `node_modules` 류 가지치기가
+    /// 잡고 있다. 즉 7 이 "놓치지 않는 최소값"이면서 비용이 늘지 않는 지점이다.
+    static func embeddedClaudeProjectRoots(under base: URL, maxDepth: Int = 7) -> [URL] {
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: base.path, isDirectory: &isDir), isDir.boolValue else { return [] }
+        guard let en = fm.enumerator(at: base, includingPropertiesForKeys: [.isDirectoryKey],
+                                     options: [.skipsPackageDescendants]) else { return [] }
+        var out: [URL] = []
+        var prunedByDepth = false
+        for case let url as URL in en {
+            let name = url.lastPathComponent
+            if name == "projects", url.deletingLastPathComponent().lastPathComponent == ".claude",
+               (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true {
+                out.append(url)
+                en.skipDescendants()   // 이 아래는 프로젝트 로그 — 루트 탐색 대상이 아니다.
+                continue
+            }
+            // 이 항목 자체는 위에서 검사한 뒤에 가지치기한다. `> maxDepth` 로 자르면 한 단계 더
+            // 내려간 뒤에야 멈춰 실제 탐색 폭이 의도보다 넓어진다.
+            if en.level >= maxDepth {
+                prunedByDepth = true
+                en.skipDescendants()
+            } else if rootScanSkippedDirectories.contains(name) {
+                en.skipDescendants()
+            }
+        }
+        // 깊이로 잘렸으면 무엇을 찾았든 남긴다. `out.isEmpty` 를 조건에 넣으면 **부분 절단**
+        // (세션 루트는 찾고 더 깊은 작업 디렉터리만 놓친 경우)이 조용히 지나가는데, 그게 가장 흔한 형태다.
+        if prunedByDepth {
+            AppLog.write("claude desktop scan: depth \(maxDepth) reached under \(base.lastPathComponent), found \(out.count) root(s) — deeper roots may be missed")
+        }
+        return out
+    }
+
+    /// 중복·중첩 루트를 제거한다. `CLAUDE_CONFIG_DIR=~/.claude` 처럼 기본 루트와 겹치게 지정하면
+    /// 같은 파일을 두 번 스캔한다 — 전역 dedup 이 합계는 바로잡지만 스캔 비용은 그대로 두 배다.
+    static func normalizedRoots(_ roots: [URL]) -> [URL] {
+        var seen = Set<String>()
+        var unique: [String] = []
+        for root in roots {
+            // 심볼릭 링크를 풀어서 비교한다(`~/.config/claude` → `~/.claude` 링크가 흔한 XDG 구성).
+            // `standardizedFileURL` 은 `..`·`.` 만 정리할 뿐 링크는 그대로 둬서 같은 트리를 두 번 훑게 된다.
+            // 비교는 소문자로 — macOS 기본 APFS 볼륨은 대소문자를 구분하지 않는다.
+            let path = root.resolvingSymlinksInPath().standardizedFileURL.path
+            if seen.insert(path.lowercased()).inserted { unique.append(path) }
+        }
+        // 짧은 경로부터 확정하고, 이미 확정된 루트의 하위면 버린다.
+        // 중첩 비교도 중복 비교와 같은 소문자 기준이어야 한다 — 한쪽만 대소문자를 무시하면
+        // `CLAUDE_CONFIG_DIR=~/.Claude` 같은 표기에서 두 검사가 엇갈려 중복 루트가 살아남는다.
+        var kept: [String] = []
+        for path in unique.sorted(by: { $0.count < $1.count })
+        where !kept.contains(where: {
+            let (p, k) = (path.lowercased(), $0.lowercased())
+            return p == k || p.hasPrefix(k + "/")
+        }) {
+            kept.append(path)
+        }
+        // 원래 순서(우선순위)를 보존해 돌려준다.
+        return unique.filter(kept.contains).map { URL(fileURLWithPath: $0) }
     }
     static var codexSessionsDir: URL {
         FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex/sessions")
@@ -103,11 +262,19 @@ enum LocalUsageReader {
     }
 
     /// `modifiedSince` 이후 파일에서 Claude 사용 엔트리(전역 dedup) — 테스트/캐시 미사용 경로.
+    /// `root` 를 주지 않으면 `claudeProjectRoots` 전체를 훑는다. 같은 턴이 여러 루트에 복사돼 있어도
+    /// `(message.id, requestId)` 전역 dedup 이 한 번만 세므로 루트가 겹쳐도 합계는 부풀지 않는다.
     static func claudeEntries(modifiedSince: Date, root: URL? = nil) -> [Entry] {
+        claudeEntries(modifiedSince: modifiedSince, roots: root.map { [$0] } ?? claudeProjectRoots)
+    }
+
+    static func claudeEntries(modifiedSince: Date, roots: [URL]) -> [Entry] {
         let fmt = localDayFormatter()
         var all: [Entry] = []
-        for file in jsonlFiles(in: root ?? claudeProjectsDir, modifiedSince: modifiedSince) {
-            all.append(contentsOf: parseClaudeFile(file, fmt: fmt))
+        for root in roots {
+            for file in jsonlFiles(in: root, modifiedSince: modifiedSince) {
+                all.append(contentsOf: parseClaudeFile(file, fmt: fmt))
+            }
         }
         return dedupKeepMax(all)
     }

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -373,6 +373,11 @@ struct L {
           "No Claude credential found. Sign in to Claude Code to see limits. If you only use Codex you can ignore this.",
           "Claude の認証情報が見つかりません。Claude Code にサインインすると上限が表示されます。Codex のみなら無視して構いません。")
     }
+    var limitRefreshReauthNeeded: String {
+        t("Claude 자격증명에 계정 로그인 정보가 없어요. Claude Code 에서 `/login` 으로 다시 로그인하면 한도가 표시됩니다.",
+          "Your Claude credential has no account sign-in. Run `/login` in Claude Code to sign in again and limits will appear.",
+          "Claude の認証情報にアカウントのサインインが含まれていません。Claude Code で `/login` を実行して再度サインインすると上限が表示されます。")
+    }
     var limitRefreshGeneric: String {
         t("Claude 한도 조회에 실패했어요. 잠시 후 다시 시도하세요.",
           "Couldn't fetch Claude limits. Please try again shortly.",

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -6,6 +6,9 @@ enum LimitsError: Error {
     case keychainUnavailable(OSStatus)
     case keychainInteractionNotAllowed
     case credentialFormat
+    /// 자격증명은 읽혔지만 Claude 계정 OAuth(`claudeAiOauth`)가 없다 — MCP 서버 OAuth 상태만 들어있는 경우.
+    /// Claude Code 2.1.x 에서 관측된다. 형식 오류가 아니라 재로그인이 필요한 상태라 따로 구분한다.
+    case credentialMissingAccountOAuth
     case httpStatus(Int)
     /// 429 — 서버가 지정한 Retry-After(초, 없으면 nil). 폴링 백오프 판단에 사용.
     case rateLimited(retryAfter: TimeInterval?)
@@ -90,8 +93,12 @@ private actor OAuthAccessTokenCache {
         // → Keychain 읽기는 명시적 사용자 동작(설정/팝오버의 갱신 버튼, allowKeychainPrompt=true)에서만
         // 수행한다. 캐시된 토큰이 살아있는 동안은 자동 폴링이 그 토큰으로 계속 한도를 갱신하고, 만료되면
         // 한도는 마지막 값으로 stale 표시된 뒤 사용자가 갱신을 누를 때 재취득된다.
+        // 자동 경로는 여기서 끝난다(키체인 미열람). 파일이 있는데 계정 OAuth 만 없으면 재로그인이
+        // 답이므로 그때만 안내를 바꾼다 — 판정은 이 분기 안에서 해야 사용자 경로가 파일을 두 번 읽지 않는다.
         guard allowKeychainPrompt else {
-            throw LimitsError.keychainInteractionNotAllowed
+            throw Self.credentialsFileIsAccountOAuthMissing()
+                ? LimitsError.credentialMissingAccountOAuth
+                : LimitsError.keychainInteractionNotAllowed
         }
 
         // 사용자 동작 경로: 무프롬프트로 먼저 시도(과거 '항상 허용'했다면 조용히 성공), 안 되면 프롬프트를
@@ -136,6 +143,23 @@ private actor OAuthAccessTokenCache {
     // 불일치로 접근 허용 프롬프트를 유발했다. 토큰은 인메모리 + Claude 키체인 무UI 읽기 +
     // .credentials.json 로 충분히 조용히 취득된다.
 
+    /// 자격증명 파일이 존재하지만 계정 OAuth 가 없는 상태인지(만료는 여기 해당 없음 — 그건 재취득 대상).
+    ///
+    /// 설정 위치를 옮긴 사용자(`CLAUDE_CONFIG_DIR`)는 판정에서 제외한다. 이 경로는 기본 위치를 하드코딩하는데,
+    /// 옮긴 뒤 남은 옛 파일이 `mcpOAuth` 만 담고 있으면 실제로는 로그인된 사용자에게 매 폴링마다 재로그인
+    /// 배너를 띄우게 된다. 옮긴 자격증명이 어디 있는지는 확인된 바 없으므로 추측하지 않고 판정을 접는다
+    /// (한도는 키체인 경로로 계속 동작한다).
+    private nonisolated static func credentialsFileIsAccountOAuthMissing() -> Bool {
+        // 프로세스 환경만 본다 — 셸 조회(`shellAwareClaudeConfigDir`)를 부르면 이 자동 폴링 경로가
+        // 안내 문구 하나를 고르려고 로그인 셸 spawn(수백 ms~수 초)을 유발하고, 그 동안 토큰 캐시 actor 가
+        // 막힌다. 값이 필요한 쪽(사용량 스캔)이 이미 셸 조회를 하므로 여기서 감당할 이유가 없다.
+        guard ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"]?.isEmpty ?? true else { return false }
+        let url = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/.credentials.json")
+        guard let data = try? Data(contentsOf: url) else { return false }
+        return OAuthCredentialData.isAccountOAuthMissing(data)
+    }
+
     private nonisolated static func readClaudeCredentialsFile() throws -> OAuthCredentialData.Credential? {
         let url = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude/.credentials.json")
@@ -171,7 +195,10 @@ private actor OAuthAccessTokenCache {
             throw LimitsError.keychainUnavailable(status)
         }
         guard let credential = OAuthCredentialData.credential(from: data) else {
-            throw LimitsError.credentialFormat
+            // 항목은 있는데 계정 OAuth 만 없는 상태(MCP OAuth 전용)는 재로그인 안내 대상이라 구분한다.
+            throw OAuthCredentialData.isAccountOAuthMissing(data)
+                ? LimitsError.credentialMissingAccountOAuth
+                : LimitsError.credentialFormat
         }
         return credential
     }
@@ -192,6 +219,19 @@ enum OAuthCredentialData {
             guard let expiresAt else { return false }
             return expiresAt <= Date().addingTimeInterval(60)
         }
+    }
+
+    /// JSON 은 멀쩡한데 `claudeAiOauth` 만 없는 상태인지. Claude Code 2.1.x 의 자격증명 항목이
+    /// MCP 서버 OAuth(`mcpOAuth`) 상태만 담고 계정 토큰은 안 담는 경우가 있어, 이때는 파싱 실패를
+    /// "형식 오류"가 아니라 "재로그인 필요"로 안내해야 한다.
+    /// (JSON 자체가 깨진 경우는 여기 해당하지 않는다 — 그건 형식 오류다.)
+    ///
+    /// `json["claudeAiOauth"] == nil` 로 검사하면 안 된다. 명시적 JSON `null` 은 `NSNull` 로 디코드돼
+    /// `!= nil` 이 참이 되므로, 로그아웃 상태(`"claudeAiOauth": null`)를 "값 있음"으로 오판해 재로그인
+    /// 안내 대신 "자격증명 없음"을 띄운다. 딕셔너리로 캐스팅되는지로 판단한다.
+    static func isAccountOAuthMissing(_ data: Data) -> Bool {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return false }
+        return (json["claudeAiOauth"] as? [String: Any]) == nil
     }
 
     static func credential(from data: Data) -> Credential? {

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -702,6 +702,8 @@ final class UsageStore {
             return l.limitRefreshHTTPError(status)
         case .keychainUnavailable, .credentialFormat:
             return l.limitRefreshNoCredential
+        case .credentialMissingAccountOAuth:
+            return l.limitRefreshReauthNeeded
         case .keychainInteractionNotAllowed, .keychainAccessDisabled:
             return l.limitRefreshGeneric
         }

--- a/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
@@ -183,6 +183,31 @@ final class LocalUsageCacheTests: XCTestCase {
         XCTAssertEqual(second.map(\.output), [111], "mtime/size 불변이면 재파싱하면 안 된다")
     }
 
+    /// 프로덕션은 루트를 여러 개 훑는다(CLI 기본 + CLAUDE_CONFIG_DIR + Claude Desktop 임베디드).
+    /// 단일 루트만 주면 그 루프가 1회로 단락돼 브랜치가 안 덮이므로, 다중 루트 시임으로 실제 경로를 밟는다.
+    func testMultipleRootsAreScannedAndDedupedAcrossRoots() async throws {
+        let second = root.deletingLastPathComponent().appendingPathComponent("second-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: second, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: second) }
+
+        try writeFile("a.jsonl", lines: [claudeLine(id: "shared", output: 10)])
+        try [claudeLine(id: "shared", output: 10), claudeLine(id: "only-second", output: 7)]
+            .joined(separator: "\n")
+            .write(to: second.appendingPathComponent("b.jsonl"), atomically: true, encoding: .utf8)
+
+        let cache = LocalUsageCache(claudeRoots: [root, second], fileURL: cacheFile)
+        let entries = await cache.claudeEntries(modifiedSince: since)
+
+        XCTAssertEqual(Set(entries.map(\.output)), [10, 7], "두 루트가 합산돼야 한다")
+        XCTAssertEqual(entries.filter { $0.id == "m-shared|r-shared" }.count, 1,
+                       "두 루트에 같은 턴이 있으면 한 번만 세야 한다")
+
+        // 대조군: 두 번째 루트를 빼면 only-second 가 사라진다 — 위 단언이 다중 루트를 실제로 밟았다는 보증.
+        let single = LocalUsageCache(claudeRoot: root, fileURL: cacheFile.appendingPathExtension("single"))
+        let singleEntries = await single.claudeEntries(modifiedSince: since)
+        XCTAssertEqual(singleEntries.count, 1)
+    }
+
     /// mtime 이 바뀌면 재파싱한다.
     func testChangedFileIsReparsed() async throws {
         try writeFile("a.jsonl", lines: [claudeLine(id: "1", output: 111)])

--- a/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
@@ -82,6 +82,176 @@ final class LocalUsageReaderTests: XCTestCase {
         XCTAssertNil(LocalUsageReader.daily(entries: entries, localDay: "2000-01-01"))
     }
 
+    // MARK: Claude 스캔 루트 (CLI 기본 + CLAUDE_CONFIG_DIR + Claude Desktop 임베디드 세션)
+
+    /// Desktop 세션 스토어는 `<store>/<uuid>/<uuid>/local_<uuid>/.claude/projects` 처럼 UUID 단계가
+    /// 여러 겹이라 고정 경로로 못 잡는다. 그리고 `.claude` 는 **hidden** 이라 탐색이 `skipsHiddenFiles`
+    /// 를 쓰면 아무것도 못 찾는다 — 이 테스트가 정확히 그 브랜치를 밟는다(결함 조건).
+    func testEmbeddedRootsFindHiddenClaudeProjectsDirs() {
+        let base = tempDir()
+        let session = base.appendingPathComponent("2eb6d133/a3a236da/local_35a9f8a7")
+        let projects = session.appendingPathComponent(".claude/projects")
+        try? FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+        // 같은 세션의 감사 로그·업로드는 사용량 로그가 아니라 루트 후보가 아니다.
+        try? FileManager.default.createDirectory(
+            at: session.appendingPathComponent("uploads"), withIntermediateDirectories: true)
+
+        let found = LocalUsageReader.embeddedClaudeProjectRoots(under: base)
+        XCTAssertEqual(found.map(\.standardizedFileURL.path), [projects.standardizedFileURL.path])
+    }
+
+    func testEmbeddedRootsIgnoreMissingBaseAndDepthLimit() {
+        XCTAssertEqual(
+            LocalUsageReader.embeddedClaudeProjectRoots(
+                under: URL(fileURLWithPath: "/nonexistent-\(UUID().uuidString)")).count, 0)
+
+        let base = tempDir()
+        let deep = base.appendingPathComponent("a/b/c/d/e/f/g/.claude/projects")
+        try? FileManager.default.createDirectory(at: deep, withIntermediateDirectories: true)
+        XCTAssertEqual(LocalUsageReader.embeddedClaudeProjectRoots(under: base, maxDepth: 4).count, 0)
+    }
+
+    /// 실제 Desktop 레이아웃(`<uuid>/<uuid>/local_<uuid>/.claude/projects`)은 base 기준 **깊이 5**다.
+    /// 기본 `maxDepth` 가 그 경계에 붙어 있으면 Desktop 이 한 단계만 더 중첩해도 조용히 0건이 된다 —
+    /// 이 테스트가 실제 경계와 여유를 함께 고정한다.
+    func testEmbeddedRootsDepthBoundaryMatchesRealLayoutWithHeadroom() {
+        let base = tempDir()
+        let real = base.appendingPathComponent("2eb6d133/a3a236da/local_35a9f8a7/.claude/projects")
+        try? FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+
+        XCTAssertEqual(LocalUsageReader.embeddedClaudeProjectRoots(under: base, maxDepth: 4).count, 0,
+                       "깊이 5 레이아웃은 maxDepth 4 로는 안 잡혀야 한다(경계 확인)")
+        XCTAssertEqual(LocalUsageReader.embeddedClaudeProjectRoots(under: base, maxDepth: 5).count, 1)
+        // 기본값은 미래 중첩 여유를 포함해야 한다.
+        XCTAssertEqual(LocalUsageReader.embeddedClaudeProjectRoots(under: base).count, 1)
+
+        // 세션 작업 디렉터리 아래 저장소(깊이 7)도 기본값으로 잡혀야 한다 — Desktop 세션에서 클론해
+        // 작업하면 이 모양이 된다. 이게 기본 깊이의 실제 하한을 정한다.
+        let nested = base.appendingPathComponent("2eb6d133/a3a236da/local_35a9f8a7/outputs/myrepo/.claude/projects")
+        try? FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        XCTAssertEqual(LocalUsageReader.embeddedClaudeProjectRoots(under: base).count, 2)
+        XCTAssertEqual(LocalUsageReader.embeddedClaudeProjectRoots(under: base, maxDepth: 6).count, 1,
+                       "깊이 6 이면 작업 디렉터리 아래 저장소를 놓친다(하한 근거)")
+    }
+
+    /// 깊이만 제한하면 폭이 안 막힌다 — 세션 샌드박스에 워크스페이스가 있으면 수만 건을 훑는다.
+    func testEmbeddedRootsDoNotDescendIntoBulkDirectories() {
+        let base = tempDir()
+        let session = base.appendingPathComponent("s1/s2/local_x")
+        try? FileManager.default.createDirectory(
+            at: session.appendingPathComponent(".claude/projects"), withIntermediateDirectories: true)
+        // node_modules 안에 .claude/projects 모양이 있어도 따라가지 않는다(가지치기 확인).
+        try? FileManager.default.createDirectory(
+            at: session.appendingPathComponent("node_modules/pkg/.claude/projects"),
+            withIntermediateDirectories: true)
+
+        let found = LocalUsageReader.embeddedClaudeProjectRoots(under: base)
+        XCTAssertEqual(found.count, 1)
+        XCTAssertFalse(found[0].path.contains("node_modules"))
+    }
+
+    /// 이름 기반 가지치기는 *조상* 이름 하나로 그 아래 전부를 자른다. 실제 세션 레이아웃에 존재하는
+    /// `uploads`·`outputs`, 그리고 흔한 프로젝트 이름 `build`·`target` 을 목록에 넣으면 그 안에서 돌린
+    /// 정당한 Claude 세션이 통째로 사라진다 — 이 변경이 없애려던 "조용한 0건"의 재생산이다.
+    /// 앞의 테스트는 가지치기의 *긍정* 방향만 봤기 때문에 이 회귀를 통과시켰다.
+    func testEmbeddedRootsFindRootsUnderWorkDirectoryNames() {
+        let base = tempDir()
+        let session = base.appendingPathComponent("u1/u2/local_x")
+        for work in ["outputs/myrepo", "uploads/repo2", "build", "target"] {
+            try? FileManager.default.createDirectory(
+                at: session.appendingPathComponent("\(work)/.claude/projects"),
+                withIntermediateDirectories: true)
+        }
+        let found = LocalUsageReader.embeddedClaudeProjectRoots(under: base).map(\.path)
+        for work in ["outputs", "uploads", "build", "target"] {
+            XCTAssertTrue(found.contains { $0.contains("/\(work)/") || $0.contains("/\(work)/.claude") },
+                          "\(work) 아래의 정당한 루트가 잘렸다")
+        }
+    }
+
+    /// `CLAUDE_CONFIG_DIR` 파싱: 콤마 분리·공백 트림·빈 조각 무시·틸드 확장.
+    func testConfigDirParsingHandlesCommasWhitespaceAndTilde() {
+        let home = URL(fileURLWithPath: "/Users/testhome")
+        let roots = LocalUsageReader.computeClaudeProjectRoots(
+            configDirValue: " /a/one , ,~/two ", home: home).map(\.path)
+
+        XCTAssertTrue(roots.contains("/a/one/projects"))
+        XCTAssertTrue(roots.contains(NSString(string: "~/two").expandingTildeInPath + "/projects"))
+        XCTAssertFalse(roots.contains { $0 == "/projects" })          // 빈 조각이 루트로 새지 않는다
+        XCTAssertTrue(roots.contains("/Users/testhome/.claude/projects"))
+        XCTAssertTrue(roots.contains("/Users/testhome/.config/claude/projects"))
+        // 값이 없으면 CLI 기본 위치만 남는다.
+        let none = LocalUsageReader.computeClaudeProjectRoots(configDirValue: nil, home: home).map(\.path)
+        XCTAssertFalse(none.contains { $0.hasPrefix("/a/one") })
+    }
+
+    /// 심볼릭 링크로 같은 트리를 두 번 가리켜도 한 번만 스캔해야 한다(합계는 dedup 이 지키지만 비용은 아니다).
+    func testNormalizedRootsFoldSymlinkedDuplicates() {
+        let base = tempDir()
+        let real = base.appendingPathComponent("real/projects")
+        try? FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+        let link = base.appendingPathComponent("linked")
+        try? FileManager.default.createSymbolicLink(at: link, withDestinationURL: base.appendingPathComponent("real"))
+
+        let folded = LocalUsageReader.normalizedRoots([real, link.appendingPathComponent("projects")])
+        XCTAssertEqual(folded.count, 1, "심볼릭 링크로 중복된 루트는 접혀야 한다")
+    }
+
+    /// `CLAUDE_CONFIG_DIR=~/.claude` 처럼 기본 루트와 겹치게 지정하면 같은 트리를 두 번 스캔한다.
+    /// 합계는 전역 dedup 이 바로잡지만 스캔 비용은 두 배라, 루트 단계에서 접어야 한다.
+    func testNormalizedRootsDropsDuplicatesAndNestedRootsKeepingOrder() {
+        let roots = [
+            URL(fileURLWithPath: "/Users/x/.claude/projects"),
+            URL(fileURLWithPath: "/Users/x/.config/claude/projects"),
+            URL(fileURLWithPath: "/Users/x/.claude/projects"),           // 완전 중복
+            URL(fileURLWithPath: "/Users/x/.claude/projects/sub"),       // 중첩
+            URL(fileURLWithPath: "/Users/x/.claude/projects-other"),     // 접두사만 같음 — 남아야 함
+        ]
+        XCTAssertEqual(LocalUsageReader.normalizedRoots(roots).map(\.path), [
+            "/Users/x/.claude/projects",
+            "/Users/x/.config/claude/projects",
+            "/Users/x/.claude/projects-other",
+        ])
+    }
+
+    /// 루트가 여러 개면 합산하되, 같은 턴이 두 루트에 복사돼 있어도(Desktop 이 CLI 세션을 공유하는 경우)
+    /// `(message.id, requestId)` 전역 dedup 으로 한 번만 센다.
+    func testMultipleRootsSumButShareGlobalDedup() {
+        let cli = tempDir(), desktop = tempDir()
+        let ts = "2026-06-30T10:00:00.000Z"
+        write([claudeLine(id: "A", req: "R1", model: "claude-opus-4-8", ts: ts, i: 100, o: 10, cw: 0, cr: 0)],
+              to: cli, sub: "p")
+        write([
+            claudeLine(id: "A", req: "R1", model: "claude-opus-4-8", ts: ts, i: 100, o: 10, cw: 0, cr: 0),
+            claudeLine(id: "B", req: "R2", model: "claude-opus-4-8", ts: ts, i: 7, o: 3, cw: 0, cr: 0),
+        ], to: desktop, sub: "p")
+
+        let entries = LocalUsageReader.claudeEntries(modifiedSince: .distantPast, roots: [cli, desktop])
+        XCTAssertEqual(entries.count, 2)                                  // A 는 한 번만
+        XCTAssertEqual(entries.reduce(0) { $0 + $1.total }, 110 + 10)
+
+        // 대조군: Desktop 루트를 빼면 B 가 사라진다 — 이 테스트가 실제로 다중 루트를 밟고 있다는 보증.
+        XCTAssertEqual(LocalUsageReader.claudeEntries(modifiedSince: .distantPast, roots: [cli]).count, 1)
+    }
+
+    /// 기본 루트 목록에 CLI 기본 위치가 항상 들어있고 중복이 없어야 한다(구성 실수 가드).
+    /// `claudeProjectRoots` 를 직접 쓰면 로그인 셸을 띄워 개발자의 `.zshrc` 를 실행하고 그 기기의
+    /// `CLAUDE_CONFIG_DIR` 에 따라 결과가 달라진다 — 유닛 테스트는 hermetic 시임으로 판정한다.
+    func testDefaultRootsContainCLIPathAndAreUnique() {
+        let home = URL(fileURLWithPath: "/Users/testhome")
+        let roots = LocalUsageReader.computeClaudeProjectRoots(configDirValue: nil, home: home).map(\.path)
+        XCTAssertTrue(roots.contains(home.appendingPathComponent(
+            LocalUsageReader.defaultRelativeProjectsPath).path))
+        XCTAssertEqual(Set(roots).count, roots.count)
+    }
+
+    /// CLI 기본 위치는 `claudeProjectsDir` 와 루트 목록이 같은 상수를 공유해야 한다
+    /// (양쪽에 리터럴을 따로 쓰면 한쪽만 바뀌어도 아무도 못 잡는다).
+    func testDefaultProjectsPathHasSingleSource() {
+        XCTAssertTrue(LocalUsageReader.claudeProjectsDir.path
+            .hasSuffix("/" + LocalUsageReader.defaultRelativeProjectsPath))
+    }
+
     // MARK: Codex 파싱 (input=total−cached, cacheRead=cached, output, cacheWrite=0)
 
     private func codexLine(ts: String, input: Int = 1_000, cached: Int = 200,

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -828,6 +828,32 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(UsageStore.friendlyLimitError(LimitsError.credentialFormat, l), l.limitRefreshNoCredential)
         XCTAssertEqual(UsageStore.friendlyLimitError(LimitsError.keychainInteractionNotAllowed, l), l.limitRefreshGeneric)
         XCTAssertEqual(UsageStore.friendlyLimitError(StubError.boom, l), l.limitRefreshGeneric)   // 비 LimitsError
+        // 계정 OAuth 없음은 "자격증명 없음"이 아니라 재로그인 안내다 — 두 메시지가 갈려야 한다.
+        XCTAssertEqual(UsageStore.friendlyLimitError(LimitsError.credentialMissingAccountOAuth, l),
+                       l.limitRefreshReauthNeeded)
+        XCTAssertNotEqual(l.limitRefreshReauthNeeded, l.limitRefreshNoCredential)
+    }
+
+    /// 자격증명 항목이 MCP 서버 OAuth 상태만 담고 계정 토큰(`claudeAiOauth`)은 없는 경우
+    /// (Claude Code 2.1.x 에서 관측) — 형식 오류로 뭉뚱그리면 "재로그인하면 된다"를 안내 못 한다.
+    func testAccountOAuthMissingIsDistinguishedFromMalformedCredential() {
+        func data(_ json: String) -> Data { Data(json.utf8) }
+
+        XCTAssertTrue(OAuthCredentialData.isAccountOAuthMissing(
+            data(#"{"mcpOAuth":{"some-server":{"accessToken":"x"}}}"#)))
+        // 깨진 JSON·계정 OAuth 가 있는 경우는 이 분기가 아니다(형식 오류 / 정상).
+        XCTAssertFalse(OAuthCredentialData.isAccountOAuthMissing(data("not json at all")))
+        XCTAssertFalse(OAuthCredentialData.isAccountOAuthMissing(
+            data(#"{"claudeAiOauth":{"accessToken":"t"}}"#)))
+        // 명시적 JSON null 은 NSNull 로 디코드돼 `!= nil` 이 참이 된다 — 로그아웃 상태를 "값 있음"으로
+        // 오판하면 재로그인 안내 대신 "자격증명 없음"이 뜬다(CLAUDE.md 의 JSON null 금지 규칙).
+        XCTAssertTrue(OAuthCredentialData.isAccountOAuthMissing(
+            data(#"{"claudeAiOauth":null,"mcpOAuth":{}}"#)))
+
+        // 파싱 자체는 계정 OAuth 가 있을 때만 성공한다.
+        XCTAssertNil(OAuthCredentialData.credential(from: data(#"{"mcpOAuth":{}}"#)))
+        XCTAssertEqual(
+            OAuthCredentialData.credential(from: data(#"{"claudeAiOauth":{"accessToken":"t"}}"#))?.accessToken, "t")
     }
 
     // MARK: Cursor provider aggregation

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -1,0 +1,221 @@
+---
+summary: "결함 대응 프로토콜로 축적된 구체 규칙 — 한 번 겪은 부류의 실수를 다시 겪지 않기 위한 원장."
+read_when:
+  - 결함·회귀·공백을 고치는 중 (프로토콜 4단계의 '부류 스윕'·'영구 캡처' 근거)
+  - 동시성/await·옵셔널 판정·캐시 무효화·외부 로그 포맷을 건드릴 때
+  - 메뉴바·플로팅 펫 등 상시 표시 애니메이션의 성능을 손볼 때
+  - 세이브 이전/병합·외부 파일 입력 경로를 만들 때
+---
+
+# 결함 대응 축적 규칙
+
+`CLAUDE.md` §결함 대응 프로토콜의 4단계(근본원인 → 부류 스윕 → 회귀 테스트 → 영구 캡처)를 거쳐
+남은 규칙들이다. 각 항목은 실제로 겪은 회귀에 묶여 있다.
+
+## 판정·데이터
+
+- **옵셔널 tautology.** 옵셔널 필드라도 *생산자가 항상 채우면* `x != nil` 은 항상 참이다. "값이 있나"는
+  의미값으로 검사한다(예: `totalTokens > 0`, 또는 진짜 nil 가능한 필드 `activeBlock`). — weekTotal 회귀(#56).
+- **JSON `null` 은 "값 있음"이 아니다.** `obj["x"] != nil` 은 `NSNull` 에도 참이라 `intValue` 가 0 을 돌려주고,
+  그 0 으로 캐시분을 빼면 토큰이 통째로 사라진다. 숫자 필드는 `NSNull`·문자열·부재를 모두 nil 로 만드는
+  추출기(`intOrNil`/`doubleOrNil`)로 읽고, 대체 스펠링 폴백은 그 nil 로 판단한다.
+  **숫자만의 문제가 아니다** — 존재 판정에도 같은 함정이 있다. `json["claudeAiOauth"] == nil` 로 계정 OAuth
+  유무를 보면 `"claudeAiOauth": null`(로그아웃 상태)이 "있음"으로 판정돼 재로그인 안내 대신 엉뚱한 메시지가
+  나간다. 기대 타입으로 캐스팅되는지로 판단한다(`(json["x"] as? [String: Any]) == nil`). 회귀 가드는
+  부재·`null`·정상 셋을 모두 넣어야 한다 — 부재와 정상만 넣으면 통과하면서 `null` 을 못 잡는다.
+- **관대 디코딩(`lenient`/`Lossy`)을 유지하려면 신뢰경계의 값 범위 검증이 짝으로 와야 한다.** 관대 디코딩은
+  "한 필드가 깨져도 도감을 안 날린다"를 얻는 대신 "말이 안 되는 값도 통과시킨다"를 떠안는다. 자기 앱이 쓴
+  파일만 읽을 땐 무해하지만, **외부 파일을 읽는 경로가 생기는 순간 그 트레이드오프가 라이브가 된다** —
+  `Int.max` 같은 값이 그대로 저장되면 이후 산술이 Swift 오버플로 트랩으로 프로세스를 죽이고, 재기동해도
+  같은 파일을 읽어 다시 죽는다(`load()` 의 `.corrupt` 복구는 디코드가 *성공*하므로 발동 안 함 → 파일을
+  손으로 지우기 전까지 앱 사용 불가). 방어는 다운스트림 산술 지점마다가 아니라 **값이 들어오는 경계 한
+  곳**에서(`SaveTransfer.sanitized`). 자르는 대상은 산술에 쓰이는 수치뿐 — 도감·인벤토리 *항목*은 잘라내면
+  데이터 손실이다. (딥리뷰 2026-08-03: SIGTRAP 재현.)
+
+## 외부 로그·사용량 소스
+
+- **외부 로그 포맷은 *상위 소스의 writer* 로 검증한다 — 내 픽스처는 증거가 아니다.** 새 프로바이더 파서를
+  쓸 때 "이렇게 생겼을 것"으로 픽스처를 만들면 파서와 픽스처가 같은 오해를 공유해 테스트가 전부 통과하면서
+  실사용은 0 을 표시한다(#133: 봉투 래퍼 키를 `update` 로 봤으나 실제는 `params`, `timestamp` 는 ISO 문자열이
+  아니라 Unix `u64` 초 — 실제 라인은 한 건도 안 잡혔다). 순서: ① 업스트림에서 *쓰는* 코드(직렬화 구조체·serde
+  계약 테스트)를 열어 키·타입·의미를 확정 ② 그 계약으로 픽스처 작성 ③ 가능하면 실파일 1건 캡처. 특히
+  **같은 스펠링이 표면마다 의미가 다를 수 있다**(Grok `inputTokens`=캐시 포함 durable wire vs `input_tokens`=캐시
+  제외 헤드리스 투영) — 별칭으로 합치면 캐시분을 두 번 빼거나 두 번 더한다.
+- **사용량 소스의 "복사·재기록" 경로를 먼저 찾아라 (이중집계·재날짜화).** 세션 fork·재생·서브에이전트는 같은
+  지출을 여러 파일에 남기거나 시각을 다시 찍는다. 규칙: ① dedup 키는 *턴 자체* 의 전역 유일 id(파일·세션 경로를
+  섞지 마라 — 복사본이 별건이 된다) ② 시각은 *기록* 시각이 아니라 *턴* 시각(fork 는 봉투 timestamp 를 새로
+  찍는다 → 주/월 합계가 포크 시점으로 몰린다) ③ 부모에 접혀 들어오는 자식(서브에이전트) 세션은 제외.
+- **로그 루트는 한 곳이 아니다.** Claude 사용 로그는 CLI 기본 위치 말고도 `CLAUDE_CONFIG_DIR`(콤마 다중),
+  XDG 스타일 `~/.config/claude/projects`, 그리고 Claude Desktop 임베디드 세션(`local-agent-mode-sessions`/
+  `claude-code-sessions` 아래 세션마다 자체 `.claude/projects`)에 남는다. 루트 추가는
+  `LocalUsageReader.claudeProjectRoots` 한 곳에서만 한다. 임베디드 루트 탐색은 `.claude` 가 **hidden** 이라
+  `skipsHiddenFiles` 를 켜면 조용히 0건이 된다 — 회귀 가드
+  `testEmbeddedRootsFindHiddenClaudeProjectsDirs` 가 그 브랜치를 밟는다.
+- **GUI 앱은 셸 환경을 상속하지 않는다 — 환경변수로 설정되는 경로는 셸에 물어봐야 한다.** Finder/launchd 로
+  뜬 `.app` 의 `ProcessInfo.processInfo.environment` 에는 `~/.zshrc` 의 export 가 없다. 그래서
+  `CLAUDE_CONFIG_DIR` 같은 값을 프로세스 환경에서만 읽으면 **CLI·`swift test` 에서는 통과하고 배포된 앱에서만
+  0 을 표시**해 재현이 안 된다. 레포에 이미 같은 부류의 해법이 있다(`BinaryLocator.shellResolve` 가 PATH 때문에
+  `zsh -ilc` 를 띄운다) — 새 환경변수도 `BinaryLocator.shellEnvironmentValue` 로 조회한다. 단 셸 spawn 은
+  실측 ~0.44s 라 **프로세스 생애 1회만**(`static let` lazy) 캐시하고, 주기적으로 갱신되는 캐시(TTL)에 묶지 마라 —
+  그 값을 안 쓰는 대다수 사용자까지 갱신마다 비용을 문다.
+- **디렉터리 탐색은 깊이만 막으면 폭이 안 막히지만, 이름 기반 가지치기는 더 위험하다.** 깊이 가지치기는
+  `> maxDepth` 가 아니라 `>= maxDepth` 에서 걸어야 한 단계 더 내려가지 않는다(전자는 상한+1 까지 방문).
+  깊이 상한은 **실제 레이아웃 깊이를 테스트로 고정**하고 여유를 둔다 — 경계에 붙여 두면 상위 소스가 한 단계
+  중첩하는 순간 조용히 0건이 된다(`testEmbeddedRootsDepthBoundaryMatchesRealLayoutWithHeadroom`).
+  **이름으로 가지치는 목록에는 사용자 작업 트리가 될 수 있는 이름을 절대 넣지 마라** — 이름 하나가 *조상*
+  으로 걸리면 그 아래 전부가 사라진다. 실측 회귀: 폭을 줄이려고 `uploads`·`outputs`·`build`·`target` 을
+  넣었는데, `uploads`·`outputs` 는 실제 세션 레이아웃에 존재하는 디렉터리고 그 안에서 돌린 Claude 세션은
+  정당한 루트다 → 원래 고치려던 "조용한 0건"을 그대로 재생산했다. 목록은 패키지·VCS 내부처럼 사용자 코드가
+  아닌 것만(`node_modules`·`.git`·`venv`·`.venv`) 두고, 폭 제어의 주 수단은 깊이 상한으로 둔다.
+- **가지치기·필터 테스트는 양방향으로 단언하라.** "제외돼야 할 것이 제외됐나"만 보면 "포함돼야 할 것이 함께
+  잘렸나"를 못 잡는다. 위 회귀가 정확히 그렇게 통과했다 — `testEmbeddedRootsDoNotDescendIntoBulkDirectories`
+  는 `node_modules` 가 잘리는 것만 확인했고, 같은 목록이 정당한 루트를 자르는 건 아무도 안 봤다. 짝이 되는
+  가드가 `testEmbeddedRootsFindRootsUnderWorkDirectoryNames` 다.
+- **락을 쥔 채 외부 프로세스를 기다리지 마라.** 캐시 갱신 락 안에서 로그인 셸 spawn(최대 8초 대기)이나
+  파일시스템 전체 탐색을 하면, `UsageStore` 가 taskGroup 으로 병렬 fetch 하는 다른 프로바이더까지 그 뒤에
+  줄 선다. 결과가 idempotent 하면 **계산은 락 밖에서** 하고 락은 필드 대입에만 쥔다(경합 시 중복 계산이
+  블로킹보다 낫다).
+- **자식 프로세스 출력은 드레인하되, 드레인에 별도의 짧은 상한을 두지 마라.** 파이프 버퍼(64KB) 데드락을
+  막으려 백그라운드 드레인으로 바꾸면서 세마포어에 2초 상한을 걸었더니, **종료를 무한정 기다리던 이전 동작에서
+  값을 얻던 경우가 nil 이 됐다**(실측 회귀). 셸이 exit 해도 rc 가 띄운 백그라운드 잡(zsh-async·zinit turbo 등)이
+  stdout write end 를 쥐고 있으면 EOF 가 늦게 온다 — 드레인은 **전체 타임아웃의 남은 예산**을 줘야 한다
+  (실측: 고정 2초 → nil / 남은 예산 → 4.03초에 값). 그리고 포기할 땐 `handle.close()` 로 리더를 깨워라 —
+  안 닫으면 `readDataToEndOfFile` 에 박힌 워커 스레드가 호출마다 하나씩 영구히 쌓인다(재시도가 타이머로
+  반복되는 상주 앱에서는 하루 수백 개).
+- **두 개의 완화책을 동시에 바꾸면 각각은 옳아도 조합이 회귀가 된다.** 이름 가지치기 목록을 줄이면서(정확성)
+  깊이 상한을 함께 올렸더니(여유) 열거량이 수백 배로 뛰었다 — 각 변경은 단독으로는 무해했고, 폭을 잡던 것이
+  이름 목록이었는데 그걸 줄이는 순간 깊이가 유일한 제어가 됐기 때문이다. 완화책을 조정할 땐 **어느 쪽이 실제로
+  비용을 잡고 있었는지 측정**하고 한 번에 하나씩 바꾼다. 최종값은 측정으로 정한다(실측: 깊이 6=놓침,
+  7=전부 찾음·방문 100, 8·9=방문 그대로 → 7 이 "놓치지 않는 최소값이면서 비용이 안 느는 지점").
+- **`precondition` 은 릴리스 빌드에서도 앱을 죽인다 — 테스트 전용 시임을 지키는 데 쓰지 마라.** 잘못 써도
+  결과가 "테스트가 엉뚱한 대상을 본다"에 그치는 실수를 SIGTRAP 으로 키운다(`-Ounchecked` 아니면 안 사라짐).
+  도달 불가한 곳이면 더더욱 값이 없다. 우선순위를 주석으로 적거나, 애초에 잘못 쓸 수 없는 시그니처로 바꿔라.
+- **하위 레이어 호출이 비싼 초기화를 트리거하지 않는지 보라.** 안내 문구 하나를 고르려고 부른 함수가
+  `static let` 첫 접근 → 로그인 셸 spawn 을 유발해, 자동 폴링 경로의 actor 를 수백 ms~수 초 막을 수 있다.
+  값이 필요한 쪽(그 값을 실제로 쓰는 경로)에서 초기화를 트리거하고, 부수적 분기에서는 싼 소스
+  (`ProcessInfo.environment`)만 본다.
+- **유닛 테스트가 로그인 셸을 띄우면 hermetic 하지 않다.** 프로덕션 진입점(`claudeProjectRoots`)을 테스트에서
+  직접 부르면 개발자의 `.zshrc` 가 실행되고, 그 기기에 `CLAUDE_CONFIG_DIR` 이 export 돼 있으면 결과가 달라진다.
+  주입 시임(`computeClaudeProjectRoots(configDirValue:home:)`)으로 판정하고, 실환경 확인은 일회성 프로브로
+  분리한다.
+- **경로 dedup 은 심볼릭 링크를 풀고 대소문자를 무시해야 한다.** `standardizedFileURL` 은 `..`·`.` 만 정리하고
+  링크는 그대로 둔다. `~/.config/claude` → `~/.claude` 링크 같은 구성에서 같은 트리를 두 번 열거·파싱하게 된다
+  (합계는 전역 dedup 이 지키지만 스캔 비용과 캐시 blob 은 두 배). `resolvingSymlinksInPath()` 로 풀고
+  비교 키는 소문자로 — macOS 기본 APFS 는 대소문자를 구분하지 않는다.
+- **테스트 시임이 프로덕션 브랜치를 단락시키지 않는지 확인하라.** 다중 루트 순회를 넣고 시임은 단일 루트만
+  받게 두면(`claudeRoot.map { [$0] }`) 기존 테스트 전부가 루프를 1회로 단락시켜, 실제로 도는 코드는 무테스트로
+  남는다. 새 브랜치를 만들면 **그 브랜치를 밟는 시임**을 같이 만든다(`LocalUsageCache(claudeRoots:)` +
+  `testMultipleRootsAreScannedAndDedupedAcrossRoots`, 단일 루트 대조군 포함).
+- **파일 밖 상태에 의존하는 판정을 파싱 캐시 안에서 하지 마라.** `LocalUsageCache` blob 은 그 파일의
+  `(path, mtime, size)` 로만 무효화된다. 옆 파일(예: Grok `summary.json` 의 `session_kind`)로 결정되는
+  포함·제외를 파서 안에서 하면, 근거가 나중에 바뀌어도 파일이 안 바뀌어 판정이 영구히 굳는다. 그런 판정은
+  파일 선택 단계(`collect(include:)`)에 둬 매 새로고침 재평가되게 한다.
+
+## 자격증명·Keychain
+
+- **앱 소유 keychain 항목 금지.** 앱이 만든 keychain 항목은 코드서명(cdhash)이 바뀔 때마다(로컬 재빌드·
+  실사용자 매 업그레이드) 항목 ACL 이 안 맞아 접근 허용 프롬프트를 유발한다 — **no-UI 쿼리로도 이 ACL
+  프롬프트는 억제 안 됨**(#58). 토큰류는 인메모리 캐시 + 파일(`~/.claude/.credentials.json`) 재취득으로
+  처리하고, 앱 전용 keychain 캐시 항목을 새로 만들지 말 것.
+- **자동 폴링은 Claude 키체인을 절대 읽지 마라(키체인 읽기는 사용자 동작 전용).** no-UI 쿼리
+  (`kSecUseAuthenticationUIFail`/`LAContext`)는 '인증' 프롬프트만 억제할 뿐 **잠긴·미승인 login 키체인의
+  '암호 입력' 다이얼로그는 못 막는다** — 실측: 캐시 만료 폴 도중 `SecItemCopyMatching` 이 13초간 블록하며
+  팝업(토큰 만료 시점마다 하루 몇 회, 아침 등). self-signed 앱은 '항상 허용' 승인도 불안정. → 타이머 경로
+  `fetch(allowKeychainPrompt: false)` 는 캐시+파일만 쓰고 키체인은 건드리지 않는다(`OAuthLimitsProvider`
+  의 `guard allowKeychainPrompt` 가 키체인 읽기 앞에 위치). 키체인 읽기는 명시적 사용자 버튼
+  (설정 갱신·팝오버 `claudeLimitsRefreshRow`, `refreshLimitTokenFromKeychain`)에서만. 캐시 토큰이 살아있는
+  동안은 자동 폴이 그 토큰으로 한도를 계속 갱신하고, 만료되면 stale 표시 후 사용자가 갱신한다. 회귀 가드:
+  `testAutoRefreshUsesNoPromptPathManualUsesPromptPath`. (완전 근절은 Developer ID notarization 으로
+  '항상 허용' 승인을 안정화하는 것뿐 — 신뢰된 서명 신원이라야 ACL 승인이 지속된다. 미도입.)
+- **자격증명 "없음"과 "계정 로그인 없음"은 다른 안내다.** Claude Code 2.1.x 의 `Claude Code-credentials`
+  항목이 MCP 서버 OAuth(`mcpOAuth`) 상태만 담고 계정 토큰(`claudeAiOauth`)은 안 담는 경우가 있다. 이때
+  파싱 실패를 형식 오류로 뭉뚱그리면 "재로그인하면 된다"를 안내 못 해 한도 섹션이 원인 불명으로 사라진다.
+  → `LimitsError.credentialMissingAccountOAuth` 로 구분해 재로그인 안내를 띄운다
+  (`OAuthCredentialData.isAccountOAuthMissing`).
+
+## 동시성
+
+- **비동기 완료가 "그 사이 교체된 대상"에 착지하지 않게 하라 — 상태를 통째로 바꾸는 경로를 새로 만들면
+  진행 중인 await 를 전수 점검한다.** 이 레포가 세 번 겪은 부류다(#136·#138 스프라이트, 그리고 세이브
+  불러오기 중 부화). `isHatching` 같은 중복 실행 락은 *같은 작업의 재진입*만 막을 뿐, await 창에서 상태가
+  **다른 주체로 교체되는 것**은 못 막는다. 방어는 두 형태 중 하나로 통일한다: ① `activeGeneration` 을
+  진입 시 캡처하고 mutation 직전 재검사(`hatchCore`·`revealDitto`·`loadCurrentLine`) ② 대상을 id 로 다시
+  찾아 없으면 무시(`dexChainNames` 의 `firstIndex(where: id)`). 회귀 가드는 sleep 이 아니라 신호(actor +
+  continuation)로 await 지점을 정확히 잡아 재현한다 — `testImportDuringHatchDiscardsTheHatch`.
+  **세대는 호출 체인에서 *가장 이른* await 앞에서 캡처하라 — 안쪽 함수에서 캡처하면 가드가 자동 통과한다.**
+  딥리뷰 실측: `hatchCore` 에만 가드를 넣었더니 `hatchIfNeeded` 의 `chooseBase()` 창에 들어온 교체를 못
+  막았다. `hatchCore` 는 *교체 이후*의 세대를 캡처하므로 `activeGeneration == generation` 이 항상 참이 된다
+  (출발할 때 봐야 할 시계를 도착해서 보는 격). 가드를 넣을 땐 그 함수 위의 await 까지 거슬러 확인하고,
+  회귀 테스트도 **그 await 를 실제로 지나는 진입점**으로 써라 — `hatch(baseID:)` 경로 테스트는
+  `chooseBase()` 를 안 지나 통과하면서 아무것도 지키지 않았다(`testImportDuringSpeciesRollDiscardsTheHatch`).
+
+## 표시·UI
+
+- **컴팩트 표시는 오늘 사용한 프로바이더만.** 메뉴바(`menuLines`) 등 좁은 표시에서 한도·상태를 보일 땐
+  `snapshots` 의 오늘 토큰>0 으로 게이트한다 — 설치만 되고 오늘 안 쓴 프로바이더(Codex 등)를 노출하지
+  마라(#56 "미사용 프로바이더 탭" 계열의 표시 버전). 팝오버 상세 뷰는 전체 노출 유지(의도된 상세). 함정:
+  Claude 한도(OAuth)·Codex 한도(프로세스)는 *설치/인증만 돼 있으면 오늘 사용과 무관하게 값이 존재*하므로
+  `limits != nil`/`codexLimits != nil` 만으로 표시하면 미사용 프로바이더가 샌다.
+- **다중 토글 UI 레이아웃은 조합표 전수로.** 토글/입력이 여러 개인 표시 레이아웃을 바꿀 때, 사용자
+  지시가 여러 메시지에 걸쳐 진화하면 각 지시를 **전체 대체가 아니라 특정 조합(행)에 대한 제약**으로
+  누적한다. 구현 전 **모든 토글 조합 → 기대 출력 표**를 만들어 누적 지시와 대조·확인하고, 각 조합을
+  테스트로 고정한다(`testMenuLinesAllCombinations` 처럼). — 회귀: "토큰+비용 세로로"(2개 활성 케이스
+  지시)를 전역 규칙으로 오해해 "3줄 금지"(3개 활성 케이스 제약)를 깨고 3줄을 만든 사례. 두 지시는 서로
+  다른 조합에 관한 것이라 **둘 다 성립**해야 했다(2개→세로, 3개→토큰·비용 한 줄+한도 아랫줄). 최신
+  지시가 이전 제약과 충돌해 보이면 조합별로 재조정하고, 못 풀면 조합표로 되물어라.
+- **메뉴바(상태아이템) stale dim 금지.** 시간 기반 stale(=`isStale`)로 `appearsDisabled` 를 켜면
+  슬립/런치 직후 refresh 완료 전 몇 초간 메뉴바가 회색이 돼 '고장/비활성'으로 오인된다(사용자 반복 지적,
+  `&& lastUpdated != nil` 로 런치만 막는 건 슬립-후 stale 을 못 막음). '오래됨' 신호는 팝오버에서만.
+- **UI 변경 → 스크린샷 stale** 은 `release.sh` 가 자동 경고(`CLAUDE.md` §릴리스) — 통과의례화 방지.
+
+## 에너지 (상시 표시 애니메이션)
+
+- **메뉴바 상태아이템 = idle CPU 저격수 (두 규칙 필수).** 실측: 라이브 앱 idle ~14% CPU → 수정 후 ~2%.
+  ① **`statusItem.button.image` 대입은 반드시 `setDisableActions` 트랜잭션 안에서** (`AppDelegate.setStatusImage`).
+  레이어 백드 `NSStatusBarButton` 은 이미지 대입마다 `NSStatusItemScene` 암묵적 전환 애니메이션
+  (`updateSettings:transition:` → `NSAnimationContext runAnimationGroup:`)을 돌려 상태바를 재합성한다 —
+  5fps 스프라이트 루프면 이 전환이 CPU를 먹는다. `CATransaction.begin()/setDisableActions(true)/commit()` 로
+  즉시 반영해 전환을 없앤다(애니메이션은 유지). ② **`.transient` NSPopover 는 `contentViewController` 를
+  평생 보유**해 닫혀도 `NSHostingView` 트리가 상주하며 매 디스플레이 사이클 재레이아웃된다(특히
+  `Text(_, style:.relative)` 가 `requestUpdate` 로 self-invalidation → `StackLayout.placeChildren` 폭주). 위
+  전환 CA 커밋이 이 레이아웃을 flush해 둘이 곱해진다. → `NSPopoverDelegate.popoverDidClose` 에서
+  `contentViewController = nil`, 열 때 재생성(`buildPopoverContent`). ③ 메뉴 애니는 팝오버 열림 중 정지
+  (`menuShouldAnimate` 에 `!popover.isShown`) — 팝오버 SpriteView가 이미 애니메이션하고, 트래킹 중 상태아이콘
+  리드로우는 WindowServer 부하(데스크톱 비컨볼) 위험. **status-item 전용 앱은 occlusion 이 실제로 잘 안
+  떠서**(앱이 status item 표시 중엔 occluded 안 됨) occlusion 게이팅은 보조 — 슬립/열림 게이팅이 실질 방어.
+  검증 함정: bare/`open -n` 보조 인스턴스는 애니메이션이 안 돌아 14%를 **재현 못 함** → 실측은 설치된
+  primary 앱 교체로만. **배터리(idle wakeup) 차원:** CPU% 낮아도 button.image 대입마다 레이어 dirty →
+  CA 커밋 → WindowServer 디스플레이 사이클 왕복이 wakeup을 증폭한다(실측 ~47 wakeup/s). `setStatusImage`
+  diff-gate(동일 프레임 객체 재대입 스킵 — 애니 프레임은 서로 다른 객체라 정상 통과) + GIF fps 하한 0.4s(≈2.5fps)
+  + `Timer.tolerance` 0.5(코얼레싱)로 ~5 wakeup/s(−89%), 애니메이션 유지. 배터리-vs-AC/thermal 적응·CADisplayLink
+  전환은 1인 로컬 노트북 기준 수확체감으로 판정, 미도입(필요 시 Agent Team 계획 참조). (Agent Team 조사 + 실측, 2026-07-22.)
+- **항상 뜬 애니메이션 표면은 메뉴바와 같은 idle 규율을 공유한다.** 플로팅 펫(`FloatingPetPanel`)처럼 상시
+  표시되는 두 번째 GIF 표면을 더할 땐 메뉴바 규율을 그대로 상속해야 회귀(#102 후속)를 안 만든다: ① GIF fps
+  하한(`SpriteView(minFrameDelay:)` — 펫은 `FloatingPetView.frameFloor` 0.4s≈2.5fps, 팝오버 등 *일시적* 표시는
+  0=네이티브) + `Task.sleep(for:tolerance:)` 코얼레싱, ② 저전력 모드 정적화(`FloatingPetController.shouldAnimate(lowPower:)`
+  — `NSProcessInfoPowerStateDidChange` 관찰 후 콘텐츠 재구성), ③ 숨김/슬립 시 `contentView=nil` 로 프레임 루프 정지
+  (팝오버 `popoverDidClose` 패턴). 회귀 가드: `FloatingPetEnergyTests`(fps 하한 clamp·`frameFloor>0`·팝오버 불변·
+  low-power 정적화 순수 판정 — SwiftUI `.task` 타이밍 자체는 호스트 없이 xctest 불가라 순수 경로만 잠금). occlusion 게이팅은
+  all-spaces/`.floating` 펫이 실제로 거의 안 가려져 메뉴바와 동일 수확체감으로 미도입. (#102 리뷰 지적 반영, 2026-07-22.)
+
+## 알림
+
+- **휘발성 필드를 dedup/identity 키에 쓰지 마라.** 매 fetch/refresh 마다 값이 변하는 필드(예: rolling
+  한도 창의 `resets_at`)를 알림 중복방지 키에 넣으면 매번 새 키가 되어 dedup 이 무력화된다 — 주간 한도
+  알림이 80·81·84…갱신마다 반복되던 회귀. 임계값 알림은 **엣지 트리거**(직전 tier 보다 높아진 순간만
+  발화, 경고선 아래로 내려가면 재무장)로 구현하고, 판정은 부수효과(실 알림 전송·`.app` 번들 가드)와
+  분리한 **순수 함수**(`UsageStore.evaluateLimitAlerts`)로 테스트한다 — 번들 가드 때문에 실 발화 경로는
+  xctest 에서 조기 return 되어 커버 불가였던 게 무테스트의 원인.
+
+## 상태 파일 이전·병합
+
+- **상태 파일을 옮기거나 합칠 땐 "진행"과 "이 기기 장부"를 먼저 분류하라.** 같은 파일에 살아도 성격이
+  다르다 — `usedSinceInstall`·`dex`·`inventory`·`candyGrantTier` 는 어느 기기에서든 참인 **진행**이고,
+  `claimedTodayTokens`·`lastDate`·`installBaselineSet` 은 *그 기기가* 어디까지 적립했나를 적은 **로컬
+  장부**다. 장부를 그대로 들여오면 옛 기기의 오늘 최고치가 문턱이 되어 `update` 의
+  `todayTokens > claimedTodayTokens` 게이트가 이전 당일 내내 거짓 → 새 기기 사용분이 조용히 안 잡힌다
+  (자정에 저절로 낫기 때문에 버그로 안 보인다). 반대로 계정 전역 근거로 만들어진 원장(`candyGrantTier`
+  — 한도 창 key)은 **버리면** 같은 창에서 재지급된다. 이전·병합 경로를 만들 땐 필드를 전수로 이 두 부류에
+  넣어 보고, 로컬 장부만 새 기기 기준으로 다시 잡는다(`SaveTransfer.rebasedForThisDevice`). 회귀 가드:
+  `testTransferDayTokensStillCountAfterRebase` — 재정렬 없는 대조군을 같이 돌려 결함 조건이 살아 있는지도
+  함께 확인한다(테스트가 트리거 브랜치를 실제로 밟는지 보증).

--- a/docs/reference/provider-extension.md
+++ b/docs/reference/provider-extension.md
@@ -1,0 +1,28 @@
+---
+summary: "새 사용량 소스(AI CLI)·버전매니저를 더할 때의 확장 지점과 플랫폼 종속 분기 금지 규약."
+read_when:
+  - 새 프로바이더(사용량 소스)를 추가할 때
+  - 버전매니저·설치경로 탐색을 손볼 때
+  - 코드 리뷰에서 프로바이더 분기가 범용 경로에 새는지 볼 때
+---
+
+# 확장 규약 (새 프로바이더/툴 추가)
+
+새 AI CLI(사용량 소스)·버전매니저를 더할 때 특정 플랫폼에 종속된 분기를 만들지 않는다.
+아래는 절차이며, **코드 리뷰 시 이 규약 위반을 결함으로 본다.**
+
+- **사용량 소스 추가** = `UsageProvider` 프로토콜(`Core/UsageProvider.swift`) 구현체 1개 작성 +
+  `UsageStore.init` 의 기본 `providers:` 배열(`Core/UsageStore.swift`)에 등록. 이 두 곳이 유일한 손댈 지점.
+- **범용 동작은 프로바이더 무관하게 집계**: 오늘/주/월 합계·burn tier·companion 리듬은 전 프로바이더
+  합산이어야 한다(`snapshots` reduce). 한 프로바이더에만 계산을 붙이지 마라(과거 회귀: burn 이 Claude
+  블록만 관측 → Codex/Gemini 전용 사용자 companion 이 항상 idle). 패리티 테스트가 이를 강제한다
+  (`UsageStoreTests` 의 "unknown provider" 계열).
+- **프로바이더 고유 동작만 `providerID` 로 명시 분기**: 공식 한도(Claude=HTTP·Codex=프로세스),
+  5h forecast·"현재 블록" 행처럼 *특정 프로바이더에만 존재하는* 기능만 id 로 조건 분기한다.
+  범용 경로에 `== "claude_code"` 류 리터럴 분기를 추가하는 건 금지.
+- **버전매니저/설치경로 추가** = `BinaryLocator.commonToolDirectories()` 한 곳에만 추가한다
+  (탐색·자식 프로세스 PATH 보강이 이 단일 소스를 공유).
+- **로그 스캔 루트 추가** = `LocalUsageReader.claudeProjectRoots` 같은 프로바이더별 루트 목록 한 곳에만
+  추가한다. 스캔(`LocalUsageReader`)·캐시(`LocalUsageCache`)·테스트가 그 단일 소스를 공유해야 한다.
+  루트가 겹쳐도 합계는 전역 dedup 이 바로잡지만, 중복 루트는 스캔 비용을 배로 늘리므로
+  `normalizedRoots` 로 접는다.

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -1,0 +1,52 @@
+---
+summary: "릴리스 실행 절차 — 문서·에셋 갱신 의무, 스크린샷 재생성 방법, release.sh 게이트의 함정."
+read_when:
+  - 버전을 배포할 때 (자연어 트리거 포함: "배포해줘", "릴리스 올려줘", "패치 배포")
+  - release.sh 가 문서·에셋 경고나 하드 게이트로 중단됐을 때
+  - UI 를 바꿔 스크린샷·랜딩을 갱신해야 할 때
+---
+
+# 릴리스 실행 절차
+
+버전 결정 규칙과 트리거는 `CLAUDE.md` §릴리스에 있다. 이 문서는 그 다음의 *실행 세부*를 담는다.
+체크리스트 원본은 `RELEASE.md`.
+
+## 1. 문서·이미지 갱신 (매 릴리스 필수 — "할까요?" 묻지 말고 무조건 한다)
+
+`./scripts/release.sh --check-only` 로 경고를 확인한 뒤 아래를 모두 반영한다.
+
+- **README.md/ko/ja**: 기능 목록·how-it-works·스크린샷 참조.
+- **랜딩(gh-pages orphan 브랜치) — 필수.** `git worktree add /tmp/ptb-ghpages gh-pages` → `index.html`
+  기능 카드(f#) + i18n 사전(en/ko/ja 동시·키 정합) 갱신 → 커밋 → `git push origin gh-pages` →
+  `git worktree remove`. (Pages 자동 재빌드. 커밋은 gh-pages log 모방 = `landing:` 프리픽스.)
+- **스크린샷(`assets/`)**: UI(`Sources/PokeTokenBar/UI/`) 변경 시 재생성. 기존 방식 = **HTML 렌더**
+  (팝오버 라이브 캡처 아님) — Chrome `--headless --screenshot --force-device-scale-factor=2` 로 다크
+  팝오버를 720px PNG 로 그린다. 애니 GIF(home)는 프레임 합성 후 `gifsicle -O3 --lossy` 로 최적화
+  (PIL 재인코딩 단독은 용량 팽창 주의). 언어별 이미지(`settings.png`/`-ko`/`-ja` 등) 각 README 참조.
+- homebrew-tap cask caveat.
+
+### 게이트의 함정
+
+- `release.sh` 문서검토는 *커밋된* 상태를 비교 → 스크린샷을 스테이징만 하면 경고 프롬프트가
+  여전히 뜬다. 미리 커밋하거나 프롬프트에 `y`(스테이징분이 release.sh line 93-94 에서 릴리스 커밋에 함께 담김).
+- **신규 기능 = 신규 에셋 (하드 게이트, 프롬프트로 못 넘김).** 직전 태그 이후 `Sources/**/UI/` 를 건드린
+  `feat:` 커밋이 있는데 `assets/` 에 **새로 추가된** 파일이 없으면 `release.sh` 가 중단한다
+  (**예외 없음** — 통과시키려면 에셋을 만들거나 커밋 타입을 바꿔야 한다). 기존 staleness 검사는 "에셋이 하나라도 바뀌었나"만
+  보기 때문에 **기존 스크린샷만 다시 그려도 통과**한다 — 2.5.0 에서 플로팅 펫이 이미지 없이 나간 경로가
+  정확히 이것이다(`settings.png` 를 갱신해 둔 탓에 조용히 통과). 갱신(stale)과 커버리지(신규)는 다른 질문이다.
+
+## 2. 실행
+
+릴리스 노트를 작성한 뒤 반드시 `main` 브랜치에서:
+
+```bash
+# 직전 릴리스 이후 변경을 요약해 노트 파일 작성
+PTB_NOTES_FILE=/tmp/ptb-notes.md ./scripts/release.sh <version>
+```
+
+스크립트가 test-gate → 문서검토 → 범프 → 빌드검증 → 커밋·push → GitHub Release → cask → Pages 를
+순서대로 수행한다.
+
+## 3. 검증
+
+완료 후 `brew upgrade --cask poke-token-bar` 로 실제 업그레이드 동작을 확인한다.


### PR DESCRIPTION
## Problem

Claude Code writes session logs to more than one location, but the scanner only read `~/.claude/projects`. Usage from Claude Desktop sessions, and from installs whose config directory has been relocated, was missing from every total with no indication anything was skipped.

Verified on a real machine: a Claude Desktop session under `local-agent-mode-sessions/…/.claude/projects` held 32 assistant turns / 1,706,368 tokens that the app never counted.

## Scan roots

All roots now come from one place, `LocalUsageReader.claudeProjectRoots`:

| Root | Why |
|---|---|
| `CLAUDE_CONFIG_DIR` (comma-separated) | user relocated the config directory |
| `~/.config/claude/projects` | XDG-style installs |
| `~/.claude/projects` | CLI default |
| Claude Desktop embedded sessions | each session carries its own `.claude/projects` |

A GUI app launched from Finder or launchd does not inherit the login shell's environment, so `CLAUDE_CONFIG_DIR` is resolved through the shell when it is absent from the process environment — the same approach `BinaryLocator` already uses for `PATH`. That lookup is memoized for the process lifetime, and the root list is cached with a 5 minute TTL so a refresh does not re-walk the filesystem. Duplicate and nested roots are folded, resolving symlinks and comparing case-insensitively, so a relocated config pointing at the default tree is not scanned twice.

Embedded stores must be discovered by walking, because the session path contains UUID segments. Two constraints came out of measurement rather than guessing:

- `.claude` is a hidden directory, so the walk must not set `skipsHiddenFiles` — with it, discovery silently returns nothing.
- Depth is capped at 7. The session root sits at depth 5 and a repository checked out into the sandbox work directory at depth 7; 8 and 9 visit no more entries than 7. Name-based pruning is restricted to package and VCS internals (`node_modules`, `.git`, `venv`, `.venv`). Work-directory names such as `outputs` or `build` cannot go in that list — they exist in the real layout, and pruning by an ancestor's name drops every legitimate root beneath it, reproducing the undercount this change removes.

When the depth cap does truncate the walk, that is now logged with the number of roots found, so a future layout change surfaces instead of quietly reducing totals.

## Credentials

Claude Code 2.1.x can leave a `Claude Code-credentials` keychain item containing only `mcpOAuth`, with no account token. Reporting that as a generic format error hid the fact that signing in again fixes it; it is now a distinct case with its own message in all three locales. Note that `claudeAiOauth: null` has to be treated as absent — the key is present as `NSNull`, so an existence check reports it as a value and picks the wrong message.

## Shell helper

`shellResolve` and the new environment lookup now share one implementation, which fixes two latent problems in the original:

- stdout is drained concurrently instead of after waiting for exit, so a shell profile writing more than the pipe buffer cannot deadlock the child.
- the read handle is closed when giving up, so the reader thread is not left blocked forever.

The drain gets the remainder of the existing timeout rather than a separate short budget. A shell that exits while a backgrounded job still holds stdout delivers EOF late, and a short budget turns cases that previously succeeded into failures.

## Documentation

`CLAUDE.md` was 22 KB and fully loaded every session. Long, situational procedure moved to `docs/reference/` with `summary` / `read_when` frontmatter, leaving the always-applicable rules inline — 22,386 B → 5,331 B. No rule text was lost (28 rule headings and 90 symbol references verified present after the split). `docs/` stays ignored for personal notes; only `docs/reference/` is published.

## Verification

- 489 tests pass, 5 skipped
- Desktop totals matched an independent measurement across four runs (32 entries / 1,706,368 tokens)
- Each new guard was checked by injecting the defect it targets and confirming it fails — including `skipsHiddenFiles`, which is otherwise invisible
