### PR TITLE
test: pin the locale when asserting grouped numbers

### DIFF
--- a/Sources/PokeTokenBar/Core/TokenFormatter.swift
+++ b/Sources/PokeTokenBar/Core/TokenFormatter.swift
@@ -18,9 +18,15 @@ enum TokenFormatter {
     }
 
     /// 팝오버 상세용 천 단위 구분 (190,612,940)
-    static func grouped(_ value: Int) -> String {
+    ///
+    /// 구분기호는 macOS 관례대로 *시스템 지역 설정*(`Locale.current`)을 따른다 — 앱 언어가 아니다.
+    /// (en/ko/ja `253,412,890` · es/de `253.412.890` · fr/ru `253 412 890`)
+    /// `locale` 파라미터는 그 관례를 바꾸려는 게 아니라 테스트가 러너의 지역 설정에 좌우되지 않게
+    /// 하려고 있다 — 기본값을 쓰면 프로덕션 동작은 그대로다.
+    static func grouped(_ value: Int, locale: Locale = .current) -> String {
         let f = NumberFormatter()
         f.numberStyle = .decimal
+        f.locale = locale
         return f.string(from: NSNumber(value: value)) ?? "\(value)"
     }
 

--- a/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
@@ -701,8 +701,15 @@ final class LocalUsageCacheTests: XCTestCase {
     }
 
     /// 포매터 — grouped/cost/costCompact 경계값(메뉴바·팝오버 표기 계약).
+    ///
+    /// `grouped` 는 로케일을 명시해 단언한다. 기본값(`Locale.current`)으로 두면 쉼표를 쓰지 않는
+    /// 지역 설정의 기여자 머신에서만 빨갛게 뜬다(`253 412 890` — PR #160 보고). CI(en_US)와
+    /// 국내 머신(ko_KR)은 둘 다 쉼표라 이 실패를 영영 못 본다.
+    /// cost/costCompact/percent 는 `String(format:)` 이라 로케일과 무관하다.
     func testFormatterEdges() {
-        XCTAssertEqual(TokenFormatter.grouped(253_412_890), "253,412,890")
+        XCTAssertEqual(TokenFormatter.grouped(253_412_890, locale: Locale(identifier: "en_US")), "253,412,890")
+        // 구분기호가 지역 설정을 따르는지 — locale 인자가 무시되면 여기서 걸린다.
+        XCTAssertEqual(TokenFormatter.grouped(253_412_890, locale: Locale(identifier: "es_ES")), "253.412.890")
         XCTAssertEqual(TokenFormatter.cost(48.104), "$48.10")
         XCTAssertEqual(TokenFormatter.costCompact(9.54), "$9.5")     // < 100 → 소수 1자리
         XCTAssertEqual(TokenFormatter.costCompact(311.4), "$311")    // < 10K → 정수


### PR DESCRIPTION
## Summary

`TokenFormatter.grouped` builds a `NumberFormatter` without setting a locale, so grouping follows the
**system region setting**. That is the macOS convention and this PR does not change it — the popover
and the floating-pet tooltip keep formatting exactly as before.

The problem was the assertion. `testFormatterEdges` hardcoded `"253,412,890"`, so the suite turned red
for any contributor whose region groups differently — `253 412 890` in fr/ru, `253.412.890` in es/de.
It surfaced while reviewing #160, where the contributor reported that failure and correctly identified
it as unrelated to their change. CI runs on `en_US` and my machine is `ko_KR`, both comma-grouping, so
neither ever sees it; the red suite looks like the contributor's fault.

* `grouped(_:locale:)` now takes an explicit locale, defaulting to `.current`. Production call sites
  are untouched, so behaviour is identical.
* The test pins `en_US` instead of inheriting the runner's region, and adds an `es_ES` case so the
  argument cannot be silently ignored.

## Verification

* `./scripts/test-gate.sh` — 625 tests, 0 failures, logic-core line coverage 89.70%.
* Guard checked by injecting the defect rather than trusting a green run: removing `f.locale = locale`
  makes the new `es_ES` assertion fail (`"253,412,890"` vs `"253.412.890"`); restoring it passes.
* Swept the rest of the suite for the same class — `grouped` was the only locale-sensitive assertion.
  `cost`, `costCompact`, `percent` and `compact` all use `String(format:)`, which is locale-independent,
  and date formatting in `Sources` already pins `en_US_POSIX`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Other: test determinism

## UI changes

None — grouping still follows the system region.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed
- [x] Tests were added or updated for this change
