### PR TITLE
perf: stop a degenerate fork hint from parsing every rollout

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -414,6 +414,10 @@ enum LocalUsageReader {
         for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
             autoreleasepool {   // JSONSerialization 의 autoreleased 객체를 라인마다 배출(콜드 파싱 피크 억제)
                 let record = String(line)
+                // NOTE: 여기에 `line.contains("session_meta")` prefilter 를 넣으면 **느려진다**.
+                // 실측(실기기 57 rollout, release 빌드, best of 3 × 2회): 없음 1.80/1.84s vs 있음 2.17/2.19s.
+                // Swift `String.contains(_:)` 는 grapheme 단위 탐색이라 라인마다 훑는 비용이
+                // JSONSerialization 의 파싱보다 크다 — "파싱 줄 수를 줄이면 빨라진다"는 직관이 틀린 자리다.
                 if let meta = codexSessionMeta(record) {
                     if sessionID == nil {
                         // subagent meta는 `id`가 child이고 `session_id`가 parent일 수 있으므로 id 우선.
@@ -542,8 +546,15 @@ enum LocalUsageReader {
             let unresolved = allFiles.filter { !rolloutsByPath.keys.contains($0.path) }
             // 이미 아는 세션 id 와 파일명으로 후보를 좁혀 먼저 확인한다(파일을 열지 않는다).
             let hinted = unresolved.filter {
-                if case .known(let id) = sessionIDKnowledge($0), id == parentID { return true }
-                return $0.url.lastPathComponent.contains(parentID)
+                switch sessionIDKnowledge($0) {
+                case .known(let id):
+                    // 세션 id 를 아는 파일은 그 값으로만 판정한다. 파일명까지 보면 id 가 다른데도
+                    // 후보로 뽑혀, 인덱스가 warm 이어도 매 새로고침 같은 파일을 다시 full-parse 한다.
+                    return id == parentID
+                case .unknown:
+                    return isUsableFilenameHint(parentID)
+                        && $0.url.lastPathComponent.contains(parentID)
+                }
             }
             if adopt(hinted) { continue }
 
@@ -571,6 +582,14 @@ enum LocalUsageReader {
             probeSessionID: { codexRolloutSessionID(at: $0.url) }
         )
         return resolveCodexRollouts(rollouts, includedPaths: includedPaths)
+    }
+
+    /// 파일명 부분일치로 부모 후보를 좁힐 때 쓸 수 있는 id 인가.
+    /// 퇴화된 값(빈 문자열·`"-"` 같은 구분자만)은 거의 모든 rollout 파일명에 걸려 후보 필터가
+    /// 아무것도 걸러내지 못하고 전 rollout 을 full-parse 시킨다 — 실측 300파일 기준 0.009s → 18.2s.
+    /// 이건 파일을 열지 않는 값싼 사전 필터일 뿐이라, 통과해도 내용 대조는 그대로 수행된다.
+    static func isUsableFilenameHint(_ id: String) -> Bool {
+        id.count >= 4 && id.contains { $0.isLetter || $0.isNumber }
     }
 
     private static func codexSessionMeta(_ line: String) -> CodexSessionMeta? {

--- a/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
@@ -1064,4 +1064,51 @@ final class LocalUsageReaderTests: XCTestCase {
         XCTAssertEqual(entries.first?.cacheRead, 0)
     }
 
+    // MARK: Codex 파싱 비용 경계 (딥리뷰 후속)
+
+    /// 퇴화된 `forked_from_id` 는 파일명 부분일치로 거의 모든 rollout 을 후보로 만들어,
+    /// 후보 필터가 아무것도 못 거르고 전량 full-parse 된다(실측 300파일 0.009s → 18.2s).
+    /// 값싼 사전 필터라 통과 여부가 결과를 바꾸면 안 된다 — 정상 id 는 그대로 통과해야 한다.
+    func testDegenerateParentHintIsNotUsedToNarrowCandidates() {
+        XCTAssertFalse(LocalUsageReader.isUsableFilenameHint("-"), "구분자 하나는 전 파일명에 일치")
+        XCTAssertFalse(LocalUsageReader.isUsableFilenameHint(""))
+        XCTAssertFalse(LocalUsageReader.isUsableFilenameHint("----"), "영숫자가 없으면 힌트 가치 없음")
+        XCTAssertTrue(LocalUsageReader.isUsableFilenameHint("parent"))
+        XCTAssertTrue(LocalUsageReader.isUsableFilenameHint("00000000-0000-7000-8000-000000000001"))
+    }
+
+    /// 퇴화 힌트가 들어와도 결과 자체는 정상이어야 한다(성능 가드가 정확성을 바꾸지 않음).
+    func testDegenerateParentHintStillResolvesUsageCorrectly() {
+        let dir = tempDir()
+        write([
+            #"{"type":"session_meta","timestamp":"2026-07-29T01:00:00.000Z","payload":{"id":"child","forked_from_id":"-","thread_source":"user"}}"#,
+            codexStateLine(ts: "2026-07-29T01:00:00.010Z",
+                           cumulativeInput: 100, cumulativeOutput: 10, lastInput: 100, lastOutput: 10),
+            codexStateLine(ts: "2026-07-29T01:00:05.000Z",
+                           cumulativeInput: 300, cumulativeOutput: 30, lastInput: 200, lastOutput: 20),
+        ], to: dir, name: "rollout-child.jsonl", sub: "child")
+        let entries = LocalUsageReader.codexEntries(modifiedSince: .distantPast, root: dir)
+        XCTAssertEqual(entries.map(\.total), [220], "부모 없는 fork — 기존 timing trim 결과 그대로")
+    }
+
+    /// 부모 대조가 실제로 replay 를 잘라내는지 — 부모 링크·subagent 판정이 `session_meta` 에서
+    /// 나오므로 그 줄 처리를 건드리는 변경(예: prefilter 도입)이 조용히 깨뜨리지 않게 고정한다.
+    func testForkReplayIsTrimmedAgainstTheParentRollout() {
+        let dir = tempDir()
+        write([
+            #"{"type":"session_meta","timestamp":"2026-07-29T01:00:00.000Z","payload":{"id":"parent","session_id":"parent"}}"#,
+            codexStateLine(ts: "2026-07-29T01:00:00.010Z",
+                           cumulativeInput: 100, cumulativeOutput: 10, lastInput: 100, lastOutput: 10),
+        ], to: dir, name: "rollout-parent.jsonl", sub: "parent")
+        write([
+            forkedSessionMeta(ts: "2026-07-29T02:00:00.000Z"),
+            codexStateLine(ts: "2026-07-29T02:00:00.010Z",
+                           cumulativeInput: 100, cumulativeOutput: 10, lastInput: 100, lastOutput: 10),
+            codexStateLine(ts: "2026-07-29T02:00:05.000Z",
+                           cumulativeInput: 300, cumulativeOutput: 30, lastInput: 200, lastOutput: 20),
+        ], to: dir, name: "rollout-child.jsonl", sub: "child")
+        let entries = LocalUsageReader.codexEntries(modifiedSince: .distantPast, root: dir)
+        XCTAssertEqual(entries.map(\.total).sorted(), [110, 220], "부모 replay 는 대조로 잘리고 자기 턴만 남는다")
+    }
+
 }


### PR DESCRIPTION
Narrowing parent candidates by filename substring assumes the parent id carries enough shape to filter on. A rollout whose `forked_from_id` is something like `"-"` matches nearly every filename, so the cheap pre-filter selects everything and the expensive content comparison then runs against the whole tree.

Measured on 300 rollouts (~420 KB each):

| | |
| --- | --- |
| no parent link | 0.009s |
| orphaned parent, probe sweep | 0.18s |
| `forked_from_id: "-"` | **18.2s** |

A warm session-id index did not help, because a file whose id is already known stayed a candidate on filename alone. Known files are now decided by their id, and the filename hint is only consulted for files we haven't identified yet — and only when the id has enough shape to actually narrow anything.

This is a pre-filter that avoids opening files; anything it lets through is still content-verified, so resolution results are unchanged. A test covers that a degenerate hint still resolves usage the same way.

## A measurement that went the other way

The obvious companion change — pre-filtering the parse loop with `line.contains("session_meta")` so only metadata lines hit `JSONSerialization` — makes things **slower**:

| | best of 3, release, real tree |
| --- | --- |
| without pre-filter | 1.80s / 1.84s |
| with pre-filter | 2.17s / 2.19s |

Swift's `String.contains` walks graphemes, and that per-line scan costs more than letting `JSONSerialization` reject the line. I've left the numbers in a comment at that spot so the next reader doesn't reintroduce it. Worth knowing before trusting the same trick at the two nearby `contains` guards.

537 tests pass.
