### PR TITLE
Add user-configurable additional scan folders with wildcard support

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -58,6 +58,10 @@ enum LocalUsageReader {
     ///
     /// - `CLAUDE_CONFIG_DIR`: 사용자가 설정 위치를 옮긴 경우. 콤마로 여러 개를 줄 수 있고 각각 `<값>/projects`.
     /// - `~/.config/claude/projects`, `~/.claude/projects`: CLI 기본 위치(전자는 XDG 스타일 설치).
+    /// - 사용자 지정 스캔 폴더(설정): 계정별 격리 래퍼나 커스텀 레이아웃은 세션 로그가
+    ///   위 어디에도 안 남는다. 래퍼가 `CLAUDE_CONFIG_DIR` 를 자식 프로세스에만 주입하면 셸 조회로도
+    ///   못 잡으므로, 사용자가 폴더를 직접 등록하는 것이 유일한 범용 경로다. `*` 와일드카드를 지원해
+    ///   인스턴스가 늘어도 설정을 다시 만질 필요가 없게 한다.
     /// - Claude Desktop 임베디드 세션: 세션 디렉터리마다 CLI 와 같은 모양의 `.claude/projects` 를 갖는다.
     ///   Desktop 으로 일한 사용량이 여기에만 남으므로 빼면 조용히 누락된다.
     /// 계산에 파일시스템 탐색 + (GUI 앱에선) 로그인 셸 조회가 들어가는데 새로고침은 분 단위로 돈다.
@@ -67,6 +71,7 @@ enum LocalUsageReader {
     /// 테스트·진단용 — 캐시를 무시하고 지금 상태로 계산한다.
     static func computeClaudeProjectRoots(
         configDirValue: String? = shellAwareClaudeConfigDir(),
+        customRootsValue: String? = storedCustomScanRoots(),
         home: URL = FileManager.default.homeDirectoryForCurrentUser) -> [URL]
     {
         var roots: [URL] = []
@@ -80,6 +85,9 @@ enum LocalUsageReader {
         }
         roots.append(home.appendingPathComponent(Self.configRelativeProjectsPath))
         roots.append(home.appendingPathComponent(Self.defaultRelativeProjectsPath))
+        if let raw = customRootsValue {
+            roots.append(contentsOf: expandedCustomRoots(raw))
+        }
 
         let desktop = home.appendingPathComponent("Library/Application Support/Claude")
         for store in ["local-agent-mode-sessions", "claude-code-sessions"] {
@@ -101,6 +109,57 @@ enum LocalUsageReader {
         if let v = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"], !v.isEmpty { return v }
         return BinaryLocator.shellEnvironmentValue("CLAUDE_CONFIG_DIR")
     }()
+
+    /// 사용자 지정 스캔 폴더 설정(`UserDefaults`). `UsageStore` 가 같은 키에 쓴다 — GUI 앱은 셸 env 를
+    /// 상속하지 않으므로 `CLAUDE_CONFIG_DIR` 류 다중 경로를 실제로 쓸 수 있는 곳은 앱 설정뿐이다.
+    static let customScanRootsDefaultsKey = "customScanRoots"
+
+    static func storedCustomScanRoots() -> String? {
+        UserDefaults.standard.string(forKey: customScanRootsDefaultsKey)
+    }
+
+    /// 설정 변경 즉시 루트 캐시를 비운다 — TTL(300초)을 기다리면 사용자가 폴더를 추가하고도
+    /// 다음 몇 번의 새로고침 동안 숫자가 안 변해 "설정이 안 먹었다"로 보인다.
+    static func invalidateProjectRootsCache() { rootsCache.invalidate() }
+
+    /// 사용자 지정 스캔 폴더 파싱: 콤마·개행 구분, 공백 트림, `~` 확장, 세그먼트 단위 `*` 와일드카드.
+    /// 항목은 `CLAUDE_CONFIG_DIR` 와 달리 **로그 루트 자체**를 가리킨다(`/projects` 를 덧붙이지 않는다)
+    /// — 래퍼마다 레이아웃이 달라 접미사를 강제하면 표현 못 하는 배치가 생긴다.
+    /// 확장 결과는 존재하는 디렉터리만 남기고 정렬한다(루트 목록이 흔들리면 진단이 어렵다).
+    /// 존재하지 않는 항목은 오류가 아니다 — 인스턴스가 아직 없는 패턴을 미리 등록해 둘 수 있어야 한다.
+    static func expandedCustomRoots(_ raw: String) -> [URL] {
+        let fm = FileManager.default
+        var out: [URL] = []
+        for part in raw.split(whereSeparator: { $0 == "," || $0.isNewline }) {
+            let pattern = part.trimmingCharacters(in: .whitespaces)
+            guard !pattern.isEmpty else { continue }
+            let absolute = NSString(string: pattern).expandingTildeInPath
+            guard absolute.hasPrefix("/") else { continue }   // 상대 경로는 GUI 앱에서 기준이 없다
+
+            var paths = [""]
+            for segment in absolute.split(separator: "/").map(String.init) {
+                if segment.contains("*") {
+                    var next: [String] = []
+                    for base in paths {
+                        guard let names = try? fm.contentsOfDirectory(atPath: base.isEmpty ? "/" : base)
+                        else { continue }
+                        // fnmatch: `*` 외에 `?`·`[]` 도 공짜로 온다. 플래그 0 → 숨김 파일(.claude 류)도 매치.
+                        next.append(contentsOf: names.sorted()
+                            .filter { fnmatch(segment, $0, 0) == 0 }
+                            .map { base + "/" + $0 })
+                    }
+                    paths = next
+                } else {
+                    paths = paths.map { $0 + "/" + segment }
+                }
+            }
+            var isDir: ObjCBool = false
+            out.append(contentsOf: paths
+                .filter { fm.fileExists(atPath: $0, isDirectory: &isDir) && isDir.boolValue }
+                .map { URL(fileURLWithPath: $0) })
+        }
+        return out
+    }
 
     private static let rootsCache = RootsCache()
 
@@ -127,6 +186,13 @@ enum LocalUsageReader {
             computedAt = Date()
             lock.unlock()
             return fresh
+        }
+
+        func invalidate() {
+            lock.lock()
+            cached = nil
+            computedAt = nil
+            lock.unlock()
         }
     }
 

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -154,6 +154,16 @@ struct L {
     var statusChecksHint: String { t("Claude·OpenAI 장애를 팝오버에 표시 (알림 아님)", "Show Claude / OpenAI incidents in the popover (not a notification)", "Claude・OpenAIの障害をポップオーバーに表示（通知ではない）") }
     var warning: String { t("경고", "Warning", "警告") }
     var critical: String { t("임박", "Critical", "切迫") }
+    var customScanRootsLabel: String { t("추가 스캔 폴더", "Additional scan folders", "追加スキャンフォルダ") }
+    var customScanRootsHint: String {
+        t("Claude 세션 로그(.jsonl)를 더 찾을 폴더 — 멀티 계정 래퍼 등 기본 위치 밖의 사용량용. 콤마·줄바꿈 구분, * 와일드카드 지원",
+          "Extra folders to scan for Claude session logs (.jsonl) — for usage outside the default locations, e.g. multi-account wrappers. Comma/newline separated, * wildcard supported",
+          "Claudeセッションログ(.jsonl)を追加で探すフォルダ — マルチアカウントラッパーなど既定外の使用量向け。カンマ・改行区切り、*ワイルドカード対応")
+    }
+    var customScanRootsPlaceholder: String { "~/some/dir/*/projects" }
+    func customScanRootsMatches(_ n: Int) -> String {
+        t("지금 \(n)개 폴더에 매치", "Matches \(n) folder(s) now", "現在\(n)個のフォルダに一致")
+    }
     var aggregationNote: String { t("토큰 집계 기준: totalTokens (input + output + cache, 로컬 날짜)", "Token basis: totalTokens (input + output + cache, local date)", "集計基準: totalTokens (input + output + cache, ローカル日付)") }
     var close: String { t("닫기", "Close", "閉じる") }
 

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -96,6 +96,17 @@ final class UsageStore {
     var floatingPetBubbleAlerts: Bool {
         didSet { defaults.set(floatingPetBubbleAlerts, forKey: "floatingPetBubbleAlerts") }
     }
+    /// 사용자 지정 스캔 폴더(콤마·개행 구분, `*` 와일드카드) — 파싱·확장 의미는
+    /// `LocalUsageReader.expandedCustomRoots` 가 정본. 저장 키도 reader 와 공유한다
+    /// (reader 는 didSet 경로 밖(RootsCache 갱신)에서도 스스로 읽어야 하기 때문).
+    var customScanRoots: String {
+        didSet {
+            guard customScanRoots != oldValue else { return }
+            defaults.set(customScanRoots, forKey: LocalUsageReader.customScanRootsDefaultsKey)
+            LocalUsageReader.invalidateProjectRootsCache()
+            Task { await refresh() }   // 다음 자동 폴(최대 refreshInterval)을 기다리게 하지 않는다
+        }
+    }
     var disableKeychainAccess: Bool {
         didSet {
             defaults.set(disableKeychainAccess, forKey: "disableKeychainAccess")   // 저장 누락이던 기존 버그 — 재시작 후 풀렸음
@@ -425,6 +436,7 @@ final class UsageStore {
         floatingPetSize = d.object(forKey: "floatingPetSize") as? Double ?? 96
         floatingPetBubbleAlerts = d.object(forKey: "floatingPetBubbleAlerts") as? Bool ?? true
         disableKeychainAccess = d.object(forKey: "disableKeychainAccess") as? Bool ?? false
+        customScanRoots = d.string(forKey: LocalUsageReader.customScanRootsDefaultsKey) ?? ""
 
         reschedule()
 

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -355,6 +355,22 @@ struct SettingsView: View {
                         .padding(.horizontal, 12).padding(.bottom, 6)
                 }
                 Divider()
+                groupRow {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(l.customScanRootsLabel)
+                        Text(l.customScanRootsHint).font(.caption2).foregroundStyle(.tertiary)
+                        TextField(l.customScanRootsPlaceholder, text: $store.customScanRoots)
+                            .textFieldStyle(.roundedBorder).font(.caption)
+                        // 오타·잘못된 패턴을 저장 전에 알 수 있는 유일한 신호 — 다음 새로고침까지
+                        // 숫자가 안 변하는 것만으로는 "매치 0"과 "이미 집계됨"을 구분할 수 없다.
+                        if !store.customScanRoots.trimmingCharacters(in: .whitespaces).isEmpty {
+                            Text(l.customScanRootsMatches(
+                                LocalUsageReader.expandedCustomRoots(store.customScanRoots).count))
+                                .font(.caption2).foregroundStyle(.tertiary)
+                        }
+                    }
+                }
+                Divider()
                 Text(l.aggregationNote)
                     .font(.caption2).foregroundStyle(.tertiary)
                     .padding(.horizontal, 12).padding(.vertical, 8)

--- a/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
@@ -169,6 +169,46 @@ final class LocalUsageReaderTests: XCTestCase {
         }
     }
 
+    /// 사용자 지정 스캔 폴더: 콤마·개행 분리, `*` 세그먼트 확장, 존재하는 디렉터리만, 정렬 순서.
+    /// 계정별 격리 래퍼의 `instances/<name>/projects` 레이아웃이 동기 사례라 그 모양으로 검증한다.
+    func testCustomScanRootsExpandGlobAndKeepOnlyExistingDirs() {
+        let base = tempDir()
+        for name in ["b-inst", "a-inst"] {
+            try? FileManager.default.createDirectory(
+                at: base.appendingPathComponent("instances/\(name)/projects"),
+                withIntermediateDirectories: true)
+        }
+        try? FileManager.default.createDirectory(          // projects 없는 인스턴스 — 제외돼야 함
+            at: base.appendingPathComponent("instances/empty"),
+            withIntermediateDirectories: true)
+        let literal = base.appendingPathComponent("literal")
+        try? FileManager.default.createDirectory(at: literal, withIntermediateDirectories: true)
+        try? "x".write(to: base.appendingPathComponent("file"), atomically: true, encoding: .utf8)
+
+        let raw = "\(base.path)/instances/*/projects, \(literal.path)\n\(base.path)/nope/*, \(base.path)/file, relative/path"
+        let roots = LocalUsageReader.expandedCustomRoots(raw).map(\.path)
+
+        XCTAssertEqual(roots, [
+            base.appendingPathComponent("instances/a-inst/projects").path,   // 와일드카드 매치는 정렬 순
+            base.appendingPathComponent("instances/b-inst/projects").path,
+            literal.path,
+        ], "glob 확장·존재 필터·정렬이 어긋났다: \(roots)")
+    }
+
+    /// 사용자 지정 폴더는 기본 루트에 **더해지고**(union), 값이 없으면 아무것도 바뀌지 않는다.
+    func testComputeRootsUnionCustomRootsAndDefaultUnchangedWithoutValue() {
+        let home = URL(fileURLWithPath: "/Users/testhome")
+        let extra = tempDir()
+        let roots = LocalUsageReader.computeClaudeProjectRoots(
+            configDirValue: nil, customRootsValue: extra.path, home: home).map(\.path)
+        XCTAssertTrue(roots.contains(extra.resolvingSymlinksInPath().path))
+        XCTAssertTrue(roots.contains("/Users/testhome/.claude/projects"))
+
+        let none = LocalUsageReader.computeClaudeProjectRoots(
+            configDirValue: nil, customRootsValue: nil, home: home).map(\.path)
+        XCTAssertFalse(none.contains(extra.resolvingSymlinksInPath().path))
+    }
+
     /// `CLAUDE_CONFIG_DIR` 파싱: 콤마 분리·공백 트림·빈 조각 무시·틸드 확장.
     func testConfigDirParsingHandlesCommasWhitespaceAndTilde() {
         let home = URL(fileURLWithPath: "/Users/testhome")


### PR DESCRIPTION
## Problem

Some setups keep Claude session logs outside every root the app scans — for example launchers that isolate each account into its own config directory and inject a per-account `CLAUDE_CONFIG_DIR` only into their child processes. That env var is invisible to both the process environment and the login-shell probe, so the menu bar silently under-reports (on my machine, roughly 3/4 of a day's tokens were missing).

The reader already parses comma-separated `CLAUDE_CONFIG_DIR` values, but GUI users cannot actually use that capability: setting it shell-wide breaks the Claude CLI itself, which reads the value as a single path.

A symlink workaround inside `~/.claude/projects` does not work either — `FileManager.enumerator` does not follow directory symlinks (verified empirically).

## Change

Expose the existing multi-root capability as an app setting instead of hardcoding any specific tool's layout:

- **`customScanRoots` setting (Settings > Advanced)** — comma/newline-separated folders, tilde expansion, per-segment `*` wildcards (via `fnmatch`, so `?`/`[]` come for free). Entries point at log roots directly (no `/projects` suffix assumed), because layouts differ between tools.
- Only existing directories survive expansion, sorted for deterministic root lists. Not-yet-existing patterns are allowed, so instances created later are picked up without touching the setting again.
- Wired into `computeClaudeProjectRoots` — the single source shared by scan/cache/tests. `normalizedRoots` still folds overlaps with the default roots, so a redundant entry costs nothing.
- The settings field shows a live "matches N folders" count, so a typo is visible immediately instead of waiting a refresh cycle. Changing the value invalidates the roots cache and triggers a refresh.
- ko/en/ja strings added.

A whole per-account layout is covered with one wildcard entry (e.g. `<base>/instances/*/projects`); any other custom layout works the same way — no tool-specific code or dependency added.

## Verification

- New tests: glob expansion / existence filtering / ordering (`testCustomScanRootsExpandGlobAndKeepOnlyExistingDirs`), union with defaults and no-op without a value (`testComputeRootsUnionCustomRootsAndDefaultUnchangedWithoutValue`). Full suite: 620 tests, 0 failures.
- Real-machine E2E: with one wildcard entry covering an isolated per-account layout, the menu total matched an independent re-aggregation of all transcripts (same local-day window, keep-max dedup on `(message.id, requestId)`) to the exact token; with the setting empty, behavior is unchanged.

## Notes

- Default behavior is untouched — with the setting empty, the root list is identical to before.
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
