### PR TITLE
fix: reject speech-bubble copy that the view would truncate (#167)

### DIFF
--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -32,6 +32,19 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
     static let bubbleHorizontalPadding: CGFloat = 8
     /// Fixed text column — wraps instead of growing past the panel (`bubbleMinWidth` − 16).
     static let bubbleContentWidth: CGFloat = bubbleMinWidth - (bubbleHorizontalPadding * 2)
+    /// `SpeechBubbleView` body `.lineLimit`. Measure and view must share this — a
+    /// headroom-only guard stays green for 3-line copy that still fits 70pt (#167).
+    static let bubbleBodyLineLimit = 2
+
+    /// Chrome size plus the signals the view actually fails on: wrap count vs
+    /// `bubbleBodyLineLimit`, and single-line width vs the content column.
+    struct SpeechBubbleLayout: Equatable {
+        var size: NSSize
+        var bodyLineCount: Int
+        var unclampedTitleWidth: CGFloat
+        var unclampedBodyWidth: CGFloat
+        var wouldTruncate: Bool
+    }
 
     private var onOpenPopover: (() -> Void)?
     private var onHide: (() -> Void)?
@@ -111,19 +124,51 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
     /// Pure AppKit typography — keeps the layout test free of SwiftUI hosting.
     static func measureSpeechBubble(title: String, body: String,
                                     contentWidth: CGFloat = bubbleContentWidth) -> NSSize {
+        measureSpeechBubbleLayout(title: title, body: body, contentWidth: contentWidth).size
+    }
+
+    /// Layout the view draws: unconstrained chrome (`size`) plus wrap count and
+    /// single-line widths. `size.width` is clamped to the column (cannot fail a
+    /// `≤ panel.width` assert); `unclamped*Width` is the check that can.
+    static func measureSpeechBubbleLayout(title: String, body: String,
+                                          contentWidth: CGFloat = bubbleContentWidth) -> SpeechBubbleLayout {
         let titleFont = NSFont.systemFont(ofSize: 11, weight: .bold)
         let bodyFont = NSFont.systemFont(ofSize: 10)
-        let constraint = NSSize(width: contentWidth, height: 10_000)
+        let wrap = NSSize(width: contentWidth, height: 10_000)
+        let unclamped = NSSize(width: CGFloat.greatestFiniteMagnitude, height: 10_000)
         let opts: NSString.DrawingOptions = [.usesLineFragmentOrigin, .usesFontLeading]
         let titleRect = (title as NSString).boundingRect(
-            with: constraint, options: opts, attributes: [.font: titleFont])
+            with: wrap, options: opts, attributes: [.font: titleFont])
         let bodyRect = (body as NSString).boundingRect(
-            with: constraint, options: opts, attributes: [.font: bodyFont])
+            with: wrap, options: opts, attributes: [.font: bodyFont])
+        let unclampedTitle = (title as NSString).boundingRect(
+            with: unclamped, options: opts, attributes: [.font: titleFont])
+        let unclampedBody = (body as NSString).boundingRect(
+            with: unclamped, options: opts, attributes: [.font: bodyFont])
         let textWidth = min(contentWidth, max(titleRect.width, bodyRect.width))
         let textHeight = ceil(titleRect.height) + 2 + ceil(bodyRect.height)
         // Match SpeechBubbleView: horizontal padding ×2, vertical 6, bottom pad 6 for the tail.
         let hPad = bubbleHorizontalPadding * 2
-        return NSSize(width: textWidth + hPad, height: textHeight + 12 + 6)
+        let bodyLineCount = wrappedLineCount(body, font: bodyFont, width: contentWidth)
+        return SpeechBubbleLayout(
+            size: NSSize(width: textWidth + hPad, height: textHeight + 12 + 6),
+            bodyLineCount: bodyLineCount,
+            unclampedTitleWidth: unclampedTitle.width,
+            unclampedBodyWidth: unclampedBody.width,
+            wouldTruncate: bodyLineCount > bubbleBodyLineLimit)
+    }
+
+    /// Wrap count at `width` using the same `boundingRect` path as `size`, so a
+    /// height-jump fixture and `bodyLineCount` cannot disagree.
+    private static func wrappedLineCount(_ string: String, font: NSFont, width: CGFloat) -> Int {
+        guard !string.isEmpty else { return 0 }
+        let opts: NSString.DrawingOptions = [.usesLineFragmentOrigin, .usesFontLeading]
+        let wrapped = (string as NSString).boundingRect(
+            with: NSSize(width: width, height: 10_000), options: opts, attributes: [.font: font])
+        let single = ("Ay" as NSString).boundingRect(
+            with: NSSize(width: 10_000, height: 10_000), options: opts, attributes: [.font: font])
+        let unit = max(single.height, 1)
+        return max(1, Int((wrapped.height / unit).rounded()))
     }
 
     private func sync() {
@@ -401,7 +446,7 @@ struct FloatingPetView: View {
     }
 }
 
-/// Transient limit-alert bubble. Width is capped so ko/en/ja wrap instead of clipping the panel.
+/// Transient limit-alert bubble. Width is capped so copy wraps instead of clipping the panel.
 private struct SpeechBubbleView: View {
     let alert: UsageStore.LimitAlert
     let l: L
@@ -414,7 +459,7 @@ private struct SpeechBubbleView: View {
             Text(l.notifBody(alert.window, TokenFormatter.percent(alert.utilization)))
                 .font(.system(size: 10))
                 .foregroundColor(.secondary)
-                .lineLimit(2)
+                .lineLimit(FloatingPetController.bubbleBodyLineLimit)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(width: FloatingPetController.bubbleContentWidth, alignment: .leading)

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -201,6 +201,12 @@ final class FloatingPetEnergyTests: XCTestCase {
     /// not intrinsic `.fixedSize` that clipped ja by ~9pt (owner review on #124).
     /// Iterate `allCases`, never a literal list: a hardcoded `[.ko, .en, .ja]` silently stopped
     /// covering Spanish the moment #159 landed, which is exactly when a layout guard matters.
+    ///
+    /// The view draws body with `.lineLimit(2)` (#167). An unconstrained height check
+    /// against `bubbleHeadroom` stays green for 3-line copy that still measures ≤70pt
+    /// while the view truncates — so this guard fails on `wouldTruncate`, not only overflow.
+    /// The tautological `measured.width ≤ panel.width` is gone: `measureSpeechBubble`
+    /// clamps width to the column by construction, so that assert could never fail.
     func testLocalizedAlertBubbleFitsDefaultPanel() {
         let pet: CGFloat = 96
         let panel = FloatingPetController.panelSize(petSize: pet, showingBubble: true)
@@ -211,18 +217,115 @@ final class FloatingPetEnergyTests: XCTestCase {
                 + FloatingPetController.bubbleHorizontalPadding * 2,
             FloatingPetController.bubbleMinWidth,
             "content column + horizontal padding must equal panel width")
+        XCTAssertEqual(
+            FloatingPetController.bubbleBodyLineLimit, 2,
+            "must stay in lockstep with SpeechBubbleView.lineLimit")
 
         for lang in AppLanguage.allCases {
             let l = L(lang)
-            let title = l.notifCritical
-            let body = l.notifBody(l.claudeFiveHour, TokenFormatter.percent(85))
-            let measured = FloatingPetController.measureSpeechBubble(title: title, body: body)
-            XCTAssertLessThanOrEqual(
-                measured.width, panel.width + 0.5,
-                "\(lang.rawValue) bubble width \(measured.width) must fit panel \(panel.width)")
-            XCTAssertLessThanOrEqual(
-                measured.height, FloatingPetController.bubbleHeadroom - 2,
-                "\(lang.rawValue) bubble height \(measured.height) must fit headroom \(FloatingPetController.bubbleHeadroom)")
+            for title in [l.notifCritical, l.notifWarning] {
+                for window in Self.alertWindows(l) {
+                    let body = l.notifBody(window, TokenFormatter.percent(85))
+                    let layout = FloatingPetController.measureSpeechBubbleLayout(title: title, body: body)
+                    XCTAssertFalse(
+                        layout.wouldTruncate,
+                        "\(lang.rawValue) '\(title)' / '\(body)' wraps to \(layout.bodyLineCount) lines and would truncate at lineLimit(\(FloatingPetController.bubbleBodyLineLimit))")
+                    XCTAssertLessThanOrEqual(
+                        layout.size.height, FloatingPetController.bubbleHeadroom - 2,
+                        "\(lang.rawValue) bubble height \(layout.size.height) must fit headroom \(FloatingPetController.bubbleHeadroom)")
+                }
+            }
         }
+    }
+
+    /// #167: 3-line copy that still fits the 70pt headroom must fail the guard.
+    /// Height-only would stay green (owner's table: 3-line ≈69pt). Injected independently
+    /// of Localization.swift so a green localized run can't hide a broken truncate check.
+    func testThreeLineBodyThatFitsHeadroomWouldTruncate() {
+        let title = "Límite inminente"
+        let body = Self.bodyWrappingExtraLines(2, title: title)
+        let layout = FloatingPetController.measureSpeechBubbleLayout(title: title, body: body)
+        XCTAssertEqual(layout.bodyLineCount, 3)
+        XCTAssertLessThanOrEqual(
+            layout.size.height, FloatingPetController.bubbleHeadroom - 2,
+            "precondition: 3-line copy still fits the panel — the defect is truncation, not overflow")
+        XCTAssertTrue(
+            layout.wouldTruncate,
+            "view lineLimit(2) truncates this copy; a headroom-only guard would miss it")
+    }
+
+    /// Two-line wrap is the view's designed capacity — must not trip truncation.
+    func testTwoLineBodyDoesNotTruncate() {
+        let title = "Límite inminente"
+        let body = Self.bodyWrappingExtraLines(1, title: title)
+        let layout = FloatingPetController.measureSpeechBubbleLayout(title: title, body: body)
+        XCTAssertEqual(layout.bodyLineCount, 2)
+        XCTAssertFalse(layout.wouldTruncate)
+        XCTAssertLessThanOrEqual(layout.size.height, FloatingPetController.bubbleHeadroom - 2)
+    }
+
+    /// 4-line copy overflows the panel *and* truncates — the other threshold in the owner's table.
+    func testFourLineBodyExceedsHeadroomAndWouldTruncate() {
+        let title = "Límite inminente"
+        let body = Self.bodyWrappingExtraLines(3, title: title)
+        let layout = FloatingPetController.measureSpeechBubbleLayout(title: title, body: body)
+        XCTAssertEqual(layout.bodyLineCount, 4)
+        XCTAssertTrue(layout.wouldTruncate)
+        XCTAssertGreaterThan(
+            layout.size.height, FloatingPetController.bubbleHeadroom - 2,
+            "4-line unconstrained height must miss the panel so the overflow assert can still fail")
+    }
+
+    /// Unclamped single-line width must be able to exceed the content column.
+    /// `measureSpeechBubble` returns `min(contentWidth, …) + padding` (= panel width),
+    /// so comparing that to `panel.width` can never fail (#167).
+    func testUnclampedBubbleTextWidthCanExceedContentColumn() {
+        let title = "Límite inminente"
+        let body = String(repeating: "M", count: 80)
+        let layout = FloatingPetController.measureSpeechBubbleLayout(title: title, body: body)
+        XCTAssertGreaterThan(
+            layout.unclampedBodyWidth, layout.size.width,
+            "unclamped width must exceed the clamped chrome, not echo min(contentWidth, …) + padding")
+        XCTAssertGreaterThan(
+            layout.unclampedBodyWidth, FloatingPetController.bubbleContentWidth)
+
+        let short = FloatingPetController.measureSpeechBubbleLayout(title: "Hi", body: "Hi")
+        XCTAssertEqual(short.bodyLineCount, 1)
+        XCTAssertFalse(short.wouldTruncate)
+        XCTAssertLessThanOrEqual(short.unclampedBodyWidth, FloatingPetController.bubbleContentWidth)
+        XCTAssertLessThanOrEqual(short.unclampedTitleWidth, FloatingPetController.bubbleContentWidth)
+    }
+
+    /// Window names that `buildLimitWindows` can put in a bubble body.
+    private static func alertWindows(_ l: L) -> [String] {
+        [
+            l.claudeFiveHour,
+            l.claudeWeekly,
+            "Claude \(l.weeklyOpus)",
+            "Claude \(l.weeklySonnet)",
+            l.codexPersonalLimit,
+            "Codex \(l.codexWindow(300))",
+            "Codex \(l.codexWindow(10_080))",
+            "Claude \(l.claudeLimitEntry(kind: "weekly_scoped", model: "Opus"))",
+        ]
+    }
+
+    /// Grow a wrapping body until unconstrained `measureSpeechBubble` height has jumped
+    /// `extraLines` times past a single line. Independent of `bodyLineCount` so the
+    /// fixture still works if that field is the thing under test.
+    private static func bodyWrappingExtraLines(_ extraLines: Int, title: String) -> String {
+        var text = "word"
+        var lastHeight = FloatingPetController.measureSpeechBubble(title: title, body: text).height
+        var jumps = 0
+        for _ in 0..<400 {
+            text += " word"
+            let height = FloatingPetController.measureSpeechBubble(title: title, body: text).height
+            if height > lastHeight + 2 {
+                jumps += 1
+                lastHeight = height
+                if jumps == extraLines { return text }
+            }
+        }
+        return text
     }
 }


### PR DESCRIPTION
## Summary

`testLocalizedAlertBubbleFitsDefaultPanel` was added after Japanese copy clipped the bubble by ~9pt (#124). It measured with `measureSpeechBubble`, which lays text out at `height: 10_000`, then asserted the chrome fits `bubbleHeadroom` (72pt − 2).

`SpeechBubbleView` draws the body with `.lineLimit(2)`. Those are different thresholds. Owner's table on #167: 3-line copy measures ~69pt (guard passes) and is truncated in the view. 4-line copy is the first height that fails (~81pt). None of the four shipped languages wrap past two lines today, so the guard stayed green for the copy that would actually clip.

The width assert could never fail either: `measureSpeechBubble` returns `min(contentWidth, …) + padding`, which is `panel.width` by construction.

`measureSpeechBubbleLayout` now reports the signals the view fails on:

- `bodyLineCount` / `wouldTruncate` — wrap count at the 164pt column vs `bubbleBodyLineLimit` (shared with the view; a literal `2` in only one place can drift)
- `unclampedTitleWidth` / `unclampedBodyWidth` — single-line width, not `min(contentWidth, …)`
- `size` stays unconstrained so the 4-line overflow assert can still go red

No visible bubble change. `Localization.swift` is untouched.

## Type of change

- [x] Bug fix

## UI changes

No visible change. `SpeechBubbleView` now reads `.lineLimit(FloatingPetController.bubbleBodyLineLimit)` instead of a literal `2` — same value, so measure and view cannot drift.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change

## Tests

`FloatingPetEnergyTests`:

- `testThreeLineBodyThatFitsHeadroomWouldTruncate` — 3-line body, height ≤ 70pt, `wouldTruncate == true`. This is the #167 gap: a headroom-only guard stays green here.
- `testTwoLineBodyDoesNotTruncate` — two-line wrap is the view's designed capacity.
- `testFourLineBodyExceedsHeadroomAndWouldTruncate` — the other row of the table (truncate **and** overflow). A∥B: truncate-only and overflow are separate tests.
- `testUnclampedBubbleTextWidthCanExceedContentColumn` — `unclampedBodyWidth > size.width`, so the width check is not `min(contentWidth, …) + padding`.
- `testLocalizedAlertBubbleFitsDefaultPanel` — every `AppLanguage`, both titles, every window `buildLimitWindows` can put in a body. Fails on `wouldTruncate`, not on clamped width.

The 2/3/4-line fixtures grow a wrapping string until unconstrained `measureSpeechBubble` height jumps, so they do not hardcode a twin of `bodyLineCount`.

Confirmed by injection, not by a green run: lengthening the Spanish `claudeFiveHour` until the body wrapped to 3 lines made `testLocalizedAlertBubbleFitsDefaultPanel` fail (`es` / `Límite inminente` / 3 lines). Restored afterwards. `Localization.swift` is not in this diff.

`swift test --filter FloatingPetEnergyTests`: 12 tests, 0 failures.

Full suite: 629 pass, 9 skipped, 0 failures.

## How to verify

```bash
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --filter FloatingPetEnergyTests
```

To re-check the injection: temporarily lengthen one `claudeFiveHour` string in `Localization.swift` until it wraps to three lines, run `--filter testLocalizedAlertBubbleFitsDefaultPanel` (must go red), then restore.