### PR TITLE
fix: update the menu bar sprite immediately when the companion changes between usage polls

### DIFF
--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -68,6 +68,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         popover.delegate = self   // 닫힐 때(popoverDidClose) 호스팅 컨트롤러 해제 → 숨은 채 재레이아웃 비용 제거
 
         observeStore()
+        observeCompanionSprite()
         observeDisplaySleep()
         applyState()
     }
@@ -82,6 +83,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.applyState()
                 self.observeStore()
+            }
+        }
+    }
+
+    /// Companion 스프라이트 정체성(종/shiny) 관찰 — 사탕 진화·졸업(BagView), 세이브 가져오기,
+    /// 부화·메타몽 리빌 async 완료처럼 store 갱신 틱 없이 companion 만 바뀌는 경로에서도 메뉴바
+    /// 스프라이트를 즉시 갱신한다. observeStore(menuTitle)만으론 다음 사용량 폴링(기본 120s)까지
+    /// 이전 포켓몬이 남는다(사탕 졸업 후 메뉴바 잔상 리포트 — UsageStore.onRefresh 주석과 같은 부류).
+    private func observeCompanionSprite() {
+        withObservationTracking {
+            _ = companion.currentSpeciesID
+            _ = companion.currentIsShiny
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.ensureMenuAnimation()
+                self.syncMenuAnimation()
+                self.observeCompanionSprite()
             }
         }
     }

--- a/Tests/PokeTokenBarTests/RareCandyTests.swift
+++ b/Tests/PokeTokenBarTests/RareCandyTests.swift
@@ -1,3 +1,4 @@
+import Observation
 import XCTest
 @testable import PokeTokenBar
 
@@ -265,6 +266,25 @@ final class RareCandyStoreTests: XCTestCase {
         XCTAssertEqual(result, .graduated)
         XCTAssertNil(s.state.active)
         XCTAssertEqual(s.dexEntries.count, 1)
+    }
+
+    /// [회귀] 사탕 졸업은 store 폴링 틱 없이도 스프라이트 정체성(currentSpeciesID/currentIsShiny)
+    /// 관찰을 발화해야 한다 — AppDelegate.observeCompanionSprite 가 이 발화로 메뉴바 스프라이트를 즉시
+    /// 갱신한다. 발화가 없으면 메뉴바가 다음 사용량 폴링(기본 120s)까지 이전 포켓몬으로 남는다
+    /// (리포트: 사탕 졸업 직후 메뉴바 잔상). 진화(.evolved)도 같은 applyUsage 경로라 함께 보호된다.
+    func testCandyGraduationFiresSpriteIdentityObservation() async {
+        let s = store(rcNoEvo)
+        await s.hatch(baseID: 20)
+        s.applyUsage(700_000_000)   // 졸업 총량 750M 잔여 50M ≤ 100M
+        giveCandies(s, 1)
+        let fired = expectation(description: "sprite identity observation fired")
+        withObservationTracking {
+            _ = s.currentSpeciesID
+            _ = s.currentIsShiny
+        } onChange: { fired.fulfill() }
+        XCTAssertEqual(s.useRareCandy(), .graduated)
+        await fulfillment(of: [fired], timeout: 1)
+        XCTAssertNil(s.currentSpeciesID, "졸업 → 알(메뉴바 스프라이트 키 nil)")
     }
 
     /// 알(부화 전)에는 사용 불가 — 재고가 있어도 소모되지 않는다.

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -163,6 +163,16 @@ read_when:
   지시)를 전역 규칙으로 오해해 "3줄 금지"(3개 활성 케이스 제약)를 깨고 3줄을 만든 사례. 두 지시는 서로
   다른 조합에 관한 것이라 **둘 다 성립**해야 했다(2개→세로, 3개→토큰·비용 한 줄+한도 아랫줄). 최신
   지시가 이전 제약과 충돌해 보이면 조합별로 재조정하고, 못 풀면 조합표로 되물어라.
+- **수동 관찰(withObservationTracking) 표면은 companion 직접 변이 경로까지 추적해야 한다.** SwiftUI
+  표면(팝오버·플로팅 펫)은 읽는 속성을 자동 추적하지만, AppKit 수동 관찰(`AppDelegate`)은 *등록한 속성만*
+  본다. 메뉴바 스프라이트 갱신이 `observeStore`(=`store.menuTitle`)에만 걸려 있으면 store 틱 없이
+  companion 만 바뀌는 경로 — 사탕 진화·졸업(`useRareCandy`), 세이브 가져오기(`applySave`),
+  `hatchIfNeeded`·`revealDitto` 의 async 완료 — 는 다음 사용량 폴링(기본 120s)까지 이전 포켓몬이
+  메뉴바에 남는다(사탕 졸업 직후 잔상 리포트). 같은 부류의 선례가 `UsageStore.onRefresh` 주석(한도
+  변경이 menuTitle 미변경으로 companion 에 안 전달)이다. 표시가 파생되는 원천(`currentSpeciesID`·
+  `currentIsShiny`)을 직접 추적하는 관찰 루프를 별도로 건다(`AppDelegate.observeCompanionSprite`).
+  회귀 가드: `testCandyGraduationFiresSpriteIdentityObservation` — AppDelegate 쪽 배선은 AppKit
+  (NSStatusBar)이라 헤드리스 테스트 불가, 관찰 계약(변이가 발화하는지)을 CompanionStore 쪽에서 고정.
 - **메뉴바(상태아이템) stale dim 금지.** 시간 기반 stale(=`isStale`)로 `appearsDisabled` 를 켜면
   슬립/런치 직후 refresh 완료 전 몇 초간 메뉴바가 회색이 돼 '고장/비활성'으로 오인된다(사용자 반복 지적,
   `&& lastUpdated != nil` 로 런치만 막는 건 슬립-후 stale 을 못 막음). '오래됨' 신호는 팝오버에서만.


### PR DESCRIPTION
## Problem

Feeding a rare candy that evolves or graduates the companion left the menu bar showing the previous Pokémon until the next usage poll (default 120 s). The popover and the floating pet updated immediately — they are SwiftUI surfaces that automatically track what they read — so only the menu bar lagged.

## Cause

The menu bar sprite was refreshed only from the `store.menuTitle` observation (`AppDelegate.observeStore`). A rare candy mutates `CompanionStore` directly (`useRareCandy` → `applyUsage` → `graduate`) without touching `UsageStore`, so nothing fired until the next poll happened to change the menu text. The gap never showed before because ordinary evolution is driven by usage, which always arrives through a store tick.

## Fix

`AppDelegate.observeCompanionSprite()` — a second `withObservationTracking` loop on the sprite identity (`currentSpeciesID` / `currentIsShiny`) that re-resolves the menu frames as soon as it changes. `advanceMenu()` already applies the current frame even while animation is paused, so the sprite swaps instantly even with the popover open.

Observing the derived values instead of firing explicit events from each transition covers every store-independent mutation path at once: candy evolution and graduation, save import (`applySave`), and the async completions of hatching and Ditto reveal. An event-based wiring would have to be planted at each of those call sites — the existing `Celebration` enum has no `graduate` case, which is exactly the coverage risk that style carries.

## Tests

- New guard `testCandyGraduationFiresSpriteIdentityObservation`: a candy graduation must fire the sprite-identity observation with no store tick. The AppDelegate wiring is NSStatusBar and cannot run headless, so the guard pins the CompanionStore side of the contract.
- The guard was checked by injecting the defect it targets (`@ObservationIgnored` on `state`) and confirming it fails, then reverted.
- Full suite: 531 tests pass, 0 failures.
- Defect class recorded in `docs/reference/defect-log.md`: manual observation surfaces must track companion-direct mutation paths, not just store-derived signals.
