### PR TITLE
feat: add track Kiro CLI usage

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI）を、macOS メニューバーの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
+PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI）を、macOS メニューバーの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
 
-> トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI データから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
+> トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI データから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
 
 ## なぜ
 
@@ -33,7 +33,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 
 ## しくみ
 
-1. 🥚 **いつも通りコーディング。** Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI で使うトークンがタマゴを温めます — 追加の操作は不要です。
+1. 🥚 **いつも通りコーディング。** Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI で使うトークンがタマゴを温めます — 追加の操作は不要です。
 2. 🐣 **孵化。** [PokéAPI](https://pokeapi.co/) の**第1〜5世代すべての進化系統（起点329種）**から、公式の捕獲率で重み付けされて生まれます — よくいるポケモンは頻繁に、伝説は129回に1回。孵化したポケモンは育成中もすぐに **図鑑** に表示されます。孵化ごとに25種類のせいかくがひとつ決まり — **ごくまれな偶然で ✨ 色違いが生まれます**。
 3. ⚡ **進化。** コーディングを続けると実際の進化ツリー（1/2/3段階、分岐）に沿って育ち、各段階で小さな演出が流れます。
 4. 🎓 **卒業 & 収集。** 最終進化 + 閾値で **図鑑** に永久保存されます — レアなほど時間がかかり（ヘビーユーザーで common ≈3日 → legendary ≈24日）— 新しいタマゴが届きます。
@@ -97,7 +97,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 ## そのほかにも
 
 - **インタラクティブなフローティングペット** — ホバーで今日の使用量、クリックでメイン画面、右クリックでメニュー。上限アラートは吹き出しでも表示。
-- **サービス別タブ** — Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI のうち2つ以上が検出されると、小さなタブでサービス別の詳細を切替（今日の合計は合算のまま）。
+- **サービス別タブ** — Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI のうち2つ以上が検出されると、小さなタブでサービス別の詳細を切替（今日の合計は合算のまま）。
 - **公式の上限** — Claude・Codex の5時間／週間使用率とリセットのカウントダウンを、今日の数字のすぐ下に。
 - **消費予測** — 現在の5時間ウィンドウが100%に達する時刻を予測。
 - **アプリ内アップデート** — ワンクリックの更新確認、設定に現在のバージョンを表示。
@@ -115,6 +115,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 | **Cursor** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Grok CLI** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Copilot CLI** | 今日 · 5時間ブロック · 週 · 月 | — |
+| **Kiro CLI** | 今日 · 5時間ブロック · 週 · 月 | — (推定値) |
 
 すべてローカルから読み取り — 外部の使用量CLIは不要。ツール追加はプロバイダーファイル1つで完結します（[CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) 参照）。
 
@@ -122,7 +123,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 
 ### 必要条件
 
-macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI データから直接読み取り、外部の使用量 CLI は不要です。
+macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI データから直接読み取り、外部の使用量 CLI は不要です。
 
 ### Homebrew
 
@@ -164,6 +165,7 @@ swift test                   # ユニットテスト
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite 読み取り専用；`cursorDiskKV` バブルエントリの `tokenCount` |
 | `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` レコード（ターン単位の `usage`、サーバー報告のコスト）；`$GROK_HOME` を設定していればそのパス；サブエージェントのセッションは親ターンに合算済みのため除外 |
 | `~/.copilot/session-store.db` | Copilot CLI daily/blocks/weekly/monthly | SQLite 読み取り専用；`assistant_usage_events` の1行が API 呼び出し1回；`$COPILOT_HOME` を設定していればそのパス；`input_tokens` にキャッシュ分が含まれるため cache read/write を差し引いて集計；premium request 課金のためコストは推定しない |
+| `~/Library/Application Support/kiro-cli/data.sqlite3` | Kiro CLI daily/blocks/weekly/monthly | SQLite 読み取り専用；会話履歴 JSON（`conversations`/`conversations_v2`）；Kiro のローカル DB は実際のトークン数を記録せず、サーバー側セッションも無いため、input は毎ターン再送される累積会話テキストをバイト÷4 で**推定**（output は実際のストリーミング応答バイトから算出）；`/clear`・圧縮で消えた会話の集計済みトークンはアプリ再起動まで数え続ける；コストは推定しない |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 公式 5h/週間 % | 非公式 endpoint；Keychain は**更新ボタンを押した時のみ**読み取り — 自動更新では読みません |
 | `codex app-server` | Codex 公式 5h/週間 % | ローカル子プロセス；アカウント snapshot のみ、モデル turn なし |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | ポケモンの種・進化 | ランタイム取得；ローカルキャッシュ、バンドルしない |
@@ -173,7 +175,7 @@ swift test                   # ユニットテスト
 
 ## プライバシー & 権限
 
-- **オンデバイス。** トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI データから直接読み取ります。使用量のアップロードも、モデルの推論実行も行いません。
+- **オンデバイス。** トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI データから直接読み取ります。使用量のアップロードも、モデルの推論実行も行いません。
 - **外部リクエスト。** 本アプリは完全オフラインではありません。7つのホストに接続します — `pokeapi.co`・`graphql.pokeapi.co`（種・進化）、`raw.githubusercontent.com`（スプライト）、`api.anthropic.com`（Claude 公式の上限）、`status.claude.com`・`status.openai.com`（障害バナー — 設定でオフ可）、`api.github.com`（アップデート確認）。**いずれのリクエストにも使用量・トークン・プロンプト・プロジェクトのパスは含まれません** — 送られるのはリクエストそのものだけです。
 - **Keychain（任意）。** Claude OAuth 資格情報は**更新ボタンを押した時のみ**読み取ります（設定、またはポップオーバーの上限行）。自動更新では Keychain に触れないためパスワードのプロンプトは表示されず、`~/.claude/.credentials.json` があればそちらから取得します。トークンはメモリ上にのみ保持し、**アプリ自身の Keychain 項目は作成しません。** トークンが期限切れになると、上限は更新するまで以前の値（stale）として表示されます。設定でオフにすると上限セクションが非表示になります。
 - **ポケモンのアセット** はランタイムに PokéAPI から取得し、`~/Library/Application Support/PokeTokenBar/` にのみキャッシュされます。アプリのバイナリおよびリリース成果物にポケモンのアセットは含まれません。

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · Antigravity · OpenCode · Hermes Agent · Cursor · Grok CLI · Copilot CLI)을 macOS 메뉴바 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
+PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · Antigravity · OpenCode · Hermes Agent · Cursor · Grok CLI · Copilot CLI · Kiro CLI)을 macOS 메뉴바 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
 
-> 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI 데이터에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
+> 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 데이터에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
 
 ## 왜
 
@@ -33,7 +33,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 
 ## 어떻게 자라나요
 
-1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
+1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
 2. 🐣 **부화.** [PokéAPI](https://pokeapi.co/)의 **1~5세대 모든 진화 계보(시작점 329종)**에서 공식 capture rate 가중으로 태어납니다 — 흔한 포켓몬은 자주, 전설은 부화 129번에 1번. 부화한 포켓몬은 키우는 동안에도 **도감**에 바로 나타납니다. 부화마다 25종 성격 중 하나가 정해지고 — **아주 특별한 우연으론 ✨ 이로치가 태어납니다**.
 3. ⚡ **진화.** 계속 코딩하면 실제 진화 트리(1/2/3단, 분기)를 따라 자라고, 단계마다 작은 연출이 반겨줍니다.
 4. 🎓 **졸업 & 수집.** 최종 진화 + 임계 도달 시 **도감**에 영구 보존됩니다 — 희귀할수록 오래 걸리고(헤비 유저 기준 common ≈3일 → legendary ≈24일) — 새 알이 도착합니다.
@@ -97,7 +97,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 ## 이 밖에도
 
 - **인터랙티브 플로팅 펫** — 호버로 오늘 사용량, 클릭으로 메인 창, 우클릭 메뉴; 한도 알림은 말풍선으로도 표시.
-- **서비스별 탭** — Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI 중 2개 이상 감지되면 작은 탭으로 상세를 서비스별 전환(오늘 합계는 통합 유지).
+- **서비스별 탭** — Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 중 2개 이상 감지되면 작은 탭으로 상세를 서비스별 전환(오늘 합계는 통합 유지).
 - **공식 한도** — Claude·Codex 5시간/주간 사용률 + 리셋 카운트다운을 오늘 숫자 바로 아래에.
 - **소진 예측** — 현재 5시간 창이 100%에 도달할 시각 예측.
 - **인앱 업데이트** — 원클릭 업데이트 확인, 설정에 현재 버전 표시.
@@ -115,6 +115,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 | **Cursor** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Grok CLI** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Copilot CLI** | 오늘 · 5시간 블록 · 주 · 월 | — |
+| **Kiro CLI** | 오늘 · 5시간 블록 · 주 · 월 | — (추정치) |
 
 모두 로컬에서 읽습니다 — 외부 사용량 CLI 불필요. 도구 추가는 프로바이더 파일 하나면 됩니다([CONTRIBUTING.ko.md](CONTRIBUTING.ko.md) 참고).
 
@@ -122,7 +123,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 
 ### 요구사항
 
-macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI 데이터에서 직접 읽으며 외부 사용량 CLI가 필요 없습니다.
+macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 데이터에서 직접 읽으며 외부 사용량 CLI가 필요 없습니다.
 
 ### Homebrew
 
@@ -164,6 +165,7 @@ swift test                   # 단위 테스트
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite 읽기 전용; `cursorDiskKV` 버블 엔트리의 `tokenCount` |
 | `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` 레코드(턴 단위 `usage`, 서버 보고 비용); `$GROK_HOME` 설정 시 그 경로; 서브에이전트 세션은 토큰이 부모 턴에 이미 포함돼 제외 |
 | `~/.copilot/session-store.db` | Copilot CLI daily/blocks/weekly/monthly | SQLite 읽기 전용; `assistant_usage_events` 1행 = API 호출 1건; `$COPILOT_HOME` 설정 시 그 경로; `input_tokens` 에 캐시 프롬프트가 이미 포함돼 캐시 read/write 를 빼고 집계; premium request 과금이라 비용은 추정하지 않음 |
+| `~/Library/Application Support/kiro-cli/data.sqlite3` | Kiro CLI daily/blocks/weekly/monthly | SQLite 읽기 전용; 대화 히스토리 JSON(`conversations`/`conversations_v2`); Kiro 로컬 DB 는 실제 토큰 수를 저장하지 않고 서버 측 세션도 없어, input 은 매 턴 재전송되는 누적 대화 텍스트를 바이트÷4 로 **추정**(output 은 실제 스트리밍 응답 바이트 기준); `/clear`·압축으로 지워진 대화의 이미 집계된 토큰은 앱을 재시작하기 전까지는 계속 집계됨; 비용은 추정하지 않음 |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 공식 5h/주간 % | 비공식 endpoint; Keychain 은 **갱신 버튼을 누를 때만** 읽음 — 자동 폴링은 읽지 않음 |
 | `codex app-server` | Codex 공식 5h/주간 % | 로컬 자식 프로세스; 계정 snapshot만, 모델 turn 없음 |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | 포켓몬 종·진화 | 런타임 fetch; 로컬 캐시, 번들 안 함 |
@@ -173,7 +175,7 @@ swift test                   # 단위 테스트
 
 ## 프라이버시 & 권한
 
-- **온디바이스.** 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI 데이터에서 직접 읽습니다. 사용량을 업로드하거나 모델 turn을 실행하지 않습니다.
+- **온디바이스.** 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 데이터에서 직접 읽습니다. 사용량을 업로드하거나 모델 turn을 실행하지 않습니다.
 - **외부 요청.** 앱은 완전 오프라인이 아닙니다. 7개 호스트에 접속합니다 — `pokeapi.co`·`graphql.pokeapi.co`(종·진화), `raw.githubusercontent.com`(스프라이트), `api.anthropic.com`(Claude 공식 한도), `status.claude.com`·`status.openai.com`(장애 배너 — 설정에서 끌 수 있음), `api.github.com`(업데이트 확인). **어느 요청에도 사용량·토큰·프롬프트·프로젝트 경로는 담기지 않습니다** — 요청 자체만 나갑니다.
 - **Keychain(선택).** Claude OAuth 자격증명은 **갱신 버튼을 누를 때만** 읽습니다(설정, 또는 팝오버의 한도 행). 자동 폴링은 Keychain 을 건드리지 않으므로 비밀번호 프롬프트가 뜨지 않고, `~/.claude/.credentials.json` 이 있으면 그쪽에서 가져옵니다. 토큰은 메모리에만 두며 **앱 자체 Keychain 항목은 만들지 않습니다.** 토큰이 만료되면 한도는 갱신 전까지 이전 값(stale)으로 표시됩니다. 설정에서 끄면 한도 섹션만 숨겨집니다.
 - **포켓몬 에셋**은 런타임에 PokéAPI에서 받아오며 `~/Library/Application Support/PokeTokenBar/`에만 캐시됩니다. 앱 바이너리와 릴리스 아티팩트에는 포켓몬 에셋이 포함되지 않습니다.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI & Copilot CLI — into a growing **Pokémon companion** in your macOS menu bar. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
+PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI & Kiro CLI — into a growing **Pokémon companion** in your macOS menu bar. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
 
-> Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, and Copilot CLI data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
+> Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
 
 ## Why
 
@@ -33,7 +33,7 @@ PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, 
 
 ## How it works
 
-1. 🥚 **Code as usual.** The tokens you burn in Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, or Copilot CLI incubate an egg — nothing extra to run.
+1. 🥚 **Code as usual.** The tokens you burn in Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, or Kiro CLI incubate an egg — nothing extra to run.
 2. 🐣 **Hatch.** Eggs hatch into Pokémon with real evolution lines from [PokéAPI](https://pokeapi.co/) — any Gen 1–5 line (329 possible starts), weighted by the official capture rate: commons hatch often, a legendary is a 1-in-129 event. It appears in your **Pokédex** immediately while you raise it. Every hatch rolls one of 25 natures — and once in a rare while, the egg hatches **✨ Shiny**.
 3. ⚡ **Evolve.** Keep coding and it grows through its actual evolution tree (1/2/3 stages, branching), with a little flash celebration at each step.
 4. 🎓 **Graduate & collect.** Final form + threshold permanently archives it in your **Pokédex** — rarer takes longer (≈3 days common → ≈24 days legendary at heavy use) — and a fresh egg arrives.
@@ -97,7 +97,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 ## Also in the box
 
 - **Interactive floating pet** — hover for today's usage, click to open the main window, right-click for a menu; limit alerts can pop up as speech bubbles.
-- **Per-service tabs** — when two or more of Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, and Copilot CLI are detected, compact tabs switch between them; today's total stays combined.
+- **Per-service tabs** — when two or more of Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI are detected, compact tabs switch between them; today's total stays combined.
 - **Official limits** — Claude & Codex 5-hour / weekly utilization with reset countdowns, right under today's numbers.
 - **Burn-rate forecast** — projects when the current 5h window hits 100%.
 - **In-app updates** — one-click update check; current version shown in Settings.
@@ -115,6 +115,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 | **Cursor** | today · 5h block · week · month | — |
 | **Grok CLI** | today · 5h block · week · month | — |
 | **Copilot CLI** | today · 5h block · week · month | — |
+| **Kiro CLI** | today · 5h block · week · month | — (estimated) |
 
 All read locally — no external usage CLI required. Adding a tool is one provider file (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 
@@ -122,7 +123,7 @@ All read locally — no external usage CLI required. Adding a tool is one provid
 
 ### Requirements
 
-macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, and Copilot CLI data, with no external usage CLI required.
+macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data, with no external usage CLI required.
 
 ### Homebrew
 
@@ -164,6 +165,7 @@ swift test                   # unit tests
 | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor daily/blocks/weekly/monthly | SQLite read-only; `cursorDiskKV` bubble entries with `tokenCount` |
 | `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` records (per-turn `usage`, server-reported cost); honours `$GROK_HOME`; subagent sessions are skipped because their tokens are already folded into the parent turn |
 | `~/.copilot/session-store.db` | Copilot CLI daily/blocks/weekly/monthly | SQLite read-only; one `assistant_usage_events` row per API call; honours `$COPILOT_HOME`; `input_tokens` already contains the cached prompt, so cache reads/writes are subtracted; premium-request billing, so no cost is estimated |
+| `~/Library/Application Support/kiro-cli/data.sqlite3` | Kiro CLI daily/blocks/weekly/monthly | SQLite read-only; conversation history JSON (`conversations`/`conversations_v2`); Kiro's local database never records real token counts, and there is no server-side session, so input is a bytes÷4 **estimate** of the accumulated conversation text resent on every turn (output likewise from the real streamed response size); a `/clear`d or compacted conversation's already-counted tokens stay counted until the app restarts; no cost is estimated |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude official 5h/weekly % | unofficial endpoint; the Keychain is read **only when you press refresh** — auto-polling never reads it |
 | `codex app-server` | Codex official 5h/weekly % | local child process; account snapshot only, no model turn |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | Pokémon species &amp; evolution | runtime fetch; cached locally, never bundled |
@@ -173,7 +175,7 @@ swift test                   # unit tests
 
 ## Privacy & permissions
 
-- **On-device.** Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, and Copilot CLI data. The app never uploads usage or runs model turns.
+- **On-device.** Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data. The app never uploads usage or runs model turns.
 - **Outbound requests.** The app is not fully offline. It talks to seven hosts: `pokeapi.co` and `graphql.pokeapi.co` (species/evolution), `raw.githubusercontent.com` (sprites), `api.anthropic.com` (Claude official limits), `status.claude.com` and `status.openai.com` (incident banner — off switch in Settings), and `api.github.com` (update check). **None of them carry your usage, tokens, prompts, or project paths** — only the request itself.
 - **Keychain (optional).** The Claude OAuth credential is read **only when you press a refresh button** (Settings, or the limits row in the popover). Automatic polling never touches the Keychain, so it never raises a password prompt; when available, the credential is taken from `~/.claude/.credentials.json` instead. The token is held in memory only — the app creates no Keychain item of its own. Once the token expires, limits stay visible but stale until you refresh. Turn it off in Settings — the limits section simply hides.
 - **Pokémon assets** are fetched at runtime from PokéAPI and cached only under `~/Library/Application Support/PokeTokenBar/`. The app binary and its release artifacts contain no Pokémon assets.

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -6,6 +6,7 @@ private enum LocalAdditionalSource: String, Sendable {
     case hermes
     case cursor
     case copilot
+    case kiro
 }
 
 /// OpenCode usage from its local SQLite database and legacy message files.
@@ -71,6 +72,35 @@ struct LocalCopilotProvider: UsageProvider {
 
     func fetchEnrichment() async -> ProviderEnrichment {
         let entries = await LocalAdditionalUsageCache.shared.entries(for: .copilot)
+        return enrichment(entries: entries)
+    }
+}
+
+/// Kiro CLI usage estimated from its local conversation-history database.
+///
+/// Kiro's `RequestMetadata` (verified against `aws/amazon-q-developer-cli`, the upstream
+/// kiro-cli forks) never persists a token count. Tokens here are a bytes/4 estimate built
+/// from the stored conversation text — see `kiroTurnEntries` for why the ready-made
+/// `user_prompt_length` field can't be used as-is. There is no real dollar figure to
+/// report on top of an estimate (`reportsCost = false`, same reasoning as Copilot).
+///
+/// Kiro also *deletes* turns from its database on `/clear` or compaction (unlike every other
+/// local source here, whose on-disk logs only grow), so this provider merges each scan with
+/// previously-seen entries — see the `.kiro` case in `LocalAdditionalUsageCache`. A cleared
+/// conversation's already-counted tokens stay counted for the rest of the app's process
+/// lifetime, but are lost like any other in-memory cache on the next app restart.
+struct LocalKiroProvider: UsageProvider {
+    let id = "kiro"
+    let displayName = "Kiro"
+    let reportsCost = false
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .kiro)
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey())
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .kiro)
         return enrichment(entries: entries)
     }
 }
@@ -145,6 +175,16 @@ private actor LocalAdditionalUsageCache {
         case .hermes:
             since = periodStart
             afterRowIDByPath = [:]
+        case .kiro:
+            // Kiro rewrites a conversation's whole history JSON in place every turn — there
+            // is no append-only table with a monotonic id to watermark, so every scan
+            // re-reads and re-derives entries (idempotent via the stable per-turn id).
+            // Unlike Hermes' durable `sessions` table, `/clear` and compaction *delete* turns
+            // from Kiro's DB outright, so this source also merges with `existing` below —
+            // a cleared turn must stay counted for the rest of the process lifetime, not
+            // silently drop out of today's total.
+            since = periodStart
+            afterRowIDByPath = [:]
         }
         let existing = previous?.entries ?? []
         let task = Task.detached(priority: .utility) {
@@ -155,6 +195,9 @@ private actor LocalAdditionalUsageCache {
                 return (LocalUsageReader.dedupKeepMax(existing + loaded), [:])
             case .hermes:
                 return (LocalAdditionalUsageReader.hermesEntries(modifiedSince: since), [:])
+            case .kiro:
+                let loaded = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since)
+                return (LocalUsageReader.dedupKeepMax(existing + loaded), [:])
             case .cursor:
                 let loaded = LocalAdditionalUsageReader.cursorEntries(
                     modifiedSince: since, afterRowIDByPath: afterRowIDByPath)
@@ -744,6 +787,140 @@ enum LocalAdditionalUsageReader {
         let time = text.dropFirst(11)
         if !time.contains("Z"), !time.contains("+"), !time.contains("-") { text += "Z" }
         return parseISO8601(text)
+    }
+
+    // MARK: Kiro CLI database
+
+    static var defaultKiroRoots: [URL] {
+        environmentPaths("KIRO_CLI_HOME")
+            ?? [FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Application Support/kiro-cli")]
+    }
+
+    /// Read Kiro CLI usage turns newer than `modifiedSince`.
+    ///
+    /// Kiro persists a conversation as one row whose `value` column holds the *entire*
+    /// history as JSON, rewritten in place on every turn — there is no per-row token count
+    /// (see the type doc on `LocalKiroProvider`) and no append-only id to watermark, so this
+    /// re-parses every stored conversation on every call. Two schema generations coexist:
+    /// `conversations_v2` (kiro-cli < 2.0.1, dedicated `conversation_id`/`key`/timestamp
+    /// columns) and `conversations` (2.0.1+, keyed by working directory; the JSON itself
+    /// carries `conversation_id`). Both wrap the same turn shape, so they share a parser.
+    static func kiroEntries(
+        modifiedSince: Date,
+        roots: [URL]? = nil
+    ) -> [LocalUsageReader.Entry] {
+        let sourceRoots = roots ?? defaultKiroRoots
+        var entries: [LocalUsageReader.Entry] = []
+        for root in sourceRoots {
+            entries += kiroDatabaseEntries(kiroDatabaseURL(from: root), modifiedSince: modifiedSince)
+        }
+        return LocalUsageReader.dedupKeepMax(entries)
+    }
+
+    private static func kiroDatabaseURL(from root: URL) -> URL {
+        root.pathExtension == "sqlite3" ? root : root.appendingPathComponent("data.sqlite3")
+    }
+
+    private static func kiroDatabaseEntries(
+        _ database: URL,
+        modifiedSince: Date
+    ) -> [LocalUsageReader.Entry] {
+        var entries: [LocalUsageReader.Entry] = []
+
+        // kiro-cli < 2.0.1: one row per conversation, with dedicated id/timestamp columns.
+        let v2Rows = query(database, sql: "SELECT conversation_id, value FROM conversations_v2") {
+            statement -> (id: String?, value: String)? in
+            guard let value = columnText(statement, 1) else { return nil }
+            return (columnText(statement, 0), value)
+        }
+        for row in v2Rows ?? [] {
+            guard let object = jsonObject(data: Data(row.value.utf8)) else { continue }
+            let conversationID = row.id ?? stringValue(object["conversation_id"]) ?? database.path
+            entries += kiroTurnEntries(conversationID: conversationID, object: object, modifiedSince: modifiedSince)
+        }
+
+        // kiro-cli 2.0.1+: one row per working directory; the conversation id lives in the JSON.
+        let v1Rows = query(database, sql: "SELECT value FROM conversations") {
+            statement -> String? in columnText(statement, 0)
+        }
+        for value in v1Rows ?? [] {
+            guard let object = jsonObject(data: Data(value.utf8)),
+                  let conversationID = stringValue(object["conversation_id"]) else { continue }
+            entries += kiroTurnEntries(conversationID: conversationID, object: object, modifiedSince: modifiedSince)
+        }
+
+        return entries
+    }
+
+    /// Bytes-per-token used to turn estimated byte counts into an approximate token count.
+    /// There is nothing more precise available locally.
+    private static let kiroBytesPerToken = 4
+
+    /// Kiro has no server-side session — every turn resends the *whole* conversation, so a
+    /// turn's real prompt size is the accumulated history plus its own new user message.
+    /// `request_metadata.user_prompt_length` is **not** that: in kiro-cli's upstream
+    /// (`aws/amazon-q-developer-cli`, `crates/chat-cli/src/cli/chat/parser.rs`) it is assigned
+    /// from `conversation_state.user_input_message.content.len()` — only the bytes the user
+    /// just typed, excluding the resent history entirely. Using it as-is would undercount a
+    /// prompt by orders of magnitude once a conversation has any length. `response_size`
+    /// (`received_response_size`, accumulated from the actual streamed response/tool-input
+    /// bytes) has no such gap and is used as-is for output.
+    private static func kiroTurnEntries(
+        conversationID: String,
+        object: Object,
+        modifiedSince: Date
+    ) -> [LocalUsageReader.Entry] {
+        guard let turns = object["history"] as? [Any] else { return [] }
+        var entries: [LocalUsageReader.Entry] = []
+        // `latest_summary` stands in for turns compaction deleted from `history` — it still
+        // gets resent on every later request, so it seeds the running total (matches the
+        // reference `kiro-usage` tool's `cumulative = summary_tok`).
+        var cumulativeHistoryBytes = kiroJSONValueByteLength(object["latest_summary"] ?? 0)
+        for turn in turns {
+            guard let turnObject = turn as? Object else { continue }
+            let userBytes = kiroFieldByteLength(turnObject["user"])
+            // Bytes must accumulate into history even for turns skipped below (missing
+            // timestamp, outside the window) — later turns still resend them.
+            defer { cumulativeHistoryBytes += userBytes + kiroFieldByteLength(turnObject["assistant"]) }
+
+            guard let meta = turnObject["request_metadata"] as? Object,
+                  // A turn missing its timestamp has nothing stable to key an entry id on —
+                  // skip it rather than invent one, matching the reference `kiro-usage` tool.
+                  let rawTimestamp = doubleValue(meta["request_start_timestamp_ms"]), rawTimestamp > 0,
+                  let date = dateValue(meta["request_start_timestamp_ms"]),
+                  date >= modifiedSince else { continue }
+            let promptBytes = cumulativeHistoryBytes + userBytes
+            guard let entry = makeEntry(
+                id: "kiro|\(conversationID)|\(Int64(rawTimestamp))",
+                date: date,
+                model: stringValue(meta["model_id"]) ?? "unknown",
+                input: promptBytes / kiroBytesPerToken,
+                output: intValue(meta["response_size"]) / kiroBytesPerToken) else { continue }
+            entries.append(entry)
+        }
+        return entries
+    }
+
+    /// Byte length of a turn's `user`/`assistant` field, matching the reference `kiro-usage`
+    /// tool's `_text_len`: sum the stringified value of every key except `images` (a base64
+    /// blob that would otherwise dwarf the actual text and isn't separately token-modeled here).
+    private static func kiroFieldByteLength(_ value: Any?) -> Int {
+        guard let dict = value as? Object else {
+            if let string = value as? String { return string.utf8.count }
+            return 0
+        }
+        return dict.reduce(0) { total, entry in
+            entry.key == "images" ? total : total + kiroJSONValueByteLength(entry.value)
+        }
+    }
+
+    private static func kiroJSONValueByteLength(_ value: Any) -> Int {
+        if let string = value as? String { return string.utf8.count }
+        if let number = value as? NSNumber { return number.stringValue.utf8.count }
+        if let array = value as? [Any] { return array.reduce(0) { $0 + kiroJSONValueByteLength($1) } }
+        if let dict = value as? Object { return dict.values.reduce(0) { $0 + kiroJSONValueByteLength($1) } }
+        return 0
     }
 
     // MARK: Shared utilities

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -397,7 +397,7 @@ final class UsageStore {
     init(providers: [any UsageProvider] = [
         LocalClaudeProvider(), LocalCodexProvider(), LocalGeminiProvider(),
         LocalAntigravityProvider(), LocalOpenCodeProvider(), LocalHermesProvider(),
-        LocalCursorProvider(), LocalGrokProvider(), LocalCopilotProvider(),
+        LocalCursorProvider(), LocalGrokProvider(), LocalCopilotProvider(), LocalKiroProvider(),
     ],
          claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),

--- a/Tests/PokeTokenBarTests/KiroUsageTests.swift
+++ b/Tests/PokeTokenBarTests/KiroUsageTests.swift
@@ -1,0 +1,530 @@
+import SQLite3
+import XCTest
+@testable import PokeTokenBar
+
+final class KiroUsageTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PokeTokenBar-KiroUsageTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+        temporaryDirectory = nil
+    }
+
+    // MARK: - Token accounting
+
+    /// Kiro's `RequestMetadata` never carries a real token count (verified against the
+    /// `aws/amazon-q-developer-cli` source kiro-cli forks). Output is a bytes/4 estimate off
+    /// the real streamed `response_size`; a first turn's input is a bytes/4 estimate off the
+    /// user's own message, since there is no prior history yet to resend.
+    func testFirstTurnInputIsTheUserMessageByteEstimate() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entry.input, 100, "400 bytes / 4 = 100 estimated input tokens")
+        XCTAssertEqual(entry.output, 50, "200 bytes / 4 = 50 estimated output tokens")
+        XCTAssertEqual(entry.cacheRead, 0)
+        XCTAssertEqual(entry.cacheWrite, 0)
+        XCTAssertEqual(entry.model, "claude-sonnet-4.5")
+        XCTAssertEqual(entry.id, "kiro|conv-1|1780000000000")
+    }
+
+    /// Kiro has no server-side session — every turn resends the whole conversation. Using
+    /// only `request_metadata.user_prompt_length` (just the newly typed message; verified
+    /// against its assignment site in kiro-cli's upstream) would undercount a long-running
+    /// conversation by orders of magnitude, so a later turn's input must include everything
+    /// said before it.
+    func testLaterTurnInputIncludesTheAccumulatedConversationHistory() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400),
+                     assistantText: String(repeating: "a", count: 800),
+                     responseBytes: 800),
+                turn(timestampMs: 1_780_000_100_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 40), responseBytes: 40),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+
+        let second = try XCTUnwrap(entries.first { $0.id == "kiro|conv-1|1780000100000" })
+        XCTAssertEqual(second.input, (400 + 800 + 40) / 4,
+                       "must resend turn 1's user+assistant text plus turn 2's own message")
+    }
+
+    /// A turn skipped for its own entry (outside the window, missing timestamp) still
+    /// happened — later turns in the same conversation still resend its text as history.
+    func testSkippedTurnsStillContributeToLaterHistory() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turnMissingTimestamp(model: "claude-sonnet-4.5",
+                                      userText: String(repeating: "u", count: 400),
+                                      assistantText: String(repeating: "a", count: 400)),
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 40), responseBytes: 40),
+            ]),
+        ])
+
+        let entry = try XCTUnwrap(LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).first)
+        XCTAssertEqual(entry.input, (400 + 400 + 40) / 4)
+    }
+
+    /// `latest_summary` stands in for turns compaction deleted from `history` — it is still
+    /// resent on every later request, so a post-compaction turn must count it as history too,
+    /// not start accumulation from zero.
+    func testLatestSummarySeedsTheAccumulatedHistory() throws {
+        let summaryText = String(repeating: "s", count: 120)
+        let turnJSON = try turnJSONString(
+            turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                 userText: String(repeating: "u", count: 40), responseBytes: 40))
+        let json = """
+        {"conversation_id":"conv-1","latest_summary":["\(summaryText)"],"history":[\(turnJSON)]}
+        """
+        try seedV2Raw(rows: [(id: "conv-1", value: json)])
+
+        let entry = try XCTUnwrap(LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).first)
+        XCTAssertEqual(entry.input, (120 + 40) / 4)
+    }
+
+    // MARK: - Rescan stability
+
+    /// The `.kiro` cache case merges each scan with previously-seen entries
+    /// (`dedupKeepMax(existing + loaded)`) instead of replacing them, because Kiro deletes
+    /// turns from its DB on `/clear`/compaction. That merge only behaves if two scans of an
+    /// unchanged database agree on entry ids — otherwise it would double rather than merge.
+    func testRescanningTheSameDatabaseProducesStableEntryIDs() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400),
+                     assistantText: String(repeating: "a", count: 200), responseBytes: 200),
+                turn(timestampMs: 1_780_000_100_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 40), responseBytes: 40),
+            ]),
+        ])
+        let since = try date("2026-01-01T00:00:00Z")
+
+        let first = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+
+        XCTAssertEqual(Set(first.map(\.id)), Set(second.map(\.id)))
+        XCTAssertEqual(LocalUsageReader.dedupKeepMax(first + second).count, first.count,
+                       "merging two identical scans must not double the entries")
+    }
+
+    func testMissingModelIDFallsBackToUnknown() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: nil,
+                     userText: String(repeating: "u", count: 40), responseBytes: 40),
+            ]),
+        ])
+
+        let entry = try XCTUnwrap(LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).first)
+        XCTAssertEqual(entry.model, "unknown")
+    }
+
+    /// A turn whose prompt and response were both empty carries no signal — `makeEntry`'s
+    /// shared zero-token guard drops it, same as every other local provider.
+    func testZeroByteTurnsAreSkipped() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: "", responseBytes: 0),
+                turn(timestampMs: 1_780_000_001_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 4), responseBytes: 0),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertEqual(entries.map(\.id), ["kiro|conv-1|1780000001000"])
+    }
+
+    /// A base64 `images` blob would otherwise dwarf the actual text — it is excluded from the
+    /// byte estimate rather than silently inflating every turn after it.
+    func testImagesFieldIsExcludedFromTheByteEstimate() throws {
+        var userField: [String: Any] = ["content": String(repeating: "u", count: 40)]
+        userField["images"] = [String(repeating: "x", count: 1_000_000)]
+        let turnObject: [String: Any] = [
+            "user": userField, "assistant": [:],
+            "request_metadata": [
+                "request_start_timestamp_ms": 1_780_000_000_000,
+                "model_id": "claude-sonnet-4.5",
+                "response_size": 40,
+            ],
+        ]
+        try seedV2(conversations: [(id: "conv-1", turns: [turnObject])])
+
+        let entry = try XCTUnwrap(LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).first)
+        XCTAssertEqual(entry.input, 10, "only the 40-byte `content` field counts, not the image blob")
+    }
+
+    // MARK: - Timestamps / windowing
+
+    /// A turn without `request_start_timestamp_ms` has nothing stable to key an entry id on,
+    /// so it must be skipped rather than assigned a made-up id.
+    func testTurnsMissingTimestampAreSkipped() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turnMissingTimestamp(model: "claude-sonnet-4.5",
+                                      userText: String(repeating: "u", count: 400)),
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertEqual(entries.count, 1)
+    }
+
+    func testTurnsBeforeTheWindowAreExcluded() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_766_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+                turn(timestampMs: 1_767_500_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: date(fromMillis: 1_767_000_000_000), roots: [temporaryDirectory])
+        XCTAssertEqual(entries.map(\.id), ["kiro|conv-1|1767500000000"])
+    }
+
+    /// A turn object missing `request_metadata` entirely (or a malformed history array) must
+    /// not crash the scan — it is simply skipped, same as any other unparseable turn.
+    func testConversationWithoutRequestMetadataIsSkipped() throws {
+        let json = """
+        {"conversation_id":"conv-1","history":[{"user":{},"assistant":{}}]}
+        """
+        try seedV2Raw(rows: [(id: "conv-1", value: json)])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    // MARK: - Schema generations
+
+    /// kiro-cli < 2.0.1 stores each conversation as its own row in `conversations_v2` with a
+    /// dedicated `conversation_id` column.
+    func testReadsTheV2ConversationsTable() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertEqual(entries.map(\.id), ["kiro|conv-1|1780000000000"])
+    }
+
+    /// kiro-cli 2.0.1+ keys `conversations` by working directory and drops the dedicated
+    /// timestamp/id columns — the conversation id must be read out of the JSON body instead.
+    func testReadsTheV1ConversationsTable() throws {
+        try seedV1(conversations: [
+            (cwd: "/Users/dev/project", id: "conv-2", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 800), responseBytes: 400),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entry.id, "kiro|conv-2|1780000000000")
+        XCTAssertEqual(entry.input, 200)
+        XCTAssertEqual(entry.output, 100)
+    }
+
+    /// A `conversations` (v1) row whose JSON has no `conversation_id` cannot be keyed at all
+    /// — it must be dropped, not counted under a made-up or empty id.
+    func testV1RowWithoutConversationIDIsSkipped() throws {
+        let json = """
+        {"history":[{"request_metadata":{"request_start_timestamp_ms":1780000000000,\
+        "model_id":"claude-sonnet-4.5","response_size":200}}]}
+        """
+        try seedV1Raw(rows: [(cwd: "/Users/dev/project", value: json)])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    /// A row whose `value` is not parseable JSON (write torn mid-checkpoint, hand edit, future
+    /// schema this reader doesn't understand yet) must be skipped, not crash the scan — the same
+    /// external-file resilience every other local reader in this file gets.
+    func testMalformedJSONRowsAreSkippedInBothSchemas() throws {
+        try seedV2Raw(rows: [(id: "conv-1", value: "{not valid json")])
+        try seedV1Raw(rows: [(cwd: "/Users/dev/project", value: "{not valid json")])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    /// A conversation JSON without a `history` array (unexpected shape, not just an empty one)
+    /// must not crash — it simply contributes no turns.
+    func testConversationWithoutHistoryArrayIsSkipped() throws {
+        try seedV2Raw(rows: [(id: "conv-1", value: #"{"conversation_id":"conv-1"}"#)])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    /// Both schema generations can be present at once during a kiro-cli upgrade. If the same
+    /// conversation is mid-migration and shows up in both tables, it must not be double-counted.
+    func testSameConversationInBothTablesIsNotDoubleCounted() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+            ]),
+        ])
+        try seedV1(conversations: [
+            (cwd: "/Users/dev/project", id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertEqual(entries.count, 1, "the same turn id from both tables must collapse to one entry")
+    }
+
+    /// Two independent conversations, one only in each table, must both be counted — the v1
+    /// table is not just a fallback that stops scanning once v2 has rows.
+    func testConversationsAcrossBothTablesAreBothCounted() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+            ]),
+        ])
+        try seedV1(conversations: [
+            (cwd: "/Users/dev/other-project", id: "conv-2", turns: [
+                turn(timestampMs: 1_780_000_100_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 800), responseBytes: 400),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertEqual(Set(entries.map(\.id)),
+                       ["kiro|conv-1|1780000000000", "kiro|conv-2|1780000100000"])
+    }
+
+    // MARK: - Roots
+
+    func testAcceptsADirectDatabasePathAsRoot() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory.appendingPathComponent("data.sqlite3")])
+        XCTAssertEqual(entries.count, 1)
+    }
+
+    func testNonexistentRootReturnsNothing() {
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: .distantPast, roots: [URL(fileURLWithPath: "/nonexistent/kiro-cli/home")])
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    func testDefaultRootIsTheKiroCliHome() {
+        let expected = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/kiro-cli")
+        let roots = LocalAdditionalUsageReader.defaultKiroRoots
+        if ProcessInfo.processInfo.environment["KIRO_CLI_HOME"] == nil {
+            XCTAssertEqual(roots, [expected])
+        }
+        XCTAssertFalse(roots.isEmpty)
+    }
+
+    // MARK: - Aggregation
+
+    func testDailyAggregatesEveryTurnOfTheDay() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 400), responseBytes: 200),
+                turn(timestampMs: 1_780_000_100_000, model: "claude-sonnet-4.5",
+                     userText: "", responseBytes: 40),
+            ]),
+        ])
+
+        let entries = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        let day = try XCTUnwrap(entries.first?.localDay)
+        let daily = try XCTUnwrap(LocalUsageReader.daily(entries: entries, localDay: day))
+        XCTAssertEqual(daily.totalTokens, entries.reduce(0) { $0 + $1.total })
+    }
+
+    // MARK: - Provider identity
+
+    func testLocalKiroProviderIdentity() {
+        let provider = LocalKiroProvider()
+        XCTAssertEqual(provider.id, "kiro")
+        XCTAssertEqual(provider.displayName, "Kiro")
+        XCTAssertFalse(provider.reportsCost, "tokens are a bytes/4 estimate — no real dollar cost to report")
+    }
+
+    // MARK: - Fixture construction
+
+    private func turn(
+        timestampMs: Int64, model: String?,
+        userText: String, assistantText: String = "", responseBytes: Int = 0
+    ) -> [String: Any] {
+        var metadata: [String: Any] = [
+            "request_start_timestamp_ms": timestampMs,
+            "response_size": responseBytes,
+            "time_between_chunks": [],
+            "tool_use_ids_and_names": [],
+        ]
+        if let model { metadata["model_id"] = model }
+        return [
+            "user": ["content": userText], "assistant": ["content": assistantText],
+            "request_metadata": metadata,
+        ]
+    }
+
+    private func turnMissingTimestamp(model: String?, userText: String, assistantText: String = "") -> [String: Any] {
+        var metadata: [String: Any] = ["response_size": 0]
+        if let model { metadata["model_id"] = model }
+        return [
+            "user": ["content": userText], "assistant": ["content": assistantText],
+            "request_metadata": metadata,
+        ]
+    }
+
+    private func conversationJSON(id: String, turns: [[String: Any]]) throws -> String {
+        let object: [String: Any] = ["conversation_id": id, "history": turns, "latest_summary": NSNull()]
+        let data = try JSONSerialization.data(withJSONObject: object)
+        return String(data: data, encoding: .utf8)!
+    }
+
+    /// A single turn dict, serialized standalone for hand-assembling a conversation JSON
+    /// string (used when a test needs to control `latest_summary` directly).
+    private func turnJSONString(_ turn: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: turn)
+        return String(data: data, encoding: .utf8)!
+    }
+
+    private func date(_ value: String) throws -> Date {
+        try XCTUnwrap(ISO8601DateFormatter().date(from: value))
+    }
+
+    private func date(fromMillis ms: Int64) -> Date {
+        Date(timeIntervalSince1970: Double(ms) / 1000)
+    }
+
+    private var databaseURL: URL {
+        temporaryDirectory.appendingPathComponent("data.sqlite3")
+    }
+
+    private func seedV2(conversations: [(id: String, turns: [[String: Any]])]) throws {
+        let rows = try conversations.map { (id: $0.id, value: try conversationJSON(id: $0.id, turns: $0.turns)) }
+        try seedV2Raw(rows: rows)
+    }
+
+    private func seedV2Raw(rows: [(id: String, value: String)]) throws {
+        try execute(databaseURL, sql: """
+        CREATE TABLE IF NOT EXISTS conversations_v2 (
+            conversation_id TEXT PRIMARY KEY,
+            key TEXT,
+            created_at INTEGER,
+            updated_at INTEGER,
+            value TEXT
+        );
+        """)
+        for row in rows {
+            try insert(
+                databaseURL,
+                sql: "INSERT INTO conversations_v2 (conversation_id, key, created_at, updated_at, value) VALUES (?1, ?2, 0, 0, ?3)",
+                text: [row.id, "/Users/dev/project", row.value])
+        }
+    }
+
+    private func seedV1(conversations: [(cwd: String, id: String, turns: [[String: Any]])]) throws {
+        let rows = try conversations.map {
+            (cwd: $0.cwd, value: try conversationJSON(id: $0.id, turns: $0.turns))
+        }
+        try seedV1Raw(rows: rows)
+    }
+
+    private func seedV1Raw(rows: [(cwd: String, value: String)]) throws {
+        try execute(databaseURL, sql: """
+        CREATE TABLE IF NOT EXISTS conversations (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """)
+        for row in rows {
+            try insert(
+                databaseURL,
+                sql: "INSERT INTO conversations (key, value) VALUES (?1, ?2)",
+                text: [row.cwd, row.value])
+        }
+    }
+
+    private func execute(_ databaseURL: URL, sql: String) throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(databaseURL.path, &database), SQLITE_OK)
+        guard let database else { throw NSError(domain: "SQLite", code: 1) }
+        defer { sqlite3_close(database) }
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
+        let message = errorMessage.map { String(cString: $0) }
+        sqlite3_free(errorMessage)
+        XCTAssertEqual(result, SQLITE_OK, message ?? "SQLite statement failed")
+        if result != SQLITE_OK { throw NSError(domain: "SQLite", code: Int(result)) }
+    }
+
+    private func insert(_ databaseURL: URL, sql: String, text: [String]) throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(databaseURL.path, &database), SQLITE_OK)
+        guard let database else { throw NSError(domain: "SQLite", code: 1) }
+        defer { sqlite3_close(database) }
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(database, sql, -1, &statement, nil), SQLITE_OK)
+        guard let statement else { throw NSError(domain: "SQLite", code: 2) }
+        defer { sqlite3_finalize(statement) }
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        for (index, value) in text.enumerated() {
+            sqlite3_bind_text(statement, Int32(index + 1), value, -1, transient)
+        }
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+    }
+}

--- a/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
+++ b/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
@@ -134,7 +134,7 @@ final class LocalAdditionalUsageTests: XCTestCase {
         XCTAssertEqual(
             Set(store.registeredProviderIDs),
             Set(["claude_code", "codex", "gemini", "antigravity",
-                 "opencode", "hermes", "cursor", "grok", "copilot"]))
+                 "opencode", "hermes", "cursor", "grok", "copilot", "kiro"]))
     }
 
     func testPrintRealOpenCodeAggregate() throws {

--- a/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
@@ -21,7 +21,7 @@ final class ProviderTabLayoutTests: XCTestCase {
     private var allProviders: [ProviderSnapshot] {
         [("claude_code", "Claude Code"), ("codex", "Codex"), ("gemini", "Gemini"),
          ("antigravity", "Antigravity"), ("opencode", "OpenCode"), ("hermes", "Hermes Agent"),
-         ("cursor", "Cursor"), ("grok", "Grok"), ("copilot", "Copilot")]
+         ("cursor", "Cursor"), ("grok", "Grok"), ("copilot", "Copilot"), ("kiro", "Kiro")]
             .map { snapshot($0.0, $0.1) }
     }
 

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -579,6 +579,27 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertNil(store.lastErrorDescription)
     }
 
+    /// [issue #115 DoD] 신규 provider(kiro) 의 snapshot 이 today/week/month/burn 전부에 흘러가는지 확인.
+    /// (파서/스키마 회귀는 KiroUsageTests.swift 담당 — 여기는 store 집계 경로만 본다.)
+    func testKiroSnapshotFlowsThroughTodayWeekMonthAndBurn() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(100_000_000))
+        let kiro = FakeUsageProvider(id: "kiro", displayName: "Kiro", daily: todayDaily(50_000_000), reportsCost: false)
+        kiro.enrichment = ProviderEnrichment(
+            activeBlock: block(tokensPerMinute: 200_000), blocksOK: true,
+            weekTotal: PeriodUsage(period: "w", totalTokens: 90_000_000, totalCost: 0),
+            monthTotal: PeriodUsage(period: "m", totalTokens: 300_000_000, totalCost: 0),
+            periodsOK: true)
+        let store = makeStore(providers: [claude, kiro])
+        await store.refresh(scheduleEmptyRetry: false)
+
+        XCTAssertEqual(store.todayTotalTokens, 150_000_000)
+        XCTAssertEqual(store.todayTokensByProvider["kiro"], 50_000_000)
+        XCTAssertEqual(store.weekTotalTokens, 90_000_000)
+        XCTAssertEqual(store.monthTotalTokens, 300_000_000)
+        XCTAssertEqual(store.burnTier, .fast, "burn 이 kiro 의 활성 블록을 반영")
+        XCTAssertEqual(store.snapshot(preferring: "kiro")?.providerID, "kiro", "탭에 노출됨")
+    }
+
     func testCodexOnlyWhenClaudeHasNoData() async {
         let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: nil) // 데이터 없음
         let codex = FakeUsageProvider(id: "codex", displayName: "Codex", daily: todayDaily(50_000_000))


### PR DESCRIPTION
 ## Summary
Kiro CLI stores conversation history locally in `~/Library/Application Support/kiro- cli/data.sqlite3`, but no provider previously read it. This PR adds `LocalKiroProvider` to track Kiro CLI token usage and feed it into companion progression and usage tracking.

### Key Implementation Details:
- **`LocalKiroProvider` Registration**: Implemented on top of the shared additional-source cache and registered in `UsageStore.init`. Reports tokens only (`reportsCost = false`), as Kiro does not report per-token dollar costs.
- **Dual Schema Support**: Handles both `conversations_v2` (kiro-cli < 2.0.1, dedicated ID/timestamp columns) and `conversations` (kiro-cli 2.0.1+, directory-keyed with `conversation_id` inside JSON).
- **Cumulative Prompt Token Estimation**:
      - Kiro lacks server-side sessions and resends the entire conversation history on every turn. Because `user_prompt_length` only records the immediate user input bytes, the reader accumulates `user` and `assistant` text lengths byte-by-byte (using a 4-bytes-per-token heuristic).
      - Seeded with `latest_summary` so post-compaction turns continue counting the history represented by the summary.
      - Base64 `images` blobs are excluded from byte counting to prevent token inflation.
      - Output tokens are estimated directly from actual streamed response bytes (`response_size`).
 - **Cache Persistence for Cleared Sessions**: Kiro deletes turns from its database on `/clear` or compaction. The `.kiro` cache merges each scan with previously-seen entries so tokens already counted during the app lifecycle are preserved.
 - **Tests & Documentation**: Added comprehensive unit tests in `KiroUsageTests.swift` (530 lines) and updated READMEs (EN/KO/JA).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

 ## UI changes

_No direct changes under `Sources/PokeTokenBar/UI/`._

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING (../CONTRIBUTING.md))
- [x] Tests were added or updated for this change
