### PR TITLE
fix: say why an Antigravity conversation was lost, and stop caching the failure

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
@@ -48,9 +48,9 @@ enum LocalAntigravityUsageReader {
             entries += read.entries
             reads.append((database.deletingPathExtension().lastPathComponent, read))
         }
-        // The one place the side effect lives. `AppLog.write` returns early outside the bundled
-        // app, so the decision above it is kept pure and tested on its own (`lossLog`).
-        for line in lossLog(reads) { AppLog.write(line) }
+        // The one place the side effects live. `AppLog.write` returns early outside the bundled
+        // app, so the decisions above it are kept pure and tested on their own.
+        for line in lossLog(reads) + discardLog(reads) { AppLog.write(line) }
         // `response_id` is unique per call, so this only ever collapses a re-read.
         return LocalUsageReader.dedupKeepMax(entries)
     }
@@ -83,8 +83,9 @@ enum LocalAntigravityUsageReader {
     /// what this reader used to do, is what let a store that could never be read pass for a
     /// store that was never used.
     enum ConversationRead: Sendable {
-        /// Read through to `SQLITE_DONE`: these rows are all of them.
-        case complete([LocalUsageReader.Entry])
+        /// Read through to `SQLITE_DONE`: these rows are all of them. `discardedCounters` is how
+        /// many token fields across those rows carried a value too large to be a count.
+        case complete(entries: [LocalUsageReader.Entry], discardedCounters: Int)
         /// The scan stopped early — BUSY because the CLI was writing, or a damaged page. Half a
         /// conversation must not pass for the whole of it, so the rows read so far are dropped.
         case incompleteScan(status: Int32, rows: Int)
@@ -96,7 +97,7 @@ enum LocalAntigravityUsageReader {
         case notAConversation
 
         var entries: [LocalUsageReader.Entry] {
-            if case .complete(let entries) = self { return entries }
+            if case .complete(let entries, _) = self { return entries }
             return []
         }
     }
@@ -112,7 +113,7 @@ enum LocalAntigravityUsageReader {
     /// nothing at all — the same reason the limit-alert decision was split out of its own
     /// side effect.
     static func lossLog(_ reads: [(conversation: String, read: ConversationRead)]) -> [String] {
-        let losses = reads.compactMap { entry -> String? in
+        capped(reads.compactMap { entry -> String? in
             switch entry.read {
             case .complete, .notAConversation:
                 return nil
@@ -123,11 +124,28 @@ enum LocalAntigravityUsageReader {
                 return "antigravity: lost conversation=\(entry.conversation) reason=unreadable"
                     + (status.map { " status=\($0)" } ?? "")
             }
+        }) { total, hidden in
+            "antigravity: lost \(total) conversation(s) this scan (\(hidden) not named)"
         }
-        guard losses.count > namedLossLimit else { return losses }
-        return Array(losses.prefix(namedLossLimit))
-            + ["antigravity: lost \(losses.count) conversation(s) this scan"
-               + " (\(losses.count - namedLossLimit) not named)"]
+    }
+
+    /// Token counters dropped for being too large to be counts, totalled per store. Reporting
+    /// them where they happen would be up to four lines per record — tens of thousands from one
+    /// scan of a live store — and the point of the ceiling is that this is rare enough to notice.
+    static func discardLog(_ reads: [(conversation: String, read: ConversationRead)]) -> [String] {
+        capped(reads.compactMap { entry -> String? in
+            guard case .complete(_, let discarded) = entry.read, discarded > 0 else { return nil }
+            return "antigravity: conversation=\(entry.conversation) discarded=\(discarded)"
+                + " token counter(s) over \(AntigravityProto.tokenCeiling)"
+        }) { total, hidden in
+            "antigravity: discarded token counters in \(total) conversation(s) (\(hidden) not named)"
+        }
+    }
+
+    private static func capped(_ lines: [String], summary: (Int, Int) -> String) -> [String] {
+        guard lines.count > namedLossLimit else { return lines }
+        return Array(lines.prefix(namedLossLimit))
+            + [summary(lines.count, lines.count - namedLossLimit)]
     }
 
     static func conversationEntries(
@@ -151,6 +169,7 @@ enum LocalAntigravityUsageReader {
 
         let conversation = database.deletingPathExtension().lastPathComponent
         var entries: [LocalUsageReader.Entry] = []
+        var discardedCounters = 0
         var rows = 0
         while true {
             let step = sqlite3_step(statement)
@@ -162,9 +181,10 @@ enum LocalAntigravityUsageReader {
                     let count = Int(sqlite3_column_bytes(statement, 1))
                     guard count > 0 else { return }
                     let blob = Data(bytes: pointer, count: count)
-                    guard let entry = parseGenerationMetadata(
-                        blob, conversation: conversation, index: index, formatter: formatter),
-                          entry.date >= modifiedSince else { return }
+                    let record = parseGenerationMetadata(
+                        blob, conversation: conversation, index: index, formatter: formatter)
+                    discardedCounters += record.discardedCounters
+                    guard let entry = record.entry, entry.date >= modifiedSince else { return }
                     entries.append(entry)
                 }
                 continue
@@ -175,7 +195,7 @@ enum LocalAntigravityUsageReader {
             guard step == SQLITE_DONE else { return .incompleteScan(status: step, rows: rows) }
             break
         }
-        return .complete(entries)
+        return .complete(entries: entries, discardedCounters: discardedCounters)
     }
 
     /// `mode=ro` cannot create the `-shm` file a WAL database needs, so it fails outright on
@@ -204,16 +224,24 @@ enum LocalAntigravityUsageReader {
 
     // MARK: Parsing one generation record
 
+    /// What one `gen_metadata` row yielded. `discardedCounters` travels with the entry because
+    /// `tokenCount` runs four times per row and a live store holds thousands of them — the scan
+    /// totals these rather than reporting each one where it happens.
+    struct Record: Sendable {
+        var entry: LocalUsageReader.Entry?
+        var discardedCounters = 0
+    }
+
     static func parseGenerationMetadata(
         _ blob: Data,
         conversation: String,
         index: Int64,
         formatter: DateFormatter
-    ) -> LocalUsageReader.Entry? {
+    ) -> Record {
         let bytes = [UInt8](blob)
         guard let chatModel = AntigravityProto.message(bytes[...], field: 1),
               let usage = AntigravityProto.message(chatModel, field: 4),
-              let date = createdAt(chatModel) else { return nil }
+              let date = createdAt(chatModel) else { return Record() }
 
         // The turn's own id, not the file it happens to sit in — a copied conversation must
         // not read as fresh spend. `response_id` is populated on every recorded call.
@@ -224,15 +252,22 @@ enum LocalAntigravityUsageReader {
         // by the prefix, because Antigravity is a subscription and bills no per-token amount.
         let model = AntigravityProto.string(chatModel, field: 19) ?? "unknown"
 
-        return makeEntry(
-            id: identity,
-            date: date,
-            localDay: formatter.string(from: date),
-            model: "antigravity/\(model)",
-            input: AntigravityProto.tokenCount(usage, field: 2),
-            output: AntigravityProto.tokenCount(usage, field: 3),
-            cacheWrite: AntigravityProto.tokenCount(usage, field: 4),
-            cacheRead: AntigravityProto.tokenCount(usage, field: 5))
+        let input = AntigravityProto.tokenCount(usage, field: 2)
+        let output = AntigravityProto.tokenCount(usage, field: 3)
+        let cacheWrite = AntigravityProto.tokenCount(usage, field: 4)
+        let cacheRead = AntigravityProto.tokenCount(usage, field: 5)
+
+        return Record(
+            entry: makeEntry(
+                id: identity,
+                date: date,
+                localDay: formatter.string(from: date),
+                model: "antigravity/\(model)",
+                input: input ?? 0,
+                output: output ?? 0,
+                cacheWrite: cacheWrite ?? 0,
+                cacheRead: cacheRead ?? 0),
+            discardedCounters: [input, output, cacheWrite, cacheRead].filter { $0 == nil }.count)
     }
 
     /// `chat_start_metadata.created_at`, a `google.protobuf.Timestamp`.
@@ -276,9 +311,12 @@ enum AntigravityProto {
     /// every refresh until the file changed. A count this large is a sentinel, not a count.
     static let tokenCeiling: UInt64 = 1_000_000_000
 
-    static func tokenCount(_ data: ArraySlice<UInt8>, field: Int) -> Int {
-        guard let value = varint(data, field: field), value <= tokenCeiling else { return 0 }
-        return Int(value)
+    /// `nil` means the field was there and its value cannot be a count. That is not the same as
+    /// the field being absent, which is a legitimate zero — `cache_write_tokens` is declared and
+    /// never written — and the caller needs to tell them apart to be able to say one happened.
+    static func tokenCount(_ data: ArraySlice<UInt8>, field: Int) -> Int? {
+        guard let value = varint(data, field: field) else { return 0 }
+        return value <= tokenCeiling ? Int(value) : nil
     }
 
     static func varint(_ data: ArraySlice<UInt8>, field: Int) -> UInt64? {

--- a/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
@@ -39,41 +39,103 @@ enum LocalAntigravityUsageReader {
 
     /// Usage rows whose `created_at` falls at or after `modifiedSince`.
     static func entries(modifiedSince: Date, root: URL? = nil) -> [LocalUsageReader.Entry] {
-        let directory = root ?? defaultRoot
-        let formatter = LocalUsageReader.localDayFormatter()
-        var entries: [LocalUsageReader.Entry] = []
-        var reads: [(conversation: String, read: ConversationRead)] = []
-        for database in databases(in: directory, modifiedSince: modifiedSince) {
-            let read = conversationEntries(database, modifiedSince: modifiedSince, formatter: formatter)
-            entries += read.entries
-            reads.append((database.deletingPathExtension().lastPathComponent, read))
-        }
+        let scanned = scan(root: root ?? defaultRoot, modifiedSince: modifiedSince, known: [:])
         // The one place the side effects live. `AppLog.write` returns early outside the bundled
         // app, so the decisions above it are kept pure and tested on their own.
-        for line in lossLog(reads) + discardLog(reads) { AppLog.write(line) }
-        // `response_id` is unique per call, so this only ever collapses a re-read.
-        return LocalUsageReader.dedupKeepMax(entries)
+        for line in scanned.log { AppLog.write(line) }
+        return assemble(scanned.blobs, since: modifiedSince)
+    }
+
+    /// One conversation store's rows, valid for as long as its `(mtime, size)` hold. The rows
+    /// are deliberately *unfiltered*: the window is applied after the lookup, so one blob serves
+    /// both the daily call and the enrichment call — the contract `LocalUsageCache.Blob` keeps,
+    /// and the reason a blob cache needs no time-based expiry.
+    struct Blob: Sendable {
+        let mtime: Date
+        let size: Int
+        let entries: [LocalUsageReader.Entry]
+    }
+
+    /// What one sweep produced: the surviving blobs keyed by path, and the lines it left behind.
+    struct Scan: Sendable {
+        var blobs: [String: Blob]
+        var log: [String]
+    }
+
+    /// Rows from every blob, narrowed to the window and deduplicated. `response_id` is unique
+    /// per call, so the dedup only ever collapses the same turn copied into a second store.
+    static func assemble(_ blobs: [String: Blob], since: Date) -> [LocalUsageReader.Entry] {
+        LocalUsageReader.dedupKeepMax(blobs.values.flatMap(\.entries).filter { $0.date >= since })
+    }
+
+    /// Reads every conversation store the window admits, reusing any blob in `known` whose
+    /// signature still matches. `known` is empty for a one-shot read.
+    static func scan(root: URL, modifiedSince: Date, known: [String: Blob]) -> Scan {
+        let formatter = LocalUsageReader.localDayFormatter()
+        var blobs: [String: Blob] = [:]
+        var reads: [(conversation: String, read: ConversationRead)] = []
+
+        for database in databases(in: root) {
+            // Stat before the read, never after. A commit that lands mid-read then differs from
+            // the stored signature on the next sweep and is re-read; stat afterwards and that
+            // same commit is frozen into a signature that already looks current.
+            guard let signature = signature(of: database), signature.mtime >= modifiedSince else { continue }
+            let key = database.path
+            if let blob = known[key], blob.mtime == signature.mtime, blob.size == signature.size {
+                blobs[key] = blob
+                continue
+            }
+
+            let read = conversationEntries(database, formatter: formatter)
+            reads.append((database.deletingPathExtension().lastPathComponent, read))
+            switch read {
+            case .complete(let entries, _):
+                blobs[key] = Blob(mtime: signature.mtime, size: signature.size, entries: entries)
+            case .notAConversation:
+                // A permanent property of the file, so cache the empty — otherwise every
+                // database in the directory that is not a conversation store is reopened on
+                // every refresh for the life of the install.
+                blobs[key] = Blob(mtime: signature.mtime, size: signature.size, entries: [])
+            case .incompleteScan, .unreadable:
+                // Never write an empty blob under a signature that may never change again: the
+                // store would read as no usage for as long as it sat still, and the retry the
+                // discard was for would never happen. Carry the previous rows forward under
+                // their *old* signature so the next sweep tries again.
+                if let stale = known[key] { blobs[key] = stale }
+            }
+        }
+        return Scan(blobs: blobs, log: lossLog(reads) + discardLog(reads))
     }
 
     // MARK: Database discovery
 
-    /// A WAL commit lands in the `-wal` sibling and leaves the main file's timestamp alone,
-    /// so the newest of the three is the only honest "has this conversation moved" signal.
-    static func effectiveModificationDate(of database: URL) -> Date? {
+    /// The cache key for one conversation store, and the same value the scan window is tested
+    /// against. A WAL commit lands in the `-wal` sibling and leaves the main file's timestamp
+    /// and length alone, so keying on the `.db` would miss precisely the stores that had just
+    /// moved.
+    ///
+    /// `-shm` is deliberately excluded. It carries no committed data — it is a rebuildable index
+    /// over `-wal` — and a read-only WAL connection writes read marks into it, so including it
+    /// would let this reader invalidate the blob it had just written, on every sweep, forever.
+    /// For the same reason it adds nothing to the window test: a `-shm` that is newer than both
+    /// of the others means somebody read the store, not that anything was written to it.
+    static func signature(of database: URL) -> (mtime: Date, size: Int)? {
         let manager = FileManager.default
-        return [database.path, database.path + "-wal", database.path + "-shm"]
-            .compactMap { (try? manager.attributesOfItem(atPath: $0))?[.modificationDate] as? Date }
-            .max()
+        var newest: Date?
+        var size = 0
+        for path in [database.path, database.path + "-wal"] {
+            guard let attributes = try? manager.attributesOfItem(atPath: path) else { continue }
+            if let mtime = attributes[.modificationDate] as? Date {
+                newest = max(newest ?? mtime, mtime)
+            }
+            size += (attributes[.size] as? Int) ?? 0
+        }
+        return newest.map { ($0, size) }
     }
 
-    private static func databases(in root: URL, modifiedSince: Date) -> [URL] {
-        let manager = FileManager.default
-        guard let names = try? manager.contentsOfDirectory(atPath: root.path) else { return [] }
-        return names
-            .filter { $0.hasSuffix(".db") }
-            .sorted()
-            .map { root.appendingPathComponent($0) }
-            .filter { (effectiveModificationDate(of: $0) ?? .distantPast) >= modifiedSince }
+    private static func databases(in root: URL) -> [URL] {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: root.path) else { return [] }
+        return names.filter { $0.hasSuffix(".db") }.sorted().map { root.appendingPathComponent($0) }
     }
 
     // MARK: Reading one conversation
@@ -148,9 +210,11 @@ enum LocalAntigravityUsageReader {
             + [summary(lines.count, lines.count - namedLossLimit)]
     }
 
+    /// Reads every row in the store. The window is *not* applied here: these rows go into a
+    /// blob that outlives the call that produced it, and a cutoff baked into a cached unit is
+    /// wrong the moment the window moves.
     static func conversationEntries(
         _ database: URL,
-        modifiedSince: Date,
         formatter: DateFormatter
     ) -> ConversationRead {
         guard let handle = openReadOnly(database) else { return .unreadable(status: nil) }
@@ -184,7 +248,7 @@ enum LocalAntigravityUsageReader {
                     let record = parseGenerationMetadata(
                         blob, conversation: conversation, index: index, formatter: formatter)
                     discardedCounters += record.discardedCounters
-                    guard let entry = record.entry, entry.date >= modifiedSince else { return }
+                    guard let entry = record.entry else { return }
                     entries.append(entry)
                 }
                 continue
@@ -401,21 +465,21 @@ enum AntigravityProto {
 
 // MARK: - Shared read
 
-/// Shares one native read between the Antigravity provider's daily and enrichment calls, the
-/// way `LocalAdditionalUsageCache` does for the other SQLite-backed providers.
+/// Holds the parse of each conversation store between calls, keyed on that store's
+/// `(path, mtime, size)` the way `LocalUsageCache` keys its per-file blobs. The Antigravity
+/// provider's daily and enrichment calls therefore share one parse without a clock being
+/// involved: both re-stat every store, and neither reopens one that has not moved.
+///
+/// The keying replaces a 30-second expiry, which had the two failings a timer always has — it
+/// served a store that had just changed from a stale parse for up to half a minute, and once it
+/// lapsed it reopened all of them to find out that none had.
 actor LocalAntigravityUsageCache {
     static let shared = LocalAntigravityUsageCache()
 
-    private struct Cached: Sendable {
-        let loadedAt: Date
-        let monthKey: String
-        let entries: [LocalUsageReader.Entry]
-    }
-
     private let root: URL?
     private let now: @Sendable () -> Date
-    private var cached: Cached?
-    private var inFlight: Task<[LocalUsageReader.Entry], Never>?
+    private var blobs: [String: LocalAntigravityUsageReader.Blob] = [:]
+    private var inFlight: Task<LocalAntigravityUsageReader.Scan, Never>?
 
     init(root: URL? = nil, now: @escaping @Sendable () -> Date = Date.init) {
         self.root = root
@@ -423,24 +487,37 @@ actor LocalAntigravityUsageCache {
     }
 
     func entries() async -> [LocalUsageReader.Entry] {
-        let moment = now()
-        let monthKey = LocalUsageReader.monthKey(moment)
-        if let cached, cached.monthKey == monthKey, moment.timeIntervalSince(cached.loadedAt) < 30 {
-            return cached.entries
-        }
-        if let inFlight { return await inFlight.value }
+        // One scan covers every window the provider reports — the block, the week and the month
+        // — so the lower bound is the earliest of the three. It is a min of three non-decreasing
+        // functions of `now`, so it only ever advances: a bound sampled before the scan admits a
+        // superset of what the bound current after it would have, which is why the blobs stay
+        // sound across a month boundary that a `monthKey` guard used to throw them away at.
+        let since = LocalUsageReader.enrichmentScanStart(now: now())
 
-        // One scan covers every window the provider reports — the block, the week and the
-        // month — so the lower bound is the earliest of the three.
-        let since = LocalUsageReader.enrichmentScanStart(now: moment)
-        let root = root
-        let task = Task.detached(priority: .utility) {
-            LocalAntigravityUsageReader.entries(modifiedSince: since, root: root)
+        let scanned: LocalAntigravityUsageReader.Scan
+        if let inFlight {
+            // Join rather than start a second scan, and leave the log to the owner.
+            scanned = await inFlight.value
+        } else {
+            let root = self.root ?? LocalAntigravityUsageReader.defaultRoot
+            let known = blobs
+            // Nothing awaits between the miss above and this assignment — that is what stops two
+            // callers from both starting a scan.
+            let task = Task.detached(priority: .utility) {
+                LocalAntigravityUsageReader.scan(root: root, modifiedSince: since, known: known)
+            }
+            inFlight = task
+            scanned = await task.value
+            inFlight = nil
+            // A visited-only rebuild is the prune: a store that fell out of the window or off
+            // the disk leaves the cache with it, exactly rather than on a 40-day approximation.
+            blobs = scanned.blobs
+            for line in scanned.log { AppLog.write(line) }
         }
-        inFlight = task
-        let entries = await task.value
-        inFlight = nil
-        cached = Cached(loadedAt: moment, monthKey: monthKey, entries: entries)
-        return entries
+
+        // Re-sampled after the suspension. `since` above bounds discovery; this bounds what the
+        // caller is told, and the two are not the same instant.
+        return LocalAntigravityUsageReader.assemble(
+            scanned.blobs, since: LocalUsageReader.enrichmentScanStart(now: now()))
     }
 }

--- a/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
@@ -378,6 +378,20 @@ enum AntigravityProto {
     /// Tokens are `uint64` on the wire. Widening one straight into `Int` hands unbounded
     /// values to arithmetic that traps on overflow, and a trap here would kill the app on
     /// every refresh until the file changed. A count this large is a sentinel, not a count.
+    ///
+    /// This is the sibling of `LocalUsageReader.maxParsedTokenValue`, which guards the JSON
+    /// readers, and the two deliberately differ on both axes — see the PR for whether they
+    /// should be reconciled:
+    ///
+    /// - **Ceiling.** That one leaves room for sums taken straight after parsing
+    ///   (`output + thoughts`); nothing here adds two parsed values before `Entry.total`, whose
+    ///   four terms are each bounded by this, so a tighter ceiling costs nothing. A per-call
+    ///   counter three orders of magnitude past the largest context window is already a
+    ///   sentinel.
+    /// - **What happens above it.** That one clamps to the ceiling; this one discards the
+    ///   counter. Both avoid the trap. Clamping keeps a number that then dominates every
+    ///   aggregate it reaches — today's total, the burn tier, the companion — while discarding
+    ///   loses that one counter and leaves the rest of the record intact.
     static let tokenCeiling: UInt64 = 1_000_000_000
 
     /// `nil` means the field was there and its value cannot be a count. That is not the same as

--- a/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
@@ -42,9 +42,15 @@ enum LocalAntigravityUsageReader {
         let directory = root ?? defaultRoot
         let formatter = LocalUsageReader.localDayFormatter()
         var entries: [LocalUsageReader.Entry] = []
+        var reads: [(conversation: String, read: ConversationRead)] = []
         for database in databases(in: directory, modifiedSince: modifiedSince) {
-            entries += conversationEntries(database, modifiedSince: modifiedSince, formatter: formatter)
+            let read = conversationEntries(database, modifiedSince: modifiedSince, formatter: formatter)
+            entries += read.entries
+            reads.append((database.deletingPathExtension().lastPathComponent, read))
         }
+        // The one place the side effect lives. `AppLog.write` returns early outside the bundled
+        // app, so the decision above it is kept pure and tested on its own (`lossLog`).
+        for line in lossLog(reads) { AppLog.write(line) }
         // `response_id` is unique per call, so this only ever collapses a re-read.
         return LocalUsageReader.dedupKeepMax(entries)
     }
@@ -72,25 +78,84 @@ enum LocalAntigravityUsageReader {
 
     // MARK: Reading one conversation
 
-    private static func conversationEntries(
+    /// What one conversation store yielded. Three of these four produce no rows, and only one
+    /// of those three is a fact about the user's usage — collapsing them all to `[]`, which is
+    /// what this reader used to do, is what let a store that could never be read pass for a
+    /// store that was never used.
+    enum ConversationRead: Sendable {
+        /// Read through to `SQLITE_DONE`: these rows are all of them.
+        case complete([LocalUsageReader.Entry])
+        /// The scan stopped early — BUSY because the CLI was writing, or a damaged page. Half a
+        /// conversation must not pass for the whole of it, so the rows read so far are dropped.
+        case incompleteScan(status: Int32, rows: Int)
+        /// Neither `mode=ro` nor `immutable=1` could open it, or the query failed for a reason
+        /// other than the table being absent.
+        case unreadable(status: Int32?)
+        /// No `gen_metadata`: this file is not a conversation store. A permanent, legitimate
+        /// empty — `~/.gemini/antigravity-cli/conversations/` may hold databases we don't read.
+        case notAConversation
+
+        var entries: [LocalUsageReader.Entry] {
+            if case .complete(let entries) = self { return entries }
+            return []
+        }
+    }
+
+    /// At most this many stores are named per scan; the rest are counted. A store that cannot be
+    /// read is re-read on every refresh (720 times a day at the default interval), so one line
+    /// per store per scan could rotate `AppLog`'s 2 MB file — and the crash-diagnostic history
+    /// with it — several times a day on a machine whose conversation directory went bad.
+    static let namedLossLimit = 5
+
+    /// The lines one scan leaves behind. Pure on purpose: `AppLog.write` returns early outside
+    /// the bundled app (`AppEnv.isBundledApp`), so a test that watched the log file would cover
+    /// nothing at all — the same reason the limit-alert decision was split out of its own
+    /// side effect.
+    static func lossLog(_ reads: [(conversation: String, read: ConversationRead)]) -> [String] {
+        let losses = reads.compactMap { entry -> String? in
+            switch entry.read {
+            case .complete, .notAConversation:
+                return nil
+            case .incompleteScan(let status, let rows):
+                return "antigravity: lost conversation=\(entry.conversation)"
+                    + " reason=scan-incomplete status=\(status) rows=\(rows)"
+            case .unreadable(let status):
+                return "antigravity: lost conversation=\(entry.conversation) reason=unreadable"
+                    + (status.map { " status=\($0)" } ?? "")
+            }
+        }
+        guard losses.count > namedLossLimit else { return losses }
+        return Array(losses.prefix(namedLossLimit))
+            + ["antigravity: lost \(losses.count) conversation(s) this scan"
+               + " (\(losses.count - namedLossLimit) not named)"]
+    }
+
+    static func conversationEntries(
         _ database: URL,
         modifiedSince: Date,
         formatter: DateFormatter
-    ) -> [LocalUsageReader.Entry] {
-        guard let handle = openReadOnly(database) else { return [] }
+    ) -> ConversationRead {
+        guard let handle = openReadOnly(database) else { return .unreadable(status: nil) }
         defer { sqlite3_close(handle) }
 
         var statement: OpaquePointer?
-        guard sqlite3_prepare_v2(
-            handle, "SELECT idx, data FROM gen_metadata WHERE data IS NOT NULL", -1, &statement, nil) == SQLITE_OK,
-              let statement else { return [] }
+        let prepared = sqlite3_prepare_v2(
+            handle, "SELECT idx, data FROM gen_metadata WHERE data IS NOT NULL", -1, &statement, nil)
+        guard prepared == SQLITE_OK, let statement else {
+            // `SQLITE_ERROR` here is "no such table", which is a fact about the file and will
+            // never change; anything else (BUSY, I/O) is this moment failing to read a store
+            // that may well be a conversation.
+            return prepared == SQLITE_ERROR ? .notAConversation : .unreadable(status: prepared)
+        }
         defer { sqlite3_finalize(statement) }
 
         let conversation = database.deletingPathExtension().lastPathComponent
         var entries: [LocalUsageReader.Entry] = []
+        var rows = 0
         while true {
             let step = sqlite3_step(statement)
             if step == SQLITE_ROW {
+                rows += 1
                 autoreleasepool {
                     let index = sqlite3_column_int64(statement, 0)
                     guard let pointer = sqlite3_column_blob(statement, 1) else { return }
@@ -107,10 +172,10 @@ enum LocalAntigravityUsageReader {
             // The CLI writes while the app polls, so a scan can end on BUSY rather than on
             // DONE. Half a conversation would otherwise be cached as the whole of it; drop
             // it instead and let the next refresh read it entire.
-            guard step == SQLITE_DONE else { return [] }
+            guard step == SQLITE_DONE else { return .incompleteScan(status: step, rows: rows) }
             break
         }
-        return entries
+        return .complete(entries)
     }
 
     /// `mode=ro` cannot create the `-shm` file a WAL database needs, so it fails outright on

--- a/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
@@ -218,7 +218,12 @@ enum LocalAntigravityUsageReader {
         formatter: DateFormatter
     ) -> ConversationRead {
         guard let handle = openReadOnly(database) else { return .unreadable(status: nil) }
-        defer { sqlite3_close(handle) }
+        // `_v2` because the guarantee this needs is a property of the close, not of the order
+        // the `defer`s happen to run in. `sqlite3_close` leaves the handle open and leaks it if
+        // any statement is still live; today the finalize below is registered later and so runs
+        // first, but that is an accident of two lines' relative position, and this function has
+        // already grown early returns between the two.
+        defer { sqlite3_close_v2(handle) }
 
         var statement: OpaquePointer?
         let prepared = sqlite3_prepare_v2(
@@ -281,7 +286,7 @@ enum LocalAntigravityUsageReader {
                sqlite3_exec(handle, "SELECT count(*) FROM sqlite_master", nil, nil, nil) == SQLITE_OK {
                 return handle
             }
-            if let handle { sqlite3_close(handle) }
+            if let handle { sqlite3_close_v2(handle) }
         }
         return nil
     }

--- a/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
@@ -343,10 +343,133 @@ final class AntigravityUsageTests: XCTestCase {
         try FileManager.default.setAttributes([.modificationDate: stale], ofItemAtPath: database.path)
         FileManager.default.createFile(atPath: database.path + "-wal", contents: Data([0]))
 
-        let fresh = try XCTUnwrap(LocalAntigravityUsageReader.effectiveModificationDate(of: database))
-        XCTAssertGreaterThan(fresh, stale)
+        let fresh = try XCTUnwrap(LocalAntigravityUsageReader.signature(of: database))
+        XCTAssertGreaterThan(fresh.mtime, stale)
         XCTAssertEqual(LocalAntigravityUsageReader.entries(
             modifiedSince: try date("2026-01-01T00:00:00Z"), root: temporaryDirectory).count, 1)
+    }
+
+    // MARK: - Not re-reading what has not changed
+
+    /// The blob stands in for the store while its signature holds — the point of keying on the
+    /// signature at all is that an unchanged store is never reopened.
+    func testStoreWithAnUnchangedSignatureIsNotReread() throws {
+        try writeConversation("c1", records: [
+            record(responseID: "onDisk", model: "gemini-3.6-flash",
+                   createdAt: try date("2026-03-04T10:00:00Z"), input: 100, output: 20, cacheRead: 300),
+        ])
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        let planted = try plantedBlob(for: database)
+
+        let scanned = scan(known: [database.path: planted])
+        XCTAssertEqual(scanned.blobs[database.path]?.entries.map(\.id), ["planted"],
+                       "the store was reopened even though nothing about it had changed")
+    }
+
+    /// The commit a WAL database actually makes: the `.db` is untouched and the `-wal` grows.
+    func testWalCommitInvalidatesTheBlob() throws {
+        try writeConversation("c1", records: [
+            record(responseID: "onDisk", model: "gemini-3.6-flash",
+                   createdAt: try date("2026-03-04T10:00:00Z"), input: 100, output: 20, cacheRead: 300),
+        ])
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        let planted = try plantedBlob(for: database)
+        FileManager.default.createFile(atPath: database.path + "-wal", contents: Data([0, 1, 2, 3]))
+
+        let scanned = scan(known: [database.path: planted])
+        XCTAssertEqual(scanned.blobs[database.path]?.entries.map(\.id), ["antigravity|onDisk"],
+                       "a WAL commit must invalidate the blob — the `.db` alone never moves")
+    }
+
+    /// The other half, and the reason `-shm` is not in the key: a read-only connection writes
+    /// read marks into it, so a signature that included it would be invalidated by this very
+    /// reader, on every scan, and the cache would never hit at all.
+    func testShmChurnDoesNotInvalidateTheBlob() throws {
+        try writeConversation("c1", records: [
+            record(responseID: "onDisk", model: "gemini-3.6-flash",
+                   createdAt: try date("2026-03-04T10:00:00Z"), input: 100, output: 20, cacheRead: 300),
+        ])
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        let planted = try plantedBlob(for: database)
+        FileManager.default.createFile(atPath: database.path + "-shm", contents: Data([9, 9, 9, 9]))
+
+        let scanned = scan(known: [database.path: planted])
+        XCTAssertEqual(scanned.blobs[database.path]?.entries.map(\.id), ["planted"],
+                       "`-shm` churn is somebody reading the store, not somebody writing to it")
+    }
+
+    /// A read that did not finish must not be filed under the current signature: the store would
+    /// then read as no usage for as long as it sat still, and the next refresh — the whole
+    /// reason the partial read was discarded — would never come.
+    func testIncompleteScanKeepsThePreviousRowsUnderTheirOldSignature() throws {
+        try writeManyRecords("c1", count: 60, pageSize: 512)
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        try corruptLastPage(database, pageSize: 512)
+        let stale = LocalAntigravityUsageReader.Blob(
+            mtime: .distantPast, size: 0,
+            entries: try plantedBlob(for: database).entries)
+
+        let scanned = scan(known: [database.path: stale])
+        let blob = try XCTUnwrap(scanned.blobs[database.path])
+        XCTAssertEqual(blob.entries.map(\.id), ["planted"], "the rows already known were thrown away")
+        XCTAssertEqual(blob.mtime, .distantPast, "the old signature must survive so the next scan retries")
+    }
+
+    /// With nothing to carry forward there must be no blob at all — an empty one would freeze
+    /// the store as "no usage" until something happened to change it.
+    func testUnreadableStoreIsNotCachedAsAnEmptyConversation() throws {
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        try Data("not a sqlite database".utf8).write(to: database, options: .atomic)
+
+        XCTAssertNil(scan().blobs[database.path])
+    }
+
+    /// The opposite: a database with no `gen_metadata` will never grow one, so caching its empty
+    /// is what stops it being reopened on every refresh for the life of the install.
+    func testDatabaseWithoutTheExpectedTableIsCachedAsEmpty() throws {
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        try execute(database, sql: "CREATE TABLE something_else (a INTEGER);")
+
+        let blob = try XCTUnwrap(scan().blobs[database.path])
+        XCTAssertTrue(blob.entries.isEmpty)
+        XCTAssertEqual(blob.mtime, LocalAntigravityUsageReader.signature(of: database)?.mtime)
+    }
+
+    /// A store that drops out of the window leaves the cache with it — the sweep rebuilds from
+    /// what it visited, so there is no separate prune to forget to run.
+    func testStoresOutsideTheWindowLeaveTheCache() throws {
+        try writeConversation("c1", records: [
+            record(responseID: "old", model: "gemini-3.6-flash",
+                   createdAt: try date("2020-01-01T10:00:00Z"), input: 100, output: 20, cacheRead: 300),
+        ])
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        try FileManager.default.setAttributes(
+            [.modificationDate: try date("2020-01-02T00:00:00Z")], ofItemAtPath: database.path)
+        let planted = try plantedBlob(for: database)
+
+        let scanned = scan(known: [database.path: planted], modifiedSince: try date("2026-03-01T00:00:00Z"))
+        XCTAssertTrue(scanned.blobs.isEmpty)
+    }
+
+    /// The behaviour the 30-second expiry could not give: a store that changed a moment ago is
+    /// read a moment ago, not up to half a minute later.
+    func testCacheSeesAChangedStoreWithoutWaiting() async throws {
+        let recent = Date().addingTimeInterval(-600)
+        try writeConversation("c1", records: [
+            record(responseID: "first", model: "gemini-3.6-flash", createdAt: recent,
+                   input: 100, output: 20, cacheRead: 300),
+        ])
+        let cache = LocalAntigravityUsageCache(root: temporaryDirectory)
+        let before = await cache.entries()
+        XCTAssertEqual(Set(before.map(\.id)), ["antigravity|first"])
+
+        try appendRecords("c1", records: [
+            record(responseID: "second", model: "gemini-3.6-flash", createdAt: recent.addingTimeInterval(1),
+                   input: 100, output: 20, cacheRead: 300),
+        ], startingAt: 1)
+
+        let after = await cache.entries()
+        XCTAssertEqual(Set(after.map(\.id)), ["antigravity|first", "antigravity|second"])
     }
 
     // MARK: - Pricing
@@ -407,7 +530,25 @@ final class AntigravityUsageTests: XCTestCase {
     private func readConversation(_ name: String) -> LocalAntigravityUsageReader.ConversationRead {
         LocalAntigravityUsageReader.conversationEntries(
             temporaryDirectory.appendingPathComponent("\(name).db"),
-            modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
+            formatter: LocalUsageReader.localDayFormatter())
+    }
+
+    private func scan(known: [String: LocalAntigravityUsageReader.Blob] = [:],
+                      modifiedSince: Date = .distantPast) -> LocalAntigravityUsageReader.Scan {
+        LocalAntigravityUsageReader.scan(
+            root: temporaryDirectory, modifiedSince: modifiedSince, known: known)
+    }
+
+    /// A blob that does not match the file it is filed under, so a test can tell a cache hit
+    /// (the planted rows come back) from a re-read (the file's own rows do).
+    private func plantedBlob(for database: URL, id: String = "planted") throws
+    -> LocalAntigravityUsageReader.Blob {
+        let signature = try XCTUnwrap(LocalAntigravityUsageReader.signature(of: database))
+        return LocalAntigravityUsageReader.Blob(
+            mtime: signature.mtime, size: signature.size,
+            entries: [LocalUsageReader.Entry(
+                id: id, date: try date("2026-03-04T10:00:00Z"), localDay: "2026-03-04",
+                model: "antigravity/planted", input: 1, output: 0, cacheWrite: 0, cacheRead: 0)])
     }
 
     private func date(_ text: String) throws -> Date {
@@ -486,6 +627,17 @@ final class AntigravityUsageTests: XCTestCase {
                        createdAtSeconds: base + UInt64(index),
                        input: 100, output: 20, cacheRead: 300)
         }, pageSize: pageSize)
+    }
+
+    /// Appends to a store that already exists, the way the CLI does — the `.db` grows and its
+    /// timestamp moves, which is what the signature has to notice.
+    private func appendRecords(_ name: String, records: [Data], startingAt index: Int) throws {
+        var sql = ""
+        for (offset, blob) in records.enumerated() {
+            sql += "INSERT INTO gen_metadata VALUES (\(index + offset),"
+                + " X'\(blob.map { String(format: "%02x", $0) }.joined())', \(blob.count));\n"
+        }
+        try execute(temporaryDirectory.appendingPathComponent("\(name).db"), sql: sql)
     }
 
     /// Damages the b-tree page-type byte of the last page. Page 1 — the schema — is untouched on

--- a/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
@@ -137,7 +137,8 @@ final class AntigravityUsageTests: XCTestCase {
     // MARK: - Hostile input
 
     /// A `uint64` sentinel widened into `Int` would trap the process on the next addition, and
-    /// it would trap again on every refresh because the file never changes.
+    /// it would trap again on every refresh because the file never changes. Dropping it is
+    /// right; dropping it silently makes the turn read as one that used no input at all.
     func testSentinelTokenCountIsDiscardedRatherThanTrapping() throws {
         try writeConversation("c1", records: [
             record(responseID: "r1", model: "gemini-3.6-flash", createdAt: try date("2026-03-04T10:00:00Z"),
@@ -147,6 +148,46 @@ final class AntigravityUsageTests: XCTestCase {
         let entry = try XCTUnwrap(readAll().first)
         XCTAssertEqual(entry.input, 0)
         XCTAssertEqual(entry.total, 320, "the rest of the record still counts")
+
+        let read = readConversation("c1")
+        guard case .complete(_, let discarded) = read else { return XCTFail("expected a complete read") }
+        XCTAssertEqual(discarded, 1)
+        let line = try XCTUnwrap(
+            LocalAntigravityUsageReader.discardLog([(conversation: "c1", read: read)]).first)
+        XCTAssertTrue(line.contains("conversation=c1"), line)
+        XCTAssertTrue(line.contains("discarded=1"), line)
+    }
+
+    /// A counter the writer never sets is a zero, not a bad value — `cache_write_tokens` is
+    /// declared and never written, so treating "absent" as a discard would report every single
+    /// record on every scan.
+    func testAbsentCounterIsNotADiscard() throws {
+        try writeConversation("c1", records: [
+            record(responseID: "r1", model: "gemini-3.6-flash", createdAt: try date("2026-03-04T10:00:00Z"),
+                   input: 100, output: 20, cacheRead: 300),
+        ])
+
+        let read = readConversation("c1")
+        guard case .complete(let entries, let discarded) = read else {
+            return XCTFail("expected a complete read")
+        }
+        XCTAssertEqual(entries.first?.cacheWrite, 0)
+        XCTAssertEqual(discarded, 0)
+        XCTAssertTrue(LocalAntigravityUsageReader.discardLog([(conversation: "c1", read: read)]).isEmpty)
+    }
+
+    /// Same bound as the loss lines, and for the same reason.
+    func testDiscardLogNamesAFewStoresAndCountsTheRest() {
+        let limit = LocalAntigravityUsageReader.namedLossLimit
+        let reads = (0..<(limit + 2)).map {
+            (conversation: "c\($0)",
+             read: LocalAntigravityUsageReader.ConversationRead.complete(entries: [], discardedCounters: 3))
+        }
+
+        let lines = LocalAntigravityUsageReader.discardLog(reads)
+        XCTAssertEqual(lines.count, limit + 1)
+        XCTAssertEqual(lines.last?.contains("in \(limit + 2) conversation(s)"), true, lines.last ?? "")
+        XCTAssertEqual(lines.last?.contains("(2 not named)"), true, lines.last ?? "")
     }
 
     func testMalformedBlobIsIgnored() throws {
@@ -196,8 +237,7 @@ final class AntigravityUsageTests: XCTestCase {
         XCTAssertGreaterThan(probe.rows, 0, "no rows read — the failure moved to open/prepare")
         XCTAssertNotEqual(probe.status, SQLITE_DONE, "the scan finished — this no longer covers the drop")
 
-        let read = LocalAntigravityUsageReader.conversationEntries(
-            database, modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
+        let read = readConversation("c1")
         guard case .incompleteScan(let status, let rows) = read else {
             return XCTFail("expected an incomplete scan, got \(read)")
         }
@@ -223,8 +263,7 @@ final class AntigravityUsageTests: XCTestCase {
         let database = temporaryDirectory.appendingPathComponent("c1.db")
         try Data("not a sqlite database".utf8).write(to: database, options: .atomic)
 
-        let read = LocalAntigravityUsageReader.conversationEntries(
-            database, modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
+        let read = readConversation("c1")
         guard case .unreadable = read else { return XCTFail("expected unreadable, got \(read)") }
         XCTAssertTrue(read.entries.isEmpty)
 
@@ -240,8 +279,7 @@ final class AntigravityUsageTests: XCTestCase {
         let database = temporaryDirectory.appendingPathComponent("c1.db")
         try execute(database, sql: "CREATE TABLE something_else (a INTEGER);")
 
-        let read = LocalAntigravityUsageReader.conversationEntries(
-            database, modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
+        let read = readConversation("c1")
         guard case .notAConversation = read else { return XCTFail("expected notAConversation, got \(read)") }
         XCTAssertTrue(LocalAntigravityUsageReader.lossLog([(conversation: "c1", read: read)]).isEmpty)
     }
@@ -267,11 +305,10 @@ final class AntigravityUsageTests: XCTestCase {
             record(responseID: "r1", model: "gemini-3.6-flash",
                    createdAt: try date("2026-03-04T10:00:00Z"), input: 100, output: 20, cacheRead: 300),
         ])
-        let read = LocalAntigravityUsageReader.conversationEntries(
-            temporaryDirectory.appendingPathComponent("c1.db"),
-            modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
+        let read = readConversation("c1")
         XCTAssertEqual(read.entries.count, 1)
         XCTAssertTrue(LocalAntigravityUsageReader.lossLog([(conversation: "c1", read: read)]).isEmpty)
+        XCTAssertTrue(LocalAntigravityUsageReader.discardLog([(conversation: "c1", read: read)]).isEmpty)
     }
 
     // MARK: - Opening WAL databases read-only
@@ -365,6 +402,12 @@ final class AntigravityUsageTests: XCTestCase {
 
     private func readAll() -> [LocalUsageReader.Entry] {
         LocalAntigravityUsageReader.entries(modifiedSince: .distantPast, root: temporaryDirectory)
+    }
+
+    private func readConversation(_ name: String) -> LocalAntigravityUsageReader.ConversationRead {
+        LocalAntigravityUsageReader.conversationEntries(
+            temporaryDirectory.appendingPathComponent("\(name).db"),
+            modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
     }
 
     private func date(_ text: String) throws -> Date {

--- a/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
@@ -701,7 +701,7 @@ final class AntigravityUsageTests: XCTestCase {
         var handle: OpaquePointer?
         let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_URI | SQLITE_OPEN_NOMUTEX
         guard sqlite3_open_v2("file:\(database.path)?mode=ro", &handle, flags, nil) == SQLITE_OK else {
-            if let handle { sqlite3_close(handle) }
+            if let handle { sqlite3_close_v2(handle) }
             return nil
         }
         // Opening can succeed lazily; the read is what actually needs the -shm file.
@@ -710,7 +710,7 @@ final class AntigravityUsageTests: XCTestCase {
         let stepped = prepared == SQLITE_OK ? sqlite3_step(statement) : SQLITE_ERROR
         sqlite3_finalize(statement)
         guard stepped == SQLITE_ROW else {
-            sqlite3_close(handle)
+            sqlite3_close_v2(handle)
             return nil
         }
         return handle
@@ -719,7 +719,7 @@ final class AntigravityUsageTests: XCTestCase {
     private func execute(_ databaseURL: URL, sql: String) throws {
         var database: OpaquePointer?
         XCTAssertEqual(sqlite3_open(databaseURL.path, &database), SQLITE_OK)
-        defer { sqlite3_close(database) }
+        defer { sqlite3_close_v2(database) }
         var errorMessage: UnsafeMutablePointer<CChar>?
         let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
         if result != SQLITE_OK {

--- a/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
@@ -174,6 +174,106 @@ final class AntigravityUsageTests: XCTestCase {
         XCTAssertTrue(readAll().isEmpty)
     }
 
+    // MARK: - A lost conversation leaves a trace
+
+    /// A scan that cannot finish drops the rows it did read, which is right, and used to say
+    /// nothing about it, which is not: the result is indistinguishable from a conversation with
+    /// no usage, so a store that could never be read to the end read as no spend, for as long
+    /// as it stayed that way.
+    func testIncompleteScanDropsTheConversationAndNamesTheReason() throws {
+        try writeManyRecords("c1", count: 60, pageSize: 512)
+        try writeConversation("c2", records: [
+            record(responseID: "survivor", model: "gemini-3.6-flash",
+                   createdAt: try date("2026-03-04T10:00:00Z"), input: 100, output: 20, cacheRead: 300),
+        ])
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        try corruptLastPage(database, pageSize: 512)
+
+        // Assert the branch this test exists for is the one being walked: the store still opens
+        // and still hands back rows, so the loss can only be coming from the step loop. Without
+        // this the test would keep passing if the failure moved to the open.
+        let probe = try stepUntilNotARow(database)
+        XCTAssertGreaterThan(probe.rows, 0, "no rows read — the failure moved to open/prepare")
+        XCTAssertNotEqual(probe.status, SQLITE_DONE, "the scan finished — this no longer covers the drop")
+
+        let read = LocalAntigravityUsageReader.conversationEntries(
+            database, modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
+        guard case .incompleteScan(let status, let rows) = read else {
+            return XCTFail("expected an incomplete scan, got \(read)")
+        }
+        XCTAssertEqual(status, probe.status)
+        XCTAssertGreaterThan(rows, 0)
+        XCTAssertTrue(read.entries.isEmpty, "half a conversation must not pass for the whole of it")
+
+        let lines = LocalAntigravityUsageReader.lossLog([(conversation: "c1", read: read)])
+        XCTAssertEqual(lines.count, 1)
+        let line = try XCTUnwrap(lines.first)
+        XCTAssertTrue(line.contains("conversation=c1"), line)
+        XCTAssertTrue(line.contains("reason=scan-incomplete"), line)
+        XCTAssertTrue(line.contains("status=\(status)"), line)
+        XCTAssertTrue(line.contains("rows=\(rows)"), line)
+
+        // The rest of the directory is unaffected — one bad store, not a bad scan.
+        XCTAssertEqual(Set(readAll().map(\.id)), ["antigravity|survivor"])
+    }
+
+    /// A file that is not a database at all must read as unreadable rather than as an empty
+    /// conversation — the two are the same zero, and only one of them is about usage.
+    func testUnreadableStoreIsNotAnEmptyConversation() throws {
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        try Data("not a sqlite database".utf8).write(to: database, options: .atomic)
+
+        let read = LocalAntigravityUsageReader.conversationEntries(
+            database, modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
+        guard case .unreadable = read else { return XCTFail("expected unreadable, got \(read)") }
+        XCTAssertTrue(read.entries.isEmpty)
+
+        let line = try XCTUnwrap(LocalAntigravityUsageReader.lossLog([(conversation: "c1", read: read)]).first)
+        XCTAssertTrue(line.contains("conversation=c1"), line)
+        XCTAssertTrue(line.contains("reason=unreadable"), line)
+    }
+
+    /// The opposite case, and the reason the reader cannot simply log every empty read: this
+    /// directory may hold databases that are not conversation stores. A missing `gen_metadata`
+    /// is a permanent fact about the file, so naming it would repeat every refresh forever.
+    func testDatabaseWithoutTheExpectedTableIsNotReportedAsALoss() throws {
+        let database = temporaryDirectory.appendingPathComponent("c1.db")
+        try execute(database, sql: "CREATE TABLE something_else (a INTEGER);")
+
+        let read = LocalAntigravityUsageReader.conversationEntries(
+            database, modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
+        guard case .notAConversation = read else { return XCTFail("expected notAConversation, got \(read)") }
+        XCTAssertTrue(LocalAntigravityUsageReader.lossLog([(conversation: "c1", read: read)]).isEmpty)
+    }
+
+    /// A directory that has gone bad wholesale must not be able to rotate the log — `AppLog`
+    /// keeps 2 MB and the crash history lives in the same file.
+    func testLossLogNamesAFewStoresAndCountsTheRest() {
+        let limit = LocalAntigravityUsageReader.namedLossLimit
+        let reads = (0..<(limit + 4)).map {
+            (conversation: "c\($0)", read: LocalAntigravityUsageReader.ConversationRead.unreadable(status: nil))
+        }
+
+        let lines = LocalAntigravityUsageReader.lossLog(reads)
+        XCTAssertEqual(lines.count, limit + 1)
+        let summary = try? XCTUnwrap(lines.last)
+        XCTAssertEqual(summary?.contains("lost \(limit + 4) conversation(s)"), true, lines.last ?? "")
+        XCTAssertEqual(summary?.contains("(4 not named)"), true, lines.last ?? "")
+    }
+
+    /// A clean scan says nothing at all.
+    func testCompleteScanLogsNothing() throws {
+        try writeConversation("c1", records: [
+            record(responseID: "r1", model: "gemini-3.6-flash",
+                   createdAt: try date("2026-03-04T10:00:00Z"), input: 100, output: 20, cacheRead: 300),
+        ])
+        let read = LocalAntigravityUsageReader.conversationEntries(
+            temporaryDirectory.appendingPathComponent("c1.db"),
+            modifiedSince: .distantPast, formatter: LocalUsageReader.localDayFormatter())
+        XCTAssertEqual(read.entries.count, 1)
+        XCTAssertTrue(LocalAntigravityUsageReader.lossLog([(conversation: "c1", read: read)]).isEmpty)
+    }
+
     // MARK: - Opening WAL databases read-only
 
     /// Every conversation store is in WAL mode. A checkpointed one has no `-wal` sibling, and
@@ -334,9 +434,57 @@ final class AntigravityUsageTests: XCTestCase {
         try writeConversation(name, blobs: records, walMode: walMode)
     }
 
-    private func writeConversation(_ name: String, blobs: [Data], walMode: Bool = false) throws {
+    /// A store spanning several pages, so damaging the last one still leaves earlier rows
+    /// readable — which is the shape a scan that stops half way actually has.
+    private func writeManyRecords(_ name: String, count: Int, pageSize: Int) throws {
+        let base = UInt64(try date("2026-03-04T10:00:00Z").timeIntervalSince1970)
+        try writeConversation(name, blobs: (0..<count).map { index in
+            makeRecord(responseID: "r\(index)", model: "gemini-3.6-flash",
+                       createdAtSeconds: base + UInt64(index),
+                       input: 100, output: 20, cacheRead: 300)
+        }, pageSize: pageSize)
+    }
+
+    /// Damages the b-tree page-type byte of the last page. Page 1 — the schema — is untouched on
+    /// purpose, so `openReadOnly`'s probe still succeeds and the connection it returns is the
+    /// `mode=ro` one; corrupting the header instead would fail the open and cover a different
+    /// branch entirely.
+    private func corruptLastPage(_ database: URL, pageSize: Int) throws {
+        let size = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: database.path)[.size] as? Int)
+        XCTAssertGreaterThan(size / pageSize, 2, "the fixture needs more than two pages to damage the last one")
+        let handle = try FileHandle(forUpdating: database)
+        defer { try? handle.close() }
+        try handle.seek(toOffset: UInt64((size / pageSize - 1) * pageSize))
+        handle.write(Data([0x00]))   // not a valid b-tree page type
+    }
+
+    /// Walks the reader's own query so a test can assert that rows really do arrive before the
+    /// failure — i.e. that it is exercising the partial-scan branch and not a failed open.
+    private func stepUntilNotARow(_ database: URL) throws -> (rows: Int, status: Int32) {
+        var handle: OpaquePointer?
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_URI | SQLITE_OPEN_NOMUTEX
+        XCTAssertEqual(sqlite3_open_v2("file:\(database.path)?mode=ro", &handle, flags, nil), SQLITE_OK)
+        defer { sqlite3_close_v2(handle) }
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            handle, "SELECT idx, data FROM gen_metadata WHERE data IS NOT NULL",
+            -1, &statement, nil), SQLITE_OK)
+        defer { sqlite3_finalize(statement) }
+        var rows = 0
+        while true {
+            let step = sqlite3_step(statement)
+            guard step == SQLITE_ROW else { return (rows, step) }
+            rows += 1
+        }
+    }
+
+    private func writeConversation(_ name: String, blobs: [Data], walMode: Bool = false,
+                                   pageSize: Int? = nil) throws {
         let database = temporaryDirectory.appendingPathComponent("\(name).db")
-        var sql = walMode ? "PRAGMA journal_mode=WAL;\n" : ""
+        // `page_size` only takes effect before the first table exists.
+        var sql = pageSize.map { "PRAGMA page_size=\($0);\n" } ?? ""
+        sql += walMode ? "PRAGMA journal_mode=WAL;\n" : ""
         sql += "CREATE TABLE gen_metadata (idx integer, data blob, size integer NOT NULL DEFAULT 0, PRIMARY KEY (idx));\n"
         for (index, blob) in blobs.enumerated() {
             sql += "INSERT INTO gen_metadata VALUES (\(index), X'\(blob.map { String(format: "%02x", $0) }.joined())', \(blob.count));\n"

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -118,6 +118,33 @@ read_when:
   `(path, mtime, size)` 로만 무효화된다. 옆 파일(예: Grok `summary.json` 의 `session_kind`)로 결정되는
   포함·제외를 파서 안에서 하면, 근거가 나중에 바뀌어도 파일이 안 바뀌어 판정이 영구히 굳는다. 그런 판정은
   파일 선택 단계(`collect(include:)`)에 둬 매 새로고침 재평가되게 한다.
+- **캐시를 붙이는 순간 "다음 새로고침이 다시 읽는다"가 공짜가 아니다.** 부분 읽기(SQLITE_BUSY·손상 페이지)를
+  버리는 가드는 **재시도가 실제로 오는 경우에만** 가드다. TTL 시절엔 만료가 재시도를 보장했지만
+  `(path, mtime, size)` 키로 바꾸는 순간 그 보장이 사라진다 — 실패 결과를 *현재* signature 아래 blob 으로
+  넣으면 파일이 가만히 있는 한 그 소스는 영구히 "사용량 없음"으로 읽힌다. 규칙: ① 읽기 결과를 `[]`·`nil` 로
+  접지 말고 **실패와 빈 값을 구분하는 값**으로 돌려라(`LocalAntigravityUsageReader.ConversationRead`)
+  ② 일시적 실패는 캐시에 **쓰지 말고** 이전 blob 을 *옛 signature 그대로* 이어받아 다음 스캔이 다시 읽게
+  하라 ③ 영구적 사실(기대 테이블이 아예 없는 파일)만 빈 값으로 캐시한다 — 안 그러면 대화가 아닌 DB 를 매
+  새로고침 재오픈한다. 같은 이유로 **창(window) 필터를 캐시 단위 안에 굽지 마라**: blob 은 그 창보다 오래
+  살아서 다음 날 조용히 행이 빈다. 캐시는 무필터로 담고 조립 시점에 좁힌다(`assemble(_:since:)`).
+  회귀 가드: `testIncompleteScanKeepsThePreviousRowsUnderTheirOldSignature`·
+  `testUnreadableStoreIsNotCachedAsAnEmptyConversation`·`testDatabaseWithoutTheExpectedTableIsCachedAsEmpty`.
+- **캐시 무효화 키에 *내 읽기가 건드리는 파일*을 넣지 마라.** WAL 의 `-shm` 은 읽기 전용 커넥션도 read mark 를
+  쓴다. 키에 넣으면 스캔이 방금 쓴 blob 을 그 스캔 자신이 무효화해 **히트율이 영구히 0** 이 된다 — 교체하려던
+  TTL 보다 나쁘다. 커밋은 `.db`(체크포인트)나 `-wal`(append) 에 반드시 남으므로 키는 그 둘의 최신 mtime +
+  크기 합이면 충분하고, 같은 이유로 창 판정에도 `-shm` 은 무의미하다(그것만 새롭다 = 누가 *읽었다*).
+  그리고 **stat 은 읽기 앞에서** 한다 — 뒤에서 하면 읽는 중에 들어온 커밋이 이미 최신처럼 보이는 signature 에
+  굳어 영영 안 읽힌다. 회귀 가드: `testShmChurnDoesNotInvalidateTheBlob`·`testWalCommitInvalidatesTheBlob`.
+- **실패가 흔적을 안 남기면 "안 썼음"과 구분되지 않는다.** 외부 소스 리더가 실패를 `[]`/`nil` 로 접으면 사용량
+  0 과 같은 값이 된다. 프로바이더별 탭이 붙은 뒤엔 숫자가 조금 낮은 정도가 아니라 **탭이 통째로 사라진다**
+  (`UsageStore` 는 `today != nil` 이거나 활성 블록이 있을 때만 스냅샷을 만든다). 로그를 남기되 세 가지를 지켜라:
+  ① **판정은 순수 함수로 분리** — `AppLog.write` 는 `AppEnv.isBundledApp` 가드로 xctest 에서 조기 return 하므로
+  로그 파일을 보는 테스트는 아무것도 커버하지 못한다(§알림의 같은 규칙). ② **양을 묶어라** — 읽을 수 없는
+  소스는 매 새로고침 다시 읽히므로(기본 2분 = 720회/일) 대상마다 한 줄이면 2MB 로그가 하루에도 여러 번
+  회전해 크래시 이력을 밀어낸다. 스캔당 상위 N개만 이름을 남기고 나머지는 개수로 접는다. ③ **영구적 사실은
+  로그하지 마라** — "이 파일엔 그 테이블이 없다"는 바뀌지 않으므로 영원히 반복된다.
+  회귀 가드: `testIncompleteScanDropsTheConversationAndNamesTheReason`·`testLossLogNamesAFewStoresAndCountsTheRest`·
+  `testDatabaseWithoutTheExpectedTableIsNotReportedAsALoss`.
 
 ## 자격증명·Keychain
 


### PR DESCRIPTION
## Summary

The four review notes from #141, as agreed there. Each is its own commit.

**1. A lost conversation says which one it was.** `conversationEntries` was right to discard a scan that did not end on `SQLITE_DONE`, but it returned the same `[]` as a conversation with no usage and said nothing, so a store that could not be read stayed invisible for as long as it stayed that way. The read is now a value with four cases, because three of them produce no rows and only one of those three is a fact about the user's spend. A file with no `gen_metadata` is deliberately *not* a loss — this directory can hold databases that are not conversation stores, and a missing table is permanent, so naming it would print the same line every two minutes forever. `SQLITE_ERROR` from `prepare` is that case; BUSY or I/O there is a real loss.

The regression test walks the branch rather than approximating it. A lock cannot be used — `immutable=1` disables locking, so the fallback reads straight through anything a test could hold — so the fixture spans several 512-byte pages and has the last page's b-tree type byte damaged, which steps rows and then returns `SQLITE_CORRUPT`. It asserts the trigger condition first, that rows really do arrive and the scan really does not reach `DONE`, so it cannot keep passing if the failure moves to the open.

**2. Discarded token counters are reported.** `tokenCount` clamped anything above the ceiling to 0, which is the right value, but left the record looking like a turn that used no input. It now returns `nil` for a value that cannot be a count, which the *absent* case does not — `cache_write_tokens` is declared and never written, so "the writer set nothing" is a legitimate zero. Counting is per row and reporting per store: `tokenCount` runs four times a record and the live store here holds 5,572 of them.

**3. The cache keys on each store's `(mtime, size)`.** It expired after 30 seconds while `LocalUsageCache` keys per-file blobs, which has both of a timer's failings — for up to half a minute it served a store that had just changed from a parse taken before the change, and the moment it lapsed it reopened all 160 stores to find that none had moved. Measured on the live store: cold scan 0.185s, second scan 0.013s with all 160 blobs reused.

The signature is the newest of the `.db` and its `-wal` plus their two lengths. `-shm` is excluded on purpose and it is the subtle part: a read-only WAL connection writes read marks into it, so a key that included it would be invalidated by this reader's own read, on every scan — a cache that never hits, which is worse than the expiry it replaces.

Three things had to move for a blob to be sound: the window filter left the row loop (a cutoff baked into a cached unit is wrong as soon as the window moves); a read that did not finish no longer writes a blob, carrying the previous rows forward under their *old* signature so the next scan retries; and a database with no `gen_metadata` does cache its empty, because that is permanent. The `monthKey` guard went with the expiry — `enrichmentScanStart` only ever advances, and the guard was keyed on the wrong quantity anyway: at 00:30 on the 1st the month key says April while the scan window starts in March, so it threw away exactly the blobs the new week total needed.

**4. `sqlite3_close_v2`.** Nothing leaks today because the `finalize` is registered after the close and `defer` runs last-in-first-out, but that is a fact about where two lines sit, not about the call — and the function has since grown early returns between them. The error path in `openReadOnly` is the site where `v1` could already have been wrong: there is no statement to order against there at all.

**Plus the two follow-ups the protocol asks for.** `docs/reference/defect-log.md` gains the three classes these notes produced — a blob cache removing the retry that a discarded partial read depends on, why the file our own read touches cannot be in the invalidation key, and failure folded into `[]` being indistinguishable from no usage. And `AntigravityProto.tokenCeiling` now cross-references `LocalUsageReader.maxParsedTokenValue`.

**One question, on that last point.** #145 landed while #141 was open, and the two ceilings differ on both axes: 1e9 vs 1e15, and this one *discards* the counter where that one *clamps* to the ceiling. Neither divergence is accidental — nothing here adds two parsed values before `Entry.total`, so a tighter ceiling costs nothing, and clamping keeps a number that then dominates today's total, the burn tier and the companion, where discarding loses one counter and leaves the record intact. But `defect-log.md` asks for one defence point per class, so I have written the difference down rather than reconciled it. Happy to converge them either way if you would rather — it is a small change in either direction.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## Checklist

- [x] `swift build` and `swift test` pass locally — 577 tests, `scripts/test-gate.sh` reports 89.52%
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional) — nothing under `Sources/PokeTokenBar/UI/` changed, so the UI section is omitted
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change
