### PR TITLE
feat: track GitHub Copilot CLI usage

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI）を、macOS メニューバーの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
+PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI）を、macOS メニューバーの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
 
-> トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI データから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
+> トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI データから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
 
 ## なぜ
 
@@ -33,7 +33,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 
 ## しくみ
 
-1. 🥚 **いつも通りコーディング。** Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI で使うトークンがタマゴを温めます — 追加の操作は不要です。
+1. 🥚 **いつも通りコーディング。** Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI で使うトークンがタマゴを温めます — 追加の操作は不要です。
 2. 🐣 **孵化。** [PokéAPI](https://pokeapi.co/) の**第1〜5世代すべての進化系統（起点329種）**から、公式の捕獲率で重み付けされて生まれます — よくいるポケモンは頻繁に、伝説は129回に1回。孵化したポケモンは育成中もすぐに **図鑑** に表示されます。孵化ごとに25種類のせいかくがひとつ決まり — **ごくまれな偶然で ✨ 色違いが生まれます**。
 3. ⚡ **進化。** コーディングを続けると実際の進化ツリー（1/2/3段階、分岐）に沿って育ち、各段階で小さな演出が流れます。
 4. 🎓 **卒業 & 収集。** 最終進化 + 閾値で **図鑑** に永久保存されます — レアなほど時間がかかり（ヘビーユーザーで common ≈3日 → legendary ≈24日）— 新しいタマゴが届きます。
@@ -97,7 +97,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 ## そのほかにも
 
 - **インタラクティブなフローティングペット** — ホバーで今日の使用量、クリックでメイン画面、右クリックでメニュー。上限アラートは吹き出しでも表示。
-- **サービス別タブ** — Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI のうち2つ以上が検出されると、小さなタブでサービス別の詳細を切替（今日の合計は合算のまま）。
+- **サービス別タブ** — Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI のうち2つ以上が検出されると、小さなタブでサービス別の詳細を切替（今日の合計は合算のまま）。
 - **公式の上限** — Claude・Codex の5時間／週間使用率とリセットのカウントダウンを、今日の数字のすぐ下に。
 - **消費予測** — 現在の5時間ウィンドウが100%に達する時刻を予測。
 - **アプリ内アップデート** — ワンクリックの更新確認、設定に現在のバージョンを表示。
@@ -114,6 +114,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 | **Hermes Agent** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Cursor** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Grok CLI** | 今日 · 5時間ブロック · 週 · 月 | — |
+| **Copilot CLI** | 今日 · 5時間ブロック · 週 · 月 | — |
 
 すべてローカルから読み取り — 外部の使用量CLIは不要。ツール追加はプロバイダーファイル1つで完結します（[CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) 参照）。
 
@@ -121,7 +122,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 
 ### 必要条件
 
-macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI データから直接読み取り、外部の使用量 CLI は不要です。
+macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI データから直接読み取り、外部の使用量 CLI は不要です。
 
 ### Homebrew
 
@@ -162,6 +163,7 @@ swift test                   # ユニットテスト
 | `~/.hermes/state.db` | Hermes Agent daily/blocks/weekly/monthly | SQLite 読み取り専用；セッショントークン合計と保存済みコスト |
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite 読み取り専用；`cursorDiskKV` バブルエントリの `tokenCount` |
 | `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` レコード（ターン単位の `usage`、サーバー報告のコスト）；`$GROK_HOME` を設定していればそのパス；サブエージェントのセッションは親ターンに合算済みのため除外 |
+| `~/.copilot/session-store.db` | Copilot CLI daily/blocks/weekly/monthly | SQLite 読み取り専用；`assistant_usage_events` の1行が API 呼び出し1回；`$COPILOT_HOME` を設定していればそのパス；`input_tokens` にキャッシュ分が含まれるため cache read/write を差し引いて集計；premium request 課金のためコストは推定しない |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 公式 5h/週間 % | 非公式 endpoint；Keychain は**更新ボタンを押した時のみ**読み取り — 自動更新では読みません |
 | `codex app-server` | Codex 公式 5h/週間 % | ローカル子プロセス；アカウント snapshot のみ、モデル turn なし |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | ポケモンの種・進化 | ランタイム取得；ローカルキャッシュ、バンドルしない |
@@ -171,7 +173,7 @@ swift test                   # ユニットテスト
 
 ## プライバシー & 権限
 
-- **オンデバイス。** トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI データから直接読み取ります。使用量のアップロードも、モデルの推論実行も行いません。
+- **オンデバイス。** トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI データから直接読み取ります。使用量のアップロードも、モデルの推論実行も行いません。
 - **外部リクエスト。** 本アプリは完全オフラインではありません。7つのホストに接続します — `pokeapi.co`・`graphql.pokeapi.co`（種・進化）、`raw.githubusercontent.com`（スプライト）、`api.anthropic.com`（Claude 公式の上限）、`status.claude.com`・`status.openai.com`（障害バナー — 設定でオフ可）、`api.github.com`（アップデート確認）。**いずれのリクエストにも使用量・トークン・プロンプト・プロジェクトのパスは含まれません** — 送られるのはリクエストそのものだけです。
 - **Keychain（任意）。** Claude OAuth 資格情報は**更新ボタンを押した時のみ**読み取ります（設定、またはポップオーバーの上限行）。自動更新では Keychain に触れないためパスワードのプロンプトは表示されず、`~/.claude/.credentials.json` があればそちらから取得します。トークンはメモリ上にのみ保持し、**アプリ自身の Keychain 項目は作成しません。** トークンが期限切れになると、上限は更新するまで以前の値（stale）として表示されます。設定でオフにすると上限セクションが非表示になります。
 - **ポケモンのアセット** はランタイムに PokéAPI から取得し、`~/Library/Application Support/PokeTokenBar/` にのみキャッシュされます。アプリのバイナリおよびリリース成果物にポケモンのアセットは含まれません。

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · Antigravity · OpenCode · Hermes Agent · Cursor · Grok CLI)을 macOS 메뉴바 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
+PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · Antigravity · OpenCode · Hermes Agent · Cursor · Grok CLI · Copilot CLI)을 macOS 메뉴바 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
 
-> 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI 데이터에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
+> 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI 데이터에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
 
 ## 왜
 
@@ -33,7 +33,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 
 ## 어떻게 자라나요
 
-1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
+1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
 2. 🐣 **부화.** [PokéAPI](https://pokeapi.co/)의 **1~5세대 모든 진화 계보(시작점 329종)**에서 공식 capture rate 가중으로 태어납니다 — 흔한 포켓몬은 자주, 전설은 부화 129번에 1번. 부화한 포켓몬은 키우는 동안에도 **도감**에 바로 나타납니다. 부화마다 25종 성격 중 하나가 정해지고 — **아주 특별한 우연으론 ✨ 이로치가 태어납니다**.
 3. ⚡ **진화.** 계속 코딩하면 실제 진화 트리(1/2/3단, 분기)를 따라 자라고, 단계마다 작은 연출이 반겨줍니다.
 4. 🎓 **졸업 & 수집.** 최종 진화 + 임계 도달 시 **도감**에 영구 보존됩니다 — 희귀할수록 오래 걸리고(헤비 유저 기준 common ≈3일 → legendary ≈24일) — 새 알이 도착합니다.
@@ -97,7 +97,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 ## 이 밖에도
 
 - **인터랙티브 플로팅 펫** — 호버로 오늘 사용량, 클릭으로 메인 창, 우클릭 메뉴; 한도 알림은 말풍선으로도 표시.
-- **서비스별 탭** — Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI 중 2개 이상 감지되면 작은 탭으로 상세를 서비스별 전환(오늘 합계는 통합 유지).
+- **서비스별 탭** — Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI 중 2개 이상 감지되면 작은 탭으로 상세를 서비스별 전환(오늘 합계는 통합 유지).
 - **공식 한도** — Claude·Codex 5시간/주간 사용률 + 리셋 카운트다운을 오늘 숫자 바로 아래에.
 - **소진 예측** — 현재 5시간 창이 100%에 도달할 시각 예측.
 - **인앱 업데이트** — 원클릭 업데이트 확인, 설정에 현재 버전 표시.
@@ -114,6 +114,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 | **Hermes Agent** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Cursor** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Grok CLI** | 오늘 · 5시간 블록 · 주 · 월 | — |
+| **Copilot CLI** | 오늘 · 5시간 블록 · 주 · 월 | — |
 
 모두 로컬에서 읽습니다 — 외부 사용량 CLI 불필요. 도구 추가는 프로바이더 파일 하나면 됩니다([CONTRIBUTING.ko.md](CONTRIBUTING.ko.md) 참고).
 
@@ -121,7 +122,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 
 ### 요구사항
 
-macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI 데이터에서 직접 읽으며 외부 사용량 CLI가 필요 없습니다.
+macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI 데이터에서 직접 읽으며 외부 사용량 CLI가 필요 없습니다.
 
 ### Homebrew
 
@@ -162,6 +163,7 @@ swift test                   # 단위 테스트
 | `~/.hermes/state.db` | Hermes Agent daily/blocks/weekly/monthly | SQLite 읽기 전용; 세션 토큰 합계와 저장된 비용 |
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite 읽기 전용; `cursorDiskKV` 버블 엔트리의 `tokenCount` |
 | `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` 레코드(턴 단위 `usage`, 서버 보고 비용); `$GROK_HOME` 설정 시 그 경로; 서브에이전트 세션은 토큰이 부모 턴에 이미 포함돼 제외 |
+| `~/.copilot/session-store.db` | Copilot CLI daily/blocks/weekly/monthly | SQLite 읽기 전용; `assistant_usage_events` 1행 = API 호출 1건; `$COPILOT_HOME` 설정 시 그 경로; `input_tokens` 에 캐시 프롬프트가 이미 포함돼 캐시 read/write 를 빼고 집계; premium request 과금이라 비용은 추정하지 않음 |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 공식 5h/주간 % | 비공식 endpoint; Keychain 은 **갱신 버튼을 누를 때만** 읽음 — 자동 폴링은 읽지 않음 |
 | `codex app-server` | Codex 공식 5h/주간 % | 로컬 자식 프로세스; 계정 snapshot만, 모델 turn 없음 |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | 포켓몬 종·진화 | 런타임 fetch; 로컬 캐시, 번들 안 함 |
@@ -171,7 +173,7 @@ swift test                   # 단위 테스트
 
 ## 프라이버시 & 권한
 
-- **온디바이스.** 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI 데이터에서 직접 읽습니다. 사용량을 업로드하거나 모델 turn을 실행하지 않습니다.
+- **온디바이스.** 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI 데이터에서 직접 읽습니다. 사용량을 업로드하거나 모델 turn을 실행하지 않습니다.
 - **외부 요청.** 앱은 완전 오프라인이 아닙니다. 7개 호스트에 접속합니다 — `pokeapi.co`·`graphql.pokeapi.co`(종·진화), `raw.githubusercontent.com`(스프라이트), `api.anthropic.com`(Claude 공식 한도), `status.claude.com`·`status.openai.com`(장애 배너 — 설정에서 끌 수 있음), `api.github.com`(업데이트 확인). **어느 요청에도 사용량·토큰·프롬프트·프로젝트 경로는 담기지 않습니다** — 요청 자체만 나갑니다.
 - **Keychain(선택).** Claude OAuth 자격증명은 **갱신 버튼을 누를 때만** 읽습니다(설정, 또는 팝오버의 한도 행). 자동 폴링은 Keychain 을 건드리지 않으므로 비밀번호 프롬프트가 뜨지 않고, `~/.claude/.credentials.json` 이 있으면 그쪽에서 가져옵니다. 토큰은 메모리에만 두며 **앱 자체 Keychain 항목은 만들지 않습니다.** 토큰이 만료되면 한도는 갱신 전까지 이전 값(stale)으로 표시됩니다. 설정에서 끄면 한도 섹션만 숨겨집니다.
 - **포켓몬 에셋**은 런타임에 PokéAPI에서 받아오며 `~/Library/Application Support/PokeTokenBar/`에만 캐시됩니다. 앱 바이너리와 릴리스 아티팩트에는 포켓몬 에셋이 포함되지 않습니다.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor & Grok CLI — into a growing **Pokémon companion** in your macOS menu bar. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
+PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI & Copilot CLI — into a growing **Pokémon companion** in your macOS menu bar. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
 
-> Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, and Grok CLI data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
+> Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, and Copilot CLI data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
 
 ## Why
 
@@ -33,7 +33,7 @@ PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, 
 
 ## How it works
 
-1. 🥚 **Code as usual.** The tokens you burn in Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, or Grok CLI incubate an egg — nothing extra to run.
+1. 🥚 **Code as usual.** The tokens you burn in Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, or Copilot CLI incubate an egg — nothing extra to run.
 2. 🐣 **Hatch.** Eggs hatch into Pokémon with real evolution lines from [PokéAPI](https://pokeapi.co/) — any Gen 1–5 line (329 possible starts), weighted by the official capture rate: commons hatch often, a legendary is a 1-in-129 event. It appears in your **Pokédex** immediately while you raise it. Every hatch rolls one of 25 natures — and once in a rare while, the egg hatches **✨ Shiny**.
 3. ⚡ **Evolve.** Keep coding and it grows through its actual evolution tree (1/2/3 stages, branching), with a little flash celebration at each step.
 4. 🎓 **Graduate & collect.** Final form + threshold permanently archives it in your **Pokédex** — rarer takes longer (≈3 days common → ≈24 days legendary at heavy use) — and a fresh egg arrives.
@@ -97,7 +97,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 ## Also in the box
 
 - **Interactive floating pet** — hover for today's usage, click to open the main window, right-click for a menu; limit alerts can pop up as speech bubbles.
-- **Per-service tabs** — when two or more of Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, and Grok CLI are detected, compact tabs switch between them; today's total stays combined.
+- **Per-service tabs** — when two or more of Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, and Copilot CLI are detected, compact tabs switch between them; today's total stays combined.
 - **Official limits** — Claude & Codex 5-hour / weekly utilization with reset countdowns, right under today's numbers.
 - **Burn-rate forecast** — projects when the current 5h window hits 100%.
 - **In-app updates** — one-click update check; current version shown in Settings.
@@ -114,6 +114,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 | **Hermes Agent** | today · 5h block · week · month | — |
 | **Cursor** | today · 5h block · week · month | — |
 | **Grok CLI** | today · 5h block · week · month | — |
+| **Copilot CLI** | today · 5h block · week · month | — |
 
 All read locally — no external usage CLI required. Adding a tool is one provider file (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 
@@ -121,7 +122,7 @@ All read locally — no external usage CLI required. Adding a tool is one provid
 
 ### Requirements
 
-macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, and Grok CLI data, with no external usage CLI required.
+macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, and Copilot CLI data, with no external usage CLI required.
 
 ### Homebrew
 
@@ -162,6 +163,7 @@ swift test                   # unit tests
 | `~/.hermes/state.db` | Hermes Agent daily/blocks/weekly/monthly | SQLite read-only; session token totals and persisted cost |
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite read-only; `cursorDiskKV` bubble entries with `tokenCount` |
 | `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` records (per-turn `usage`, server-reported cost); honours `$GROK_HOME`; subagent sessions are skipped because their tokens are already folded into the parent turn |
+| `~/.copilot/session-store.db` | Copilot CLI daily/blocks/weekly/monthly | SQLite read-only; one `assistant_usage_events` row per API call; honours `$COPILOT_HOME`; `input_tokens` already contains the cached prompt, so cache reads/writes are subtracted; premium-request billing, so no cost is estimated |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude official 5h/weekly % | unofficial endpoint; the Keychain is read **only when you press refresh** — auto-polling never reads it |
 | `codex app-server` | Codex official 5h/weekly % | local child process; account snapshot only, no model turn |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | Pokémon species &amp; evolution | runtime fetch; cached locally, never bundled |
@@ -171,7 +173,7 @@ swift test                   # unit tests
 
 ## Privacy & permissions
 
-- **On-device.** Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, and Grok CLI data. The app never uploads usage or runs model turns.
+- **On-device.** Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, and Copilot CLI data. The app never uploads usage or runs model turns.
 - **Outbound requests.** The app is not fully offline. It talks to seven hosts: `pokeapi.co` and `graphql.pokeapi.co` (species/evolution), `raw.githubusercontent.com` (sprites), `api.anthropic.com` (Claude official limits), `status.claude.com` and `status.openai.com` (incident banner — off switch in Settings), and `api.github.com` (update check). **None of them carry your usage, tokens, prompts, or project paths** — only the request itself.
 - **Keychain (optional).** The Claude OAuth credential is read **only when you press a refresh button** (Settings, or the limits row in the popover). Automatic polling never touches the Keychain, so it never raises a password prompt; when available, the credential is taken from `~/.claude/.credentials.json` instead. The token is held in memory only — the app creates no Keychain item of its own. Once the token expires, limits stay visible but stale until you refresh. Turn it off in Settings — the limits section simply hides.
 - **Pokémon assets** are fetched at runtime from PokéAPI and cached only under `~/Library/Application Support/PokeTokenBar/`. The app binary and its release artifacts contain no Pokémon assets.

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -5,6 +5,7 @@ private enum LocalAdditionalSource: String, Sendable {
     case opencode
     case hermes
     case cursor
+    case copilot
 }
 
 /// OpenCode usage from its local SQLite database and legacy message files.
@@ -52,6 +53,24 @@ struct LocalCursorProvider: UsageProvider {
 
     func fetchEnrichment() async -> ProviderEnrichment {
         let entries = await LocalAdditionalUsageCache.shared.entries(for: .cursor)
+        return enrichment(entries: entries)
+    }
+}
+
+/// GitHub Copilot CLI usage from its local session store database.
+struct LocalCopilotProvider: UsageProvider {
+    let id = "copilot"
+    let displayName = "Copilot"
+    /// Copilot bills subscription premium requests, not per-token dollars — tokens only.
+    let reportsCost = false
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .copilot)
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey())
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .copilot)
         return enrichment(entries: entries)
     }
 }
@@ -118,6 +137,11 @@ private actor LocalAdditionalUsageCache {
         case .cursor:
             since = periodStart
             afterRowIDByPath = previous?.highWaterByPath ?? [:]
+        case .copilot:
+            // `assistant_usage_events` is append-only with an AUTOINCREMENT id — replay
+            // only the rows written since the last scan.
+            since = periodStart
+            afterRowIDByPath = previous?.highWaterByPath ?? [:]
         case .hermes:
             since = periodStart
             afterRowIDByPath = [:]
@@ -136,6 +160,17 @@ private actor LocalAdditionalUsageCache {
                     modifiedSince: since, afterRowIDByPath: afterRowIDByPath)
                 // DB rewrite / VACUUM can drop max(rowid) below the watermark — discard
                 // the stale in-memory set and take the full rescan result.
+                if loaded.didReset {
+                    return (loaded.entries, loaded.highWaterByPath)
+                }
+                return (
+                    LocalUsageReader.dedupKeepMax(existing + loaded.entries),
+                    loaded.highWaterByPath)
+            case .copilot:
+                let loaded = LocalAdditionalUsageReader.copilotEntries(
+                    modifiedSince: since, afterRowIDByPath: afterRowIDByPath)
+                // A pruned / recreated session store restarts ids — the cached rows would
+                // then collide with different events, so keep only the rescan.
                 if loaded.didReset {
                     return (loaded.entries, loaded.highWaterByPath)
                 }
@@ -519,6 +554,198 @@ enum LocalAdditionalUsageReader {
         return dateValue(value)
     }
 
+    // MARK: Copilot CLI database
+
+    struct CopilotLoadResult: Sendable {
+        var entries: [LocalUsageReader.Entry]
+        var highWaterByPath: [String: Int64]
+        /// True when a database was rescanned from scratch (watermark invalidated).
+        var didReset: Bool
+
+        /// Convenience for single-database tests.
+        var highWaterRowID: Int64 { highWaterByPath.values.max() ?? 0 }
+    }
+
+    static var defaultCopilotRoots: [URL] {
+        environmentPaths("COPILOT_HOME")
+            ?? [FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".copilot")]
+    }
+
+    /// Read Copilot CLI usage rows newer than `modifiedSince`.
+    ///
+    /// Every row in `assistant_usage_events` is one billed API call, including the ones a
+    /// subagent makes — those are separate requests, not a copy of the parent turn, so
+    /// unlike Grok's session logs there is nothing to exclude here.
+    ///
+    /// `afterRowIDByPath` carries the previous scan's high-water `id` per database so
+    /// steady-state refreshes touch only the rows appended since then.
+    static func copilotEntries(
+        modifiedSince: Date,
+        afterRowID: Int64 = 0,
+        afterRowIDByPath: [String: Int64]? = nil,
+        roots: [URL]? = nil
+    ) -> CopilotLoadResult {
+        let sourceRoots = roots ?? defaultCopilotRoots
+        let marks = copilotWatermarks(
+            roots: sourceRoots, afterRowID: afterRowID, afterRowIDByPath: afterRowIDByPath)
+        var result = scanCopilotRoots(sourceRoots, modifiedSince: modifiedSince, marks: marks)
+        if result.didReset {
+            // A partial incremental payload must not replace the cache — rescan every root cold.
+            let recovered = scanCopilotRoots(sourceRoots, modifiedSince: modifiedSince, marks: [:])
+            result = CopilotLoadResult(
+                entries: recovered.entries,
+                highWaterByPath: recovered.highWaterByPath,
+                didReset: true)
+        }
+        return result
+    }
+
+    private static func copilotWatermarks(
+        roots: [URL],
+        afterRowID: Int64,
+        afterRowIDByPath: [String: Int64]?
+    ) -> [String: Int64] {
+        if let afterRowIDByPath { return afterRowIDByPath }
+        guard afterRowID > 0 else { return [:] }
+        return Dictionary(uniqueKeysWithValues: roots.map { root in
+            (copilotDatabaseURL(from: root).path, afterRowID)
+        })
+    }
+
+    private static func copilotDatabaseURL(from root: URL) -> URL {
+        root.pathExtension == "db" ? root : root.appendingPathComponent("session-store.db")
+    }
+
+    private static func scanCopilotRoots(
+        _ sourceRoots: [URL],
+        modifiedSince: Date,
+        marks: [String: Int64]
+    ) -> CopilotLoadResult {
+        var entries: [LocalUsageReader.Entry] = []
+        var highWaterByPath: [String: Int64] = [:]
+        var didReset = false
+        for root in sourceRoots {
+            let database = copilotDatabaseURL(from: root)
+            let pathKey = database.path
+            let loaded = copilotDatabaseEntries(
+                database, modifiedSince: modifiedSince, afterRowID: marks[pathKey] ?? 0)
+            entries += loaded.entries
+            highWaterByPath[pathKey] = loaded.highWaterRowID
+            if loaded.didReset { didReset = true }
+        }
+        return CopilotLoadResult(
+            entries: LocalUsageReader.dedupKeepMax(entries.filter { $0.date >= modifiedSince }),
+            highWaterByPath: highWaterByPath,
+            didReset: didReset)
+    }
+
+    private struct CopilotDatabaseLoad {
+        var entries: [LocalUsageReader.Entry]
+        var highWaterRowID: Int64
+        var didReset: Bool
+    }
+
+    private static func copilotDatabaseEntries(
+        _ database: URL,
+        modifiedSince: Date,
+        afterRowID: Int64
+    ) -> CopilotDatabaseLoad {
+        // A failed MAX(id) is not a shrink: open/prepare can fail while the CLI writes the
+        // store. Collapsing nil → 0 would wipe the cache for up to one refresh interval.
+        guard let maxRowID = scalarInt64(database, sql: "SELECT MAX(id) FROM assistant_usage_events") else {
+            return CopilotDatabaseLoad(entries: [], highWaterRowID: afterRowID, didReset: false)
+        }
+        let didReset = afterRowID > 0 && maxRowID < afterRowID
+        let effectiveAfter = didReset ? 0 : afterRowID
+
+        // `created_at` is text, so the cutoff is a lexicographic compare, not a time compare.
+        // It is only a coarse prefilter — `scanCopilotRoots` re-filters on parsed dates — but
+        // it must never drop a row that belongs in the window, and a dropped row is lost for
+        // good once a later id advances the watermark. A same-day row in the ISO-8601 shape is
+        // safe (its "T" sorts after the cutoff's space), yet a row carrying a UTC offset can
+        // still render an earlier calendar day than the instant it represents
+        // ("2026-01-03T20:00:00-05:00" is 2026-01-04T01:00:00Z). Backing the cutoff off by a
+        // full day covers every offset SQLite accepts (±14h) and costs one extra day of rows.
+        let sql = """
+        SELECT id, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, created_at
+        FROM assistant_usage_events
+        WHERE id > ?1 AND created_at >= ?2
+        """
+        guard let rows = query(
+            database, sql: sql,
+            bindInt64: effectiveAfter,
+            bindText: copilotDayCutoff(modifiedSince),
+            row: { statement -> (Int64, LocalUsageReader.Entry?) in
+                (sqlite3_column_int64(statement, 0), parseCopilotUsageRow(statement, database: database))
+            }) else {
+            // Incomplete scan (BUSY / interrupt) — keep the prior watermark.
+            return CopilotDatabaseLoad(entries: [], highWaterRowID: afterRowID, didReset: false)
+        }
+
+        var highWater: Int64 = 0
+        var entries: [LocalUsageReader.Entry] = []
+        for (rowID, entry) in rows {
+            highWater = max(highWater, rowID)
+            if let entry { entries.append(entry) }
+        }
+        // Rows before the cutoff are filtered out in SQL, so an empty incremental read must
+        // not reset the watermark back to zero.
+        if highWater == 0 { highWater = effectiveAfter }
+        return CopilotDatabaseLoad(entries: entries, highWaterRowID: highWater, didReset: didReset)
+    }
+
+    private static func parseCopilotUsageRow(
+        _ statement: OpaquePointer,
+        database: URL
+    ) -> LocalUsageReader.Entry? {
+        let id = sqlite3_column_int64(statement, 0)
+        guard let rawDate = columnText(statement, 6),
+              let date = copilotDate(rawDate) else { return nil }
+        let model = stringValue(columnText(statement, 1)) ?? "unknown"
+        let cacheRead = columnInt(statement, 4)
+        let cacheWrite = columnInt(statement, 5)
+        // `input_tokens` is the whole prompt: cached reads and writes are a subset of it.
+        // Subtracting them keeps the same prompt tokens from being counted three times.
+        let input = max(0, columnInt(statement, 2) - cacheRead - cacheWrite)
+        // `reasoning_tokens` is a breakdown of `output_tokens`, not an extra charge.
+        return makeEntry(
+            // The row id is only unique *within* one store, and `$COPILOT_HOME` may name
+            // several. Without the database in the key, id 1 of each store would collapse
+            // into a single event during dedup and the usage would silently go missing.
+            id: "copilot|\(database.path)|\(id)",
+            date: date,
+            model: model,
+            input: input,
+            output: columnInt(statement, 3),
+            cacheWrite: cacheWrite,
+            cacheRead: cacheRead)
+    }
+
+    /// Start of the UTC day *before* `date`, in the SQLite default text shape
+    /// ("YYYY-MM-DD HH:MM:SS"), so the coarse text cutoff always sits below the window.
+    private static func copilotDayCutoff(_ date: Date) -> String {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        let shifted = date.addingTimeInterval(-86_400)
+        let parts = calendar.dateComponents([.year, .month, .day], from: shifted)
+        return String(
+            format: "%04d-%02d-%02d 00:00:00",
+            parts.year ?? 1970, parts.month ?? 1, parts.day ?? 1)
+    }
+
+    /// Copilot writes ISO-8601 with a "Z" suffix, while the column default
+    /// (`datetime('now')`) writes "YYYY-MM-DD HH:MM:SS" in UTC. Normalize both.
+    static func copilotDate(_ raw: String) -> Date? {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard text.count >= 19 else { return nil }
+        if let separator = text.firstIndex(of: " ") {
+            text.replaceSubrange(separator...separator, with: "T")
+        }
+        let time = text.dropFirst(11)
+        if !time.contains("Z"), !time.contains("+"), !time.contains("-") { text += "Z" }
+        return parseISO8601(text)
+    }
+
     // MARK: Shared utilities
 
     private static func makeEntry(
@@ -612,6 +839,7 @@ enum LocalAdditionalUsageReader {
         _ databaseURL: URL,
         sql: String,
         bindInt64: Int64? = nil,
+        bindText: String? = nil,
         row: (OpaquePointer) -> T?
     ) -> [T]? {
         guard FileManager.default.fileExists(atPath: databaseURL.path) else { return [] }
@@ -626,6 +854,10 @@ enum LocalAdditionalUsageReader {
               let statement else { return nil }
         defer { sqlite3_finalize(statement) }
         if let bindInt64 { sqlite3_bind_int64(statement, 1, bindInt64) }
+        if let bindText {
+            // SQLITE_TRANSIENT: SQLite must copy the bytes, the Swift string dies at return.
+            sqlite3_bind_text(statement, 2, bindText, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
 
         var result: [T] = []
         while true {

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -397,7 +397,7 @@ final class UsageStore {
     init(providers: [any UsageProvider] = [
         LocalClaudeProvider(), LocalCodexProvider(), LocalGeminiProvider(),
         LocalAntigravityProvider(), LocalOpenCodeProvider(), LocalHermesProvider(),
-        LocalCursorProvider(), LocalGrokProvider(),
+        LocalCursorProvider(), LocalGrokProvider(), LocalCopilotProvider(),
     ],
          claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),

--- a/Tests/PokeTokenBarTests/CopilotUsageTests.swift
+++ b/Tests/PokeTokenBarTests/CopilotUsageTests.swift
@@ -1,0 +1,364 @@
+import SQLite3
+import XCTest
+@testable import PokeTokenBar
+
+final class CopilotUsageTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PokeTokenBar-CopilotUsageTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+        temporaryDirectory = nil
+    }
+
+    // MARK: - Token accounting
+
+    /// Copilot stores `input_tokens` as the *whole* prompt, with cached reads/writes as a
+    /// subset of it. Adding the columns as-is would triple-count every cached prompt, so the
+    /// reader must subtract them — this is the accounting fault the parser exists to avoid.
+    func testCachedPromptTokensAreNotCountedTwice() throws {
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 43_792, output: 443,
+                cacheRead: 42_698, cacheWrite: 904, reasoning: 59,
+                createdAt: "2026-01-04T10:00:00.000Z"),
+        ])
+
+        let entries = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).entries
+
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entry.input, 190, "uncached prompt = input_tokens - cache_read - cache_write")
+        XCTAssertEqual(entry.cacheRead, 42_698)
+        XCTAssertEqual(entry.cacheWrite, 904)
+        XCTAssertEqual(entry.output, 443, "reasoning_tokens is a breakdown of output, not an extra charge")
+        XCTAssertEqual(entry.total, 44_235, "total must equal the prompt plus the completion, counted once")
+        XCTAssertEqual(entry.id, entryID(1))
+        XCTAssertEqual(entry.model, "claude-opus-5")
+    }
+
+    func testFullyCachedPromptKeepsZeroUncachedInput() throws {
+        try seed(rows: [
+            Row(id: 1, model: "gpt-5.4-mini", input: 57_375, output: 35,
+                cacheRead: 57_375, cacheWrite: 0, reasoning: 0,
+                createdAt: "2026-01-04T10:00:00.000Z"),
+        ])
+
+        let entry = try XCTUnwrap(LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).entries.first)
+        XCTAssertEqual(entry.input, 0)
+        XCTAssertEqual(entry.total, 57_410)
+    }
+
+    // MARK: - Timestamps
+
+    /// The column default is `datetime('now')` ("YYYY-MM-DD HH:MM:SS", UTC) while the CLI
+    /// writes ISO-8601 with a "Z". Both shapes must land in the same window.
+    func testReadsBothStoredTimestampShapes() throws {
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T10:00:00.000Z"),
+            Row(id: 2, model: "claude-opus-5", input: 200, output: 20,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04 11:00:00"),
+        ])
+
+        let entries = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).entries
+
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries.map(\.date).sorted(),
+                       [try date("2026-01-04T10:00:00Z"), try date("2026-01-04T11:00:00Z")])
+    }
+
+    /// The SQL cutoff is a lexicographic compare on text. A same-day ISO row sorts *after*
+    /// the space-separated day boundary, so rounding down to the UTC day must not drop it.
+    func testDayBoundaryCutoffKeepsSameDayIsoRows() throws {
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T00:00:01.000Z"),
+            Row(id: 2, model: "claude-opus-5", input: 200, output: 20,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-03T23:59:59.000Z"),
+        ])
+
+        let entries = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-04T12:00:00Z"), roots: [temporaryDirectory]).entries
+
+        XCTAssertEqual(entries.count, 0, "both rows precede the window and are filtered exactly")
+
+        let wider = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-04T00:00:00Z"), roots: [temporaryDirectory]).entries
+        XCTAssertEqual(wider.map(\.id), [entryID(1)], "the earlier day must stay out, the same day must stay in")
+    }
+
+    /// A row can carry a UTC offset, and a negative one renders an earlier calendar day than
+    /// the instant it represents. The coarse text cutoff must not drop it — the row would be
+    /// lost for good once a later id advances the watermark.
+    func testNegativeUTCOffsetRowIsNotDroppedByTheTextCutoff() throws {
+        try seed(rows: [
+            // 2026-01-04T01:00:00Z, but its text sorts on 2026-01-03.
+            Row(id: 1, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-03T20:00:00-05:00"),
+        ])
+
+        let entries = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-04T00:00:00Z"), roots: [temporaryDirectory]).entries
+
+        XCTAssertEqual(entries.map(\.id), [entryID(1)])
+        XCTAssertEqual(entries.first?.date, try date("2026-01-04T01:00:00Z"),
+                       "the offset must be applied, not ignored")
+    }
+
+    func testRowsWithoutTokensAreSkipped() throws {
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 0, output: 0,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T10:00:00.000Z"),
+            Row(id: 2, model: "claude-opus-5", input: 5, output: 1,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T10:01:00.000Z"),
+        ])
+
+        let entries = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).entries
+        XCTAssertEqual(entries.map(\.id), [entryID(2)])
+    }
+
+    // MARK: - Incremental reads
+
+    func testIncrementalReadReturnsOnlyRowsAfterTheWatermark() throws {
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T10:00:00.000Z"),
+        ])
+        let since = try date("2026-01-01T00:00:00Z")
+
+        let first = LocalAdditionalUsageReader.copilotEntries(modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertEqual(first.entries.count, 1)
+        XCTAssertEqual(first.highWaterRowID, 1)
+        XCTAssertFalse(first.didReset)
+
+        try insert(rows: [
+            Row(id: 2, model: "claude-opus-5", input: 300, output: 30,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T11:00:00.000Z"),
+        ])
+
+        let second = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: since, afterRowIDByPath: first.highWaterByPath, roots: [temporaryDirectory])
+        XCTAssertEqual(second.entries.map(\.id), [entryID(2)], "already-read rows must not be replayed")
+        XCTAssertEqual(second.highWaterRowID, 2)
+    }
+
+    /// An incremental read that finds nothing must keep the watermark — resetting it to zero
+    /// would replay the whole store on the next refresh.
+    func testEmptyIncrementalReadPreservesTheWatermark() throws {
+        try seed(rows: [
+            Row(id: 7, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T10:00:00.000Z"),
+        ])
+        let since = try date("2026-01-01T00:00:00Z")
+        let first = LocalAdditionalUsageReader.copilotEntries(modifiedSince: since, roots: [temporaryDirectory])
+
+        let second = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: since, afterRowIDByPath: first.highWaterByPath, roots: [temporaryDirectory])
+        XCTAssertTrue(second.entries.isEmpty)
+        XCTAssertEqual(second.highWaterRowID, 7)
+        XCTAssertFalse(second.didReset)
+    }
+
+    /// A pruned or recreated session store restarts ids below the watermark. The reader must
+    /// report the reset so the provider cache drops rows whose ids now mean something else.
+    func testRecreatedStoreBelowWatermarkTriggersColdRescan() throws {
+        try seed(rows: (1...5).map {
+            Row(id: $0, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0,
+                createdAt: "2026-01-04T10:0\($0):00.000Z")
+        })
+        let since = try date("2026-01-01T00:00:00Z")
+        let first = LocalAdditionalUsageReader.copilotEntries(modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertEqual(first.highWaterRowID, 5)
+
+        // Really recreate the store, the way `copilot` does when its session data is cleared.
+        try FileManager.default.removeItem(at: databaseURL)
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 700, output: 70,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-05T10:00:00.000Z"),
+        ])
+
+        let result = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: since, afterRowIDByPath: first.highWaterByPath, roots: [temporaryDirectory])
+
+        XCTAssertTrue(result.didReset, "ids restarting below the watermark must force a cold rescan")
+        XCTAssertEqual(result.entries.map(\.id), [entryID(1)])
+        XCTAssertEqual(result.entries.first?.total, 770, "the rescan must return the new store's rows")
+        XCTAssertEqual(result.highWaterRowID, 1)
+    }
+
+    // MARK: - Multiple stores
+
+    /// `$COPILOT_HOME` may name more than one store, and each numbers its rows from 1. Keying
+    /// entries on the row id alone would let dedup collapse two unrelated events into one.
+    func testTwoStoresWithTheSameRowIDsAreBothCounted() throws {
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T10:00:00.000Z"),
+        ])
+        let otherRoot = temporaryDirectory.appendingPathComponent("other")
+        try FileManager.default.createDirectory(at: otherRoot, withIntermediateDirectories: true)
+        let otherDatabase = otherRoot.appendingPathComponent("session-store.db")
+        try seed(rows: [
+            Row(id: 1, model: "gpt-5.4-mini", input: 400, output: 40,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T11:00:00.000Z"),
+        ], in: otherDatabase)
+
+        let result = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory, otherRoot])
+
+        XCTAssertEqual(Set(result.entries.map(\.id)),
+                       [entryID(1), entryID(1, in: otherDatabase)])
+        XCTAssertEqual(result.entries.reduce(0) { $0 + $1.total }, 110 + 440,
+                       "neither store's usage may be swallowed by the other")
+        XCTAssertEqual(result.highWaterByPath.count, 2, "each store keeps its own watermark")
+    }
+
+    // MARK: - Roots
+
+    func testAcceptsADirectDatabasePathAsRoot() throws {
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T10:00:00.000Z"),
+        ])
+
+        let entries = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory.appendingPathComponent("session-store.db")]).entries
+        XCTAssertEqual(entries.count, 1)
+    }
+
+    func testNonexistentRootReturnsNothing() {
+        let result = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: .distantPast, roots: [URL(fileURLWithPath: "/nonexistent/copilot/home")])
+        XCTAssertTrue(result.entries.isEmpty)
+        XCTAssertEqual(result.highWaterRowID, 0)
+        XCTAssertFalse(result.didReset)
+    }
+
+    func testDefaultRootIsTheCopilotHome() {
+        let expected = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".copilot")
+        let roots = LocalAdditionalUsageReader.defaultCopilotRoots
+        if ProcessInfo.processInfo.environment["COPILOT_HOME"] == nil {
+            XCTAssertEqual(roots, [expected])
+        }
+        XCTAssertFalse(roots.isEmpty)
+    }
+
+    // MARK: - Aggregation
+
+    func testDailyAggregatesEveryUsageEventOfTheDay() throws {
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T10:00:00.000Z"),
+            Row(id: 2, model: "gpt-5.4-mini", input: 250, output: 40,
+                cacheRead: 50, cacheWrite: 100, reasoning: 5, createdAt: "2026-01-04T10:05:00.000Z"),
+        ])
+
+        let entries = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).entries
+        let day = try XCTUnwrap(entries.first?.localDay)
+        let daily = try XCTUnwrap(LocalUsageReader.daily(entries: entries, localDay: day))
+
+        XCTAssertEqual(daily.totalTokens, 110 + 290)
+    }
+
+    // MARK: - Provider identity
+
+    func testLocalCopilotProviderIdentity() {
+        let provider = LocalCopilotProvider()
+        XCTAssertEqual(provider.id, "copilot")
+        XCTAssertEqual(provider.displayName, "Copilot")
+        XCTAssertFalse(provider.reportsCost, "Copilot bills premium requests — no invented dollar cost")
+    }
+
+    // MARK: - Helpers
+
+    private struct Row {
+        let id: Int
+        let model: String
+        let input, output, cacheRead, cacheWrite, reasoning: Int
+        let createdAt: String
+    }
+
+    private func date(_ value: String) throws -> Date {
+        try XCTUnwrap(ISO8601DateFormatter().date(from: value))
+    }
+
+    /// Entry ids are namespaced by database path so two stores cannot collide on row id.
+    private func entryID(_ rowID: Int, in database: URL? = nil) -> String {
+        "copilot|\((database ?? databaseURL).path)|\(rowID)"
+    }
+
+    private var databaseURL: URL {
+        temporaryDirectory.appendingPathComponent("session-store.db")
+    }
+
+    /// Mirrors the shape the Copilot CLI creates for `assistant_usage_events`.
+    private func seed(rows: [Row], in database: URL? = nil) throws {
+        let target = database ?? databaseURL
+        try execute(target, sql: """
+        CREATE TABLE assistant_usage_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            turn_index INTEGER,
+            agent_id TEXT,
+            parent_tool_call_id TEXT,
+            model TEXT NOT NULL,
+            input_tokens INTEGER,
+            output_tokens INTEGER,
+            cache_read_tokens INTEGER,
+            cache_write_tokens INTEGER,
+            reasoning_tokens INTEGER,
+            total_nano_aiu INTEGER,
+            request_multiplier REAL,
+            duration_ms INTEGER,
+            time_to_first_token_ms INTEGER,
+            inter_token_latency_ms INTEGER,
+            initiator TEXT,
+            api_endpoint TEXT,
+            reasoning_effort TEXT,
+            finish_reason TEXT,
+            content_filter_triggered INTEGER,
+            token_details_json TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        """)
+        try insert(rows: rows, in: target)
+    }
+
+    private func insert(rows: [Row], in database: URL? = nil) throws {
+        guard !rows.isEmpty else { return }
+        let values = rows.map { row in
+            """
+            (\(row.id), 'session-1', 0, NULL, NULL, '\(row.model)', \(row.input), \(row.output), \
+            \(row.cacheRead), \(row.cacheWrite), \(row.reasoning), 0, 1.0, 0, 0, 0, 'user', \
+            '/v1/messages', 'medium', 'stop', 0, NULL, '\(row.createdAt)')
+            """
+        }.joined(separator: ",\n")
+        try execute(database ?? databaseURL, sql: "INSERT INTO assistant_usage_events VALUES \(values);")
+    }
+
+    private func execute(_ databaseURL: URL, sql: String) throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(databaseURL.path, &database), SQLITE_OK)
+        guard let database else { throw NSError(domain: "SQLite", code: 1) }
+        defer { sqlite3_close(database) }
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
+        let message = errorMessage.map { String(cString: $0) }
+        sqlite3_free(errorMessage)
+        XCTAssertEqual(result, SQLITE_OK, message ?? "SQLite statement failed")
+        if result != SQLITE_OK { throw NSError(domain: "SQLite", code: Int(result)) }
+    }
+}

--- a/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
+++ b/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
@@ -134,7 +134,7 @@ final class LocalAdditionalUsageTests: XCTestCase {
         XCTAssertEqual(
             Set(store.registeredProviderIDs),
             Set(["claude_code", "codex", "gemini", "antigravity",
-                 "opencode", "hermes", "cursor", "grok"]))
+                 "opencode", "hermes", "cursor", "grok", "copilot"]))
     }
 
     func testPrintRealOpenCodeAggregate() throws {

--- a/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
@@ -21,7 +21,7 @@ final class ProviderTabLayoutTests: XCTestCase {
     private var allProviders: [ProviderSnapshot] {
         [("claude_code", "Claude Code"), ("codex", "Codex"), ("gemini", "Gemini"),
          ("antigravity", "Antigravity"), ("opencode", "OpenCode"), ("hermes", "Hermes Agent"),
-         ("cursor", "Cursor"), ("grok", "Grok")]
+         ("cursor", "Cursor"), ("grok", "Grok"), ("copilot", "Copilot")]
             .map { snapshot($0.0, $0.1) }
     }
 


### PR DESCRIPTION
## Summary

GitHub Copilot CLI records every assistant request in its own local session store
(`~/.copilot/session-store.db`, table `assistant_usage_events`), but no provider read it,
so those tokens never reached the companion or the usage tracker.

This adds `LocalCopilotProvider` on top of the existing additional-source cache
(`LocalAdditionalUsageProvider.swift`) and registers it in the default `providers:` array of
`UsageStore.init` — the two extension points named in CONTRIBUTING. Daily / 5h block / weekly /
monthly all come from the shared `LocalUsageReader` aggregation, so no generic path branches on
the new provider id.

### What the format required

- **`input_tokens` is the whole prompt.** `cache_read_tokens` and `cache_write_tokens` are a
  *subset* of it, so the reader subtracts them. Summing the columns as spelled would have
  counted a cached prompt three times — the same "same spelling, different meaning" trap the
  defect log records for Grok. Verified against a real store: a row with
  `input_tokens=43792, cache_read=42698, cache_write=904` bills 190 uncached prompt tokens,
  which matches the row's own `token_details_json` breakdown.
- **`reasoning_tokens` is a breakdown of `output_tokens`**, not an extra charge, so it is not
  added on top.
- **Every row is one billed API call**, including rows a subagent produced. Unlike Grok's
  session logs, subagent usage is not folded into the parent turn, so nothing is excluded.
- **`created_at` has two shapes**: the CLI writes ISO-8601 with a `Z`, while the column default
  (`datetime('now')`) writes `YYYY-MM-DD HH:MM:SS` in UTC. Both are parsed, offsets included.
- **The table is append-only with an AUTOINCREMENT id**, so refreshes replay only rows past the
  previous high-water id. A max id below the watermark means the store was pruned or recreated
  and forces a cold rescan, matching the Cursor watermark handling.

### Two hazards the incremental read has to respect

A row skipped once is never revisited, because a later id advances the watermark past it. Both
of these were found in review of the first push and are covered by regression tests:

- **The SQL cutoff on `created_at` is a lexicographic compare, not a time compare.** A same-day
  ISO row is safe (its `T` sorts after the cutoff's space separator), but a negative UTC offset
  renders an earlier calendar day than the instant it represents —
  `SELECT '2026-01-03T20:00:00-05:00' >= '2026-01-04 00:00:00'` is `0`, even though that row is
  `2026-01-04T01:00:00Z`. The cutoff is therefore backed off a full day, which covers every
  offset SQLite accepts (±14h); the exact filter stays in Swift.
- **Row ids are unique only within one store**, and `$COPILOT_HOME` may name several, each
  numbering from 1. Entry ids are namespaced by database path so dedup cannot collapse id 1 of
  one store into id 1 of another.

Copilot bills subscription premium requests rather than per-token dollars, so the provider
reports tokens only (`reportsCost = false`), like Cursor and Antigravity.

Reads are read-only SQLite; `$COPILOT_HOME` is honoured for a relocated Copilot home.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

No files under `Sources/PokeTokenBar/UI/` changed. The only visible effect is that a
"Copilot" tab now appears in the existing per-service tab bar once Copilot CLI usage is
detected, and its tokens join the combined totals. `ProviderTabLayoutTests` was updated so the
tab-bar overflow guards measure the registered set including the new tab.

## Verification

- `swift build` passes; CI is green on the previous push of this branch (all 14 new tests
  passed there).
- `swift test` could **not** be run on this machine — only the Command Line Tools are
  installed, so `XCTest` is unavailable (`no such module 'XCTest'`). Relying on CI for the
  suite; happy to iterate if anything fails.
- Because unit tests alone would only prove the parser agrees with my own fixtures, the
  provider was also exercised end-to-end through a scratch harness against a **frozen copy of a
  real `~/.copilot/session-store.db`** (1980 rows), going through `LocalCopilotProvider` →
  `LocalAdditionalUsageCache` → `LocalUsageReader` exactly as the app does:

  | | provider | independent SQL over the same frozen DB |
  |---|---|---|
  | today | 15,329,978 | 15,329,978 |
  | week | 22,483,451 | 22,483,451 |
  | month | 49,546,948 | 49,546,948 |

  So the cache subtraction reproduces the source of truth exactly rather than by accident, and
  the active 5h block, week and month windows populate.
- The branch-level behaviour the tests assert was also run against synthetic stores: both
  timestamp shapes, a negative UTC offset row, zero-token rows skipped, the day-boundary
  cutoff, an incremental read returning only new rows, an empty incremental read preserving the
  watermark, a store deleted and recreated with restarted ids, two stores sharing row ids, a
  direct `.db` path as root, and a nonexistent root.

## Checklist

- [x] `swift build` passes locally (`swift test` needs Xcode — see Verification)
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change
