### PR TITLE
fix: skip the Kiro rescan when the database has not changed (#178)

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -134,10 +134,20 @@ private actor LocalAdditionalUsageCache {
         /// Cursor `cursorDiskKV` / Copilot `assistant_usage_events` have no usable
         /// time column for the cache key — per-DB high-water for append-only rows.
         let highWaterByPath: [String: Int64]
+        /// Kiro skip state lives next to the entries it justifies. A month-key
+        /// drop that empties `entries` also drops the signatures, so the skip
+        /// cannot fire against an empty `existing` (#179).
+        let kiroSignatures: [String: (mtime: Date, size: Int)]
+    }
+
+    private struct ScanResult: Sendable {
+        var entries: [LocalUsageReader.Entry]
+        var highWaterByPath: [String: Int64] = [:]
+        var kiroSignatures: [String: (mtime: Date, size: Int)] = [:]
     }
 
     private var cached: [LocalAdditionalSource: Cached] = [:]
-    private var inFlight: [LocalAdditionalSource: Task<(entries: [LocalUsageReader.Entry], highWaterByPath: [String: Int64]), Never>] = [:]
+    private var inFlight: [LocalAdditionalSource: Task<ScanResult, Never>] = [:]
 
     func entries(for source: LocalAdditionalSource) async -> [LocalUsageReader.Entry] {
         let now = Date()
@@ -188,39 +198,43 @@ private actor LocalAdditionalUsageCache {
             afterRowIDByPath = [:]
         }
         let existing = previous?.entries ?? []
+        let knownKiro = previous?.kiroSignatures ?? [:]
         let task = Task.detached(priority: .utility) {
-            () -> (entries: [LocalUsageReader.Entry], highWaterByPath: [String: Int64]) in
+            () -> ScanResult in
             switch source {
             case .opencode:
                 let loaded = LocalAdditionalUsageReader.openCodeEntries(modifiedSince: since)
-                return (LocalUsageReader.dedupKeepMax(existing + loaded), [:])
+                return ScanResult(entries: LocalUsageReader.dedupKeepMax(existing + loaded))
             case .hermes:
-                return (LocalAdditionalUsageReader.hermesEntries(modifiedSince: since), [:])
+                return ScanResult(entries: LocalAdditionalUsageReader.hermesEntries(modifiedSince: since))
             case .kiro:
-                let loaded = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since)
-                return (LocalUsageReader.dedupKeepMax(existing + loaded), [:])
+                let loaded = LocalAdditionalUsageReader.kiroEntries(
+                    modifiedSince: since, knownSignatures: knownKiro)
+                return ScanResult(
+                    entries: LocalUsageReader.dedupKeepMax(existing + loaded.entries),
+                    kiroSignatures: loaded.signatures)
             case .cursor:
                 let loaded = LocalAdditionalUsageReader.cursorEntries(
                     modifiedSince: since, afterRowIDByPath: afterRowIDByPath)
                 // DB rewrite / VACUUM can drop max(rowid) below the watermark — discard
                 // the stale in-memory set and take the full rescan result.
                 if loaded.didReset {
-                    return (loaded.entries, loaded.highWaterByPath)
+                    return ScanResult(entries: loaded.entries, highWaterByPath: loaded.highWaterByPath)
                 }
-                return (
-                    LocalUsageReader.dedupKeepMax(existing + loaded.entries),
-                    loaded.highWaterByPath)
+                return ScanResult(
+                    entries: LocalUsageReader.dedupKeepMax(existing + loaded.entries),
+                    highWaterByPath: loaded.highWaterByPath)
             case .copilot:
                 let loaded = LocalAdditionalUsageReader.copilotEntries(
                     modifiedSince: since, afterRowIDByPath: afterRowIDByPath)
                 // A pruned / recreated session store restarts ids — the cached rows would
                 // then collide with different events, so keep only the rescan.
                 if loaded.didReset {
-                    return (loaded.entries, loaded.highWaterByPath)
+                    return ScanResult(entries: loaded.entries, highWaterByPath: loaded.highWaterByPath)
                 }
-                return (
-                    LocalUsageReader.dedupKeepMax(existing + loaded.entries),
-                    loaded.highWaterByPath)
+                return ScanResult(
+                    entries: LocalUsageReader.dedupKeepMax(existing + loaded.entries),
+                    highWaterByPath: loaded.highWaterByPath)
             }
         }
         inFlight[source] = task
@@ -228,7 +242,8 @@ private actor LocalAdditionalUsageCache {
         inFlight[source] = nil
         cached[source] = Cached(
             loadedAt: now, monthKey: monthKey, entries: result.entries,
-            highWaterByPath: result.highWaterByPath)
+            highWaterByPath: result.highWaterByPath,
+            kiroSignatures: result.kiroSignatures)
         return result.entries
     }
 }
@@ -803,30 +818,34 @@ enum LocalAdditionalUsageReader {
     /// file's own signature — reused from `LocalAntigravityUsageReader.signature`
     /// (`.sqlite3` + `-wal`, never `-shm`). An unchanged file returns `[]`; the
     /// `.kiro` cache merges `existing + loaded`, so that keeps previously-seen
-    /// entries. The first scan of a process has no recorded signature and is
-    /// never skipped.
+    /// entries. Signatures are supplied by that cache (`knownSignatures`) and
+    /// die with it on a month-key drop, so a skip cannot fire against empty
+    /// `existing` (#179). The first scan of a process passes `[:]`.
     static func kiroEntries(
         modifiedSince: Date,
         roots: [URL]? = nil
     ) -> [LocalUsageReader.Entry] {
+        kiroEntries(modifiedSince: modifiedSince, knownSignatures: [:], roots: roots).entries
+    }
+
+    static func kiroEntries(
+        modifiedSince: Date,
+        knownSignatures: [String: (mtime: Date, size: Int)],
+        roots: [URL]? = nil
+    ) -> (entries: [LocalUsageReader.Entry], signatures: [String: (mtime: Date, size: Int)]) {
         let sourceRoots = roots ?? defaultKiroRoots
         var entries: [LocalUsageReader.Entry] = []
+        var signatures: [String: (mtime: Date, size: Int)] = [:]
         for root in sourceRoots {
-            entries += kiroDatabaseEntries(kiroDatabaseURL(from: root), modifiedSince: modifiedSince)
+            let database = kiroDatabaseURL(from: root)
+            let scanned = kiroDatabaseEntries(
+                database, modifiedSince: modifiedSince, known: knownSignatures)
+            entries += scanned.entries
+            if let signature = scanned.signature {
+                signatures[database.path] = signature
+            }
         }
-        return LocalUsageReader.dedupKeepMax(entries)
-    }
-
-    /// Process-lifetime skip cache for #178. Tests reset it in `setUp` so one
-    /// case cannot leak a signature into the next.
-    private static let kiroScanCache = KiroDatabaseScanCache()
-
-    static func clearKiroScanCache() {
-        kiroScanCache.clear()
-    }
-
-    static func recordedKiroSignature(for database: URL) -> (mtime: Date, size: Int)? {
-        kiroScanCache.recordedSignature(for: database)
+        return (LocalUsageReader.dedupKeepMax(entries), signatures)
     }
 
     private static func kiroDatabaseURL(from root: URL) -> URL {
@@ -835,14 +854,18 @@ enum LocalAdditionalUsageReader {
 
     private static func kiroDatabaseEntries(
         _ database: URL,
-        modifiedSince: Date
-    ) -> [LocalUsageReader.Entry] {
+        modifiedSince: Date,
+        known: [String: (mtime: Date, size: Int)]
+    ) -> (entries: [LocalUsageReader.Entry], signature: (mtime: Date, size: Int)?) {
         // Stat before the read. A commit that lands mid-read then differs from
         // the stored signature on the next poll and is re-read; stat afterwards
         // and that same commit is frozen into a signature that already looks current.
         let signature = LocalAntigravityUsageReader.signature(of: database)
-        if let signature, kiroScanCache.shouldSkip(database, signature: signature) {
-            return []
+        if let signature,
+           let remembered = known[database.path],
+           remembered.mtime == signature.mtime,
+           remembered.size == signature.size {
+            return ([], signature)
         }
 
         var entries: [LocalUsageReader.Entry] = []
@@ -854,6 +877,9 @@ enum LocalAdditionalUsageReader {
             return (columnText(statement, 0), value)
         }
         // kiro-cli 2.0.1+: one row per working directory; the conversation id lives in the JSON.
+        // A 2.0.1+ store may still keep `conversations_v2` (nil here is a missing table
+        // *or* a scan that stopped early). `query` cannot tell them apart, so a BUSY on
+        // one generation plus a success on the other still counts as a completed scan.
         let v1Rows = query(database, sql: "SELECT value FROM conversations") {
             statement -> String? in columnText(statement, 0)
         }
@@ -861,7 +887,7 @@ enum LocalAdditionalUsageReader {
         // still couldn't be opened). Do not occupy the skip slot — the next
         // poll must retry. A missing table on one generation is nil while the
         // other succeeds, so "at least one non-nil" is a completed scan.
-        guard v2Rows != nil || v1Rows != nil else { return [] }
+        guard v2Rows != nil || v1Rows != nil else { return ([], nil) }
 
         for row in v2Rows ?? [] {
             guard let object = jsonObject(data: Data(row.value.utf8)) else { continue }
@@ -874,40 +900,7 @@ enum LocalAdditionalUsageReader {
             entries += kiroTurnEntries(conversationID: conversationID, object: object, modifiedSince: modifiedSince)
         }
 
-        if let signature { kiroScanCache.remember(database, signature: signature) }
-        return entries
-    }
-
-    /// Skip cache for a whole-document SQLite store that cannot be watermarked.
-    /// Signature is `LocalAntigravityUsageReader.signature` — do not copy it.
-    private final class KiroDatabaseScanCache: @unchecked Sendable {
-        private var signatures: [String: (mtime: Date, size: Int)] = [:]
-        private let lock = NSLock()
-
-        func clear() {
-            lock.lock()
-            signatures = [:]
-            lock.unlock()
-        }
-
-        func recordedSignature(for database: URL) -> (mtime: Date, size: Int)? {
-            lock.lock()
-            defer { lock.unlock() }
-            return signatures[database.path]
-        }
-
-        func shouldSkip(_ database: URL, signature: (mtime: Date, size: Int)) -> Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            guard let known = signatures[database.path] else { return false }
-            return known.mtime == signature.mtime && known.size == signature.size
-        }
-
-        func remember(_ database: URL, signature: (mtime: Date, size: Int)) {
-            lock.lock()
-            signatures[database.path] = signature
-            lock.unlock()
-        }
+        return (entries, signature)
     }
 
     /// Bytes-per-token used to turn estimated byte counts into an approximate token count.

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -793,10 +793,18 @@ enum LocalAdditionalUsageReader {
     /// Kiro persists a conversation as one row whose `value` column holds the *entire*
     /// history as JSON, rewritten in place on every turn — there is no per-row token count
     /// (see the type doc on `LocalKiroProvider`) and no append-only id to watermark, so this
-    /// re-parses every stored conversation on every call. Two schema generations coexist:
+    /// cannot advance a row id. Two schema generations coexist:
     /// `conversations_v2` (kiro-cli < 2.0.1, dedicated `conversation_id`/`key`/timestamp
     /// columns) and `conversations` (2.0.1+, keyed by working directory; the JSON itself
     /// carries `conversation_id`). Both wrap the same turn shape, so they share a parser.
+    ///
+    /// `modifiedSince` is applied *after* the JSON parse (`kiroTurnEntries`), so it
+    /// bounds the output, not the work (#178). The cheap gate is the database
+    /// file's own signature — reused from `LocalAntigravityUsageReader.signature`
+    /// (`.sqlite3` + `-wal`, never `-shm`). An unchanged file returns `[]`; the
+    /// `.kiro` cache merges `existing + loaded`, so that keeps previously-seen
+    /// entries. The first scan of a process has no recorded signature and is
+    /// never skipped.
     static func kiroEntries(
         modifiedSince: Date,
         roots: [URL]? = nil
@@ -809,6 +817,18 @@ enum LocalAdditionalUsageReader {
         return LocalUsageReader.dedupKeepMax(entries)
     }
 
+    /// Process-lifetime skip cache for #178. Tests reset it in `setUp` so one
+    /// case cannot leak a signature into the next.
+    private static let kiroScanCache = KiroDatabaseScanCache()
+
+    static func clearKiroScanCache() {
+        kiroScanCache.clear()
+    }
+
+    static func recordedKiroSignature(for database: URL) -> (mtime: Date, size: Int)? {
+        kiroScanCache.recordedSignature(for: database)
+    }
+
     private static func kiroDatabaseURL(from root: URL) -> URL {
         root.pathExtension == "sqlite3" ? root : root.appendingPathComponent("data.sqlite3")
     }
@@ -817,6 +837,14 @@ enum LocalAdditionalUsageReader {
         _ database: URL,
         modifiedSince: Date
     ) -> [LocalUsageReader.Entry] {
+        // Stat before the read. A commit that lands mid-read then differs from
+        // the stored signature on the next poll and is re-read; stat afterwards
+        // and that same commit is frozen into a signature that already looks current.
+        let signature = LocalAntigravityUsageReader.signature(of: database)
+        if let signature, kiroScanCache.shouldSkip(database, signature: signature) {
+            return []
+        }
+
         var entries: [LocalUsageReader.Entry] = []
 
         // kiro-cli < 2.0.1: one row per conversation, with dedicated id/timestamp columns.
@@ -825,15 +853,20 @@ enum LocalAdditionalUsageReader {
             guard let value = columnText(statement, 1) else { return nil }
             return (columnText(statement, 0), value)
         }
+        // kiro-cli 2.0.1+: one row per working directory; the conversation id lives in the JSON.
+        let v1Rows = query(database, sql: "SELECT value FROM conversations") {
+            statement -> String? in columnText(statement, 0)
+        }
+        // Both nil: open/prepare/step failed (BUSY, corrupt, missing file that
+        // still couldn't be opened). Do not occupy the skip slot — the next
+        // poll must retry. A missing table on one generation is nil while the
+        // other succeeds, so "at least one non-nil" is a completed scan.
+        guard v2Rows != nil || v1Rows != nil else { return [] }
+
         for row in v2Rows ?? [] {
             guard let object = jsonObject(data: Data(row.value.utf8)) else { continue }
             let conversationID = row.id ?? stringValue(object["conversation_id"]) ?? database.path
             entries += kiroTurnEntries(conversationID: conversationID, object: object, modifiedSince: modifiedSince)
-        }
-
-        // kiro-cli 2.0.1+: one row per working directory; the conversation id lives in the JSON.
-        let v1Rows = query(database, sql: "SELECT value FROM conversations") {
-            statement -> String? in columnText(statement, 0)
         }
         for value in v1Rows ?? [] {
             guard let object = jsonObject(data: Data(value.utf8)),
@@ -841,7 +874,40 @@ enum LocalAdditionalUsageReader {
             entries += kiroTurnEntries(conversationID: conversationID, object: object, modifiedSince: modifiedSince)
         }
 
+        if let signature { kiroScanCache.remember(database, signature: signature) }
         return entries
+    }
+
+    /// Skip cache for a whole-document SQLite store that cannot be watermarked.
+    /// Signature is `LocalAntigravityUsageReader.signature` — do not copy it.
+    private final class KiroDatabaseScanCache: @unchecked Sendable {
+        private var signatures: [String: (mtime: Date, size: Int)] = [:]
+        private let lock = NSLock()
+
+        func clear() {
+            lock.lock()
+            signatures = [:]
+            lock.unlock()
+        }
+
+        func recordedSignature(for database: URL) -> (mtime: Date, size: Int)? {
+            lock.lock()
+            defer { lock.unlock() }
+            return signatures[database.path]
+        }
+
+        func shouldSkip(_ database: URL, signature: (mtime: Date, size: Int)) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard let known = signatures[database.path] else { return false }
+            return known.mtime == signature.mtime && known.size == signature.size
+        }
+
+        func remember(_ database: URL, signature: (mtime: Date, size: Int)) {
+            lock.lock()
+            signatures[database.path] = signature
+            lock.unlock()
+        }
     }
 
     /// Bytes-per-token used to turn estimated byte counts into an approximate token count.

--- a/Tests/PokeTokenBarTests/KiroUsageTests.swift
+++ b/Tests/PokeTokenBarTests/KiroUsageTests.swift
@@ -9,7 +9,6 @@ final class KiroUsageTests: XCTestCase {
         temporaryDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("PokeTokenBar-KiroUsageTests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
-        LocalAdditionalUsageReader.clearKiroScanCache()
     }
 
     override func tearDownWithError() throws {
@@ -125,9 +124,7 @@ final class KiroUsageTests: XCTestCase {
 
         let first = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
         // Parse stability is a property of the reader, not of the mtime gate —
-        // clear so the second call actually re-reads (#178 would otherwise
-        // return [] and this assert would pass for the wrong reason).
-        LocalAdditionalUsageReader.clearKiroScanCache()
+        // this overload passes no known signatures, so the second call re-reads.
         let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
 
         XCTAssertEqual(Set(first.map(\.id)), Set(second.map(\.id)))
@@ -149,12 +146,14 @@ final class KiroUsageTests: XCTestCase {
         ])
         let since = try date("2026-01-01T00:00:00Z")
 
-        let first = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
-        XCTAssertEqual(first.map(\.id), ["kiro|conv-1|1780000000000"])
+        let first = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: since, knownSignatures: [:], roots: [temporaryDirectory])
+        XCTAssertEqual(first.entries.map(\.id), ["kiro|conv-1|1780000000000"])
 
-        let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
-        XCTAssertTrue(second.isEmpty, "unchanged database must not be re-parsed; empty keeps the cached entries")
-        XCTAssertEqual(LocalUsageReader.dedupKeepMax(first + second).count, first.count)
+        let second = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: since, knownSignatures: first.signatures, roots: [temporaryDirectory])
+        XCTAssertTrue(second.entries.isEmpty, "unchanged database must not be re-parsed; empty keeps the cached entries")
+        XCTAssertEqual(LocalUsageReader.dedupKeepMax(first.entries + second.entries).count, first.entries.count)
     }
 
     /// A WAL commit leaves the main file's mtime alone. Keying the skip on
@@ -169,12 +168,14 @@ final class KiroUsageTests: XCTestCase {
             ]),
         ])
         let since = try date("2026-01-01T00:00:00Z")
-        let first = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
-        XCTAssertFalse(first.isEmpty)
+        let first = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: since, knownSignatures: [:], roots: [temporaryDirectory])
+        XCTAssertFalse(first.entries.isEmpty)
 
         try Data("wal-commit".utf8).write(to: URL(fileURLWithPath: databaseURL.path + "-wal"))
-        let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
-        XCTAssertEqual(Set(second.map(\.id)), Set(first.map(\.id)),
+        let second = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: since, knownSignatures: first.signatures, roots: [temporaryDirectory])
+        XCTAssertEqual(Set(second.entries.map(\.id)), Set(first.entries.map(\.id)),
                        "a newer -wal sibling must invalidate the skip")
     }
 
@@ -189,11 +190,13 @@ final class KiroUsageTests: XCTestCase {
             ]),
         ])
         let since = try date("2026-01-01T00:00:00Z")
-        _ = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        let first = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: since, knownSignatures: [:], roots: [temporaryDirectory])
 
         try Data("shm-read-mark".utf8).write(to: URL(fileURLWithPath: databaseURL.path + "-shm"))
-        let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
-        XCTAssertTrue(second.isEmpty, "-shm churn is a read, not a write")
+        let second = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: since, knownSignatures: first.signatures, roots: [temporaryDirectory])
+        XCTAssertTrue(second.entries.isEmpty, "-shm churn is a read, not a write")
     }
 
     /// A failed open must not occupy the skip slot — otherwise a BUSY or
@@ -201,10 +204,11 @@ final class KiroUsageTests: XCTestCase {
     func testFailedOpenDoesNotOccupyTheSkipSlot() throws {
         try Data("not-a-sqlite-database".utf8).write(to: databaseURL)
         let since = try date("2026-01-01T00:00:00Z")
-        let first = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
-        XCTAssertTrue(first.isEmpty)
+        let first = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: since, knownSignatures: [:], roots: [temporaryDirectory])
+        XCTAssertTrue(first.entries.isEmpty)
         XCTAssertNil(
-            LocalAdditionalUsageReader.recordedKiroSignature(for: databaseURL),
+            first.signatures[databaseURL.path],
             "failed open must not record a signature")
 
         try FileManager.default.removeItem(at: databaseURL)
@@ -214,8 +218,58 @@ final class KiroUsageTests: XCTestCase {
                      userText: String(repeating: "u", count: 40), responseBytes: 40),
             ]),
         ])
-        let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
-        XCTAssertEqual(second.map(\.id), ["kiro|conv-1|1780000000000"])
+        let second = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: since, knownSignatures: first.signatures, roots: [temporaryDirectory])
+        XCTAssertEqual(second.entries.map(\.id), ["kiro|conv-1|1780000000000"])
+    }
+
+    /// #179 review: `existing` empties on a month-key change while a process-lifetime
+    /// skip cache does not. The skip then returns `[]` and `dedupKeepMax([] + [])`
+    /// zeros the week/block window that still reaches into last month.
+    func testSkipDoesNotSurviveAnEmptyExistingSet() throws {
+        let turnDate = try date("2026-08-31T12:00:00Z")
+        let timestampMs = Int64(turnDate.timeIntervalSince1970 * 1000)
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: timestampMs, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 40), responseBytes: 40),
+            ]),
+        ])
+
+        let august = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-08-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertFalse(august.isEmpty, "the August scan must see the 31st turn")
+
+        // Month rolls over: the actor drops `existing`. The skip must drop with it
+        // so a week window starting Aug 30 still finds the turn.
+        let september = LocalAdditionalUsageReader.kiroEntries(
+            modifiedSince: try date("2026-08-30T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertFalse(
+            LocalUsageReader.dedupKeepMax([] + september).isEmpty,
+            "skip surviving an empty existing set zeros the week/block total across the 1st")
+    }
+
+    /// Option (b): skip state is an argument, not a process-lifetime map.
+    /// A month-key drop sets `previous` to nil, so the actor passes `[:]` —
+    /// the same contract this file's `[Entry]` overload uses. A static cache
+    /// (or a test-only `clearKiroScanCache`) would re-introduce #179.
+    func testSkipStateIsPassedByTheCallerNotHeldByTheReader() throws {
+        let source = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift")
+        let text = try String(contentsOf: source, encoding: .utf8)
+        XCTAssertFalse(text.contains("KiroDatabaseScanCache"), "skip must not outlive Cached")
+        XCTAssertFalse(text.contains("kiroScanCache"))
+        XCTAssertFalse(text.contains("clearKiroScanCache"))
+        XCTAssertFalse(text.contains("recordedKiroSignature"))
+        XCTAssertTrue(
+            text.contains("previous?.kiroSignatures"),
+            "the actor must take skip state from the same Cached that holds existing")
+        XCTAssertTrue(
+            text.contains("let kiroSignatures:"),
+            "signatures live next to entries, so a month-key drop invalidates both")
     }
 
     func testMissingModelIDFallsBackToUnknown() throws {

--- a/Tests/PokeTokenBarTests/KiroUsageTests.swift
+++ b/Tests/PokeTokenBarTests/KiroUsageTests.swift
@@ -9,6 +9,7 @@ final class KiroUsageTests: XCTestCase {
         temporaryDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("PokeTokenBar-KiroUsageTests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        LocalAdditionalUsageReader.clearKiroScanCache()
     }
 
     override func tearDownWithError() throws {
@@ -123,11 +124,98 @@ final class KiroUsageTests: XCTestCase {
         let since = try date("2026-01-01T00:00:00Z")
 
         let first = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        // Parse stability is a property of the reader, not of the mtime gate —
+        // clear so the second call actually re-reads (#178 would otherwise
+        // return [] and this assert would pass for the wrong reason).
+        LocalAdditionalUsageReader.clearKiroScanCache()
         let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
 
         XCTAssertEqual(Set(first.map(\.id)), Set(second.map(\.id)))
         XCTAssertEqual(LocalUsageReader.dedupKeepMax(first + second).count, first.count,
                        "merging two identical scans must not double the entries")
+    }
+
+    /// #178: `modifiedSince` is applied after the JSON parse, so an unchanged
+    /// database still pays the full read. The cheap gate is the file's own
+    /// signature — a second scan that sees the same mtime+size must return
+    /// nothing. The `.kiro` cache merges `existing + loaded`, so empty is
+    /// the correct "nothing new" signal, not a wipe.
+    func testUnchangedDatabaseSkipsTheRescan() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 40), responseBytes: 40),
+            ]),
+        ])
+        let since = try date("2026-01-01T00:00:00Z")
+
+        let first = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertEqual(first.map(\.id), ["kiro|conv-1|1780000000000"])
+
+        let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertTrue(second.isEmpty, "unchanged database must not be re-parsed; empty keeps the cached entries")
+        XCTAssertEqual(LocalUsageReader.dedupKeepMax(first + second).count, first.count)
+    }
+
+    /// A WAL commit leaves the main file's mtime alone. Keying the skip on
+    /// `data.sqlite3` only would miss the turn that just landed — the same
+    /// class `LocalAntigravityUsageReader.signature` already records. Do not
+    /// copy that function; reuse it.
+    func testWalCommitForcesARescan() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 40), responseBytes: 40),
+            ]),
+        ])
+        let since = try date("2026-01-01T00:00:00Z")
+        let first = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertFalse(first.isEmpty)
+
+        try Data("wal-commit".utf8).write(to: URL(fileURLWithPath: databaseURL.path + "-wal"))
+        let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertEqual(Set(second.map(\.id)), Set(first.map(\.id)),
+                       "a newer -wal sibling must invalidate the skip")
+    }
+
+    /// `-shm` is a rebuildable index. A read-only connection writes read
+    /// marks into it, so including it would let the skip invalidate itself
+    /// on every poll (hit rate 0). Same exclusion as Antigravity.
+    func testShmChurnDoesNotForceARescan() throws {
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 40), responseBytes: 40),
+            ]),
+        ])
+        let since = try date("2026-01-01T00:00:00Z")
+        _ = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+
+        try Data("shm-read-mark".utf8).write(to: URL(fileURLWithPath: databaseURL.path + "-shm"))
+        let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertTrue(second.isEmpty, "-shm churn is a read, not a write")
+    }
+
+    /// A failed open must not occupy the skip slot — otherwise a BUSY or
+    /// corrupt page is frozen as "no usage" until the file's mtime moves.
+    func testFailedOpenDoesNotOccupyTheSkipSlot() throws {
+        try Data("not-a-sqlite-database".utf8).write(to: databaseURL)
+        let since = try date("2026-01-01T00:00:00Z")
+        let first = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertTrue(first.isEmpty)
+        XCTAssertNil(
+            LocalAdditionalUsageReader.recordedKiroSignature(for: databaseURL),
+            "failed open must not record a signature")
+
+        try FileManager.default.removeItem(at: databaseURL)
+        try seedV2(conversations: [
+            (id: "conv-1", turns: [
+                turn(timestampMs: 1_780_000_000_000, model: "claude-sonnet-4.5",
+                     userText: String(repeating: "u", count: 40), responseBytes: 40),
+            ]),
+        ])
+        let second = LocalAdditionalUsageReader.kiroEntries(modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertEqual(second.map(\.id), ["kiro|conv-1|1780000000000"])
     }
 
     func testMissingModelIDFallsBackToUnknown() throws {

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -46,6 +46,13 @@ read_when:
   같은 `didReset` / `highWater == 0` 규칙을 두 벌로 들고 있으면 한쪽만 고친 수정이 다른 쪽에 남는다
   (#157). 루프는 `scanIncrementalStores` 한 곳, 포맷만 콜백. 회귀는 공유 헬퍼 테스트 **그리고**
   Copilot-only / Cursor-only 각 경로(A\|\|B 의 B 단독)를 모두 밟아야 한다.
+- **파싱 뒤에 걸린 필터는 출력을 줄이지 일을 줄이지 않는다.** `modifiedSince` 가 호출부에선
+  스캔 창처럼 보이지만, 행 watermark 가 있는 리더에서만 창이다. 통문서 저장(Kiro 가 대화 JSON 을
+  제자리 재기록)은 창을 파싱 *뒤에* 적용해서 읽기·`jsonObject` 비용이 그대로다(실측 30×80턴:
+  리턴 0건도 37ms). watermark 를 못 쓰면 싼 게이트는 파일 자신의 signature 다 — 이미 있는
+  `LocalAntigravityUsageReader.signature` 를 재사용한다(`.db`/`.sqlite3` + `-wal`, `-shm` 제외).
+  첫 스캔은 기록된 signature 가 없어 건너뛰지 않고, 실패한 open 은 슬롯을 차지하지 않는다.
+  `.kiro` 캐시는 `existing + loaded` 를 병합하므로 빈 스캔은 캐시를 지우지 않는다. (#178)
 - **외부 로그 포맷은 *상위 소스의 writer* 로 검증한다 — 내 픽스처는 증거가 아니다.** 새 프로바이더 파서를
   쓸 때 "이렇게 생겼을 것"으로 픽스처를 만들면 파서와 픽스처가 같은 오해를 공유해 테스트가 전부 통과하면서
   실사용은 0 을 표시한다(#133: 봉투 래퍼 키를 `update` 로 봤으나 실제는 `params`, `timestamp` 는 ISO 문자열이

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -52,7 +52,10 @@ read_when:
   리턴 0건도 37ms). watermark 를 못 쓰면 싼 게이트는 파일 자신의 signature 다 — 이미 있는
   `LocalAntigravityUsageReader.signature` 를 재사용한다(`.db`/`.sqlite3` + `-wal`, `-shm` 제외).
   첫 스캔은 기록된 signature 가 없어 건너뛰지 않고, 실패한 open 은 슬롯을 차지하지 않는다.
-  `.kiro` 캐시는 `existing + loaded` 를 병합하므로 빈 스캔은 캐시를 지우지 않는다. (#178)
+  `.kiro` 캐시는 `existing + loaded` 를 병합하므로 빈 스캔은 캐시를 지우지 않는다.
+  signature 는 process-lifetime 맵이 아니라 `Cached` 의 `kiroSignatures` 로 entries 옆에 둔다 —
+  month-key 가 바뀌면 `previous` 가 nil 이라 skip 도 같이 죽는다. skip 이 `existing` 없이
+  남으면 `[] + []` 로 주/블록 합계가 0 이 된다(#179). (#178)
 - **외부 로그 포맷은 *상위 소스의 writer* 로 검증한다 — 내 픽스처는 증거가 아니다.** 새 프로바이더 파서를
   쓸 때 "이렇게 생겼을 것"으로 픽스처를 만들면 파서와 픽스처가 같은 오해를 공유해 테스트가 전부 통과하면서
   실사용은 0 을 표시한다(#133: 봉투 래퍼 키를 `update` 로 봤으나 실제는 `params`, `timestamp` 는 ISO 문자열이


### PR DESCRIPTION
## Summary

`LocalAdditionalUsageReader.kiroEntries` re-reads and re-parses every stored Kiro conversation on every poll. Unlike Cursor and Copilot, Kiro rewrites a conversation's whole history JSON in place, so there is no monotonic row id. That was the right call for #170; the cost is this issue.

`modifiedSince` is applied inside `kiroTurnEntries`, after the row has been read out of SQLite and `jsonObject` has parsed it. Narrowing the window skips entry construction, not the read or the parse. Owner measured 209–360 ms on a 30×80 synthetic database, and a 37 ms floor on an empty window.

The cheap gate is the file's own signature. This reuses `LocalAntigravityUsageReader.signature` (main file + `-wal`, never `-shm`) rather than copying it — a WAL commit leaves the main file's mtime alone, and a read-only connection writes read marks into `-shm`, which would make the skip invalidate itself on every poll.

An unchanged database returns `[]`. The `.kiro` cache merges `existing + loaded`, so a scan that returns nothing keeps the cached entries. A failed open (BUSY / corrupt) does not occupy the skip slot.

Skip state is not a process-lifetime map. Signatures live on `LocalAdditionalUsageCache.Cached` next to the entries they justify (option (b) from the #179 review — the same shape Antigravity uses). The actor passes `previous?.kiroSignatures ?? [:]`. A month-key drop sets `previous` to nil, so both `existing` and the skip die together. Without that, the first poll on the 1st returns `[]`, `dedupKeepMax([] + [])` is `[]`, and the week/block window that still reaches into last month reads 0 until Kiro next writes.

The `[Entry]` overload always passes `[:]`, so a one-shot read (and the parse-stability test) actually re-reads.

Class recorded in `docs/reference/defect-log.md`: a filter applied after parsing bounds the output, not the work; a skip that outlives `existing` zeros the window the skip was supposed to keep.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## UI changes

No visible change. Totals stay the same; an unchanged Kiro database is no longer fully re-parsed every 120s. Month rollover no longer drops last-month Kiro turns from the week/block totals.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change

## Tests

`KiroUsageTests` — each branch alone:

- `testUnchangedDatabaseSkipsTheRescan` — the #178 cost. Second scan with the first scan's signatures returns `[]`; `dedupKeepMax(existing + loaded)` keeps the first scan's ids.
- `testWalCommitForcesARescan` — a newer `-wal` sibling must invalidate the skip. Keying on `data.sqlite3` alone would stay green here.
- `testShmChurnDoesNotForceARescan` — `-shm` is a read mark, not a write. Including it would make hit rate 0.
- `testFailedOpenDoesNotOccupyTheSkipSlot` — garbage bytes must not appear in the returned `signatures` map, or a later valid file with a lucky-matching mtime would be treated as empty forever.
- `testRescanningTheSameDatabaseProducesStableEntryIDs` — still a parse-stability test. The `[Entry]` overload passes no known signatures, so it cannot pass by returning `[]`.
- `testSkipDoesNotSurviveAnEmptyExistingSet` — the #179 review reproduction. One Aug 31 turn; August scan sees it; September week window (`modifiedSince` Aug 30) with empty `existing` must still see it. Confirmed red against the process-lifetime cache at `4c27d3b`.
- `testSkipStateIsPassedByTheCallerNotHeldByTheReader` — source lock: no `KiroDatabaseScanCache` / `clearKiroScanCache` / `recordedKiroSignature`; the actor reads `previous?.kiroSignatures`.

`swift test --filter KiroUsageTests`: 29 tests, 0 failures.

Full suite: 682 pass, 9 skipped, 0 failures.

## How to verify

```bash
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --filter KiroUsageTests
```

No UI steps. A machine with a large Kiro `data.sqlite3` should see the second poll of an idle session return immediately instead of re-parsing every conversation. Crossing the 1st with an unchanged Kiro database must still show last week's turns in the week/block totals.