### PR TITLE
refactor: share Cursor and Copilot incremental SQLite scan (#157)

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -70,6 +70,9 @@ CI はすべてのプルリクエストで `swift build` と `swift test` を実
 - **バージョンマネージャー / インストールパスの追加** =
   `BinaryLocator.commonToolDirectories()` に追加します — 探索と子プロセスの `PATH` が
   共有する単一のソースです。
+- **追記専用 SQLite 使用量ストアの追加**（Cursor・Copilot のように rowid/`id` ウォーターマーク）=
+  `LocalAdditionalUsageReader.scanIncrementalStores` に URL / `MAX` SQL / row query /
+  parse だけ渡す。ウォーターマーク・ループをコピーしない。
 
 ## 法務 / 知的財産
 

--- a/CONTRIBUTING.ko.md
+++ b/CONTRIBUTING.ko.md
@@ -68,6 +68,9 @@ CI는 모든 풀 리퀘스트에서 `swift build`와 `swift test`를 실행합�
   (예: 공식 한도)만 `providerID`로 분기할 수 있습니다.
 - **버전 매니저 / 설치 경로 추가** = `BinaryLocator.commonToolDirectories()`에
   추가합니다 — 탐색과 자식 프로세스 `PATH`가 공유하는 단일 소스입니다.
+- **append-only SQLite 사용량 스토어 추가** (Cursor·Copilot처럼 rowid/`id` 워터마크) =
+  `LocalAdditionalUsageReader.scanIncrementalStores`에 URL / `MAX` SQL / row query /
+  parse만 넘기세요. watermark 루프를 복사하지 마세요.
 
 ## 법적 / 지식재산
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,10 @@ The app is provider-agnostic by design. When extending it, follow these rules
 - **Adding a version manager / install path** = add it to
   `BinaryLocator.commonToolDirectories()` — the single source that discovery and
   child-process `PATH` both share.
+- **Adding an append-only SQLite usage store** (rowid/`id` high-water, like Cursor
+  or Copilot) = call `LocalAdditionalUsageReader.scanIncrementalStores` with the
+  format-specific URL / `MAX` SQL / row query / parse. Do not copy the watermark
+  loop.
 
 ## Legal / intellectual property
 

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -101,7 +101,8 @@ private actor LocalAdditionalUsageCache {
         let loadedAt: Date
         let monthKey: String
         let entries: [LocalUsageReader.Entry]
-        /// Cursor `cursorDiskKV` has no time column — per-DB rowid high-water for append-only bubbles.
+        /// Cursor `cursorDiskKV` / Copilot `assistant_usage_events` have no usable
+        /// time column for the cache key — per-DB high-water for append-only rows.
         let highWaterByPath: [String: Int64]
     }
 
@@ -334,9 +335,24 @@ enum LocalAdditionalUsageReader {
         } ?? []
     }
 
-    // MARK: Cursor database
+    // MARK: Incremental SQLite stores
 
-    struct CursorLoadResult: Sendable {
+    /// How to bind one append-only row query. Column 0 must be the monotonic id
+    /// used as the per-database watermark (`rowid` for Cursor, `id` for Copilot).
+    ///
+    /// `rowSQL` is a closure rather than a single string because Cursor has two
+    /// statements (cold GLOB vs incremental `NOT INDEXED`) and Copilot binds a
+    /// second text cutoff. The watermark rules themselves stay in
+    /// `scanIncrementalStores` (#157).
+    struct IncrementalRowQuery: Sendable {
+        var sql: String
+        var bindInt64: Int64?
+        var bindText: String?
+    }
+
+    /// Shared Cursor/Copilot load payload. Identical members collapsed into one
+    /// type so a watermark fix cannot land in only one copy.
+    struct IncrementalStoreLoadResult: Sendable {
         var entries: [LocalUsageReader.Entry]
         var highWaterByPath: [String: Int64]
         /// True when any DB was rescanned from scratch (watermark invalidated).
@@ -345,6 +361,145 @@ enum LocalAdditionalUsageReader {
         /// Convenience for single-database tests.
         var highWaterRowID: Int64 { highWaterByPath.values.max() ?? 0 }
     }
+
+    typealias CursorLoadResult = IncrementalStoreLoadResult
+    typealias CopilotLoadResult = IncrementalStoreLoadResult
+
+    /// Incremental scan for append-only SQLite stores.
+    ///
+    /// Format-specific pieces (`databaseURL`, `maxRowIDSQL`, `rowSQL`, `parse`)
+    /// stay with the provider. These rules live here once:
+    /// - a failed `MAX(...)` is not a shrink (`nil` keeps the prior watermark)
+    /// - `if highWater == 0 { highWater = effectiveAfter }` so an empty
+    ///   incremental read does not replay the month
+    /// - `didReset` on any root cold-rescans **every** root so a partial
+    ///   payload cannot replace the cache
+    static func scanIncrementalStores(
+        roots: [URL],
+        modifiedSince: Date,
+        afterRowID: Int64 = 0,
+        afterRowIDByPath: [String: Int64]? = nil,
+        databaseURL: (URL) -> URL,
+        maxRowIDSQL: String,
+        rowSQL: (Int64, Date) -> IncrementalRowQuery,
+        parse: (OpaquePointer, URL) -> LocalUsageReader.Entry?
+    ) -> IncrementalStoreLoadResult {
+        let marks = incrementalWatermarks(
+            roots: roots, afterRowID: afterRowID, afterRowIDByPath: afterRowIDByPath,
+            databaseURL: databaseURL)
+        var result = scanIncrementalRoots(
+            roots, modifiedSince: modifiedSince, marks: marks,
+            databaseURL: databaseURL, maxRowIDSQL: maxRowIDSQL,
+            rowSQL: rowSQL, parse: parse)
+        if result.didReset {
+            // A partial incremental payload must not replace the cache — rescan every root cold.
+            // Keep didReset=true so the provider cache discards `existing` rather than merging.
+            let recovered = scanIncrementalRoots(
+                roots, modifiedSince: modifiedSince, marks: [:],
+                databaseURL: databaseURL, maxRowIDSQL: maxRowIDSQL,
+                rowSQL: rowSQL, parse: parse)
+            result = IncrementalStoreLoadResult(
+                entries: recovered.entries,
+                highWaterByPath: recovered.highWaterByPath,
+                didReset: true)
+        }
+        return result
+    }
+
+    /// Resolve per-database watermarks. An empty marks map means cold-scan every root.
+    private static func incrementalWatermarks(
+        roots: [URL],
+        afterRowID: Int64,
+        afterRowIDByPath: [String: Int64]?,
+        databaseURL: (URL) -> URL
+    ) -> [String: Int64] {
+        if let afterRowIDByPath { return afterRowIDByPath }
+        guard afterRowID > 0 else { return [:] }
+        return Dictionary(uniqueKeysWithValues: roots.map { root in
+            (databaseURL(root).path, afterRowID)
+        })
+    }
+
+    private static func scanIncrementalRoots(
+        _ sourceRoots: [URL],
+        modifiedSince: Date,
+        marks: [String: Int64],
+        databaseURL: (URL) -> URL,
+        maxRowIDSQL: String,
+        rowSQL: (Int64, Date) -> IncrementalRowQuery,
+        parse: (OpaquePointer, URL) -> LocalUsageReader.Entry?
+    ) -> IncrementalStoreLoadResult {
+        var entries: [LocalUsageReader.Entry] = []
+        var highWaterByPath: [String: Int64] = [:]
+        var didReset = false
+        for root in sourceRoots {
+            let database = databaseURL(root)
+            let pathKey = database.path
+            let loaded = loadIncrementalDatabase(
+                database, modifiedSince: modifiedSince,
+                afterRowID: marks[pathKey] ?? 0,
+                maxRowIDSQL: maxRowIDSQL, rowSQL: rowSQL, parse: parse)
+            entries += loaded.entries
+            highWaterByPath[pathKey] = loaded.highWaterRowID
+            if loaded.didReset { didReset = true }
+        }
+        return IncrementalStoreLoadResult(
+            entries: LocalUsageReader.dedupKeepMax(entries.filter { $0.date >= modifiedSince }),
+            highWaterByPath: highWaterByPath,
+            didReset: didReset)
+    }
+
+    private struct IncrementalDatabaseLoad {
+        var entries: [LocalUsageReader.Entry]
+        var highWaterRowID: Int64
+        var didReset: Bool
+    }
+
+    private static func loadIncrementalDatabase(
+        _ database: URL,
+        modifiedSince: Date,
+        afterRowID: Int64,
+        maxRowIDSQL: String,
+        rowSQL: (Int64, Date) -> IncrementalRowQuery,
+        parse: (OpaquePointer, URL) -> LocalUsageReader.Entry?
+    ) -> IncrementalDatabaseLoad {
+        // A failed MAX is *not* a shrink: open/prepare can fail while the writer
+        // holds the file. Collapsing nil → 0 would wipe the cache for up to one
+        // refreshInterval.
+        guard let maxRowID = scalarInt64(database, sql: maxRowIDSQL) else {
+            return IncrementalDatabaseLoad(
+                entries: [], highWaterRowID: afterRowID, didReset: false)
+        }
+        let didReset = afterRowID > 0 && maxRowID < afterRowID
+        let effectiveAfter = didReset ? 0 : afterRowID
+        let querySpec = rowSQL(effectiveAfter, modifiedSince)
+
+        // Incomplete scans (BUSY / interrupt) return nil — keep the prior watermark.
+        guard let rows = query(
+            database, sql: querySpec.sql,
+            bindInt64: querySpec.bindInt64, bindText: querySpec.bindText,
+            row: { statement -> (Int64, LocalUsageReader.Entry?) in
+                (sqlite3_column_int64(statement, 0), parse(statement, database))
+            }
+        ) else {
+            return IncrementalDatabaseLoad(
+                entries: [], highWaterRowID: afterRowID, didReset: false)
+        }
+
+        var highWater: Int64 = 0
+        var entries: [LocalUsageReader.Entry] = []
+        for (rowID, entry) in rows {
+            highWater = max(highWater, rowID)
+            if let entry { entries.append(entry) }
+        }
+        // Preserve watermark when an incremental miss returns no new rows.
+        if highWater == 0 { highWater = effectiveAfter }
+        return IncrementalDatabaseLoad(
+            entries: entries, highWaterRowID: highWater, didReset: didReset)
+    }
+
+    // MARK: Cursor database
+
 
     static var defaultCursorRoots: [URL] {
         environmentPaths("CURSOR_DATA_DIR") ?? [
@@ -361,129 +516,48 @@ enum LocalAdditionalUsageReader {
         afterRowIDByPath: [String: Int64]? = nil,
         roots: [URL]? = nil
     ) -> CursorLoadResult {
-        let sourceRoots = roots ?? defaultCursorRoots
-        let marks = Self.cursorWatermarks(
-            roots: sourceRoots, afterRowID: afterRowID, afterRowIDByPath: afterRowIDByPath)
-        var result = scanCursorRoots(sourceRoots, modifiedSince: modifiedSince, marks: marks)
-        if result.didReset {
-            // A partial incremental payload must not replace the cache — rescan every root cold.
-            // Keep didReset=true so the provider cache discards `existing` rather than merging.
-            let recovered = scanCursorRoots(sourceRoots, modifiedSince: modifiedSince, marks: [:])
-            result = CursorLoadResult(
-                entries: recovered.entries,
-                highWaterByPath: recovered.highWaterByPath,
-                didReset: true)
-        }
-        return result
+        scanIncrementalStores(
+            roots: roots ?? defaultCursorRoots,
+            modifiedSince: modifiedSince,
+            afterRowID: afterRowID,
+            afterRowIDByPath: afterRowIDByPath,
+            databaseURL: cursorDatabaseURL(from:),
+            maxRowIDSQL: "SELECT MAX(rowid) FROM cursorDiskKV",
+            rowSQL: { effectiveAfter, _ in cursorRowQuery(effectiveAfter: effectiveAfter) },
+            parse: { statement, _ in
+                parseCursorBubbleRow(statement, modifiedSince: modifiedSince)
+            })
     }
 
-    /// Resolve per-database watermarks. An empty marks map means cold-scan every root.
-    private static func cursorWatermarks(
-        roots: [URL],
-        afterRowID: Int64,
-        afterRowIDByPath: [String: Int64]?
-    ) -> [String: Int64] {
-        if let afterRowIDByPath { return afterRowIDByPath }
-        guard afterRowID > 0 else { return [:] }
-        return Dictionary(uniqueKeysWithValues: roots.map { root in
-            (cursorDatabaseURL(from: root).path, afterRowID)
-        })
+    /// cursorDiskKV: key TEXT UNIQUE, value BLOB. No time column — filter by
+    /// createdAt in JSON. Cold start uses the key index over bubbleId:* only.
+    /// Incremental: NOT INDEXED + rowid > ? walks *new* rows; without NOT INDEXED
+    /// SQLite prefers the key index. Shared with `cursorIncrementalQueryPlan` so
+    /// the EXPLAIN test pins the SQL the scanner actually runs.
+    private static func cursorRowQuery(effectiveAfter: Int64) -> IncrementalRowQuery {
+        if effectiveAfter == 0 {
+            return IncrementalRowQuery(
+                sql: "SELECT rowid, key, value FROM cursorDiskKV WHERE key GLOB 'bubbleId:*'",
+                bindInt64: nil, bindText: nil)
+        }
+        return IncrementalRowQuery(
+            sql: """
+            SELECT rowid, key, value FROM cursorDiskKV NOT INDEXED
+            WHERE rowid > ?1 AND key GLOB 'bubbleId:*'
+            """,
+            bindInt64: effectiveAfter, bindText: nil)
     }
 
     private static func cursorDatabaseURL(from root: URL) -> URL {
         root.pathExtension == "vscdb" ? root : root.appendingPathComponent("state.vscdb")
     }
 
-    private static func scanCursorRoots(
-        _ sourceRoots: [URL],
-        modifiedSince: Date,
-        marks: [String: Int64]
-    ) -> CursorLoadResult {
-        var entries: [LocalUsageReader.Entry] = []
-        var highWaterByPath: [String: Int64] = [:]
-        var didReset = false
-        for root in sourceRoots {
-            let database = cursorDatabaseURL(from: root)
-            let pathKey = database.path
-            let watermark = marks[pathKey] ?? 0
-            let loaded = cursorDatabaseEntries(database, modifiedSince: modifiedSince, afterRowID: watermark)
-            entries += loaded.entries
-            highWaterByPath[pathKey] = loaded.highWaterRowID
-            if loaded.didReset { didReset = true }
-        }
-        return CursorLoadResult(
-            entries: LocalUsageReader.dedupKeepMax(entries.filter { $0.date >= modifiedSince }),
-            highWaterByPath: highWaterByPath,
-            didReset: didReset)
-    }
-
     /// Exposed for regression tests — incremental plan must walk rowids, not the key index.
     static func cursorIncrementalQueryPlan(database: URL, afterRowID: Int64) -> String? {
         guard afterRowID > 0 else { return nil }
-        let sql = """
-        EXPLAIN QUERY PLAN
-        SELECT rowid, key, value FROM cursorDiskKV NOT INDEXED
-        WHERE rowid > ?1 AND key GLOB 'bubbleId:*'
-        """
-        return explainQueryPlan(database, sql: sql, bindInt64: afterRowID)
-    }
-
-    private struct CursorDatabaseLoad {
-        var entries: [LocalUsageReader.Entry]
-        var highWaterRowID: Int64
-        var didReset: Bool
-    }
-
-    private static func cursorDatabaseEntries(
-        _ database: URL,
-        modifiedSince: Date,
-        afterRowID: Int64
-    ) -> CursorDatabaseLoad {
-        // cursorDiskKV: key TEXT UNIQUE, value BLOB. No time column — filter by createdAt in JSON.
-        // Cold start (afterRowID == 0): GLOB uses the key index over bubbleId:* only.
-        // Incremental: NOT INDEXED + rowid > ? forces a rowid walk of *new* rows only.
-        // Without NOT INDEXED, SQLite prefers the key index and re-walks all bubble keys.
-        //
-        // A failed MAX(rowid) is *not* a shrink: open/prepare can fail while Cursor writes
-        // state.vscdb. Collapsing nil → 0 would wipe the cache for up to one refreshInterval.
-        guard let maxRowID = scalarInt64(database, sql: "SELECT MAX(rowid) FROM cursorDiskKV") else {
-            return CursorDatabaseLoad(entries: [], highWaterRowID: afterRowID, didReset: false)
-        }
-        let didReset = afterRowID > 0 && maxRowID < afterRowID
-        let effectiveAfter = didReset ? 0 : afterRowID
-
-        let sql: String
-        let bind: Int64?
-        if effectiveAfter == 0 {
-            sql = "SELECT rowid, key, value FROM cursorDiskKV WHERE key GLOB 'bubbleId:*'"
-            bind = nil
-        } else {
-            sql = """
-            SELECT rowid, key, value FROM cursorDiskKV NOT INDEXED
-            WHERE rowid > ?1 AND key GLOB 'bubbleId:*'
-            """
-            bind = effectiveAfter
-        }
-
-        // Incomplete scans (BUSY / interrupt) return nil — keep the prior watermark.
-        guard let rows = query(database, sql: sql, bindInt64: bind, row: {
-            statement -> (Int64, LocalUsageReader.Entry?) in
-            let rowID = sqlite3_column_int64(statement, 0)
-            let entry = parseCursorBubbleRow(statement, modifiedSince: modifiedSince)
-            return (rowID, entry)
-        }) else {
-            return CursorDatabaseLoad(entries: [], highWaterRowID: afterRowID, didReset: false)
-        }
-
-        var highWater: Int64 = 0
-        var entries: [LocalUsageReader.Entry] = []
-        for (rowID, entry) in rows {
-            highWater = max(highWater, rowID)
-            if let entry { entries.append(entry) }
-        }
-        // Preserve watermark when an incremental miss returns no new rows.
-        if highWater == 0 { highWater = effectiveAfter }
-        return CursorDatabaseLoad(entries: entries, highWaterRowID: highWater, didReset: didReset)
+        let query = cursorRowQuery(effectiveAfter: afterRowID)
+        return explainQueryPlan(
+            database, sql: "EXPLAIN QUERY PLAN \(query.sql)", bindInt64: query.bindInt64)
     }
 
     private static func parseCursorBubbleRow(
@@ -556,16 +630,6 @@ enum LocalAdditionalUsageReader {
 
     // MARK: Copilot CLI database
 
-    struct CopilotLoadResult: Sendable {
-        var entries: [LocalUsageReader.Entry]
-        var highWaterByPath: [String: Int64]
-        /// True when a database was rescanned from scratch (watermark invalidated).
-        var didReset: Bool
-
-        /// Convenience for single-database tests.
-        var highWaterRowID: Int64 { highWaterByPath.values.max() ?? 0 }
-    }
-
     static var defaultCopilotRoots: [URL] {
         environmentPaths("COPILOT_HOME")
             ?? [FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".copilot")]
@@ -585,113 +649,40 @@ enum LocalAdditionalUsageReader {
         afterRowIDByPath: [String: Int64]? = nil,
         roots: [URL]? = nil
     ) -> CopilotLoadResult {
-        let sourceRoots = roots ?? defaultCopilotRoots
-        let marks = copilotWatermarks(
-            roots: sourceRoots, afterRowID: afterRowID, afterRowIDByPath: afterRowIDByPath)
-        var result = scanCopilotRoots(sourceRoots, modifiedSince: modifiedSince, marks: marks)
-        if result.didReset {
-            // A partial incremental payload must not replace the cache — rescan every root cold.
-            let recovered = scanCopilotRoots(sourceRoots, modifiedSince: modifiedSince, marks: [:])
-            result = CopilotLoadResult(
-                entries: recovered.entries,
-                highWaterByPath: recovered.highWaterByPath,
-                didReset: true)
-        }
-        return result
-    }
-
-    private static func copilotWatermarks(
-        roots: [URL],
-        afterRowID: Int64,
-        afterRowIDByPath: [String: Int64]?
-    ) -> [String: Int64] {
-        if let afterRowIDByPath { return afterRowIDByPath }
-        guard afterRowID > 0 else { return [:] }
-        return Dictionary(uniqueKeysWithValues: roots.map { root in
-            (copilotDatabaseURL(from: root).path, afterRowID)
-        })
+        scanIncrementalStores(
+            roots: roots ?? defaultCopilotRoots,
+            modifiedSince: modifiedSince,
+            afterRowID: afterRowID,
+            afterRowIDByPath: afterRowIDByPath,
+            databaseURL: copilotDatabaseURL(from:),
+            maxRowIDSQL: "SELECT MAX(id) FROM assistant_usage_events",
+            rowSQL: { effectiveAfter, since in
+                // `created_at` is text, so the cutoff is a lexicographic compare, not a
+                // time compare. It is only a coarse prefilter — the shared scanner
+                // re-filters on parsed dates — but it must never drop a row that belongs
+                // in the window, and a dropped row is lost for good once a later id
+                // advances the watermark. A same-day row in the ISO-8601 shape is safe
+                // (its "T" sorts after the cutoff's space), yet a row carrying a UTC
+                // offset can still render an earlier calendar day than the instant it
+                // represents ("2026-01-03T20:00:00-05:00" is 2026-01-04T01:00:00Z).
+                // Backing the cutoff off by a full day covers every offset SQLite
+                // accepts (±14h) and costs one extra day of rows.
+                IncrementalRowQuery(
+                    sql: """
+                    SELECT id, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, created_at
+                    FROM assistant_usage_events
+                    WHERE id > ?1 AND created_at >= ?2
+                    """,
+                    bindInt64: effectiveAfter,
+                    bindText: copilotDayCutoff(since))
+            },
+            parse: { statement, database in
+                parseCopilotUsageRow(statement, database: database)
+            })
     }
 
     private static func copilotDatabaseURL(from root: URL) -> URL {
         root.pathExtension == "db" ? root : root.appendingPathComponent("session-store.db")
-    }
-
-    private static func scanCopilotRoots(
-        _ sourceRoots: [URL],
-        modifiedSince: Date,
-        marks: [String: Int64]
-    ) -> CopilotLoadResult {
-        var entries: [LocalUsageReader.Entry] = []
-        var highWaterByPath: [String: Int64] = [:]
-        var didReset = false
-        for root in sourceRoots {
-            let database = copilotDatabaseURL(from: root)
-            let pathKey = database.path
-            let loaded = copilotDatabaseEntries(
-                database, modifiedSince: modifiedSince, afterRowID: marks[pathKey] ?? 0)
-            entries += loaded.entries
-            highWaterByPath[pathKey] = loaded.highWaterRowID
-            if loaded.didReset { didReset = true }
-        }
-        return CopilotLoadResult(
-            entries: LocalUsageReader.dedupKeepMax(entries.filter { $0.date >= modifiedSince }),
-            highWaterByPath: highWaterByPath,
-            didReset: didReset)
-    }
-
-    private struct CopilotDatabaseLoad {
-        var entries: [LocalUsageReader.Entry]
-        var highWaterRowID: Int64
-        var didReset: Bool
-    }
-
-    private static func copilotDatabaseEntries(
-        _ database: URL,
-        modifiedSince: Date,
-        afterRowID: Int64
-    ) -> CopilotDatabaseLoad {
-        // A failed MAX(id) is not a shrink: open/prepare can fail while the CLI writes the
-        // store. Collapsing nil → 0 would wipe the cache for up to one refresh interval.
-        guard let maxRowID = scalarInt64(database, sql: "SELECT MAX(id) FROM assistant_usage_events") else {
-            return CopilotDatabaseLoad(entries: [], highWaterRowID: afterRowID, didReset: false)
-        }
-        let didReset = afterRowID > 0 && maxRowID < afterRowID
-        let effectiveAfter = didReset ? 0 : afterRowID
-
-        // `created_at` is text, so the cutoff is a lexicographic compare, not a time compare.
-        // It is only a coarse prefilter — `scanCopilotRoots` re-filters on parsed dates — but
-        // it must never drop a row that belongs in the window, and a dropped row is lost for
-        // good once a later id advances the watermark. A same-day row in the ISO-8601 shape is
-        // safe (its "T" sorts after the cutoff's space), yet a row carrying a UTC offset can
-        // still render an earlier calendar day than the instant it represents
-        // ("2026-01-03T20:00:00-05:00" is 2026-01-04T01:00:00Z). Backing the cutoff off by a
-        // full day covers every offset SQLite accepts (±14h) and costs one extra day of rows.
-        let sql = """
-        SELECT id, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, created_at
-        FROM assistant_usage_events
-        WHERE id > ?1 AND created_at >= ?2
-        """
-        guard let rows = query(
-            database, sql: sql,
-            bindInt64: effectiveAfter,
-            bindText: copilotDayCutoff(modifiedSince),
-            row: { statement -> (Int64, LocalUsageReader.Entry?) in
-                (sqlite3_column_int64(statement, 0), parseCopilotUsageRow(statement, database: database))
-            }) else {
-            // Incomplete scan (BUSY / interrupt) — keep the prior watermark.
-            return CopilotDatabaseLoad(entries: [], highWaterRowID: afterRowID, didReset: false)
-        }
-
-        var highWater: Int64 = 0
-        var entries: [LocalUsageReader.Entry] = []
-        for (rowID, entry) in rows {
-            highWater = max(highWater, rowID)
-            if let entry { entries.append(entry) }
-        }
-        // Rows before the cutoff are filtered out in SQL, so an empty incremental read must
-        // not reset the watermark back to zero.
-        if highWater == 0 { highWater = effectiveAfter }
-        return CopilotDatabaseLoad(entries: entries, highWaterRowID: highWater, didReset: didReset)
     }
 
     private static func parseCopilotUsageRow(

--- a/Tests/PokeTokenBarTests/CopilotUsageTests.swift
+++ b/Tests/PokeTokenBarTests/CopilotUsageTests.swift
@@ -196,6 +196,69 @@ final class CopilotUsageTests: XCTestCase {
         XCTAssertEqual(result.highWaterRowID, 1)
     }
 
+    /// Copilot-only path for the shared scanner (#157): a failed open/prepare must
+    /// not look like a shrink. Cursor already covers this; A||B needs B alone.
+    func testUnreadableDatabaseKeepsWatermarkAndDoesNotReset() throws {
+        try seed(rows: [
+            Row(id: 1, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-04T10:00:00.000Z"),
+        ])
+        let since = try date("2026-01-01T00:00:00Z")
+        let first = LocalAdditionalUsageReader.copilotEntries(modifiedSince: since, roots: [temporaryDirectory])
+        let watermark = first.highWaterRowID
+        XCTAssertGreaterThan(watermark, 0)
+
+        try Data("not-a-sqlite-database".utf8).write(to: databaseURL, options: .atomic)
+
+        let second = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: since, afterRowIDByPath: first.highWaterByPath, roots: [temporaryDirectory])
+        XCTAssertFalse(second.didReset, "failed read must not be treated as a shrink")
+        XCTAssertEqual(second.highWaterRowID, watermark)
+        XCTAssertTrue(second.entries.isEmpty)
+    }
+
+    /// Copilot-only dual-root reset: rewriting one store must still return the
+    /// other store's history in the replacement payload.
+    func testResetInOneRootKeepsOtherRootHistory() throws {
+        try seed(rows: (1...5).map {
+            Row(id: $0, model: "claude-opus-5", input: 100, output: 10,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0,
+                createdAt: "2026-01-04T10:0\($0):00.000Z")
+        })
+        let otherRoot = temporaryDirectory.appendingPathComponent("other")
+        try FileManager.default.createDirectory(at: otherRoot, withIntermediateDirectories: true)
+        let otherDatabase = otherRoot.appendingPathComponent("session-store.db")
+        try seed(rows: (1...5).map {
+            Row(id: $0, model: "gpt-5.4-mini", input: 200, output: 20,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0,
+                createdAt: "2026-01-04T11:0\($0):00.000Z")
+        }, in: otherDatabase)
+
+        let since = try date("2026-01-01T00:00:00Z")
+        let first = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: since, roots: [temporaryDirectory, otherRoot])
+        XCTAssertEqual(first.entries.count, 10)
+
+        try FileManager.default.removeItem(at: otherDatabase)
+        try seed(rows: [
+            Row(id: 1, model: "gpt-5.4-mini", input: 700, output: 70,
+                cacheRead: 0, cacheWrite: 0, reasoning: 0, createdAt: "2026-01-05T10:00:00.000Z"),
+        ], in: otherDatabase)
+
+        let second = LocalAdditionalUsageReader.copilotEntries(
+            modifiedSince: since, afterRowIDByPath: first.highWaterByPath,
+            roots: [temporaryDirectory, otherRoot])
+        XCTAssertTrue(second.didReset)
+        XCTAssertEqual(
+            second.entries.filter { $0.id.hasPrefix("copilot|\(databaseURL.path)|") }.count, 5,
+            "first store history must be in the reset payload")
+        XCTAssertEqual(second.entries.filter { $0.id.hasPrefix("copilot|\(otherDatabase.path)|") }.map(\.id),
+                       [entryID(1, in: otherDatabase)])
+        XCTAssertEqual(
+            second.highWaterByPath[databaseURL.path], first.highWaterByPath[databaseURL.path],
+            "healthy store watermark must survive the other store's cold rescan")
+    }
+
     // MARK: - Multiple stores
 
     /// `$COPILOT_HOME` may name more than one store, and each numbers its rows from 1. Keying

--- a/Tests/PokeTokenBarTests/CursorUsageTests.swift
+++ b/Tests/PokeTokenBarTests/CursorUsageTests.swift
@@ -185,6 +185,10 @@ final class CursorUsageTests: XCTestCase {
         XCTAssertFalse(
             second.entries.contains { $0.id.contains("bubbleId:b:") && !$0.id.contains("b-new") },
             "old root B bubbles must not linger after its rewrite")
+        let pathA = rootA.appendingPathComponent("state.vscdb").path
+        XCTAssertEqual(
+            second.highWaterByPath[pathA], marks[pathA],
+            "healthy root watermark must survive the other root's cold rescan")
     }
 
     func testCursorSkipsBubblesBeforeModifiedSince() throws {
@@ -239,6 +243,27 @@ final class CursorUsageTests: XCTestCase {
         XCTAssertEqual(second.entries.count, 1)
         XCTAssertEqual(second.entries.first?.id, "cursor|bubbleId:tab:b")
         XCTAssertGreaterThan(second.highWaterRowID, first.highWaterRowID)
+    }
+
+    func testCursorEmptyIncrementalReadPreservesWatermark() throws {
+        let database = temporaryDirectory.appendingPathComponent("state.vscdb")
+        try execute(database, sql: """
+        CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);
+        INSERT INTO cursorDiskKV VALUES (
+            'bubbleId:tab:a',
+            '{"tokenCount":{"inputTokens":100,"outputTokens":50},"createdAt":"2026-01-04T10:00:00.000Z","modelType":"gpt-4o"}'
+        );
+        """)
+        let since = try date("2026-01-01T00:00:00Z")
+        let first = LocalAdditionalUsageReader.cursorEntries(
+            modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertGreaterThan(first.highWaterRowID, 0)
+
+        let second = LocalAdditionalUsageReader.cursorEntries(
+            modifiedSince: since, afterRowID: first.highWaterRowID, roots: [temporaryDirectory])
+        XCTAssertTrue(second.entries.isEmpty)
+        XCTAssertEqual(second.highWaterRowID, first.highWaterRowID)
+        XCTAssertFalse(second.didReset)
     }
 
     func testParseCursorBubbleAcceptsNumericCreatedAt() {

--- a/Tests/PokeTokenBarTests/IncrementalStoreScanTests.swift
+++ b/Tests/PokeTokenBarTests/IncrementalStoreScanTests.swift
@@ -1,0 +1,164 @@
+import SQLite3
+import XCTest
+@testable import PokeTokenBar
+
+/// Pins the shared incremental SQLite scanner (#157) on a format-neutral table.
+/// Cursor and Copilot keep their own SQL/parse tests; these cover the scaffolding
+/// that must not exist twice: failed-read ≠ shrink, empty incremental keeps the
+/// watermark, and a reset in one root cold-rescans every root.
+final class IncrementalStoreScanTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PokeTokenBar-IncrementalStoreScanTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+        temporaryDirectory = nil
+    }
+
+    func testFailedMaxIsNotAShrink() throws {
+        let root = try seedRoot("a", ids: [1, 2])
+        let first = scan(roots: [root])
+        XCTAssertEqual(first.entries.count, 2)
+        let watermark = first.highWaterRowID
+        XCTAssertEqual(watermark, 2)
+
+        try Data("not-a-sqlite-database".utf8).write(
+            to: databaseURL(from: root), options: .atomic)
+
+        let second = scan(roots: [root], afterRowIDByPath: first.highWaterByPath)
+        XCTAssertFalse(second.didReset, "open/prepare failure must not look like VACUUM")
+        XCTAssertEqual(second.highWaterRowID, watermark)
+        XCTAssertTrue(second.entries.isEmpty)
+    }
+
+    func testEmptyIncrementalReadPreservesWatermark() throws {
+        let root = try seedRoot("a", ids: [7])
+        let first = scan(roots: [root])
+        XCTAssertEqual(first.highWaterRowID, 7)
+
+        let second = scan(roots: [root], afterRowIDByPath: first.highWaterByPath)
+        XCTAssertTrue(second.entries.isEmpty)
+        XCTAssertEqual(second.highWaterRowID, 7, "highWater == 0 must keep effectiveAfter")
+        XCTAssertFalse(second.didReset)
+    }
+
+    func testIncrementalReadReturnsOnlyRowsAfterWatermark() throws {
+        let root = try seedRoot("a", ids: [1])
+        let first = scan(roots: [root])
+        try insert(ids: [2], in: databaseURL(from: root))
+
+        let second = scan(roots: [root], afterRowIDByPath: first.highWaterByPath)
+        XCTAssertEqual(second.entries.map(\.id), ["scan|a-2"])
+        XCTAssertEqual(second.highWaterRowID, 2)
+        XCTAssertFalse(second.didReset)
+    }
+
+    func testShrinkInOneRootColdRescansEveryRoot() throws {
+        let rootA = try seedRoot("a", ids: Array(1...5))
+        let rootB = try seedRoot("b", ids: Array(1...5))
+        let first = scan(roots: [rootA, rootB])
+        XCTAssertEqual(first.entries.count, 10)
+        XCTAssertEqual(first.highWaterByPath.count, 2)
+
+        try FileManager.default.removeItem(at: databaseURL(from: rootB))
+        try seed(ids: [1], in: databaseURL(from: rootB))
+
+        let second = scan(roots: [rootA, rootB], afterRowIDByPath: first.highWaterByPath)
+        XCTAssertTrue(second.didReset)
+        XCTAssertEqual(
+            second.entries.filter { $0.id.hasPrefix("scan|a-") }.count, 5,
+            "root A must be in the reset payload, not only rows above its watermark")
+        XCTAssertEqual(second.entries.filter { $0.id.hasPrefix("scan|b-") }.count, 1)
+        XCTAssertEqual(second.entries.first { $0.id.hasPrefix("scan|b-") }?.id, "scan|b-1")
+        let pathA = databaseURL(from: rootA).path
+        XCTAssertEqual(
+            second.highWaterByPath[pathA], first.highWaterByPath[pathA],
+            "healthy root watermark must survive the other root's cold rescan")
+    }
+
+    // MARK: - Helpers
+
+    private func scan(
+        roots: [URL],
+        afterRowIDByPath: [String: Int64]? = nil
+    ) -> LocalAdditionalUsageReader.IncrementalStoreLoadResult {
+        LocalAdditionalUsageReader.scanIncrementalStores(
+            roots: roots,
+            modifiedSince: Date(timeIntervalSince1970: 0),
+            afterRowIDByPath: afterRowIDByPath,
+            databaseURL: databaseURL(from:),
+            maxRowIDSQL: "SELECT MAX(id) FROM events",
+            rowSQL: { effectiveAfter, _ in
+                LocalAdditionalUsageReader.IncrementalRowQuery(
+                    sql: "SELECT id, created_at, tokens FROM events WHERE id > ?1",
+                    bindInt64: effectiveAfter,
+                    bindText: nil)
+            },
+            parse: { statement, database in
+                let id = sqlite3_column_int64(statement, 0)
+                guard let created = sqlite3_column_text(statement, 1) else { return nil }
+                let tokens = Int(sqlite3_column_int64(statement, 2))
+                guard let date = ISO8601DateFormatter().date(from: String(cString: created)) else {
+                    return nil
+                }
+                let prefix = database.deletingLastPathComponent().lastPathComponent
+                return LocalUsageReader.Entry(
+                    id: "scan|\(prefix)-\(id)",
+                    date: date,
+                    localDay: "2026-01-04",
+                    model: "test",
+                    input: tokens,
+                    output: 0,
+                    cacheWrite: 0,
+                    cacheRead: 0)
+            })
+    }
+
+    private func databaseURL(from root: URL) -> URL {
+        root.pathExtension == "db" ? root : root.appendingPathComponent("store.db")
+    }
+
+    private func seedRoot(_ name: String, ids: [Int]) throws -> URL {
+        let root = temporaryDirectory.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try seed(ids: ids, in: databaseURL(from: root))
+        return root
+    }
+
+    private func seed(ids: [Int], in database: URL) throws {
+        try execute(database, sql: """
+        CREATE TABLE events (
+            id INTEGER PRIMARY KEY,
+            created_at TEXT NOT NULL,
+            tokens INTEGER NOT NULL
+        );
+        """)
+        try insert(ids: ids, in: database)
+    }
+
+    private func insert(ids: [Int], in database: URL) throws {
+        guard !ids.isEmpty else { return }
+        let values = ids.map { id in
+            "(\(id), '2026-01-04T10:00:00Z', 10)"
+        }.joined(separator: ", ")
+        try execute(database, sql: "INSERT INTO events (id, created_at, tokens) VALUES \(values);")
+    }
+
+    private func execute(_ databaseURL: URL, sql: String) throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(databaseURL.path, &database), SQLITE_OK)
+        guard let database else { throw NSError(domain: "SQLite", code: 1) }
+        defer { sqlite3_close(database) }
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
+        let message = errorMessage.map { String(cString: $0) }
+        sqlite3_free(errorMessage)
+        XCTAssertEqual(result, SQLITE_OK, message ?? "SQLite statement failed")
+        if result != SQLITE_OK { throw NSError(domain: "SQLite", code: Int(result)) }
+    }
+}

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -42,6 +42,10 @@ read_when:
 
 ## 외부 로그·사용량 소스
 
+- **append-only SQLite watermark 루프를 프로바이더마다 복사하지 마라.** Cursor 와 Copilot 이
+  같은 `didReset` / `highWater == 0` 규칙을 두 벌로 들고 있으면 한쪽만 고친 수정이 다른 쪽에 남는다
+  (#157). 루프는 `scanIncrementalStores` 한 곳, 포맷만 콜백. 회귀는 공유 헬퍼 테스트 **그리고**
+  Copilot-only / Cursor-only 각 경로(A\|\|B 의 B 단독)를 모두 밟아야 한다.
 - **외부 로그 포맷은 *상위 소스의 writer* 로 검증한다 — 내 픽스처는 증거가 아니다.** 새 프로바이더 파서를
   쓸 때 "이렇게 생겼을 것"으로 픽스처를 만들면 파서와 픽스처가 같은 오해를 공유해 테스트가 전부 통과하면서
   실사용은 0 을 표시한다(#133: 봉투 래퍼 키를 `update` 로 봤으나 실제는 `params`, `timestamp` 는 ISO 문자열이

--- a/docs/reference/provider-extension.md
+++ b/docs/reference/provider-extension.md
@@ -26,3 +26,6 @@ read_when:
   추가한다. 스캔(`LocalUsageReader`)·캐시(`LocalUsageCache`)·테스트가 그 단일 소스를 공유해야 한다.
   루트가 겹쳐도 합계는 전역 dedup 이 바로잡지만, 중복 루트는 스캔 비용을 배로 늘리므로
   `normalizedRoots` 로 접는다.
+- **append-only SQLite 사용량 스토어** (Cursor `cursorDiskKV`, Copilot `assistant_usage_events`,
+  앞으로 같은 형태의 세 번째 소스) = `LocalAdditionalUsageReader.scanIncrementalStores`. URL 매핑·
+  `MAX` SQL·row query·parse 만 넘긴다. watermark 루프를 프로바이더마다 복사하지 마라 (#157).


### PR DESCRIPTION
## Summary

Cursor and Copilot each carried a full incremental SQLite scanner. Normalising names, 96 of Copilot's 142 code lines matched Cursor — including the two watermark lines that are easy to get wrong without a crash:

- `let didReset = afterRowID > 0 && maxRowID < afterRowID`
- `if highWater == 0 { highWater = effectiveAfter }`

A fix in one copy would sit untouched in the other. This extracts `scanIncrementalStores` as sketched in #157: URL mapping, `MAX` SQL, row query, and parse stay with the provider; the watermark loop exists once. `CursorLoadResult` / `CopilotLoadResult` collapse to `IncrementalStoreLoadResult`.

`rowSQL` is a closure rather than a single string. Cursor has two statements (cold `GLOB` vs incremental `NOT INDEXED`), and Copilot binds a second text cutoff (`created_at >= ?2`). Pinning a shared string would have changed one of those paths. `cursorIncrementalQueryPlan` now calls the same `cursorRowQuery` the scanner uses, so dropping `NOT INDEXED` fails the EXPLAIN test.

#152's diagnostic split for `query()` is not in this PR. `query()` already returns `nil` unless `sqlite3_step` ends on `SQLITE_DONE`; turning that into a logged value type also touches OpenCode/Hermes and is a wider blast radius than #157.

## Type of change

- [x] Refactor / cleanup

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change

No UI changes.

## Tests

Shared helper on a format-neutral table (`IncrementalStoreScanTests`):

- `testFailedMaxIsNotAShrink` — corrupt file keeps the watermark, `didReset == false`
- `testEmptyIncrementalReadPreservesWatermark` — `highWater == 0` keeps `effectiveAfter`
- `testShrinkInOneRootColdRescansEveryRoot` — reset in B still returns A's history **and** A's watermark

Cursor-only (existing + empty incremental + healthy-root watermark on dual-root reset). Copilot-only, the path that previously had no copy of the #125 hardening tests:

- `testUnreadableDatabaseKeepsWatermarkAndDoesNotReset`
- `testResetInOneRootKeepsOtherRootHistory` (entries + healthy-store watermark)

`swift test --filter 'IncrementalStoreScanTests|CursorUsageTests|CopilotUsageTests'`: 43 tests, 0 failures.

Full suite: 624 pass, 9 skipped. The remaining failure is `LocalUsageCacheTests.testFormatterEdges` (`253 412 890` vs `253,412,890`) — locale grouping, unrelated to this change, TokenFormatter not touched.

## How to verify

```bash
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --filter 'IncrementalStoreScanTests|CursorUsageTests|CopilotUsageTests'
```