### PR TITLE
fix: flush AppLog on the willTerminate exit path (#174)

### DIFF
--- a/Sources/PokeTokenBar/Core/AppLog.swift
+++ b/Sources/PokeTokenBar/Core/AppLog.swift
@@ -43,10 +43,11 @@ enum AppLog {
     }
 
     /// Exit-path pair: enqueue, then wait until the line has been sunk.
-    /// Callers that reach `exit()` after `write` alone lose the line (#174).
+    /// Routes through the tested `backend.writeAndFlush` — a second
+    /// `write()`+`flush()` pair is untested and reintroduces #174.
     static func writeAndFlush(_ message: String) {
-        write(message)
-        flush()
+        guard AppEnv.isBundledApp else { return }
+        backend.writeAndFlush(formatted(message))
     }
 
     static func write(_ message: String) {
@@ -54,8 +55,11 @@ enum AppLog {
         // 않게(형제 write 경로 writeParitySnapshot·checkLimitNotifications 와 동일 가드). 테스트가
         // 크래시 진단 로그에 fixture 값을 남기고 회전으로 실이력을 밀어내던 결함 차단.
         guard AppEnv.isBundledApp else { return }
-        let line = "[\(ISO8601DateFormatter().string(from: Date()))] \(message)\n"
-        backend.write(line)
+        backend.write(formatted(message))
+    }
+
+    private static func formatted(_ message: String) -> String {
+        "[\(ISO8601DateFormatter().string(from: Date()))] \(message)\n"
     }
 }
 

--- a/Sources/PokeTokenBar/Core/AppLog.swift
+++ b/Sources/PokeTokenBar/Core/AppLog.swift
@@ -12,18 +12,41 @@ enum AppLog {
         return dir.appendingPathComponent("PokeTokenBar.log")
     }()
 
-    private static let queue = DispatchQueue(label: "poketokenbar.log")
-
     /// 로그 상한 — 초과 시 .old 로 1세대 회전(무한 증가 방지, 디스크 상한 ≈ 2×maxBytes = 4MB).
     /// 24/7 메뉴바 앱이라 회전이 잦아 진단 이력이 금방 사라지던 것 완화(장애 직전 컨텍스트 보존).
     /// 레퍼런스(size-capped 회전, 수 MB)에 맞춤 — 일자별 폴더는 무한 성장/정리 필요라 채택 안 함.
     private static let maxBytes = 2 * 1024 * 1024
 
+    private static let backend = AsyncLineLog(queue: DispatchQueue(label: "poketokenbar.log")) { line in
+        if let size = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int,
+           size > maxBytes {
+            let old = url.deletingPathExtension().appendingPathExtension("old.log")
+            try? FileManager.default.removeItem(at: old)
+            try? FileManager.default.moveItem(at: url, to: old)
+        }
+        if let data = line.data(using: .utf8) {
+            if let handle = try? FileHandle(forWritingTo: url) {
+                defer { try? handle.close() }
+                _ = try? handle.seekToEnd()
+                try? handle.write(contentsOf: data)
+            } else {
+                try? data.write(to: url)
+            }
+        }
+    }
+
     /// 큐에 쌓인 기록이 파일에 닿을 때까지 기다린다 — **곧 프로세스가 끝나는 자리에서만** 쓴다.
     /// `write` 는 async 라, 기록 직후 `NSApp.terminate` 이 `exit(0)` 에 닿으면 그 줄이 통째로 사라진다.
     /// serial 큐라 빈 블록을 sync 로 넣으면 앞서 넣은 기록이 모두 끝난 뒤에 돌아온다.
     static func flush() {
-        queue.sync {}
+        backend.flush()
+    }
+
+    /// Exit-path pair: enqueue, then wait until the line has been sunk.
+    /// Callers that reach `exit()` after `write` alone lose the line (#174).
+    static func writeAndFlush(_ message: String) {
+        write(message)
+        flush()
     }
 
     static func write(_ message: String) {
@@ -32,22 +55,30 @@ enum AppLog {
         // 크래시 진단 로그에 fixture 값을 남기고 회전으로 실이력을 밀어내던 결함 차단.
         guard AppEnv.isBundledApp else { return }
         let line = "[\(ISO8601DateFormatter().string(from: Date()))] \(message)\n"
-        queue.async {
-            if let size = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int,
-               size > maxBytes {
-                let old = url.deletingPathExtension().appendingPathExtension("old.log")
-                try? FileManager.default.removeItem(at: old)
-                try? FileManager.default.moveItem(at: url, to: old)
-            }
-            if let data = line.data(using: .utf8) {
-                if let handle = try? FileHandle(forWritingTo: url) {
-                    defer { try? handle.close() }
-                    _ = try? handle.seekToEnd()
-                    try? handle.write(contentsOf: data)
-                } else {
-                    try? data.write(to: url)
-                }
-            }
-        }
+        backend.write(line)
+    }
+}
+
+/// Serial line sink. `write` enqueues; `flush` waits until every earlier write
+/// has been sunk. An async logger is not a logger on an exit path (#174) —
+/// any caller that reaches `exit()` in the same turn must flush.
+///
+/// The sink is injected so tests can prove the drain without opening the
+/// production log (`AppLog.write` is a no-op under `swift test`).
+struct AsyncLineLog: Sendable {
+    let queue: DispatchQueue
+    let sink: @Sendable (String) -> Void
+
+    func write(_ line: String) {
+        queue.async { self.sink(line) }
+    }
+
+    func flush() {
+        queue.sync {}
+    }
+
+    func writeAndFlush(_ line: String) {
+        write(line)
+        flush()
     }
 }

--- a/Sources/PokeTokenBar/Core/CrashReporter.swift
+++ b/Sources/PokeTokenBar/Core/CrashReporter.swift
@@ -62,9 +62,13 @@ enum CrashReporter {
     }
 
     /// 정상 종료 — running 마커 제거 + 기록. (크래시/강제종료 땐 호출 안 됨 → 마커 잔존 → 다음 실행 감지.)
+    /// `writeAndFlush`: AppKit posts `willTerminate` and then exits, so a bare
+    /// `write` races teardown and `clean shutdown` is usually lost (#174).
+    /// The marker file itself is removed synchronously above — detection is
+    /// unaffected; this is the human-readable half of the shutdown record.
     static func markClean() {
         try? FileManager.default.removeItem(at: markerURL)
-        AppLog.write("clean shutdown")
+        AppLog.writeAndFlush("clean shutdown")
     }
 
     /// 직전 세션이 crash.log 에 남긴 크래시-시점 기록을 메인 로그로 합치고 crash.log 를 비운다.

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -39,10 +39,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         // **`CrashReporter.install` 보다도 앞**에 둔다: 뒤면 물러나는 인스턴스가 running 마커를 덮어쓰고
         // 종료 시 `markClean()` 이 발화해, 살아남은 쪽이 나중에 크래시해도 다음 실행이 정상 종료로 읽는다.
         if SingleInstance.shouldYieldToRunningInstance() {
-            AppLog.write("duplicate instance: yielding to the instance already running")
-            // write 는 async — terminate 이 곧 exit(0) 에 닿으므로 이 줄이 파일에 닿을 때까지 기다린다.
-            // 이 로그가 없으면 가드의 오작동("앱이 안 뜬다")과 크래시를 구별할 단서가 사라진다.
-            AppLog.flush()
+            // writeAndFlush: write is async and terminate reaches exit(0) in
+            // the same turn. Without the drain this line is lost (42 of 100
+            // in the #163 review) and a false positive looks like a crash.
+            AppLog.writeAndFlush("duplicate instance: yielding to the instance already running")
             NSApp.terminate(nil)
             return
         }

--- a/Tests/PokeTokenBarTests/AppLogTests.swift
+++ b/Tests/PokeTokenBarTests/AppLogTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// #174: `AppLog.write` is async, so a line written on the way out of the
+/// process races `exit(0)` and is frequently lost. `flush` (`queue.sync {}`)
+/// is the exit-path pair. `write` is gated on `AppEnv.isBundledApp`, so a
+/// test that opens the production log file would pass with or without the
+/// fix — the same split #163 left untested. These tests inject the sink so
+/// the drain is visible without touching `~/Library/Logs`.
+final class AppLogTests: XCTestCase {
+
+    /// The #174 leak: `write` returns before the sink runs. Without `flush`
+    /// the line has not landed; after `flush` it has. Dropping `flush` from
+    /// the test (or making `write` skip the queue) fails the second assert.
+    func testFlushDrainsAQueuedWriteBeforeReturning() {
+        let queue = DispatchQueue(label: "poketokenbar.log.test")
+        let landed = LineSink()
+        let log = AsyncLineLog(queue: queue) { line in
+            Thread.sleep(forTimeInterval: 0.03)
+            landed.append(line)
+        }
+
+        log.write("clean shutdown")
+        XCTAssertTrue(landed.lines.isEmpty, "write must return before the sink runs — otherwise flush is untestable")
+        log.flush()
+        XCTAssertEqual(landed.lines, ["clean shutdown"], "flush must wait for the queued write, not return while it is still in flight")
+    }
+
+    /// A second write queued ahead of flush must both land, in order.
+    /// `queue.sync {}` is a barrier behind every earlier `async`, not a
+    /// drain of only the most recent line.
+    func testFlushDrainsEveryWriteQueuedBeforeIt() {
+        let queue = DispatchQueue(label: "poketokenbar.log.test.multi")
+        let landed = LineSink()
+        let log = AsyncLineLog(queue: queue) { landed.append($0) }
+
+        log.write("launch: start")
+        log.write("clean shutdown")
+        log.flush()
+        XCTAssertEqual(landed.lines, ["launch: start", "clean shutdown"])
+    }
+
+    /// `writeAndFlush` is the call-site pair `markClean` and the duplicate
+    /// yield path must use. A caller that reaches `exit()` after `write`
+    /// alone is the defect.
+    func testWriteAndFlushLandsTheLineBeforeReturning() {
+        let queue = DispatchQueue(label: "poketokenbar.log.test.pair")
+        let landed = LineSink()
+        let log = AsyncLineLog(queue: queue) { line in
+            Thread.sleep(forTimeInterval: 0.03)
+            landed.append(line)
+        }
+
+        log.writeAndFlush("clean shutdown")
+        XCTAssertEqual(landed.lines, ["clean shutdown"])
+    }
+
+    /// Wiring: `markClean` must go through `writeAndFlush`, not `write`
+    /// alone. `AppLog.write` is a no-op under `swift test`, so calling
+    /// `markClean` cannot prove the drain. The source scan does — the same
+    /// shape as `testNoProviderReadsUsageLocationEnvDirectly`.
+    func testMarkCleanUsesWriteAndFlushNotWriteAlone() throws {
+        let source = try String(contentsOf: repositoryFile("Sources/PokeTokenBar/Core/CrashReporter.swift"))
+        let body = try XCTUnwrap(
+            functionBody(named: "markClean", in: source),
+            "CrashReporter.markClean is the willTerminate site #174 names")
+        XCTAssertTrue(
+            body.contains("AppLog.writeAndFlush(\"clean shutdown\")"),
+            "markClean must flush the clean-shutdown line; write alone races exit")
+        XCTAssertFalse(
+            body.contains("AppLog.write("),
+            "a leftover write() without flush is the original leak")
+    }
+
+    /// Sweep: the #163 yield path is the other write-then-exit site. It
+    /// already flushed; keep it on the same pair so a future edit cannot
+    /// drop one and keep the other.
+    func testDuplicateYieldUsesWriteAndFlushBeforeTerminate() throws {
+        let source = try String(contentsOf: repositoryFile("Sources/PokeTokenBar/PokeTokenBarApp.swift"))
+        let body = try XCTUnwrap(
+            functionBody(named: "applicationDidFinishLaunching", in: source),
+            "the yield path lives in applicationDidFinishLaunching")
+        XCTAssertTrue(
+            body.contains("AppLog.writeAndFlush(\"duplicate instance: yielding to the instance already running\")"),
+            "the yield path must flush before terminate — #163 review, 42/100 lost")
+        XCTAssertFalse(
+            body.contains("AppLog.write("),
+            "write() without flush on this path is the race #163 already closed")
+    }
+
+    // MARK: - Helpers
+
+    /// Sink box so the `@Sendable` log closure can append without capturing a
+    /// mutable `var`. Reads happen only after `flush`, so the queue is idle.
+    private final class LineSink: @unchecked Sendable {
+        private(set) var lines: [String] = []
+        func append(_ line: String) { lines.append(line) }
+    }
+
+    private func repositoryFile(_ relative: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // PokeTokenBarTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // repo root
+            .appendingPathComponent(relative)
+    }
+
+    /// Body of `func <name>` up to the next top-level `func` / `///` type doc
+    /// at the same indent, or end of file. Enough to pin a call inside one
+    /// method without matching a comment elsewhere in the file.
+    private func functionBody(named name: String, in source: String) -> String? {
+        let marker = "func \(name)("
+        guard let start = source.range(of: marker) else { return nil }
+        let rest = source[start.lowerBound...]
+        let next = rest.range(of: "\n    func ", options: [], range: rest.index(after: start.lowerBound)..<rest.endIndex)
+            ?? rest.range(of: "\n    ///", options: [], range: rest.index(after: start.lowerBound)..<rest.endIndex)
+        return String(rest[..<(next?.lowerBound ?? rest.endIndex)])
+    }
+}

--- a/Tests/PokeTokenBarTests/AppLogTests.swift
+++ b/Tests/PokeTokenBarTests/AppLogTests.swift
@@ -55,6 +55,25 @@ final class AppLogTests: XCTestCase {
         XCTAssertEqual(landed.lines, ["clean shutdown"])
     }
 
+    /// Production `AppLog.writeAndFlush` must go through the tested
+    /// `backend.writeAndFlush`. `write()`+`flush()` is a second, untested
+    /// pair — dropping `flush()` there reintroduces #174 with a green suite.
+    func testAppLogWriteAndFlushRoutesThroughBackend() throws {
+        let source = try String(contentsOf: repositoryFile("Sources/PokeTokenBar/Core/AppLog.swift"))
+        let body = try XCTUnwrap(
+            functionBody(named: "writeAndFlush", in: source),
+            "AppLog.writeAndFlush is the production exit-path pair")
+        XCTAssertTrue(
+            body.contains("backend.writeAndFlush("),
+            "the shipped writeAndFlush must call the tested drain, not a second pair")
+        XCTAssertTrue(
+            body.contains("AppEnv.isBundledApp"),
+            "bypassing write() without the bundled-app guard lets swift test pollute the real log")
+        XCTAssertFalse(
+            body.contains("write(message)"),
+            "write()+flush() is the untested pair the owner removed and the suite stayed green")
+    }
+
     /// Wiring: `markClean` must go through `writeAndFlush`, not `write`
     /// alone. `AppLog.write` is a no-op under `swift test`, so calling
     /// `markClean` cannot prove the drain. The source scan does — the same
@@ -74,18 +93,23 @@ final class AppLogTests: XCTestCase {
 
     /// Sweep: the #163 yield path is the other write-then-exit site. It
     /// already flushed; keep it on the same pair so a future edit cannot
-    /// drop one and keep the other.
+    /// drop one and keep the other. Scan only the yield `if` — `functionBody`
+    /// on `applicationDidFinishLaunching` spans ~ten methods and rejects a
+    /// correct launch-path `AppLog.write`.
     func testDuplicateYieldUsesWriteAndFlushBeforeTerminate() throws {
         let source = try String(contentsOf: repositoryFile("Sources/PokeTokenBar/PokeTokenBarApp.swift"))
         let body = try XCTUnwrap(
-            functionBody(named: "applicationDidFinishLaunching", in: source),
-            "the yield path lives in applicationDidFinishLaunching")
+            yieldBlock(in: source),
+            "the yield path lives in the shouldYieldToRunningInstance block")
         XCTAssertTrue(
             body.contains("AppLog.writeAndFlush(\"duplicate instance: yielding to the instance already running\")"),
             "the yield path must flush before terminate — #163 review, 42/100 lost")
         XCTAssertFalse(
             body.contains("AppLog.write("),
             "write() without flush on this path is the race #163 already closed")
+        XCTAssertTrue(
+            body.contains("NSApp.terminate"),
+            "the scanned block must still be the write-then-exit site")
     }
 
     // MARK: - Helpers
@@ -103,6 +127,16 @@ final class AppLogTests: XCTestCase {
             .deletingLastPathComponent() // Tests
             .deletingLastPathComponent() // repo root
             .appendingPathComponent(relative)
+    }
+
+    /// The `if SingleInstance.shouldYieldToRunningInstance()` block only —
+    /// not the rest of `applicationDidFinishLaunching`. A launch-path
+    /// `AppLog.write` after SIGPIPE is not an exit-path race.
+    private func yieldBlock(in source: String) -> String? {
+        guard let start = source.range(of: "if SingleInstance.shouldYieldToRunningInstance()") else { return nil }
+        let rest = source[start.lowerBound...]
+        guard let end = rest.range(of: "signal(SIGPIPE") else { return nil }
+        return String(rest[..<end.lowerBound])
     }
 
     /// Body of `func <name>` up to the next top-level `func` / `///` type doc

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -212,7 +212,7 @@ read_when:
   (`SingleInstance` — 나중에 뜬 쪽이 물러난다) **메뉴바 항목을 만들기 전**에 둔다. 위치는
   `CrashReporter.install` **앞**이어야 한다: 뒤면 물러나는 인스턴스가 running 마커를 덮어쓰고 종료 시
   `markClean()` 이 발화해, 살아남은 쪽이 나중에 크래시해도 다음 실행이 정상 종료로 읽는다.
-  물러나기 직전 로그는 `AppLog.flush()` 로 밀어낸다 — `write` 가 async 라 `terminate` 이 `exit(0)` 에
+  물러나기 직전 로그는 `AppLog.writeAndFlush` 로 밀어낸다 — `write` 가 async 라 `terminate` 이 `exit(0)` 에
   닿으면 사라지고(실측 100회 중 42회), 그 줄이 없으면 가드 오작동("앱이 안 뜬다")과 크래시를 구별할
   단서가 없다. **대가를 함께 적어둔다: 물러나는 쪽이 launchd 소유라 살아남는 인스턴스는 워치독 밖이고,
   크래시 자동 재실행은 다음 로그인까지 꺼진다** — 메뉴바 앱은 로그아웃 없이 몇 주를 돌아 공백이 길다.
@@ -226,6 +226,14 @@ read_when:
   입력을 읽어내는 층에도 가드를 따로 둔다. 회귀 가드: `SingleInstanceTests` 의 판정 8건 + 입력 3건
   (`testProcessStartTimeIsReadableForTheCurrentProcess`·`…IsPlausible`·`…IsNilForAnUnknownProcess`).
   시작 시각을 못 읽거나 같으면 아무도 물러나지 않는다 — 아이콘 하나 더 뜨는 것보다 둘 다 사라지는 쪽이 나쁘다.
+- **async logger 는 exit 경로의 로거가 아니다.** `AppLog.write` 는 백그라운드 큐에 넣고 바로 돌아온다.
+  같은 턴에 호출자가 `exit()` 에 닿으면 그 줄은 자주 사라진다(실측 100회 중 42회). 마커 파일처럼
+  동기인 반쪽만 남으면 로그는 세션이 항상 비정상 종료된 것처럼 읽히고, **줄이 없다고 분기가 안 돈
+  증거로 쓰면 안 된다**. `willTerminate` 의 `CrashReporter.markClean`(`clean shutdown`)과 중복 인스턴스
+  yield 가 그 자리 — 둘 다 `writeAndFlush`(`queue.sync {}`). 판정은 주입된 sink 로 고정한다
+  (`AppLogTests`) — `write` 는 `AppEnv.isBundledApp` 가드라 프로덕션 로그를 여는 테스트는 수정
+  여부와 무관하게 통과한다. 부류 스윕: `write` 직후 `terminate`/`exit` 하는 자리를 전수하고
+  `writeAndFlush` 로 묶는다. (#174)
 
 ## 표시·UI
 - **앱 언어와 시스템 로케일은 다른 축이다 — SwiftUI 가 스스로 만드는 문장은 로케일을 따른다.**

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -233,7 +233,9 @@ read_when:
   yield 가 그 자리 — 둘 다 `writeAndFlush`(`queue.sync {}`). 판정은 주입된 sink 로 고정한다
   (`AppLogTests`) — `write` 는 `AppEnv.isBundledApp` 가드라 프로덕션 로그를 여는 테스트는 수정
   여부와 무관하게 통과한다. 부류 스윕: `write` 직후 `terminate`/`exit` 하는 자리를 전수하고
-  `writeAndFlush` 로 묶는다. (#174)
+  `writeAndFlush` 로 묶는다. `AppLog.writeAndFlush` 는 테스트된 `backend.writeAndFlush` 를
+  타야 한다 — `write()`+`flush()` 두 번째 쌍은 가드가 안 되고, `flush()` 만 빼면 스위트가
+  초록인데 #174 가 다시 산다. (#174)
 
 ## 표시·UI
 - **앱 언어와 시스템 로케일은 다른 축이다 — SwiftUI 가 스스로 만드는 문장은 로케일을 따른다.**


### PR DESCRIPTION
## Summary

`AppLog.write` enqueues on a background queue and returns. `CrashReporter.markClean()` runs from the `willTerminate` observer; AppKit then exits, so `clean shutdown` is written only if the log queue happens to get scheduled first. Owner measured 42 of 100 lost. The marker file is removed synchronously, so crash *detection* is fine — the log just reads as if every session ended abruptly.

#163 already added `AppLog.flush()` and used it on the duplicate-yield path. This PR is the remaining site from that review, plus the sweep: both write-then-exit callers now go through `writeAndFlush`.

`write` is gated on `AppEnv.isBundledApp`, so a test that opened the production log would pass with or without the fix (the gap #163 left). The drain is pinned on `AsyncLineLog` with an injected sink — the same injection shape as #168. Dropping `flush` from `writeAndFlush` makes `testWriteAndFlushLandsTheLineBeforeReturning` fail (`landed == []`).

Class recorded in `docs/reference/defect-log.md`: an async logger is not a logger on an exit path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## UI changes

No visible change. Only the shutdown / yield log line is now guaranteed to land.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change

## Tests

`AppLogTests` — each branch alone:

- `testFlushDrainsAQueuedWriteBeforeReturning` — the #174 leak. `write` returns before the sink runs; `flush` waits. A 30ms sink makes the race visible without sleeping the test thread after flush.
- `testFlushDrainsEveryWriteQueuedBeforeIt` — `queue.sync {}` is a barrier behind every earlier `async`, not only the last line.
- `testWriteAndFlushLandsTheLineBeforeReturning` — the call-site pair. Confirmed red-then-green: removing `flush` from `writeAndFlush` fails with `landed == []`.
- `testMarkCleanUsesWriteAndFlushNotWriteAlone` — source scan of `markClean`. `AppLog.write` is a no-op under `swift test`, so calling `markClean` cannot prove the drain (same split as `testNoProviderReadsUsageLocationEnvDirectly`).
- `testDuplicateYieldUsesWriteAndFlushBeforeTerminate` — the #163 site, swept onto the same pair so a future edit cannot drop one and keep the other.

`swift test --filter AppLogTests`: 5 tests, 0 failures.

Full suite: 681 pass, 9 skipped, 0 failures.

## How to verify

```bash
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --filter AppLogTests
```

Manual: quit the bundled app from the popover. `~/Library/Logs/PokeTokenBar.log` should contain a `clean shutdown` line for that session, not only `launch:`.