### PR TITLE
fix: make the popover outside-click monitor idempotent (#168)

### DIFF
--- a/Sources/PokeTokenBar/OutsideClickMonitor.swift
+++ b/Sources/PokeTokenBar/OutsideClickMonitor.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Token holder for the popover's `NSEvent` global mouse monitor (#168 / leftover of #154).
+///
+/// Start and stop are paired: a second `start` must not overwrite a live token, or
+/// `removeMonitor` never sees it and the observer outlives the popover. Register and
+/// remove are injected so tests can prove the leak without installing a real monitor.
+struct OutsideClickMonitor {
+    private(set) var token: Any?
+
+    mutating func start(register: () -> Any?) {
+        guard token == nil else { return }
+        token = register()
+    }
+
+    mutating func stop(remove: (Any) -> Void) {
+        if let token {
+            remove(token)
+            self.token = nil
+        }
+    }
+}

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -17,7 +17,7 @@ struct PokeTokenBarApp: App {
 final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem!
     private let popover = NSPopover()
-    private var outsideClickMonitor: Any?
+    private var outsideClickMonitor = OutsideClickMonitor()
     private var store: UsageStore!
     private var companion: CompanionStore!
     private var updater: UpdateChecker!
@@ -66,7 +66,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
 
         popover.behavior = .transient
-        popover.delegate = self   // 닫힐 때(popoverDidClose) 호스팅 컨트롤러 해제 → 숨은 채 재레이아웃 비용 제거
+        popover.delegate = self   // didShow: outside-click monitor; didClose: 호스팅 해제 + 모니터 제거
 
         observeStore()
         observeCompanionSprite()
@@ -357,11 +357,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             NSApp.activate(ignoringOtherApps: true)
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             popover.contentViewController?.view.window?.makeKeyAndOrderFront(nil)
-            startOutsideClickMonitor()
             syncMenuAnimation()   // 팝오버 열림 → 메뉴바 애니메이션 정지(중복 + WindowServer 부하 회피)
             store.requestNotificationAuthorizationIfNeeded()   // 알림 권한은 사용자가 앱을 처음 열 때 요청
             Task { await updater.check() }   // 팝오버 열 때 재확인(내부 minInterval 디바운스)
         }
+    }
+
+    /// Start and stop are both delegate-driven so a second `show` path cannot
+    /// overwrite a live token (#168). `start` is also idempotent if `didShow` fires twice.
+    func popoverDidShow(_ notification: Notification) {
+        startOutsideClickMonitor()
     }
 
     /// 팝오버가 닫히면 호스팅 컨트롤러 해제(숨은 트리 재레이아웃 비용 제거) + 메뉴바 애니메이션 재개.
@@ -373,16 +378,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     /// 다른 메뉴바 팝업은 앱을 비활성화 안 시켜 .transient 가 못 닫는다 → 열림 동안만 앱 밖 클릭을 직접 감지해 닫는다(관찰 전용, 권한 불필요).
     private func startOutsideClickMonitor() {
-        outsideClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
-            Task { @MainActor in
-                guard let self, self.popover.isShown else { return }
-                self.popover.performClose(nil)
+        outsideClickMonitor.start {
+            NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
+                Task { @MainActor in
+                    guard let self, self.popover.isShown else { return }
+                    self.popover.performClose(nil)
+                }
             }
         }
     }
 
     private func stopOutsideClickMonitor() {
-        if let m = outsideClickMonitor { NSEvent.removeMonitor(m); outsideClickMonitor = nil }
+        outsideClickMonitor.stop { NSEvent.removeMonitor($0) }
     }
 
     // MARK: 디스플레이 / 메뉴바 가시성 (에너지 절약 — 안 보이면 애니메이션 정지)

--- a/Tests/PokeTokenBarTests/OutsideClickMonitorTests.swift
+++ b/Tests/PokeTokenBarTests/OutsideClickMonitorTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// #168: the popover's global mouse monitor must not drop a live token.
+/// `start` overwriting `outsideClickMonitor` without `removeMonitor` leaks a
+/// process-lifetime observer — silent, no crash. These tests inject register/remove
+/// so the leak is visible without installing a real `NSEvent` monitor.
+final class OutsideClickMonitorTests: XCTestCase {
+
+    /// Second start must not call register again and must keep the first token.
+    /// The production bug: assignment replaces the token, `removeMonitor` never
+    /// sees the first one, and a second observer stays installed.
+    func testStartTwiceKeepsFirstTokenAndDoesNotRegisterAgain() {
+        var monitor = OutsideClickMonitor()
+        var registers = 0
+        var removed: [Int] = []
+        monitor.start { registers += 1; return registers }
+        monitor.start { registers += 1; return registers }
+        XCTAssertEqual(registers, 1, "second start must be a no-op, not a new observer")
+        monitor.stop { removed.append($0 as! Int) }
+        XCTAssertEqual(removed, [1], "stop must remove the first token, not a replacement")
+    }
+
+    func testStopWhenIdleDoesNotRemove() {
+        var monitor = OutsideClickMonitor()
+        var removed = 0
+        monitor.stop { _ in removed += 1 }
+        XCTAssertEqual(removed, 0)
+    }
+
+    func testStartAfterStopRegistersAgain() {
+        var monitor = OutsideClickMonitor()
+        var registers = 0
+        monitor.start { registers += 1; return registers }
+        monitor.stop { _ in }
+        monitor.start { registers += 1; return registers }
+        XCTAssertEqual(registers, 2)
+    }
+
+    /// `addGlobalMonitorForEvents` returns `Optional`; a nil result must not block the next start.
+    func testNilRegisterDoesNotOccupyTheSlot() {
+        var monitor = OutsideClickMonitor()
+        var registers = 0
+        monitor.start { registers += 1; return nil }
+        monitor.start { registers += 1; return 1 }
+        XCTAssertEqual(registers, 2)
+        var removed: [Int] = []
+        monitor.stop { removed.append($0 as! Int) }
+        XCTAssertEqual(removed, [1])
+    }
+}


### PR DESCRIPTION
## Summary

`startOutsideClickMonitor()` could overwrite a live `NSEvent` token without calling `removeMonitor`, leaking a process-lifetime global observer if a second show path is added (#168).

- Extract `OutsideClickMonitor` with idempotent `start` / paired `stop`
- Register in `popoverDidShow` (delegate-driven, mirroring `popoverDidClose`)
- Remove registration from `togglePopover()` show path

## Type of change

- [x] Bug fix

## UI changes

No visible change — outside clicks still dismiss the popover; only monitor lifetime pairing changed.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] Tests added for the idempotent registration contract

## Tests

`OutsideClickMonitorTests` (4 cases) — inject register/remove so the leak is testable without a real global monitor:

- Second `start` is a no-op and `stop` removes the first token
- `stop` when idle does not call remove
- `start` after `stop` registers again
- Nil register result does not block a subsequent start

```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --filter OutsideClickMonitorTests
```

Fixes #168
