### PR TITLE
fix: resolve provider location env vars through the login shell

### DIFF
--- a/Sources/PokeTokenBar/Core/BinaryLocator.swift
+++ b/Sources/PokeTokenBar/Core/BinaryLocator.swift
@@ -111,12 +111,18 @@ enum BinaryLocator {
     /// 파이프 버퍼(64KB)를 넘게 찍으면 자식이 write 에서 막혀 영영 종료하지 않고, 종료를 먼저 기다리는
     /// 구조에서는 타임아웃까지 통째로 날린 뒤 nil 을 돌려준다.
     private static func shellMarkedValue(script: String, argument: String, label: String) -> String? {
+        shellMarkedOutput(script: script, arguments: [argument], label: label).flatMap(parseMarkedPath)
+    }
+
+    /// 셸을 띄워 stdout 을 통째로 돌려준다(마커 추출은 호출자 몫). 값을 **여러 개** 받는 스크립트는
+    /// 마커가 여러 쌍이라 `parseMarkedPath`(첫 쌍만) 로는 못 읽으므로 원문이 필요하다.
+    private static func shellMarkedOutput(script: String, arguments: [String], label: String) -> String? {
         let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         guard FileManager.default.isExecutableFile(atPath: shell) else { return nil }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shell)
-        process.arguments = ["-ilc", script, "sh", argument]
+        process.arguments = ["-ilc", script, "sh"] + arguments
         process.standardInput = FileHandle.nullDevice
         let output = Pipe()
         process.standardOutput = output
@@ -153,10 +159,7 @@ enum BinaryLocator {
             AppLog.write("\(label) output drain timed out")
             return nil
         }
-        guard let raw = String(data: box.data, encoding: .utf8),
-              let value = parseMarkedPath(raw)
-        else { return nil }
-        return value
+        return String(data: box.data, encoding: .utf8)
     }
 
     /// 로그인 셸에서 환경변수 하나를 읽는다. Finder/launchd 로 뜬 `.app` 은 셸 환경(`~/.zshrc` 의
@@ -166,14 +169,53 @@ enum BinaryLocator {
         // 변수명은 ASCII 대문자·숫자·밑줄만 허용 — 셸 주입 방지.
         // `isUppercase`/`isNumber` 는 유니코드 기준이라 `Σ`·키릴 `А`·`٣` 도 통과한다. 셸 메타문자는
         // 아니라 실제 주입은 안 되지만, 가드가 선언한 범위와 실제 허용 범위를 일치시킨다.
-        guard !name.isEmpty,
-              name.allSatisfy({ $0.isASCII && ($0.isUppercase || $0.isNumber || $0 == "_") })
-        else { return nil }
+        guard isShellSafeEnvironmentName(name) else { return nil }
         // 변수명은 위치 인자($1)로 넘기고 `eval` 은 그 이름의 값만 전개한다. 전개 결과는 재파싱되지
         // 않으므로 값에 셸 메타문자가 있어도 그대로 돌아온다(실측 확인).
         return shellMarkedValue(
             script: #"printf '<<<BIN:%s:BIN>>>' "$(eval printf '%s' \"\$$1\" 2>/dev/null)""#,
             argument: name, label: "\(name) shell env lookup")
+    }
+
+    /// 환경변수 **여러 개**를 셸 spawn **한 번**으로 읽는다. 이름마다 부르면 프로바이더가 늘수록
+    /// 기동이 그만큼 느려진다(셸 조회 실측 ~0.44s × 이름 수). 미설정·빈 값은 결과에서 빠지므로
+    /// 반환 딕셔너리에 키가 없는 것이 곧 "그 사용자는 이 변수를 안 쓴다"이다.
+    static func shellEnvironmentValues(_ names: [String]) -> [String: String] {
+        let safe = names.filter(isShellSafeEnvironmentName)
+        guard !safe.isEmpty else { return [:] }
+        // 이름은 전부 위치 인자로 넘기고 `$@` 로 순회한다 — 스크립트에 이름을 보간하지 않으므로
+        // 단일 조회와 같은 주입 안전성을 유지한다. 마커에 이름을 함께 실어 값과 짝을 잃지 않게 한다.
+        guard let raw = shellMarkedOutput(
+            script: #"for n in "$@"; do printf '<<<BIN:%s:%s:BIN>>>' "$n" "$(eval printf '%s' \"\$$n\" 2>/dev/null)"; done"#,
+            arguments: safe, label: "env batch lookup(\(safe.count))")
+        else { return [:] }
+
+        var out: [String: String] = [:]
+        for name in safe {
+            guard let value = parseMarkedValue(raw, name: name) else { continue }
+            out[name] = value
+        }
+        return out
+    }
+
+    /// 셸 주입 방지 — ASCII 대문자·숫자·밑줄만.
+    /// `isUppercase`/`isNumber` 는 유니코드 기준이라 `Σ`·키릴 `А`·`٣` 도 통과한다. 셸 메타문자는
+    /// 아니라 실제 주입은 안 되지만, 가드가 선언한 범위와 실제 허용 범위를 일치시킨다.
+    static func isShellSafeEnvironmentName(_ name: String) -> Bool {
+        !name.isEmpty
+            && name.allSatisfy { $0.isASCII && ($0.isUppercase || $0.isNumber || $0 == "_") }
+    }
+
+    /// `<<<BIN:NAME:value:BIN>>>` 에서 `NAME` 의 값만 추출. 프로파일 noise 와 다른 이름의 쌍은 무시.
+    /// 이름을 마커에 실어야 하는 이유: 인터랙티브 프로파일이 stdout 에 찍는 noise 가 쌍 사이에
+    /// 섞여도 순서가 아니라 이름으로 짝을 찾을 수 있다.
+    static func parseMarkedValue(_ s: String, name: String) -> String? {
+        guard let start = s.range(of: "<<<BIN:\(name):"),
+              let end = s.range(of: ":BIN>>>", range: start.upperBound..<s.endIndex)
+        else { return nil }
+        let value = s[start.upperBound..<end.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
     }
 
     /// `<<<BIN:/path/to/tool:BIN>>>` 에서 경로만 추출. 프로파일 noise 무시.

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -769,8 +769,10 @@ enum LocalAdditionalUsageReader {
             explicitCost: cost)
     }
 
+    /// GUI 앱은 셸 환경을 상속하지 않으므로 `UsageEnvironment` 를 통해 읽는다 — 프로세스 환경만
+    /// 보면 `~/.zshrc` 에 `export OPENCODE_DATA_DIR=…` 해 둔 사용자가 앱에서만 조용히 0 을 본다.
     private static func environmentPaths(_ key: String) -> [URL]? {
-        guard let raw = ProcessInfo.processInfo.environment[key] else { return nil }
+        guard let raw = UsageEnvironment.value(key) else { return nil }
         return raw.split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -92,15 +92,11 @@ enum LocalUsageReader {
     /// 프로세스 환경에 없으면 로그인 셸에 한 번 물어본다(`BinaryLocator` 가 PATH 에 쓰는 것과 같은 수법).
     /// 이 조회가 없으면 설정 위치를 옮긴 사용자는 앱에서만 0 토큰을 보고, CLI·테스트에서는 정상이라
     /// 재현이 안 된다.
-    /// 셸 조회는 프로세스 생애 1회만 한다 — 환경변수는 앱이 도는 동안 바뀌지 않는데, 루트 캐시의
-    /// TTL 에 묶으면 값을 안 쓰는 대다수 사용자까지 갱신마다 셸 spawn(실측 ~0.44s) 비용을 문다.
-    /// 못 찾은 결과(nil)도 함께 캐시해 재시도를 막는다. `static let` 은 lazy + once 라 이 자체가 캐시다.
-    static func shellAwareClaudeConfigDir() -> String? { cachedShellConfigDir }
-
-    private static let cachedShellConfigDir: String? = {
-        if let v = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"], !v.isEmpty { return v }
-        return BinaryLocator.shellEnvironmentValue("CLAUDE_CONFIG_DIR")
-    }()
+    /// 조회·캐시는 `UsageEnvironment` 가 담당한다 — 같은 문제를 가진 프로바이더 override 변수를
+    /// 한 곳에 모아 셸 spawn(실측 ~0.44s)을 이름 수와 무관하게 1회로 묶기 위해서다.
+    static func shellAwareClaudeConfigDir() -> String? {
+        UsageEnvironment.value("CLAUDE_CONFIG_DIR")
+    }
 
     private static let rootsCache = RootsCache()
 
@@ -968,8 +964,10 @@ enum LocalUsageReader {
     static let grokUpdatesFileName = "updates.jsonl"
 
     /// Grok CLI 세션 루트. CLI 와 같은 규칙으로 `$GROK_HOME` 을 우선한다.
+    /// GUI 앱은 셸 환경을 상속하지 않으므로 `UsageEnvironment` 를 통해 읽는다 — 프로세스 환경만
+    /// 보면 `~/.zshrc` 에 export 해 둔 사용자가 앱에서만 조용히 0 을 본다.
     static var grokSessionsDir: URL {
-        if let home = ProcessInfo.processInfo.environment["GROK_HOME"]?
+        if let home = UsageEnvironment.value("GROK_HOME")?
             .trimmingCharacters(in: .whitespacesAndNewlines), !home.isEmpty {
             return URL(fileURLWithPath: home).appendingPathComponent("sessions")
         }

--- a/Sources/PokeTokenBar/Core/UsageEnvironment.swift
+++ b/Sources/PokeTokenBar/Core/UsageEnvironment.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// 사용량 로그 위치를 가리키는, **사용자가 셸에 export 하는** 환경변수의 단일 조회 지점.
+///
+/// Finder/launchd 로 뜬 `.app` 은 로그인 셸 환경을 상속하지 않는다. 그래서 `~/.zshrc` 에
+/// `export COPILOT_HOME=...` 를 써 둔 사용자는 CLI 에서는 정상인데 앱에서만 사용량이 비거나
+/// 적게 나오고, 앱 안에는 그 사실을 알 방법도 고칠 방법도 없다. 프로바이더가 프로세스 환경만
+/// 읽으면 그 상태가 조용히 유지된다.
+///
+/// 새 프로바이더가 위치 override 환경변수를 쓰면 **이름만 `names` 에 추가한다** — 조회는
+/// 한 번의 셸 spawn 으로 묶이므로 프로바이더가 늘어도 기동 비용은 그대로다.
+///
+/// 여기 넣지 않는 것: 앱이 스스로 쓰는 값(`SHELL`, `PATH`)과 개발/QA 전용 override(`PTB_STATE_DIR`).
+/// 그것들은 사용자가 셸에 export 해 두고 앱이 못 봐서 생기는 문제가 아니다.
+enum UsageEnvironment {
+
+    /// 셸 조회 대상. 프로바이더별 override 이름의 정본이다.
+    static let names = [
+        "CLAUDE_CONFIG_DIR",   // Claude CLI 설정 디렉터리(콤마로 다중)
+        "OPENCODE_DATA_DIR",   // OpenCode 데이터 디렉터리
+        "HERMES_HOME",         // Hermes 홈
+        "COPILOT_HOME",        // Copilot CLI 홈
+        "GROK_HOME",           // Grok CLI 홈
+    ]
+
+    /// `name` 의 값. 프로세스 환경이 우선이고, 없으면 로그인 셸에서 읽은 값을 쓴다.
+    /// 빈 문자열은 미설정과 같게 취급한다(`export FOO=` 는 "여기 있다"가 아니다).
+    static func value(_ name: String) -> String? { resolved[name] }
+
+    /// 프로세스 생애 1회 조회. 환경변수는 앱이 도는 동안 바뀌지 않으므로 TTL 이 필요 없고,
+    /// 못 찾은 결과도 캐시된다(`resolved` 에 키가 없는 것이 곧 negative 캐시) — 재시도하면
+    /// 값을 안 쓰는 대다수 사용자가 갱신마다 셸 spawn 비용을 문다.
+    /// `static let` 은 lazy + once 라 이 자체가 캐시이자 동기화다.
+    private static let resolved: [String: String] = resolve(
+        names: names,
+        processEnvironment: ProcessInfo.processInfo.environment,
+        shellLookup: BinaryLocator.shellEnvironmentValues)
+
+    /// 조회 정책 본체 — 주입 가능하게 분리해 두 갈래를 테스트가 각각 밟는다:
+    /// 프로세스 환경에 다 있으면 셸을 **안 띄운다**, 하나라도 없으면 없는 것만 모아 **한 번** 띄운다.
+    /// 실제 셸 spawn 은 테스트에서 재현할 수 없으므로 이 분기를 검증하지 않으면
+    /// "그냥 프로세스 환경만 읽던" 회귀가 전부 통과한다.
+    static func resolve(
+        names: [String],
+        processEnvironment: [String: String],
+        shellLookup: ([String]) -> [String: String]) -> [String: String]
+    {
+        var out: [String: String] = [:]
+        var missing: [String] = []
+        for name in names {
+            // 빈 값(`export FOO=`)은 미설정과 같게 본다 — 있다고 보면 그 사용자는 존재하지 않는
+            // 경로를 스캔하고 조용히 0 을 받는다.
+            if let v = processEnvironment[name],
+               !v.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                out[name] = v
+            } else {
+                missing.append(name)
+            }
+        }
+        // 대다수 사용자(터미널 실행·override 없음)는 여기서 끝난다 — 셸을 띄우지 않는다.
+        guard !missing.isEmpty else { return out }
+
+        for (name, value) in shellLookup(missing)
+        where !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            out[name] = value
+        }
+        return out
+    }
+}

--- a/Tests/PokeTokenBarTests/UsageEnvironmentTests.swift
+++ b/Tests/PokeTokenBarTests/UsageEnvironmentTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// GUI 앱은 로그인 셸 환경을 상속하지 않는다. 사용량 로그 위치를 가리키는 override 변수를
+/// 프로세스 환경에서만 읽으면, `~/.zshrc` 에 export 해 둔 사용자는 앱에서만 조용히 0 을 보고
+/// CLI·테스트에서는 정상이라 재현이 안 된다. 이 스위트는 그 분기를 고정한다.
+final class UsageEnvironmentTests: XCTestCase {
+
+    // MARK: 조회 정책
+
+    /// 프로세스 환경에 전부 있으면 셸을 **띄우지 않는다**. 이 가드가 없으면 "일단 항상 셸을 물어보는"
+    /// 구현이 통과하고, override 를 안 쓰는 대다수 사용자가 기동마다 spawn 비용(실측 ~0.44s)을 문다.
+    func testAllPresentInProcessEnvironmentSkipsShellLookup() {
+        var shellCalls: [[String]] = []
+        let out = UsageEnvironment.resolve(
+            names: ["A_HOME", "B_HOME"],
+            processEnvironment: ["A_HOME": "/a", "B_HOME": "/b"],
+            shellLookup: { shellCalls.append($0); return [:] })
+
+        XCTAssertEqual(out, ["A_HOME": "/a", "B_HOME": "/b"])
+        XCTAssertTrue(shellCalls.isEmpty, "프로세스 환경에 다 있는데 셸을 띄웠다: \(shellCalls)")
+    }
+
+    /// 없는 것이 하나라도 있으면 **없는 것만 모아 한 번** 물어본다. 이름마다 부르면 프로바이더가
+    /// 늘수록 기동이 그만큼 느려진다.
+    func testMissingNamesBatchedIntoSingleShellLookup() {
+        var shellCalls: [[String]] = []
+        let out = UsageEnvironment.resolve(
+            names: ["A_HOME", "B_HOME", "C_HOME"],
+            processEnvironment: ["B_HOME": "/b"],
+            shellLookup: {
+                shellCalls.append($0)
+                return ["A_HOME": "/shell/a", "C_HOME": "/shell/c"]
+            })
+
+        XCTAssertEqual(shellCalls.count, 1, "셸 조회는 1회여야 한다: \(shellCalls)")
+        XCTAssertEqual(shellCalls.first, ["A_HOME", "C_HOME"], "없는 이름만 넘겨야 한다")
+        XCTAssertEqual(out, ["A_HOME": "/shell/a", "B_HOME": "/b", "C_HOME": "/shell/c"])
+    }
+
+    /// 결함 트리거 분기: 프로세스 환경에 **없어서** 셸에서만 값이 오는 경우.
+    /// 회귀(프로세스 환경만 읽기)는 정확히 이 케이스에서만 드러나고, 값이 양쪽에 다 있는
+    /// 케이스로 테스트하면 통과해 버린다.
+    func testValueVisibleOnlyToLoginShellIsPickedUp() {
+        let out = UsageEnvironment.resolve(
+            names: ["COPILOT_HOME"],
+            processEnvironment: [:],
+            shellLookup: { _ in ["COPILOT_HOME": "/Users/someone/relocated"] })
+
+        XCTAssertEqual(out["COPILOT_HOME"], "/Users/someone/relocated",
+                       "GUI 앱에서만 안 보이던 값을 못 집었다 — 회귀")
+    }
+
+    /// `export FOO=` 는 "여기 있다"가 아니다. 빈 값을 값으로 받으면 존재하지 않는 경로를
+    /// 스캔하고 조용히 0 을 받는다.
+    func testBlankProcessValueFallsBackToShell() {
+        let out = UsageEnvironment.resolve(
+            names: ["HERMES_HOME"],
+            processEnvironment: ["HERMES_HOME": "   "],
+            shellLookup: { _ in ["HERMES_HOME": "/real"] })
+        XCTAssertEqual(out["HERMES_HOME"], "/real")
+    }
+
+    /// 셸이 공백만 돌려줘도 미설정으로 본다(위와 같은 이유, 반대 방향).
+    func testBlankShellValueIsDiscarded() {
+        let out = UsageEnvironment.resolve(
+            names: ["HERMES_HOME"],
+            processEnvironment: [:],
+            shellLookup: { _ in ["HERMES_HOME": "  \n "] })
+        XCTAssertNil(out["HERMES_HOME"])
+    }
+
+    // MARK: 배치 마커 파싱
+
+    /// 값이 여러 개면 마커 쌍도 여러 개다. 순서가 아니라 **이름으로** 짝을 찾아야
+    /// 인터랙티브 프로파일이 중간에 찍는 noise 에 밀리지 않는다.
+    func testParseMarkedValuePicksPairByNameAcrossNoise() {
+        let raw = """
+        neofetch banner line
+        <<<BIN:A_HOME:/first:BIN>>>oh-my-zsh noise<<<BIN:B_HOME:/second:BIN>>>
+        trailing noise
+        """
+        XCTAssertEqual(BinaryLocator.parseMarkedValue(raw, name: "A_HOME"), "/first")
+        XCTAssertEqual(BinaryLocator.parseMarkedValue(raw, name: "B_HOME"), "/second")
+        XCTAssertNil(BinaryLocator.parseMarkedValue(raw, name: "C_HOME"), "없는 이름은 nil")
+    }
+
+    /// 미설정 변수는 빈 값으로 돌아온다 — 빈 문자열을 값으로 승격하면 안 된다.
+    func testParseMarkedValueTreatsEmptyPairAsAbsent() {
+        XCTAssertNil(BinaryLocator.parseMarkedValue("<<<BIN:A_HOME::BIN>>>", name: "A_HOME"))
+    }
+
+    /// 이름이 다른 이름의 접두사여도 섞이지 않는다(`A_HOME` vs `A_HOME_EXTRA`).
+    func testParseMarkedValueDoesNotConfusePrefixNames() {
+        let raw = "<<<BIN:A_HOME_EXTRA:/extra:BIN>>><<<BIN:A_HOME:/plain:BIN>>>"
+        XCTAssertEqual(BinaryLocator.parseMarkedValue(raw, name: "A_HOME_EXTRA"), "/extra")
+    }
+
+    // MARK: 셸 주입 가드
+
+    func testShellSafeEnvironmentNameRejectsInjectionShapes() {
+        for good in ["GROK_HOME", "A1_B2", "X"] {
+            XCTAssertTrue(BinaryLocator.isShellSafeEnvironmentName(good), good)
+        }
+        // 소문자·유니코드 대문자·메타문자·빈 문자열은 모두 거부.
+        for bad in ["", "grok_home", "A-B", "A B", "A;rm -rf /", "Σ", "А", "٣", "A$B"] {
+            XCTAssertFalse(BinaryLocator.isShellSafeEnvironmentName(bad), bad)
+        }
+    }
+
+    /// 이름이 전부 거부되면 셸을 띄우지 않고 즉시 빈 결과.
+    func testShellEnvironmentValuesRejectsAllUnsafeNamesWithoutSpawning() {
+        XCTAssertTrue(BinaryLocator.shellEnvironmentValues([]).isEmpty)
+        XCTAssertTrue(BinaryLocator.shellEnvironmentValues(["bad name", "x"]).isEmpty)
+    }
+
+    // MARK: 레지스트리 무결성 (부류 재발 방지)
+
+    /// 사용량 위치 override 변수를 `UsageEnvironment` 를 거치지 않고 프로세스 환경에서 직독하면
+    /// 이 테스트가 깨진다. 새 프로바이더가 같은 실수를 반복하는 것을 기계로 막는 지점이다.
+    ///
+    /// 허용 목록은 "사용자가 셸에 export 해 두는 값이 아닌 것"만 담는다:
+    /// - `UsageEnvironment` 자신(프로세스 환경을 읽는 유일한 정당한 위치)
+    /// - `BinaryLocator`: 자식 프로세스 환경 구성과 `SHELL` — 앱이 쓰는 값이지 사용자 override 가 아니다
+    /// - `CompanionStore`: `PTB_STATE_DIR` 은 개발/QA 격리용
+    /// - `OAuthLimitsProvider`: 의도적으로 프로세스 환경만 본다(자동 폴링 경로에서 셸 spawn 금지 —
+    ///   해당 함수 주석 참조). 값이 필요한 사용량 스캔 쪽이 이미 셸 조회를 한다.
+    func testNoProviderReadsUsageLocationEnvDirectly() throws {
+        let allowed: Set<String> = [
+            "UsageEnvironment.swift",
+            "BinaryLocator.swift",
+            "CompanionStore.swift",
+            "OAuthLimitsProvider.swift",
+        ]
+        let sources = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()    // PokeTokenBarTests
+            .deletingLastPathComponent()    // Tests
+            .deletingLastPathComponent()    // repo root
+            .appendingPathComponent("Sources/PokeTokenBar")
+
+        var offenders: [String] = []
+        let enumerator = try XCTUnwrap(FileManager.default.enumerator(
+            at: sources, includingPropertiesForKeys: nil))
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            guard !allowed.contains(url.lastPathComponent) else { continue }
+            let text = try String(contentsOf: url, encoding: .utf8)
+            for (index, line) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated()
+            where line.contains("ProcessInfo.processInfo.environment[") {
+                offenders.append("\(url.lastPathComponent):\(index + 1)")
+            }
+        }
+
+        XCTAssertTrue(offenders.isEmpty, """
+            사용량 위치 환경변수는 UsageEnvironment 를 통해 읽어야 한다(GUI 앱은 셸 환경 미상속).
+            직독 지점: \(offenders.joined(separator: ", "))
+            """)
+    }
+
+    /// 실제로 조회되는 이름 집합이 프로바이더 override 와 어긋나지 않게 고정한다.
+    func testRegisteredNamesCoverEveryProviderOverride() {
+        for name in ["CLAUDE_CONFIG_DIR", "OPENCODE_DATA_DIR", "HERMES_HOME", "COPILOT_HOME", "GROK_HOME"] {
+            XCTAssertTrue(UsageEnvironment.names.contains(name), "\(name) 이 조회 대상에서 빠졌다")
+        }
+        XCTAssertEqual(Set(UsageEnvironment.names).count, UsageEnvironment.names.count, "이름 중복")
+        for name in UsageEnvironment.names {
+            XCTAssertTrue(BinaryLocator.isShellSafeEnvironmentName(name), "\(name) 은 셸 조회가 거부한다")
+        }
+    }
+}

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -70,6 +70,16 @@ read_when:
   `zsh -ilc` 를 띄운다) — 새 환경변수도 `BinaryLocator.shellEnvironmentValue` 로 조회한다. 단 셸 spawn 은
   실측 ~0.44s 라 **프로세스 생애 1회만**(`static let` lazy) 캐시하고, 주기적으로 갱신되는 캐시(TTL)에 묶지 마라 —
   그 값을 안 쓰는 대다수 사용자까지 갱신마다 비용을 문다.
+- **위 규칙이 문서에만 있으면 다음 프로바이더가 그대로 어긴다 — 조회 지점을 하나로 모으고 테스트로 막아라.**
+  실제로 그렇게 됐다: 규칙을 적어 둔 뒤 추가된 `OPENCODE_DATA_DIR`·`HERMES_HOME`·`COPILOT_HOME`·`GROK_HOME`
+  네 개가 전부 `ProcessInfo.processInfo.environment` 직독으로 들어왔고, 해당 사용자는 배포된 앱에서만 조용히
+  적은 숫자를 봤다. 원인은 구현이 아니라 **강제 수단의 부재**다 — 산문 규칙은 새 파일을 리뷰할 때만 작동한다.
+  이제 조회는 `UsageEnvironment` 한 곳이고(이름은 `UsageEnvironment.names` 에 추가),
+  `testNoProviderReadsUsageLocationEnvDirectly` 가 `Sources/` 를 스캔해 직독 지점을 실패시킨다(허용 목록은
+  사용자 override 가 아닌 것만 — `SHELL`·`PTB_STATE_DIR` 등). 조회는 **이름 수와 무관하게 spawn 1회**로 묶는다
+  (`shellEnvironmentValues`) — 이름마다 띄우면 프로바이더가 늘수록 기동이 그만큼 느려진다.
+  프로세스 환경에 전부 있으면 셸을 아예 안 띄우는 분기도 함께 가드한다(`…SkipsShellLookup`).
+  `export FOO=` 처럼 **빈 값은 미설정으로** 취급한다 — 값으로 받으면 없는 경로를 스캔하고 조용히 0 이 된다.
 - **디렉터리 탐색은 깊이만 막으면 폭이 안 막히지만, 이름 기반 가지치기는 더 위험하다.** 깊이 가지치기는
   `> maxDepth` 가 아니라 `>= maxDepth` 에서 걸어야 한 단계 더 내려가지 않는다(전자는 상한+1 까지 방문).
   깊이 상한은 **실제 레이아웃 깊이를 테스트로 고정**하고 여유를 둔다 — 경계에 붙여 두면 상위 소스가 한 단계


### PR DESCRIPTION
## Summary

A GUI-launched `.app` does not inherit the login shell environment, so `~/.zshrc` exports never appear in `ProcessInfo.processInfo.environment`. Four provider location overrides were read from there directly:

| Variable | Read at | Provider |
| --- | --- | --- |
| `OPENCODE_DATA_DIR` | `LocalAdditionalUsageProvider.swift` (`environmentPaths`) | OpenCode |
| `HERMES_HOME` | same | Hermes |
| `COPILOT_HOME` | same | Copilot |
| `GROK_HOME` | `LocalUsageReader.swift` (`grokSessionsDir`) | Grok |

Anyone who relocated one of those data directories saw a silently low total in the menu bar, with no way to notice or fix it from inside the app. The CLI and `swift test` both inherit the shell, so the gap never reproduced outside a released build.

Claude already solved exactly this through `BinaryLocator.shellEnvironmentValue`, and `docs/reference/defect-log.md` already carried the rule — but only as prose, so every provider added afterwards reintroduced the defect.

## Change

All usage-location variables now resolve through a single `UsageEnvironment` lookup:

- **Process environment wins.** Only names missing from it are asked of the shell.
- **One spawn, not one per name.** The shell lookup costs ~0.44s measured, so per-name spawning would make startup slower with every provider added. `BinaryLocator.shellEnvironmentValues` reads them all in a single `zsh -ilc`, keyed by name in the marker so profile noise cannot desynchronize the pairs.
- **No spawn at all when the process environment already has everything** — the common case for anyone running from a terminal or without overrides.
- **Blank values (`export FOO=`) count as unset.** Treating them as set makes the app scan a nonexistent path and quietly report zero.
- **Resolved once per process, negatives included.** Environment variables do not change while the app runs.

Adding a provider override now means adding the name to `UsageEnvironment.names`; the spawn count does not change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

None — no files under `Sources/PokeTokenBar/UI/` are touched.

## Verification

- Full gate: **637 tests, 0 failures**, logic-core line coverage 89.75% (threshold 75%).
- **Both new guards were verified by injecting the defect they target**, then reverted:
  - reverting `environmentPaths` to a direct process-environment read → `testNoProviderReadsUsageLocationEnvDirectly` fails
  - removing the "everything already present" early return → `testAllPresentInProcessEnvironmentSkipsShellLookup` fails
- End-to-end against a real login shell (one that prints a `neofetch` banner, so the noise path is exercised): four names in a single spawn returned values containing spaces and shell metacharacters unchanged, and an unset name came back absent.

`testNoProviderReadsUsageLocationEnvDirectly` scans `Sources/` and fails on any direct `ProcessInfo.processInfo.environment[...]` read outside an allowlist, so the rule is enforced rather than documented. The allowlist covers only values that are not user shell exports: `BinaryLocator` (child-process environment, `SHELL`), `CompanionStore` (`PTB_STATE_DIR`, dev/QA isolation), and `OAuthLimitsProvider`.

`OAuthLimitsProvider` deliberately keeps its direct read — it avoids a shell spawn on the auto-polling path, and the usage scan that actually needs the value already performs the lookup. That reasoning is in the function's comment and is unchanged here.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed
- [x] Tests were added or updated for this change
