### PR TITLE
feat: add a setting to show limit percentages as used or remaining

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -105,6 +105,13 @@ struct L {
     var todayTokensShort: String { t("오늘 토큰", "Today's tokens", "本日のトークン") }
     var todayCost: String { t("오늘 비용 ($)", "Today's cost ($)", "本日のコスト ($)") }
     var limitPercent: String { t("한도 %", "Limit %", "上限 %") }
+    var limitDisplayModeLabel: String { t("한도 표시 방식", "Limit display", "上限の表示") }
+    var limitDisplayUsed: String { t("사용량", "Used", "使用量") }
+    var limitDisplayRemaining: String { t("남은 양", "Remaining", "残量") }
+    /// 팝오버 한도 행의 remaining 모드 표시 — %에 자기설명 접미사를 붙인다.
+    func percentRemaining(_ percent: String) -> String {
+        t("\(percent) 남음", "\(percent) left", "残り\(percent)")
+    }
     var allOffHint: String { t("전부 끄면 캐릭터만 표시됩니다", "All off shows only the character", "すべてオフにするとキャラクターのみ表示") }
     // MARK: 플로팅 펫
     var floatingPetSectionTitle: String { t("플로팅 펫", "Floating Pet", "フローティングペット") }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -61,6 +61,14 @@ final class UsageStore {
     var showLimitInMenu: Bool {
         didSet { defaults.set(showLimitInMenu, forKey: "showLimitInMenu") }
     }
+    /// 한도 % 표시 방식 — 사용한 양(기본) 또는 남은 양. 숫자 표시에만 적용되고
+    /// 경고/위험 판정·게이지 채움·알림은 사용률 원값 기준을 유지한다(경고 의미론 분리).
+    enum LimitDisplayMode: String, CaseIterable {
+        case used, remaining
+    }
+    var limitDisplayMode: LimitDisplayMode {
+        didSet { defaults.set(limitDisplayMode.rawValue, forKey: "limitDisplayMode") }
+    }
     // 알림(독립 토글)
     var limitNotifications: Bool {
         didSet { defaults.set(limitNotifications, forKey: "limitNotifications") }
@@ -166,17 +174,29 @@ final class UsageStore {
 
     /// 메뉴바 한도 줄 — **오늘 실제 사용한 프로바이더만** 한 줄에 나란히(미사용/미가용이면 nil).
     /// 한도 소스는 프로바이더 고유(Claude=OAuth·Codex=프로세스)라 providerID 로 명시 분기(확장 규약).
+    /// %는 limitDisplayMode 를 따르되 접미사 없음 — 좁은 표면이고 방향은 사용자가 고른 설정이 말해 준다
+    /// (배터리 메뉴바 % 관례). 자기설명 접미사("남음")는 팝오버 행에서만.
     private var menuLimitLine: String? {
         guard showLimitInMenu else { return nil }
         let usedToday = Set(snapshots.filter { $0.todayTotalTokens > 0 }.map(\.providerID))
         var parts: [String] = []
         if usedToday.contains("claude_code"), let utilization = limits?.fiveHour?.utilization {
-            parts.append("Claude \(TokenFormatter.percent(utilization))")
+            parts.append("Claude \(TokenFormatter.percent(limitDisplayPercent(utilization)))")
         }
         if usedToday.contains("codex"), let usedPercent = codexLimits?.maxPrimaryUsedPercent {
-            parts.append("Codex \(TokenFormatter.percent(Double(usedPercent)))")
+            parts.append("Codex \(TokenFormatter.percent(limitDisplayPercent(Double(usedPercent))))")
         }
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// 표시용 한도 % 변환 — remaining 모드면 100−사용률(0 하한: 사용률이 100 을 넘어도 음수 금지).
+    /// 순수 판정을 분리해 테스트한다. 숫자 *표시* 전용 — 색·게이지·알림 판정에는 쓰지 않는다.
+    nonisolated static func displayPercent(_ utilization: Double, mode: LimitDisplayMode) -> Double {
+        mode == .remaining ? max(0, 100 - utilization) : utilization
+    }
+
+    func limitDisplayPercent(_ utilization: Double) -> Double {
+        Self.displayPercent(utilization, mode: limitDisplayMode)
     }
 
     /// 단일 줄 표현 — 관찰(observeStore)·접근성·1줄 렌더 폴백용. 세로 렌더는 menuLines 사용.
@@ -380,6 +400,7 @@ final class UsageStore {
         showTokensInMenu = d.object(forKey: "showTokensInMenu") as? Bool ?? true
         showCostInMenu = d.object(forKey: "showCostInMenu") as? Bool ?? false
         showLimitInMenu = d.object(forKey: "showLimitInMenu") as? Bool ?? false
+        limitDisplayMode = LimitDisplayMode(rawValue: d.string(forKey: "limitDisplayMode") ?? "") ?? .used
         limitNotifications = d.object(forKey: "limitNotifications") as? Bool ?? true
         companionNotifications = d.object(forKey: "companionNotifications") as? Bool ?? true
         updateNotificationsEnabled = d.object(forKey: "updateNotificationsEnabled") as? Bool ?? true

--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -67,6 +67,7 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
             _ = store.currentBubbleAlert
             _ = store.todayTotalTokens
             _ = store.highestLimitUtilization
+            _ = store.limitDisplayMode   // hover 툴팁 %가 파생되는 값 — 수동 관찰 표면은 파생 원천을 직접 추적(defect-log §표시·UI)
             _ = companion.language
         } onChange: { [weak self] in
             Task { @MainActor in
@@ -168,6 +169,7 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
         FloatingPetView.hoverTooltip(
             todayTokens: store.todayTotalTokens,
             limitUtilization: store.highestLimitUtilization,
+            mode: store.limitDisplayMode,
             l: L(companion.language))
     }
 
@@ -388,10 +390,12 @@ struct FloatingPetView: View {
                    value: store.currentBubbleAlert)
     }
 
-    static func hoverTooltip(todayTokens: Int, limitUtilization: Double?, l: L) -> String {
+    static func hoverTooltip(todayTokens: Int, limitUtilization: Double?,
+                             mode: UsageStore.LimitDisplayMode, l: L) -> String {
         let usage = TokenFormatter.grouped(todayTokens)
         if let pct = limitUtilization {
-            return l.floatingPetHoverWithLimit(usage, TokenFormatter.percent(pct))
+            let text = TokenFormatter.percent(UsageStore.displayPercent(pct, mode: mode))
+            return l.floatingPetHoverWithLimit(usage, mode == .remaining ? l.percentRemaining(text) : text)
         }
         return l.floatingPetHoverTokensOnly(usage)
     }

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -349,6 +349,13 @@ struct PopoverView: View {
     }
 
 
+    /// 한도 % 표시 문자열 — remaining 모드면 남은 %에 자기설명 접미사("남음/left/残り").
+    /// 게이지 채움·경고색은 사용률 원값 기준 유지 — 숫자 텍스트만 모드를 따른다.
+    private func limitPercentText(_ utilization: Double) -> String {
+        let text = TokenFormatter.percent(store.limitDisplayPercent(utilization))
+        return store.limitDisplayMode == .remaining ? l.percentRemaining(text) : text
+    }
+
     @ViewBuilder
     private func limitRow(name: String, window: LimitWindow?) -> some View {
         if let window, let utilization = window.utilization {
@@ -357,7 +364,7 @@ struct PopoverView: View {
                     Text(name)
                         .font(.callout)
                     Spacer()
-                    Text(TokenFormatter.percent(utilization))
+                    Text(limitPercentText(utilization))
                         .font(.callout)
                         .monospacedDigit()
                         .foregroundStyle(limitColor(utilization))
@@ -475,7 +482,7 @@ struct PopoverView: View {
                     Text(name)
                         .font(.callout)
                     Spacer()
-                    Text(TokenFormatter.percent(utilization))
+                    Text(limitPercentText(utilization))
                         .font(.callout)
                         .monospacedDigit()
                         .foregroundStyle(limitColor(utilization))
@@ -505,7 +512,7 @@ struct PopoverView: View {
                         .font(.caption)
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
-                    Text(TokenFormatter.percent(utilization))
+                    Text(limitPercentText(utilization))
                         .font(.callout)
                         .monospacedDigit()
                         .foregroundStyle(limitColor(utilization))

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -119,6 +119,16 @@ struct SettingsView: View {
             }
             Divider()
             groupRow {
+                Text(l.limitDisplayModeLabel)
+                Spacer()
+                Picker("", selection: $store.limitDisplayMode) {
+                    Text(l.limitDisplayUsed).tag(UsageStore.LimitDisplayMode.used)
+                    Text(l.limitDisplayRemaining).tag(UsageStore.LimitDisplayMode.remaining)
+                }
+                .labelsHidden().pickerStyle(.segmented).fixedSize()
+            }
+            Divider()
+            groupRow {
                 VStack(alignment: .leading, spacing: 1) {
                     Text(l.launchAtLogin)
                     if !isBundledApp {

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -187,14 +187,19 @@ final class FloatingPetEnergyTests: XCTestCase {
     }
 
     /// Hover tooltip is localized and pure — tokens always; limit % only when provided.
+    /// Remaining mode inverts the % and adds the self-describing suffix.
     func testHoverTooltipBuilder() {
         let l = L(.en)
         XCTAssertEqual(
-            FloatingPetView.hoverTooltip(todayTokens: 12_345, limitUtilization: nil, l: l),
+            FloatingPetView.hoverTooltip(todayTokens: 12_345, limitUtilization: nil, mode: .used, l: l),
             l.floatingPetHoverTokensOnly(TokenFormatter.grouped(12_345)))
         XCTAssertEqual(
-            FloatingPetView.hoverTooltip(todayTokens: 12_345, limitUtilization: 42, l: l),
+            FloatingPetView.hoverTooltip(todayTokens: 12_345, limitUtilization: 42, mode: .used, l: l),
             l.floatingPetHoverWithLimit(TokenFormatter.grouped(12_345), TokenFormatter.percent(42)))
+        XCTAssertEqual(
+            FloatingPetView.hoverTooltip(todayTokens: 12_345, limitUtilization: 42, mode: .remaining, l: l),
+            l.floatingPetHoverWithLimit(TokenFormatter.grouped(12_345),
+                                        l.percentRemaining(TokenFormatter.percent(58))))
     }
 
     /// Japanese (and ko/en) alert copy must fit the default bubble panel — width-capped wrap,

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -523,6 +523,47 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertTrue(three[1].contains("Claude"))           // 아랫줄=한도
     }
 
+    // MARK: 한도 표시 방식 (used / remaining)
+
+    /// 표시 변환 순수 판정 — remaining = 100−사용률, 0 하한(사용률 100 초과 시 음수 금지), 경계 포함.
+    func testLimitDisplayPercentModes() {
+        XCTAssertEqual(UsageStore.displayPercent(40, mode: .used), 40)
+        XCTAssertEqual(UsageStore.displayPercent(40, mode: .remaining), 60)
+        XCTAssertEqual(UsageStore.displayPercent(0, mode: .remaining), 100)
+        XCTAssertEqual(UsageStore.displayPercent(100, mode: .remaining), 0)
+        XCTAssertEqual(UsageStore.displayPercent(120, mode: .remaining), 0, "100% 초과 사용 → 남은 양 0 클램프")
+        XCTAssertEqual(UsageStore.displayPercent(40.5, mode: .remaining), 59.5, "소수 유지")
+    }
+
+    /// remaining 모드의 메뉴바 한도 줄 — 숫자만 반전, 프로바이더 라벨·조합 규칙은 그대로.
+    func testMenuBarLimitRemainingModeInvertsPercents() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(10_000_000))
+        let codex = FakeUsageProvider(id: "codex", displayName: "Codex", daily: todayDaily(5_000_000))
+        let store = makeStore(
+            providers: [claude, codex],
+            claude: claudeLimits(fiveHourUtil: 40, resetsAt: "2099-01-01T00:00:00Z"),
+            codex: codexLimits(primaryUsed: 85))
+        store.showTokensInMenu = false
+        store.showCostInMenu = false
+        store.showLimitInMenu = true
+        store.limitDisplayMode = .remaining
+        await store.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(store.menuTitle.contains("Claude 60%"), "used 40 → remaining 60: \(store.menuTitle)")
+        XCTAssertTrue(store.menuTitle.contains("Codex 15%"), "used 85 → remaining 15: \(store.menuTitle)")
+
+        store.limitDisplayMode = .used
+        XCTAssertTrue(store.menuTitle.contains("Claude 40%"), "used 모드 복귀: \(store.menuTitle)")
+    }
+
+    /// 설정 영속 — 기본은 used(기존 사용자 무변화), remaining 선택은 재시작(같은 defaults 재로드) 후 유지.
+    func testLimitDisplayModePersistsAcrossRestart() {
+        let s1 = makeStore(providers: [])
+        XCTAssertEqual(s1.limitDisplayMode, .used, "기본값 = used(현행 표시 유지)")
+        s1.limitDisplayMode = .remaining
+        let s2 = makeStore(providers: [])
+        XCTAssertEqual(s2.limitDisplayMode, .remaining, "같은 defaults 재로드 → 유지")
+    }
+
     // MARK: 집계
 
     func testAggregatesTodayTokensAcrossProviders() async {


### PR DESCRIPTION
## What

Settings > General gains a **Limit display** segmented control: **Used** (default) or **Remaining**. Remaining mode shows every limit percentage as what is left instead of what has been consumed.

## Behavior

With a window at 40% utilization:

| Surface | Used (default) | Remaining |
|---|---|---|
| Menu bar limit line | `Claude 40%` | `Claude 60%` (bare %, battery-style) |
| Popover Claude / Codex limit rows | `40%` | `60% left` / `60% 남음` / `残り60%` |
| Popover Codex personal spend row | `$used/$limit · 40%` | counts unchanged, % inverts with suffix |
| Floating pet hover tooltip | `(limit 40%)` | `(limit 60% left)` |
| Gauge fill · warning colors | by utilization | **unchanged** — still by utilization |
| Threshold notifications · pet bubbles | by utilization | **unchanged** |

Only the displayed number inverts. "4% left" still renders a 96%-filled red gauge and still fires the critical alert — the display preference is kept out of the warning semantics and the alert edge-trigger state. Overrun (>100% used) clamps remaining at 0 instead of going negative; fractional utilizations keep their fraction.

The default is Used, so existing installs render exactly as before.

## Implementation

- The conversion is one pure function, `UsageStore.displayPercent(_:mode:)`, with the clamp; the menu bar line, the three popover rows, and the pet tooltip all consume it. No provider-specific branches — limits from future providers pick the mode up automatically.
- Setting persists via UserDefaults (`limitDisplayMode`); labels and the remaining suffix are localized in en/ko/ja.
- The floating pet's manual observation loop now also tracks `limitDisplayMode` (defect-log rule: manual `withObservationTracking` surfaces must track every value their display derives from), so flipping the setting updates the tooltip immediately. The menu bar picks it up through the existing `menuTitle` observation.

## Tests

- `testLimitDisplayPercentModes` — pure conversion: identity in used mode, inversion, bounds (0/100), overrun clamp (120 → 0), fractions.
- `testMenuBarLimitRemainingModeInvertsPercents` — menu bar line: Claude 40 → 60%, Codex 85 → 15%, and back to used.
- `testLimitDisplayModePersistsAcrossRestart` — used default; remaining survives a reload of the same defaults.
- `testHoverTooltipBuilder` — extended with a remaining case (suffix included).
- Existing `testMenuLinesAllCombinations` (full toggle table) passes unchanged — line composition rules untouched.
- Full suite passes.

README / landing screenshots will be refreshed at release time per the release asset gate (this is a UI-affecting feature).
