### PR TITLE
test: cover every AppLanguage in the localization guards

### DIFF
--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -197,8 +197,10 @@ final class FloatingPetEnergyTests: XCTestCase {
                                         l.percentRemaining(TokenFormatter.percent(58))))
     }
 
-    /// Japanese (and ko/en) alert copy must fit the default bubble panel — width-capped wrap,
+    /// Alert copy in *every* language must fit the default bubble panel — width-capped wrap,
     /// not intrinsic `.fixedSize` that clipped ja by ~9pt (owner review on #124).
+    /// Iterate `allCases`, never a literal list: a hardcoded `[.ko, .en, .ja]` silently stopped
+    /// covering Spanish the moment #159 landed, which is exactly when a layout guard matters.
     func testLocalizedAlertBubbleFitsDefaultPanel() {
         let pet: CGFloat = 96
         let panel = FloatingPetController.panelSize(petSize: pet, showingBubble: true)
@@ -210,7 +212,7 @@ final class FloatingPetEnergyTests: XCTestCase {
             FloatingPetController.bubbleMinWidth,
             "content column + horizontal padding must equal panel width")
 
-        for lang in [AppLanguage.ko, .en, .ja] {
+        for lang in AppLanguage.allCases {
             let l = L(lang)
             let title = l.notifCritical
             let body = l.notifBody(l.claudeFiveHour, TokenFormatter.percent(85))

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -689,8 +689,9 @@ final class SaveTransferTests: XCTestCase {
 
     /// 매핑이 어긋나면 `SaveTransferError` 는 LocalizedError 가 아니라 "The operation couldn't be
     /// completed. (PokeTokenBar.SaveTransferError error 0.)" 가 그대로 사용자에게 뜬다.
+    /// 언어는 `allCases` 로 돈다 — 리터럴 목록은 언어가 늘어난 순간 조용히 커버를 멈춘다.
     func testImportErrorMessagesAreLocalizedNotRawSwiftText() {
-        for lang in [AppLanguage.ko, .en, .ja] {
+        for lang in AppLanguage.allCases {
             let l = L(lang)
             let notSave = l.importErrorMessage(SaveTransferError.notASaveFile)
             let newer = l.importErrorMessage(SaveTransferError.newerSchema(found: 2, supported: 1))


### PR DESCRIPTION
## Summary

Two tests enumerated the UI languages literally (`for lang in [AppLanguage.ko, .en, .ja]`), so both
silently stopped covering every language when Spanish landed in #159. They now iterate
`AppLanguage.allCases`, which is what `RareCandyTests` already does.

* `Tests/PokeTokenBarTests/PerformanceTests.swift` — `testLocalizedAlertBubbleFitsDefaultPanel`.
  This is the guard added after Japanese alert copy clipped the bubble by ~9pt (#124), so a language
  dropping out of it is the worst place for the gap.
* `Tests/PokeTokenBarTests/SaveTransferTests.swift` — `testImportErrorMessagesAreLocalizedNotRawSwiftText`.

Spanish passes both guards as they stand, so this closes a coverage gap rather than fixing a defect.
No source changes.

## Verification

* Both tests pass with `allCases` (Spanish included).
* Guard sensitivity checked by injecting a defect rather than trusting a green run: replacing the
  Spanish 5-hour-session label with progressively longer copy, the bubble guard stays green through a
  three-line body (measured height 69pt vs the 70pt headroom limit) and fails at four lines (81pt).
  So it catches copy that overflows the panel, not copy that merely exceeds the view's `lineLimit(2)`.
  Tightening that is a separate question and is left out of this PR.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Other: test coverage

## UI changes

None — tests only.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed
- [x] Tests were added or updated for this change
