### PR TITLE
feat: add a Linux (GTK3 + StatusNotifierItem) frontend, verified on K…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,150 @@
+# PokeTokenBar — canonical runbook.
+#
+# `make` with no target prints the list below. Targets are grouped by platform where they differ:
+# the Linux tray frontend and the macOS .app bundle are built by different toolchains, but share
+# one source tree and one test suite.
+#
+# Release is deliberately NOT a target — scripts/release.sh is interactive, irreversible and
+# macOS-only. See docs/reference/release-workflow.md.
+
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+UNAME_S := $(shell uname -s)
+BIN_NAME := PokeTokenBar
+DEBUG_BIN := $(shell swift build --show-bin-path 2>/dev/null)/$(BIN_NAME)
+RELEASE_BIN := $(shell swift build -c release --show-bin-path 2>/dev/null)/$(BIN_NAME)
+
+# Installed layout (Linux, user-scoped — no root anywhere in this Makefile).
+PREFIX ?= $(HOME)/.local
+INSTALL_BIN := $(PREFIX)/bin/poketokenbar
+DESKTOP_FILE := $(PREFIX)/share/applications/poketokenbar.desktop
+ICON_FILE := $(PREFIX)/share/icons/hicolor/512x512/apps/poketokenbar.png
+
+# The version lives in exactly one place; AppVersion.swift is generated from it.
+VERSION := $(shell grep -oE 'VERSION="[0-9.]+"' scripts/build-app.sh | grep -oE '[0-9.]+')
+VERSION_SWIFT := Sources/PokeTokenBar/Core/Platform/AppVersion.swift
+
+.PHONY: help build release run stop test test-gate version-sync version-check \
+        install uninstall autostart-enable autostart-disable autostart-status \
+        app clean
+
+help:   ## Show this help
+	@echo "PokeTokenBar $(VERSION) — $(UNAME_S)"
+	@echo
+	@grep -hE '^[a-z0-9-]+:.*?##' $(MAKEFILE_LIST) \
+	  | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[1m%-18s\033[0m %s\n", $$1, $$2}'
+	@echo
+ifeq ($(UNAME_S),Linux)
+	@echo "  Start here:  make run"
+else
+	@echo "  Start here:  make app"
+endif
+
+# ---------------------------------------------------------------- build & run
+
+build: version-check   ## Build (debug)
+	swift build
+
+release: version-check   ## Build (release, optimised)
+	swift build -c release
+
+run: build   ## Build and run the tray app in the foreground (Ctrl-C to stop)
+ifneq ($(UNAME_S),Linux)
+	@echo "make run is Linux-only — on macOS use 'make app'." >&2; exit 1
+endif
+	@# The app yields to an already-running instance, so a stale copy would make this look
+	@# like it exited for no reason. Say so instead of leaving the user guessing.
+	@if pgrep -x $(BIN_NAME) >/dev/null; then \
+	  echo "note: an instance is already running (pid $$(pgrep -x $(BIN_NAME) | tr '\n' ' ')) — 'make stop' first"; \
+	fi
+	$(DEBUG_BIN)
+
+stop:   ## Stop a running tray app
+	@# -x matches the process name exactly. Matching the full command line (-f) would also match
+	@# this very make invocation and kill the shell running it.
+	@pkill -x $(BIN_NAME) && echo "stopped" || echo "not running"
+
+# --------------------------------------------------------------------- tests
+
+test:   ## Run the test suite
+	swift test
+
+test-gate:   ## Run the pre-commit gate (tests + logic-core line coverage)
+	./scripts/test-gate.sh
+
+# ------------------------------------------------------------------- version
+
+version-sync:   ## Regenerate AppVersion.swift from scripts/build-app.sh
+	@sed -i.bak -E 's/(static let compiled = )"[0-9.]+"/\1"$(VERSION)"/' $(VERSION_SWIFT) \
+	  && rm -f $(VERSION_SWIFT).bak
+	@echo "AppVersion.compiled = $(VERSION)"
+
+version-check:   ## Fail if AppVersion.swift has drifted from scripts/build-app.sh
+	@compiled=$$(grep -oE 'static let compiled = "[0-9.]+"' $(VERSION_SWIFT) | grep -oE '[0-9.]+'); \
+	if [[ "$$compiled" != "$(VERSION)" ]]; then \
+	  echo "✗ version drift: AppVersion.compiled=$$compiled but build-app.sh VERSION=$(VERSION)" >&2; \
+	  echo "  fix: make version-sync" >&2; \
+	  exit 1; \
+	fi
+
+# ------------------------------------------------------------- install (Linux)
+
+install: release   ## Install to ~/.local (binary, .desktop, icon)
+ifneq ($(UNAME_S),Linux)
+	@echo "make install is Linux-only — on macOS use 'make app'." >&2; exit 1
+endif
+	install -Dm755 $(RELEASE_BIN) $(INSTALL_BIN)
+	install -Dm644 assets/icon.png $(ICON_FILE)
+	@# StartupWMClass ties the window (app id "poketokenbar") to this entry, which is what gives
+	@# the task bar its icon and name. The app is listed normally: it has real windows now, so
+	@# hiding it with NoDisplay would only make it unlaunchable from the menu.
+	@install -d $(dir $(DESKTOP_FILE))
+	@printf '%s\n' \
+	  '[Desktop Entry]' \
+	  'Type=Application' \
+	  'Name=PokeTokenBar' \
+	  'Comment=AI coding usage in your tray, with a Pokemon companion' \
+	  'Exec=$(INSTALL_BIN)' \
+	  'Icon=poketokenbar' \
+	  'Categories=System;Monitor;' \
+	  'StartupWMClass=poketokenbar' \
+	  'X-GNOME-Autostart-enabled=true' \
+	  > $(DESKTOP_FILE)
+	@echo
+	@echo "installed: $(INSTALL_BIN)"
+	@case ":$$PATH:" in *":$(PREFIX)/bin:"*) ;; \
+	  *) echo "warning: $(PREFIX)/bin is not on your PATH" ;; esac
+	@echo "next:      make autostart-enable   # start it at login"
+
+uninstall:   ## Remove everything 'make install' wrote, and any autostart unit
+	-@$(MAKE) --no-print-directory autostart-disable 2>/dev/null || true
+	rm -f $(INSTALL_BIN) $(DESKTOP_FILE) $(ICON_FILE)
+	rm -f $(HOME)/.config/systemd/user/poketokenbar.service
+	@systemctl --user daemon-reload 2>/dev/null || true
+	@echo "uninstalled (data in ~/.local/share/PokeTokenBar was kept — delete it by hand to reset)"
+
+# Autostart delegates to the binary, which owns the systemd unit definition (Core/LoginItem.swift).
+# Writing the unit here instead would give it a second, silently diverging copy.
+autostart-enable:   ## Enable launch at login (systemd --user)
+	@$(or $(wildcard $(INSTALL_BIN)),$(DEBUG_BIN)) --enable-autostart
+
+autostart-disable:   ## Disable launch at login
+	@$(or $(wildcard $(INSTALL_BIN)),$(DEBUG_BIN)) --disable-autostart
+
+autostart-status:   ## Report whether launch at login is enabled
+	@$(or $(wildcard $(INSTALL_BIN)),$(DEBUG_BIN)) --autostart-status
+
+# ------------------------------------------------------------- bundle (macOS)
+
+# build-app.sh takes no arguments and always does both steps: assemble the bundle in build/ and
+# copy it into /Applications (terminating any running copy first). There is no build-only mode, so
+# this is one target rather than two.
+app:   ## Build the .app bundle and install it into /Applications (macOS)
+	./scripts/build-app.sh
+
+# --------------------------------------------------------------------- misc
+
+clean:   ## Remove build artifacts
+	swift package clean
+	rm -rf .build/release .build/debug

--- a/Package.swift
+++ b/Package.swift
@@ -1,18 +1,59 @@
 // swift-tools-version: 6.0
 import PackageDescription
 
+// One target, with platform-specific sources and dependencies attached conditionally.
+// Splitting Core into its own library target would mean opening ~9,500 lines of internal
+// declarations to public purely so the UI can reach them, and would break
+// `@testable import PokeTokenBar` in all 33 test files. Wrapping whole files instead — the macOS
+// UI in `#if os(macOS)`, the Linux frontend in `#if os(Linux)` — buys the same isolation.
+// It also leaves test-gate.sh's coverage paths and build-app.sh's product path valid as they are.
 let package = Package(
     name: "PokeTokenBar",
     platforms: [.macOS(.v14)],
     targets: [
+        // Linux-only C system libraries — the dependency conditions keep them out of macOS builds.
+        .systemLibrary(
+            name: "CSQLite",
+            path: "Sources/CSQLite",
+            pkgConfig: "sqlite3",
+            providers: [.apt(["libsqlite3-dev"]), .yum(["sqlite-devel"])]
+        ),
+        .systemLibrary(
+            name: "CZlib",
+            path: "Sources/CZlib",
+            pkgConfig: "zlib",
+            providers: [.apt(["zlib1g-dev"]), .yum(["zlib-devel"])]
+        ),
+        .systemLibrary(
+            name: "CGtk",
+            path: "Sources/CGtk",
+            pkgConfig: "appindicator3-0.1",
+            providers: [.apt(["libgtk-3-dev", "libayatana-appindicator3-dev"])]
+        ),
+        .systemLibrary(
+            name: "CNotify",
+            path: "Sources/CNotify",
+            pkgConfig: "libnotify",
+            providers: [.apt(["libnotify-dev"])]
+        ),
         .executableTarget(
             name: "PokeTokenBar",
+            dependencies: [
+                .target(name: "CSQLite", condition: .when(platforms: [.linux])),
+                .target(name: "CZlib", condition: .when(platforms: [.linux])),
+                .target(name: "CGtk", condition: .when(platforms: [.linux])),
+                .target(name: "CNotify", condition: .when(platforms: [.linux])),
+            ],
             path: "Sources/PokeTokenBar",
-            linkerSettings: [.linkedLibrary("sqlite3")]
+            // On Linux, linking is handled by `link "sqlite3"` in the CSQLite module map.
+            linkerSettings: [.linkedLibrary("sqlite3", .when(platforms: [.macOS]))]
         ),
         .testTarget(
             name: "PokeTokenBarTests",
-            dependencies: ["PokeTokenBar"],
+            dependencies: [
+                "PokeTokenBar",
+                .target(name: "CSQLite", condition: .when(platforms: [.linux])),
+            ],
             path: "Tests/PokeTokenBarTests",
             resources: [
                 .copy("Fixtures/CodexFork"),

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,6 +8,7 @@
 
 [![Release](https://img.shields.io/github/v/release/chattymin/PokeTokenBar?color=444d56&label=release)](https://github.com/chattymin/PokeTokenBar/releases)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
+[![Linux](https://img.shields.io/badge/Linux-KDE%20Plasma%20%28%E9%83%A8%E5%88%86%29-1793d1)](#linux-kde-plasma)
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)
 [![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
@@ -17,7 +18,7 @@
 
 </div>
 
-PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI）を、macOS メニューバーの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
+PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI）を、macOS メニューバー、そして [部分的に](#linux-kde-plasma) Linux の KDE Plasma システムトレイの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
 
 > トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI データから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
 
@@ -125,6 +126,8 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 
 macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI データから直接読み取り、外部の使用量 CLI は不要です。
 
+Linux は **部分対応** です — [Linux (KDE Plasma)](#linux-kde-plasma) を参照。
+
 ### Homebrew
 
 ```bash
@@ -151,6 +154,36 @@ swift build                  # デバッグ
 swift test                   # ユニットテスト
 ./scripts/build-app.sh       # release → PokeTokenBar.app → /Applications
 ```
+
+### Linux (KDE Plasma)
+
+GTK3 フロントエンドが同じパートナーと使用量トラッカーをシステムトレイに表示します。**Arch Linux・
+KDE Plasma 6・Wayland** でビルドと動作確認をしています。StatusNotifierItem を実装したデスクトップ
+なら動作するはずですが、それ以外は未検証です。パッケージはまだないので自分でビルドします:
+
+```bash
+sudo pacman -S --needed swift-bin gtk3 libappindicator libnotify   # ディストリに合わせて
+make run                     # ビルドして実行
+make install                 # → ~/.local/bin（root 不要）、.desktop エントリとアイコン付き
+make autostart-enable        # ログイン時に自動起動（systemd --user）
+```
+
+`make` だけで全ターゲットが一覧表示されます。
+
+**動くもの:** アニメーションするパートナーと今日の使用量を載せたトレイアイコン、ホーム／ショップ／
+バッグ／コレクションのウィンドウ、進化ライン、公式の5時間・週間上限メーター、上限・孵化・進化の
+デスクトップ通知、フローティングペット、設定（言語・更新間隔・自動起動・通知）。使用量の解析、
+パートナーの進行、セーブデータは macOS と **同じコード** です。
+
+**まだ動かないもの:**
+
+| 未対応 | 理由 |
+|---|---|
+| フローティングペットのドラッグ・位置の記憶 | Wayland はクライアントが自分のウィンドウ位置を知ることも決めることも許しません — KWin のウィンドウルールで配置してください |
+| ウィンドウがトレイアイコンに吸着せず、フォーカスを失っても閉じない | 同じ理由（パネル項目の隣にサーフェスを置く手段がない） |
+| セーブのエクスポート・インポート | GTK のファイル選択ダイアログが必要です（macOS の設定にはあります） |
+| 図鑑の詳細画面・捕獲ログ | コレクションはグリッドとレア度の集計のみ表示します |
+| アプリ内アップデート・Homebrew cask | アプリが Linux のインストール形態を判別できないため、リリースページを開くまでで止まります |
 
 ## データソース
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,6 +8,7 @@
 
 [![Release](https://img.shields.io/github/v/release/chattymin/PokeTokenBar?color=444d56&label=release)](https://github.com/chattymin/PokeTokenBar/releases)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
+[![Linux](https://img.shields.io/badge/Linux-KDE%20Plasma%20%28%EB%B6%80%EB%B6%84%29-1793d1)](#linux-kde-plasma)
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)
 [![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
@@ -17,7 +18,7 @@
 
 </div>
 
-PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · Antigravity · OpenCode · Hermes Agent · Cursor · Grok CLI · Copilot CLI · Kiro CLI)을 macOS 메뉴바 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
+PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · Antigravity · OpenCode · Hermes Agent · Cursor · Grok CLI · Copilot CLI · Kiro CLI)을 macOS 메뉴바 — 그리고 [부분적으로](#linux-kde-plasma) Linux 의 KDE Plasma 시스템 트레이 — 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
 
 > 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 데이터에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
 
@@ -125,6 +126,8 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 
 macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 데이터에서 직접 읽으며 외부 사용량 CLI가 필요 없습니다.
 
+Linux 는 **부분 지원**입니다 — [Linux (KDE Plasma)](#linux-kde-plasma) 참고.
+
 ### Homebrew
 
 ```bash
@@ -151,6 +154,35 @@ swift build                  # 디버그
 swift test                   # 단위 테스트
 ./scripts/build-app.sh       # release → PokeTokenBar.app → /Applications
 ```
+
+### Linux (KDE Plasma)
+
+GTK3 프런트엔드가 같은 companion 과 사용량 트래커를 시스템 트레이에 올립니다. **Arch Linux · KDE
+Plasma 6 · Wayland** 에서 빌드·검증했습니다. StatusNotifierItem 을 구현한 데스크톱이면 동작할
+것으로 보이지만 그 외 환경은 검증하지 않았습니다. 아직 패키지는 없고 직접 빌드합니다:
+
+```bash
+sudo pacman -S --needed swift-bin gtk3 libappindicator libnotify   # 배포판에 맞는 패키지로
+make run                     # 빌드 후 실행
+make install                 # → ~/.local/bin (root 불필요), .desktop 항목·아이콘 포함
+make autostart-enable        # 로그인 시 자동 시작 (systemd --user)
+```
+
+`make` 만 치면 전체 타깃이 나옵니다.
+
+**되는 것:** 애니메이션 companion 과 오늘 사용량이 붙은 트레이 아이콘, 홈/상점/가방/컬렉션 창,
+진화 라인, 공식 5시간·주간 한도 게이지, 한도·부화·진화 데스크톱 알림, 플로팅 펫, 설정(언어·주기·
+자동 시작·알림). 사용량 파싱·companion 진행·세이브는 macOS 와 **같은 코드**입니다.
+
+**아직 안 되는 것:**
+
+| 공백 | 이유 |
+|---|---|
+| 플로팅 펫 드래그·위치 기억 | Wayland 는 클라이언트가 자기 창 위치를 알거나 정하는 것을 막습니다 — KWin 창 규칙으로 배치하세요 |
+| 창이 트레이 아이콘에 붙지 않고, 포커스를 잃어도 닫히지 않음 | 같은 이유(패널 항목 옆에 표면을 놓을 방법이 없음) |
+| 세이브 내보내기·가져오기 | GTK 파일 선택창이 필요합니다(macOS 설정에는 있음) |
+| 도감 상세 화면·포획 로그 | 컬렉션은 그리드와 희귀도 집계만 표시합니다 |
+| 인앱 업데이트·Homebrew cask | 앱이 Linux 설치 형태를 알 수 없어 릴리스 페이지를 여는 데서 멈춥니다 |
 
 ## 데이터 소스
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Release](https://img.shields.io/github/v/release/chattymin/PokeTokenBar?color=444d56&label=release)](https://github.com/chattymin/PokeTokenBar/releases)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
+[![Linux](https://img.shields.io/badge/Linux-KDE%20Plasma%20%28partial%29-1793d1)](#linux-kde-plasma)
 [![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
 [![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)
 [![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
@@ -17,7 +18,7 @@
 
 </div>
 
-PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI & Kiro CLI — into a growing **Pokémon companion** in your macOS menu bar. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
+PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI & Kiro CLI — into a growing **Pokémon companion** in your macOS menu bar — and, [partially](#linux-kde-plasma), in your KDE Plasma system tray on Linux. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
 
 > Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
 
@@ -125,6 +126,8 @@ All read locally — no external usage CLI required. Adding a tool is one provid
 
 macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data, with no external usage CLI required.
 
+Linux is **partially supported** — see [Linux (KDE Plasma)](#linux-kde-plasma).
+
 ### Homebrew
 
 ```bash
@@ -151,6 +154,37 @@ swift build                  # debug
 swift test                   # unit tests
 ./scripts/build-app.sh       # release → PokeTokenBar.app → /Applications
 ```
+
+### Linux (KDE Plasma)
+
+A GTK3 frontend puts the same companion and usage tracker in the system tray. Built and verified on
+**Arch Linux, KDE Plasma 6, Wayland**; it should work on any desktop that implements
+StatusNotifierItem, but nothing else has been tested. There is no package yet — build it:
+
+```bash
+sudo pacman -S --needed swift-bin gtk3 libappindicator libnotify   # or your distro's equivalents
+make run                     # build and run
+make install                 # → ~/.local/bin (no root), with .desktop entry and icon
+make autostart-enable        # start at login (systemd --user)
+```
+
+`make` on its own lists every target.
+
+**What works:** the tray icon with your animated companion and today's usage; the main window with
+Home / Shop / Bag / Collection; the evolution line; official 5-hour and weekly limit meters;
+desktop notifications for limits, hatches and evolutions; the floating pet; and Settings
+(language, interval, autostart, notifications). All usage parsing, companion progression and save
+data are the same code as macOS.
+
+**What doesn't, yet:**
+
+| Gap | Why |
+|---|---|
+| Floating pet can't be dragged or remember its position | Wayland denies clients their own surface position — place it with a KWin window rule |
+| The window doesn't anchor to the tray icon or close on focus-out | Same reason: no way to position a surface next to a panel item |
+| Save export / import | Needs a GTK file chooser (macOS Settings has it) |
+| Pokédex detail view and catch log | Collection shows the grid and rarity counts only |
+| In-app update / Homebrew cask | Linux install method is unknown to the app, so it opens the release page instead |
 
 ## Data sources
 

--- a/Sources/CGtk/module.modulemap
+++ b/Sources/CGtk/module.modulemap
@@ -1,0 +1,4 @@
+module CGtk [system] {
+    header "shim.h"
+    export *
+}

--- a/Sources/CGtk/shim.h
+++ b/Sources/CGtk/shim.h
@@ -1,0 +1,5 @@
+/* GTK3 + AppIndicator for the Linux frontend.
+   `appindicator3-0.1`'s pkg-config flags already carry the gtk+-3.0 include and
+   link flags, so one pkgConfig name covers both headers. */
+#include <gtk/gtk.h>
+#include <libappindicator/app-indicator.h>

--- a/Sources/CNotify/module.modulemap
+++ b/Sources/CNotify/module.modulemap
@@ -1,0 +1,4 @@
+module CNotify [system] {
+    header "shim.h"
+    export *
+}

--- a/Sources/CNotify/shim.h
+++ b/Sources/CNotify/shim.h
@@ -1,0 +1,3 @@
+/* libnotify — the Linux stand-in for UserNotifications. Kept out of `CGtk`
+   because SwiftPM allows a system-library target only one pkgConfig name. */
+#include <libnotify/notify.h>

--- a/Sources/CSQLite/module.modulemap
+++ b/Sources/CSQLite/module.modulemap
@@ -1,0 +1,5 @@
+module CSQLite [system] {
+    header "shim.h"
+    link "sqlite3"
+    export *
+}

--- a/Sources/CSQLite/shim.h
+++ b/Sources/CSQLite/shim.h
@@ -1,0 +1,4 @@
+/* Linux has no `SQLite3` system module (that name is Darwin-only), so the
+   sqlite3 C API is re-exported under `CSQLite`. Core files pick between the two
+   with `#if canImport(SQLite3)`. */
+#include <sqlite3.h>

--- a/Sources/CZlib/module.modulemap
+++ b/Sources/CZlib/module.modulemap
@@ -1,0 +1,5 @@
+module CZlib [system] {
+    header "shim.h"
+    link "z"
+    export *
+}

--- a/Sources/CZlib/shim.h
+++ b/Sources/CZlib/shim.h
@@ -1,0 +1,3 @@
+/* zlib — compresses the usage-cache snapshot on Linux.
+   macOS uses Foundation's `NSData.compressed(using: .zlib)` and never links this. */
+#include <zlib.h>

--- a/Sources/PokeTokenBar/Core/AppEnv.swift
+++ b/Sources/PokeTokenBar/Core/AppEnv.swift
@@ -1,11 +1,32 @@
 import Foundation
 
-/// 실행 환경 판별 — 한 곳에서만 정의해 중복 게이트의 drift(일부만 조건이 어긋나는 것)를 막는다.
+/// Execution-environment checks — defined in one place so duplicated gates cannot drift apart.
 enum AppEnv {
-    /// 정식 `.app` 번들로 실행 중인가. 알림 전송·키체인 읽기·스프라이트 프리패치·프로덕션 로그 기록 등
-    /// "실앱 전용" 부수효과의 단일 게이트 — `swift test`/로우 바이너리(dev 실행)에선 false.
-    /// bundleIdentifier(Info.plist)와 경로 접미사를 함께 확인(둘 다 실앱에서만 참).
-    static var isBundledApp: Bool {
+    /// Whether this is a real, installed app. The single gate for "real app only" side effects —
+    /// notifications, keychain reads, sprite prefetch, production logging — so `swift test` and
+    /// dev runs stay out of the user's data.
+    ///
+    /// - macOS: is it a proper `.app` bundle (bundleIdentifier + path suffix — both true only for
+    ///   a real install).
+    /// - Linux: there is no bundle, so this asks **are we running out of the SwiftPM build
+    ///   directory**. `swift run` / `swift test` products always live under `.build/`, so dev runs
+    ///   are filtered exactly, while installed copies (`/usr/bin`, `~/.local/bin`) are not — the
+    ///   same meaning as the macOS branch, at the same precision.
+    static var isProductionInstall: Bool {
+        #if os(macOS)
         Bundle.main.bundleIdentifier != nil && Bundle.main.bundlePath.hasSuffix(".app")
+        #else
+        !executablePath.contains("/.build/")
+        #endif
     }
+
+    #if !os(macOS)
+    /// The executable's real path (`/proc/self/exe`), resolved through any install symlink.
+    private static let executablePath: String = {
+        if let resolved = try? FileManager.default.destinationOfSymbolicLink(atPath: "/proc/self/exe") {
+            return resolved
+        }
+        return CommandLine.arguments.first ?? ""
+    }()
+    #endif
 }

--- a/Sources/PokeTokenBar/Core/AppLog.swift
+++ b/Sources/PokeTokenBar/Core/AppLog.swift
@@ -6,8 +6,7 @@ enum AppLog {
     static var logFileURL: URL { url }
 
     private static let url: URL = {
-        let dir = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("Logs")
+        let dir = PlatformPaths.logsDirectory
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir.appendingPathComponent("PokeTokenBar.log")
     }()
@@ -30,7 +29,7 @@ enum AppLog {
         // 실제 .app 실행에서만 기록 — swift test / 로우 바이너리 실행이 프로덕션 로그를 오염시키지
         // 않게(형제 write 경로 writeParitySnapshot·checkLimitNotifications 와 동일 가드). 테스트가
         // 크래시 진단 로그에 fixture 값을 남기고 회전으로 실이력을 밀어내던 결함 차단.
-        guard AppEnv.isBundledApp else { return }
+        guard AppEnv.isProductionInstall else { return }
         let line = "[\(ISO8601DateFormatter().string(from: Date()))] \(message)\n"
         queue.async {
             if let size = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int,

--- a/Sources/PokeTokenBar/Core/BinaryLocator.swift
+++ b/Sources/PokeTokenBar/Core/BinaryLocator.swift
@@ -60,17 +60,36 @@ enum BinaryLocator {
     /// 새 버전매니저 지원 시 여기 한 곳만 추가하면 두 경로 모두에 반영된다.
     static func commonToolDirectories() -> [String] {
         let home = NSHomeDirectory()
-        return [
+        // Only the head and tail are platform-specific; **the version-manager block is shared** —
+        // mise, asdf, volta and bun use the same paths on both. Order is priority (first match
+        // wins), so the existing macOS order is left untouched.
+        #if os(macOS)
+        let systemFirst = [
             "/opt/homebrew/bin",                 // Homebrew (Apple Silicon)
             "/usr/local/bin",                    // Homebrew (Intel) / npm prefix
+        ]
+        let systemLast = ["/usr/bin"]
+        #else
+        let systemFirst = [
+            "/home/linuxbrew/.linuxbrew/bin",    // Homebrew on Linux
+            "/usr/local/bin",                    // npm prefix / manual install
+        ]
+        let systemLast = [
+            "\(home)/.local/share/pnpm",         // pnpm global bin
+            "\(home)/.local/share/flatpak/exports/bin",   // Flatpak (user install)
+            "/var/lib/flatpak/exports/bin",      // Flatpak (system install)
+            "/snap/bin",                         // Snap
+            "/usr/bin",
+        ]
+        #endif
+        return systemFirst + [
             "\(home)/.local/share/mise/shims",   // mise (shims 모드)
             "\(home)/.asdf/shims",               // asdf
             "\(home)/.volta/bin",                // Volta
             "\(home)/.bun/bin",                  // Bun
             "\(home)/.npm-global/bin",           // npm prefix=~/.npm-global
             "\(home)/.local/bin",
-            "/usr/bin",
-        ]
+        ] + systemLast
     }
 
     /// 버전매니저 공통 shim/bin 경로 + 주어진 정적 경로. (절대경로 우선 탐색용)
@@ -81,7 +100,7 @@ enum BinaryLocator {
     private static func locate(_ binary: String, staticPaths: [String]) -> String? {
         let fm = FileManager.default
         // 0) 사용자 수동 지정
-        if let override = UserDefaults.standard.string(forKey: "\(binary)Path"),
+        if let override = PlatformDefaults.standard.string(forKey: "\(binary)Path"),
            !override.isEmpty, fm.isExecutableFile(atPath: override) {
             return override
         }

--- a/Sources/PokeTokenBar/Core/CodexRateLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/CodexRateLimitsProvider.swift
@@ -42,7 +42,7 @@ struct CodexRateLimitsProvider: CodexLimitsProviding {
     }
 
     private static func requestLines() throws -> [String] {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.0"
+        let version = AppVersion.current
         let messages: [[String: Any]] = [
             [
                 "method": "initialize",

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Observation
-import UserNotifications
 
 /// 게임 상태의 출처. 설치 이후 토큰 사용량으로 포켓몬을 진화시키고, 최종체 + 추가 임계 도달 시
 /// 도감(라인 전체)에 보존 + 새 알. 진화 트리/희귀도/이름은 PokeProviding 으로 런타임 주입.
@@ -48,7 +47,7 @@ final class CompanionStore {
          clock: @escaping () -> Date = Date.init,
          fileURL: URL? = nil,
          rng: any RandomNumberGenerator = SystemRandomNumberGenerator(),
-         dittoDisguiseRollingEnabled: Bool = AppEnv.isBundledApp) {
+         dittoDisguiseRollingEnabled: Bool = AppEnv.isProductionInstall) {
         self.provider = provider
         self.clock = clock
         self.fileURL = fileURL ?? Self.defaultURL()
@@ -69,8 +68,7 @@ final class CompanionStore {
         if !override.isEmpty {
             dir = URL(fileURLWithPath: override, isDirectory: true)
         } else {
-            dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-                .appendingPathComponent("PokeTokenBar")
+            dir = PlatformPaths.appDirectory()
         }
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir.appendingPathComponent("companion-state.json")
@@ -82,6 +80,23 @@ final class CompanionStore {
     func setLanguage(_ lang: AppLanguage) { state.language = lang; save() }
     /// 앱 전체 UI 문자열 — language 변경 시 자동 재렌더.
     var l: L { L(language) }
+
+    /// The one-line mood text under the companion.
+    ///
+    /// Lives here rather than in a view because both frontends show it, and the mapping from state
+    /// to sentence is a product decision, not a layout one — duplicating it is how the two
+    /// platforms end up disagreeing about what the same state says.
+    var statusLine: String {
+        switch displayState {
+        case .egg:     return l.statusEgg
+        case .idle:    return l.statusIdle
+        case .working: return l.statusWorking
+        case .focus:   return l.statusFocus
+        case .tired:   return l.statusTired
+        case .sleep:   return l.statusSleep
+        case .levelUp: return justEvolvedTo.map { l.statusEvolved($0) } ?? l.statusGrew
+        }
+    }
 
     var hasActive: Bool { state.active != nil }
     var rarity: Rarity? { state.active?.rarity }
@@ -790,15 +805,12 @@ final class CompanionStore {
     /// companion 이벤트 시스템 알림(.app + 토글 ON 일 때만). 한도 알림과 독립.
     private var notifSeq = 0
     private func notifyCompanionEvent(_ title: String, _ body: String) {
-        guard AppEnv.isBundledApp else { return }
-        guard UserDefaults.standard.object(forKey: "companionNotifications") as? Bool ?? true else { return }
+        guard AppEnv.isProductionInstall else { return }
+        guard PlatformDefaults.standard.object(forKey: "companionNotifications") as? Bool ?? true else { return }
         notifSeq += 1
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = body
-        content.sound = .default
-        UNUserNotificationCenter.current().add(
-            UNNotificationRequest(identifier: "companion-event-\(notifSeq)", content: content, trigger: nil))
+        PlatformNotifier.post(
+            identifier: "companion-event-\(notifSeq)", title: title, body: body,
+            sound: true, critical: false)
     }
 
     // MARK: 부화
@@ -870,7 +882,7 @@ final class CompanionStore {
         guard let line = try? await provider.line(baseSpeciesID: id) else { return }   // 라인 예열
         // 스프라이트 예열 — 부화 직후 보일 것들: base 정적+애니메이션, shiny 롤(1/64) 대비 shiny 애니메이션.
         // .app 번들에서만(단위 테스트가 실네트워크에 닿지 않도록 — 알림과 동일한 게이트).
-        if AppEnv.isBundledApp {
+        if AppEnv.isProductionInstall {
             _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: false, shiny: false)
             _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: true, shiny: false)
             _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: true, shiny: true)

--- a/Sources/PokeTokenBar/Core/CrashReporter.swift
+++ b/Sources/PokeTokenBar/Core/CrashReporter.swift
@@ -1,4 +1,6 @@
+#if os(macOS)
 import AppKit
+#endif
 import Foundation
 
 /// 앱이 크래시·강제종료·OOM(SIGKILL)·런치실패로 죽으면 **반드시 로그(AppLog)에 흔적**을 남긴다(전역 처리).
@@ -17,14 +19,26 @@ import Foundation
 ///
 /// crash.log 의 기록은 **다음 실행 때 메인 로그로 합쳐 비운다**(사용자는 PokeTokenBar.log 한 곳만 봐도 됨).
 enum CrashReporter {
-    private static let logsDir: URL =
-        FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("Logs")
+    private static let logsDir: URL = PlatformPaths.logsDirectory
     private static var markerURL: URL { logsDir.appendingPathComponent("PokeTokenBar.running") }
     /// 크래시-시점 기록 전용(회전 안 함). 시그널/예외 핸들러가 async-signal-safe 하게 append.
     private static var crashLogURL: URL { logsDir.appendingPathComponent("PokeTokenBar.crash.log") }
     /// 위 crash.log 로 미리 연 fd(설치 시 1회 open). 회전 대상이 아니라 세션 내내 유효.
     nonisolated(unsafe) fileprivate static var logFD: Int32 = -1
+
+    #if !os(macOS)
+    /// The marker path the SIGTERM/SIGINT handler unlinks — allocated up front, because the
+    /// handler itself must not allocate.
+    nonisolated(unsafe) fileprivate static var markerPathForSignalHandler: UnsafeMutablePointer<CChar>?
+
+    /// Clean-exit signal — clear the marker, then hand off to the default action.
+    /// async-signal-safe: unlink/signal/raise only.
+    private static let cleanExitHandler: @convention(c) (Int32) -> Void = { received in
+        if let path = CrashReporter.markerPathForSignalHandler { _ = unlink(path) }
+        signal(received, SIG_DFL)
+        raise(received)
+    }
+    #endif
 
     /// 앱 기동 최초에 1회 호출(가능한 한 이르게 — 런치 초기 크래시도 잡히게).
     static func install(version: String) {
@@ -42,9 +56,20 @@ enum CrashReporter {
         AppLog.write("launch: PokeTokenBar \(version) 시작")
 
         // 3) 정상 종료 시 마커 제거(다음 실행이 '비정상'으로 오인하지 않게).
+        #if os(macOS)
         NotificationCenter.default.addObserver(
             forName: NSApplication.willTerminateNotification, object: nil, queue: .main
         ) { _ in markClean() }
+        #else
+        // Linux has no equivalent of willTerminate, so two paths cover it:
+        //  - user Quit (tray menu) → the frontend calls markClean() itself, same place as AppDelegate.
+        //  - SIGTERM/SIGINT (logout, systemctl stop, Ctrl-C) → the handler below.
+        // The handler does not call markClean() because that function is not async-signal-safe
+        // (FileManager and AppLog allocate and take locks). Clearing the marker needs nothing but
+        // unlink, so the path is built as a C string in advance and only that is called.
+        markerPathForSignalHandler = strdup(markerURL.path)
+        for sig in [SIGTERM, SIGINT] { signal(sig, CrashReporter.cleanExitHandler) }
+        #endif
 
         // 2) 치명 시그널 → crash.log 에 발생 시점 기록(async-signal-safe).
         logFD = open(crashLogURL.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
@@ -53,12 +78,17 @@ enum CrashReporter {
         }
 
         // 4) 잡히지 않은 NSException — 동기 write(비-시그널 컨텍스트라 문자열 포맷 가능).
+        // Linux has no Obj-C runtime, so this layer does not exist there. Swift's own fatal errors
+        // (fatalError, force-unwrap) land on SIGILL/SIGTRAP on both platforms and are caught by the
+        // signal handler in (2), so nothing is left uncovered.
+        #if os(macOS)
         NSSetUncaughtExceptionHandler { ex in
             let line = "[CRASH] uncaught exception: \(ex.name.rawValue) — \(ex.reason ?? "")\n"
             if let d = line.data(using: .utf8) {
                 d.withUnsafeBytes { _ = write(CrashReporter.logFD, $0.baseAddress, $0.count) }
             }
         }
+        #endif
     }
 
     /// 정상 종료 — running 마커 제거 + 기록. (크래시/강제종료 땐 호출 안 됨 → 마커 잔존 → 다음 실행 감지.)

--- a/Sources/PokeTokenBar/Core/KeychainAccess.swift
+++ b/Sources/PokeTokenBar/Core/KeychainAccess.swift
@@ -1,18 +1,24 @@
 import Foundation
 
-#if os(macOS)
-import Darwin
-import LocalAuthentication
-import Security
-
+/// The process-wide keychain-read gate — **shared across platforms**.
+///
+/// Confining it to macOS would split `UsageStore`'s settings plumbing (`disableKeychainAccess`
+/// didSet) per platform, leaving the same toggle wired to nothing on one of them — a dead switch.
+/// Linux has no keychain for the gate to actually block, but keeping the store/restore behaviour
+/// identical is what lets the settings UI be shared.
 enum KeychainAccessGate {
     /// 프로세스 전역 게이트(메모리) — 기동 시 저장값으로 1회 시드하고, 영속은
     /// UsageStore.disableKeychainAccess(didSet)가 전담한다. UserDefaults.standard 에
     /// 직접 쓰던 이전 구현은 테스트 실행이 실제 사용자 설정을 오염시켰다.
     /// (Bool 단일 플래그 — MainActor 쓰기/actor 읽기의 경합은 무해)
     nonisolated(unsafe) static var isDisabled: Bool =
-        UserDefaults.standard.bool(forKey: "disableKeychainAccess")
+        PlatformDefaults.standard.bool(forKey: "disableKeychainAccess")
 }
+
+#if os(macOS)
+import Darwin
+import LocalAuthentication
+import Security
 
 enum KeychainNoUIQuery {
     private static let uiFailPolicy = resolveUIFailPolicy()

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -1,5 +1,9 @@
 import Foundation
-import SQLite3
+#if canImport(SQLite3)
+import SQLite3   // Darwin-only module name
+#else
+import CSQLite   // Linux: the Sources/CSQLite module map
+#endif
 
 private enum LocalAdditionalSource: String, Sendable {
     case opencode
@@ -546,10 +550,8 @@ enum LocalAdditionalUsageReader {
 
     static var defaultCursorRoots: [URL] {
         environmentPaths("CURSOR_DATA_DIR") ?? [
-            FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/Cursor/User/globalStorage"),
-            FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/Cursor Nightly/User/globalStorage"),
+            PlatformPaths.electronAppData("Cursor").appendingPathComponent("User/globalStorage"),
+            PlatformPaths.electronAppData("Cursor Nightly").appendingPathComponent("User/globalStorage"),
         ]
     }
 
@@ -783,9 +785,7 @@ enum LocalAdditionalUsageReader {
     // MARK: Kiro CLI database
 
     static var defaultKiroRoots: [URL] {
-        environmentPaths("KIRO_CLI_HOME")
-            ?? [FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/kiro-cli")]
+        environmentPaths("KIRO_CLI_HOME") ?? [PlatformPaths.cliToolData("kiro-cli")]
     }
 
     /// Read Kiro CLI usage turns newer than `modifiedSince`.

--- a/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalAntigravityUsageReader.swift
@@ -1,5 +1,9 @@
 import Foundation
-import SQLite3
+#if canImport(SQLite3)
+import SQLite3   // Darwin-only module name
+#else
+import CSQLite   // Linux: the Sources/CSQLite module map
+#endif
 
 /// Antigravity CLI usage, read from the conversation stores the CLI writes under
 /// `~/.gemini/antigravity-cli/conversations/<conversation>.db`.
@@ -171,7 +175,7 @@ enum LocalAntigravityUsageReader {
     static let namedLossLimit = 5
 
     /// The lines one scan leaves behind. Pure on purpose: `AppLog.write` returns early outside
-    /// the bundled app (`AppEnv.isBundledApp`), so a test that watched the log file would cover
+    /// the bundled app (`AppEnv.isProductionInstall`), so a test that watched the log file would cover
     /// nothing at all — the same reason the limit-alert decision was split out of its own
     /// side effect.
     static func lossLog(_ reads: [(conversation: String, read: ConversationRead)]) -> [String] {

--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -117,9 +117,7 @@ actor LocalUsageCache {
     }
 
     private static let defaultFileURL: URL = {
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("PokeTokenBar")
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dir = PlatformPaths.appDirectory()
         return dir.appendingPathComponent("usage-cache.json")
     }()
 
@@ -315,7 +313,7 @@ actor LocalUsageCache {
         loaded = true
         guard let raw = try? Data(contentsOf: fileURL) else { return }
         // zlib 압축 스냅샷(현행) → 실패 시 평문 JSON(구버전 캐시) 폴백
-        let data = (try? (raw as NSData).decompressed(using: .zlib) as Data) ?? raw
+        let data = PlatformCompression.decompress(raw) ?? raw
         guard let snap = try? JSONDecoder().decode(Snapshot.self, from: data) else { return }
         claudeCache = snap.claude
         codexCache = snap.codex
@@ -364,7 +362,7 @@ actor LocalUsageCache {
             grokParserVersion: Self.grokParserVersion)
         if let data = try? JSONEncoder().encode(snap) {
             // JSON 은 zlib 로 크게 압축됨(수 MB → 수백 KB). 실패 시 평문 저장(로드가 양쪽 다 처리).
-            let out = (try? (data as NSData).compressed(using: .zlib) as Data) ?? data
+            let out = PlatformCompression.compress(data) ?? data
             try? out.write(to: fileURL, options: .atomic)
             dirty = false
             lastSave = now()

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -81,7 +81,7 @@ enum LocalUsageReader {
         roots.append(home.appendingPathComponent(Self.configRelativeProjectsPath))
         roots.append(home.appendingPathComponent(Self.defaultRelativeProjectsPath))
 
-        let desktop = home.appendingPathComponent("Library/Application Support/Claude")
+        let desktop = PlatformPaths.electronAppData("Claude")
         for store in ["local-agent-mode-sessions", "claude-code-sessions"] {
             roots.append(contentsOf: embeddedClaudeProjectRoots(under: desktop.appendingPathComponent(store)))
         }

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -91,6 +91,11 @@ struct L {
 
     // MARK: 푸터
     var refreshNow: String { t("지금 새로고침", "Refresh now", "今すぐ更新", "Actualizar ahora") }
+    /// Tray menu item that opens the main window. macOS opens the popover by clicking the status
+    /// item; a StatusNotifierItem click opens the menu instead, so Linux needs an explicit entry.
+    var openWindow: String { t("열기", "Open", "開く", "Abrir") }
+    /// First state of the tray menu summary row, before any usage has been read.
+    var loading: String { t("불러오는 중…", "Loading…", "読み込み中…", "Cargando…") }
     var updated: String { t("갱신", "Updated", "更新", "Actualizado") }
     var settings: String { t("설정", "Settings", "設定", "Ajustes") }
     var back: String { t("뒤로", "Back", "戻る", "Atrás") }

--- a/Sources/PokeTokenBar/Core/LoginItem.swift
+++ b/Sources/PokeTokenBar/Core/LoginItem.swift
@@ -1,4 +1,8 @@
+#if os(macOS)
 import ServiceManagement
+#else
+import Foundation
+#endif
 
 /// 로그인 시 실행 + **크래시/비정상 종료 시 자동 재실행**(launchd KeepAlive).
 ///
@@ -12,11 +16,12 @@ import ServiceManagement
 /// (= 로그인 실행과 크래시-재실행이 한 토글로 묶임 — 메뉴바 앱엔 자연스러운 결합).
 @MainActor
 enum LoginItem {
+    #if os(macOS)
     static let plistName = "io.github.chattymin.poketokenbar.login.plist"
     static let label = "io.github.chattymin.poketokenbar.login"
     private static var agent: SMAppService { SMAppService.agent(plistName: plistName) }
 
-    /// 현재 "로그인 시 실행(+크래시 자동 재실행)" 활성 여부.
+    /// Whether "launch at login (+ restart on crash)" is currently enabled.
     static var isEnabled: Bool { agent.status == .enabled }
 
     /// 토글 — 켜면 에이전트 등록(로그인 실행+KeepAlive), 끄면 해제. 실패 시 throw(호출부가 표면화).
@@ -38,4 +43,99 @@ enum LoginItem {
             AppLog.write("login item migration failed (mainApp 유지): \(error)")
         }
     }
+    #else
+    // MARK: Linux — systemd --user unit
+
+    private static let unitName = "poketokenbar.service"
+    private static var unitURL: URL {
+        let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        return home.appendingPathComponent(".config/systemd/user/\(unitName)")
+    }
+
+    /// Whether "launch at login (+ restart on crash)" is currently enabled.
+    static var isEnabled: Bool { systemctl(["is-enabled", "--quiet", unitName]) == 0 }
+
+    /// Toggle — writes and enables the unit, or disables it. Throws on failure so the caller can surface it.
+    ///
+    /// `Restart=on-failure` is the direct translation of launchd's `KeepAlive.SuccessfulExit=false`:
+    /// it comes back from a crash or OOM (exit ≠ 0) but not from a clean exit (user Quit, update).
+    /// `RestartSec=10` matches `ThrottleInterval` 10s and stops a restart storm.
+    static func setEnabled(_ on: Bool) throws {
+        if on {
+            try writeUnit()
+            _ = systemctl(["daemon-reload"])   // make systemd pick up the unit just written
+            guard systemctl(["enable", unitName]) == 0 else {
+                throw AutostartError.commandFailed("systemctl --user enable \(unitName)")
+            }
+        } else {
+            guard systemctl(["disable", unitName]) == 0 else {
+                throw AutostartError.commandFailed("systemctl --user disable \(unitName)")
+            }
+        }
+    }
+
+    /// The macOS-only migration (legacy login item → agent). Linux has no such legacy form, so no-op.
+    static func migrateFromLegacyLoginItemIfNeeded() {}
+
+    enum AutostartError: Error, CustomStringConvertible {
+        case commandFailed(String)
+        case executablePathUnavailable
+
+        var description: String {
+            switch self {
+            case .commandFailed(let command): return "failed: \(command)"
+            case .executablePathUnavailable: return "could not determine the executable path"
+            }
+        }
+    }
+
+    /// Write the unit file. `ExecStart` embeds **the real path of the running binary**.
+    /// Using a bare name would depend on PATH, and in the common case of a `~/.local/bin` copy
+    /// alongside a system one, login would start the wrong binary.
+    ///
+    /// It hangs off `graphical-session.target` because a tray icon cannot appear without a display
+    /// (under `default.target` it would start before the session, die immediately, and spin on
+    /// Restart). Plasma 6 raises that target by default — on desktops that do not, the toggle will
+    /// not actually autostart anything, so an XDG autostart `.desktop` fallback is still needed
+    /// (roadmap Phase 8).
+    private static func writeUnit() throws {
+        guard let executable = executablePath else { throw AutostartError.executablePathUnavailable }
+        let unit = """
+        [Unit]
+        Description=PokeTokenBar — Pokémon usage tray
+        PartOf=graphical-session.target
+        After=graphical-session.target
+
+        [Service]
+        Type=simple
+        ExecStart=\(executable)
+        Restart=on-failure
+        RestartSec=10
+
+        [Install]
+        WantedBy=graphical-session.target
+
+        """
+        try FileManager.default.createDirectory(
+            at: unitURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try unit.write(to: unitURL, atomically: true, encoding: .utf8)
+    }
+
+    private static var executablePath: String? {
+        (try? FileManager.default.destinationOfSymbolicLink(atPath: "/proc/self/exe"))
+            ?? CommandLine.arguments.first
+    }
+
+    @discardableResult
+    private static func systemctl(_ arguments: [String]) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/systemctl")
+        process.arguments = ["--user"] + arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do { try process.run() } catch { return -1 }
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+    #endif
 }

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -1,9 +1,16 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking   // Linux: URLSession/URLRequest live in this separate module
+#endif
+#if os(macOS)
 import Security
+#endif
 
 enum LimitsError: Error {
     case keychainAccessDisabled
-    case keychainUnavailable(OSStatus)
+    /// Keychain lookup failure code. macOS's `OSStatus` is an `Int32`, so it carries through
+    /// unchanged; the underlying type is spelled out because Linux has no `OSStatus`.
+    case keychainUnavailable(Int32)
     case keychainInteractionNotAllowed
     case credentialFormat
     /// 자격증명은 읽혔지만 Claude 계정 OAuth(`claudeAiOauth`)가 없다 — MCP 서버 OAuth 상태만 들어있는 경우.
@@ -101,6 +108,16 @@ private actor OAuthAccessTokenCache {
                 : LimitsError.keychainInteractionNotAllowed
         }
 
+        #if !os(macOS)
+        // Linux has no keychain: the only credential path is `~/.claude/.credentials.json` above,
+        // and if that came up empty there is nowhere further to look, even on a user action like
+        // the refresh button. So this stops here instead of taking the prompt path. A file with
+        // only MCP OAuth still maps to the same "log in again" guidance as macOS.
+        throw Self.credentialsFileIsAccountOAuthMissing()
+            ? LimitsError.credentialMissingAccountOAuth
+            : LimitsError.credentialFormat
+        #else
+
         // 사용자 동작 경로: 무프롬프트로 먼저 시도(과거 '항상 허용'했다면 조용히 성공), 안 되면 프롬프트를
         // 동반해 읽어 최초 1회 '항상 허용'을 유도한다.
         if let credential = Self.readClaudeKeychainSilently() {
@@ -110,8 +127,10 @@ private actor OAuthAccessTokenCache {
         let credential = try Self.readClaudeKeychain(allowKeychainPrompt: true)
         cachedCredential = credential
         return credential.accessToken
+        #endif
     }
 
+    #if os(macOS)
     /// 무프롬프트 Keychain 읽기 — no-UI 쿼리라 권한이 없으면 프롬프트 대신 errSecInteractionNotAllowed.
     /// '아직 항상 허용 전'(interactionNotAllowed)은 정상 흐름이라 조용히 nil. 그 외(형식 오류·접근 불가)는
     /// 진단을 위해 로그를 남기고 nil — 자동 경로가 왜 토큰을 못 구했는지 추적 가능하게.
@@ -125,6 +144,7 @@ private actor OAuthAccessTokenCache {
             return nil
         }
     }
+    #endif
 
     /// 마지막으로 사용한 자격증명의 플랜 정보. accessToken() 이 모든 경로에서 cachedCredential 을
     /// 반환 토큰과 일치시키므로, fetch 가 토큰 취득 직후 호출하면 동일 자격증명 기준이다.
@@ -170,6 +190,7 @@ private actor OAuthAccessTokenCache {
         return credential
     }
 
+    #if os(macOS)
     private nonisolated static func readClaudeKeychain(
         allowKeychainPrompt: Bool) throws -> OAuthCredentialData.Credential
     {
@@ -202,6 +223,7 @@ private actor OAuthAccessTokenCache {
         }
         return credential
     }
+    #endif
 }
 
 enum OAuthCredentialData {

--- a/Sources/PokeTokenBar/Core/Platform/AppVersion.swift
+++ b/Sources/PokeTokenBar/Core/Platform/AppVersion.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// The app version — Info.plist on macOS, a compile-time constant on Linux.
+///
+/// Linux has no bundle: `Bundle.main` points at the executable's directory and there is no
+/// Info.plist. So the version is baked into the source, but **the single source of truth is still
+/// `VERSION` in `scripts/build-app.sh`** — `make version-sync` reads it from there and rewrites
+/// `compiled` below. Keeping two places in sync by hand guarantees they drift (each release bumps
+/// only one), so the Makefile build regenerates it and the release gate compares them.
+enum AppVersion {
+    /// Synced with `VERSION` in scripts/build-app.sh — do not edit by hand (`make version-sync`).
+    static let compiled = "2.5.1"
+
+    /// The version used for display, update comparison and the User-Agent.
+    static var current: String {
+        #if os(macOS)
+        // Info.plist wins for a real install; running without a bundle (dev) falls back to `compiled`.
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? compiled
+        #else
+        compiled
+        #endif
+    }
+}

--- a/Sources/PokeTokenBar/Core/Platform/PlatformCompat.swift
+++ b/Sources/PokeTokenBar/Core/Platform/PlatformCompat.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+// Minimal fill-ins for things Darwin Foundation has and corelibs-foundation does not.
+//
+// Everything here is an API whose **meaning is macOS-specific, leaving Linux with nothing to do**.
+// A harmless no-op beats sprinkling `#if` through the call sites: conditional compilation in the
+// middle of a scan loop hurts to read, and invites fixing only one branch later.
+
+#if !canImport(ObjectiveC)
+/// Obj-C autorelease pool — Linux has no Obj-C runtime, so there is no pool.
+///
+/// The callers (log scan loops) use it to **release one iteration's temporaries promptly**, and on
+/// Linux Swift objects are already freed by ARC as they leave scope. So this no-op is not a feature
+/// removed; it is a property that already holds on that platform.
+@inline(__always)
+func autoreleasepool<Result>(invoking body: () throws -> Result) rethrows -> Result {
+    try body()
+}
+#endif
+
+/// App Nap suppression — stops macOS throttling a background app until the ccusage subprocess
+/// times out.
+///
+/// Linux has no equivalent behaviour (its scheduler does not put apps to sleep this way), so the
+/// token is empty and ending it is a no-op — there is nothing to suppress, not something we fail
+/// to suppress.
+enum PlatformActivity {
+    #if os(macOS)
+    typealias Token = NSObjectProtocol
+
+    static func beginUserInitiated(reason: String) -> Token {
+        ProcessInfo.processInfo.beginActivity(
+            options: .userInitiatedAllowingIdleSystemSleep, reason: reason)
+    }
+
+    static func end(_ token: Token) {
+        ProcessInfo.processInfo.endActivity(token)
+    }
+    #else
+    typealias Token = Void
+
+    static func beginUserInitiated(reason: String) -> Token {}
+
+    static func end(_ token: Token) {}
+    #endif
+}

--- a/Sources/PokeTokenBar/Core/Platform/PlatformCompression.swift
+++ b/Sources/PokeTokenBar/Core/Platform/PlatformCompression.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+#if !os(macOS)
+import CZlib
+#endif
+
+/// Usage-cache snapshot compression — Foundation's `NSData.compressed(using: .zlib)` on macOS,
+/// zlib directly on Linux.
+///
+/// **The two platforms produce different bytes** (Apple's `.zlib` is raw DEFLATE with no header;
+/// below is a standard zlib stream with a length prefix). Cache files are machine-local and never
+/// travel between platforms, so this does not matter — and even if one did, the caller already
+/// falls back to "failed to decompress → treat as plaintext", which costs a cache miss and nothing else.
+enum PlatformCompression {
+    /// nil on failure — the caller stores plaintext instead (compression is an optimisation,
+    /// not a correctness requirement).
+    static func compress(_ data: Data) -> Data? {
+        #if os(macOS)
+        return try? (data as NSData).compressed(using: .zlib) as Data
+        #else
+        guard !data.isEmpty else { return nil }
+        // Prefix the original length as 8 little-endian bytes. zlib's `uncompress` demands the
+        // output buffer size up front, and without it you have to retry with a growing buffer —
+        // snapshots run to several MB, so that retry cost eats the compression win. Eight bytes
+        // removes the problem entirely.
+        var bound = compressBound(uLong(data.count))
+        var out = Data(count: Int(bound) + 8)
+        let status: Int32 = out.withUnsafeMutableBytes { rawOut -> Int32 in
+            guard let outBase = rawOut.baseAddress else { return Z_BUF_ERROR }
+            var length = UInt64(data.count).littleEndian
+            withUnsafeBytes(of: &length) { outBase.copyMemory(from: $0.baseAddress!, byteCount: 8) }
+            return data.withUnsafeBytes { rawIn -> Int32 in
+                guard let inBase = rawIn.baseAddress else { return Z_BUF_ERROR }
+                return compress2(
+                    outBase.advanced(by: 8).assumingMemoryBound(to: Bytef.self), &bound,
+                    inBase.assumingMemoryBound(to: Bytef.self), uLong(data.count),
+                    Z_DEFAULT_COMPRESSION)
+            }
+        }
+        guard status == Z_OK else { return nil }
+        return out.prefix(Int(bound) + 8)
+        #endif
+    }
+
+    /// nil on failure — the caller reads it as an older plaintext cache and decodes the raw bytes.
+    static func decompress(_ data: Data) -> Data? {
+        #if os(macOS)
+        return try? (data as NSData).decompressed(using: .zlib) as Data
+        #else
+        guard data.count > 8 else { return nil }
+        var length: UInt64 = 0
+        _ = withUnsafeMutableBytes(of: &length) { data.prefix(8).copyBytes(to: $0) }
+        length = UInt64(littleEndian: length)
+        // A corrupt or plaintext file can carry an enormous value where the length should be.
+        // Trusting it means one damaged cache makes the app allocate gigabytes, so cap it and
+        // treat anything above the cap as "not one of ours".
+        guard length > 0, length <= 512 * 1024 * 1024 else { return nil }
+        let payload = data.suffix(from: data.startIndex + 8)
+        var out = Data(count: Int(length))
+        var produced = uLongf(length)
+        let status: Int32 = out.withUnsafeMutableBytes { rawOut -> Int32 in
+            guard let outBase = rawOut.baseAddress else { return Z_BUF_ERROR }
+            return payload.withUnsafeBytes { rawIn -> Int32 in
+                guard let inBase = rawIn.baseAddress else { return Z_BUF_ERROR }
+                return uncompress(
+                    outBase.assumingMemoryBound(to: Bytef.self), &produced,
+                    inBase.assumingMemoryBound(to: Bytef.self), uLong(payload.count))
+            }
+        }
+        guard status == Z_OK, produced == uLongf(length) else { return nil }
+        return out
+        #endif
+    }
+}

--- a/Sources/PokeTokenBar/Core/Platform/PlatformDefaults.swift
+++ b/Sources/PokeTokenBar/Core/Platform/PlatformDefaults.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// The settings store, pinned to a stable identity on every platform.
+///
+/// macOS keys `UserDefaults.standard` on the bundle identifier, so preferences follow the app
+/// wherever it is installed. **corelibs-foundation keys it on the executable's filename** and
+/// writes `~/.config/<name>.plist`, which means the same app answers to a different settings file
+/// depending on how it was launched: `.build/debug/PokeTokenBar` and an installed `poketokenbar`
+/// would each keep their own language, interval and toggles, and `make run` would appear to forget
+/// everything the installed copy was told.
+///
+/// Naming the suite explicitly removes the dependence on the filename. The identifier matches the
+/// macOS bundle id so the two platforms describe the same product.
+enum PlatformDefaults {
+    static let suiteName = "io.github.chattymin.poketokenbar"
+
+    // `UserDefaults` is thread-safe by contract but not marked `Sendable`, and this is a
+    // read-only handle resolved once at startup.
+    nonisolated(unsafe) static let standard: UserDefaults = {
+        #if os(macOS)
+        return .standard
+        #else
+        // A named suite cannot fail for a plain identifier, but falling back to `.standard` keeps
+        // settings working rather than crashing if it ever did.
+        return UserDefaults(suiteName: suiteName) ?? .standard
+        #endif
+    }()
+}

--- a/Sources/PokeTokenBar/Core/Platform/PlatformNotifier.swift
+++ b/Sources/PokeTokenBar/Core/Platform/PlatformNotifier.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+#if os(macOS)
+import UserNotifications
+#else
+import CNotify
+#endif
+
+/// System notifications — UserNotifications on macOS, libnotify (D-Bus
+/// `org.freedesktop.Notifications`) on Linux.
+///
+/// Callers (limit alerts in `UsageStore`, companion events in `CompanionStore`) are already gated
+/// on `AppEnv.isProductionInstall`, so this does not re-check. Two gates for one decision is how
+/// they end up disagreeing.
+enum PlatformNotifier {
+    /// Request notification permission (idempotent) — once, at a user-intent moment.
+    /// Linux has no such concept (showing notifications is the desktop's business), so it is a no-op.
+    static func requestAuthorization() {
+        #if os(macOS)
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        #endif
+    }
+
+    /// Post one notification.
+    /// - Parameters:
+    ///   - identifier: replaces an earlier notification with the same key, so a limit window only
+    ///     ever occupies one slot.
+    ///   - sound: whether to play a sound.
+    ///   - critical: urgency. **Deliberately separate from `sound`** — on Linux CRITICAL means
+    ///     "stays until the user dismisses it" (KDE never auto-dismisses), so attaching it to
+    ///     companion events, which only want a sound, would leave hatch alerts parked on screen.
+    ///     macOS has no equivalent concept and ignores it.
+    static func post(identifier: String, title: String, body: String, sound: Bool, critical: Bool) {
+        #if os(macOS)
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = sound ? .default : nil
+        UNUserNotificationCenter.current().add(
+            UNNotificationRequest(identifier: identifier, content: content, trigger: nil))
+        #else
+        guard initializeIfNeeded() else { return }
+        guard let notification = notify_notification_new(title, body, nil) else { return }
+        defer { g_object_unref(notification) }
+        notify_notification_set_urgency(
+            notification, critical ? NOTIFY_URGENCY_CRITICAL : NOTIFY_URGENCY_NORMAL)
+        // Carries over the replace-by-identifier meaning from macOS so limit alerts update in
+        // place instead of stacking. Not a standard hint — support varies by notification daemon
+        // (unsupported ones simply show a new notification), but where it works it stops the
+        // panel filling up with one alert per limit window.
+        notify_notification_set_hint_string(notification, "x-canonical-private-synchronous", identifier)
+        if sound {
+            notify_notification_set_hint_string(
+                notification, "sound-name", critical ? "dialog-warning" : "message-new-instant")
+        }
+        notify_notification_show(notification, nil)
+        #endif
+    }
+
+    #if !os(macOS)
+    /// `notify_init` runs once per process. On failure (no D-Bus — headless, container) we give up
+    /// on notifications quietly.
+    nonisolated(unsafe) private static var initialized: Bool?
+    private static func initializeIfNeeded() -> Bool {
+        if let initialized { return initialized }
+        let ok = notify_init("PokeTokenBar") != 0
+        initialized = ok
+        if !ok { AppLog.write("notify_init failed — notifications disabled (no D-Bus session?)") }
+        return ok
+    }
+    #endif
+}

--- a/Sources/PokeTokenBar/Core/Platform/PlatformOpener.swift
+++ b/Sources/PokeTokenBar/Core/Platform/PlatformOpener.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+#if os(macOS)
+import AppKit
+#endif
+
+/// Opening URLs and files — LaunchServices on macOS, xdg-open on Linux.
+enum PlatformOpener {
+    /// Open a URL with the default handler (release page, mailto, …); `true` if it opened.
+    /// Callers validate the scheme before calling (`UpdateChecker`'s https + github.com allowlist).
+    ///
+    /// Only one caller needs the result — "report a problem". If no mail handler exists it has to
+    /// show the address instead, and swallowing the outcome would leave the user pressing a button
+    /// that does nothing.
+    @discardableResult
+    static func open(_ url: URL) -> Bool {
+        #if os(macOS)
+        return NSWorkspace.shared.open(url)
+        #else
+        return launch("/usr/bin/xdg-open", [url.absoluteString])
+        #endif
+    }
+
+    /// Reveal a file in the file manager, selected ("show log file").
+    static func reveal(_ fileURL: URL) {
+        #if os(macOS)
+        NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+        #else
+        // The freedesktop interface Dolphin and Nautilus implement, which opens the folder with
+        // the file *selected*. On desktops that do not implement it gdbus fails and we fall back
+        // to opening the parent directory — no selection, but the user can still find the file,
+        // which beats nothing opening at all.
+        let ok = launch("/usr/bin/gdbus", [
+            "call", "--session",
+            "--dest", "org.freedesktop.FileManager1",
+            "--object-path", "/org/freedesktop/FileManager1",
+            "--method", "org.freedesktop.FileManager1.ShowItems",
+            "[\"\(fileURL.absoluteString)\"]", "",
+        ])
+        if !ok { launch("/usr/bin/xdg-open", [fileURL.deletingLastPathComponent().path]) }
+        #endif
+    }
+
+    #if !os(macOS)
+    /// Launch an external handler and **wait for it** — xdg-open returns immediately and gdbus
+    /// finishes quickly, so there is no blocking cost, and it lets gdbus's exit status drive the
+    /// fallback decision.
+    @discardableResult
+    private static func launch(_ binary: String, _ arguments: [String]) -> Bool {
+        guard FileManager.default.isExecutableFile(atPath: binary) else { return false }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.arguments = arguments
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do { try process.run() } catch { return false }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
+    #endif
+}

--- a/Sources/PokeTokenBar/Core/Platform/PlatformPaths.swift
+++ b/Sources/PokeTokenBar/Core/Platform/PlatformPaths.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Storage-location seam — the one place `~/Library/…` (macOS) and XDG (Linux) diverge.
+///
+/// **The macOS expressions are copied verbatim from the old code.** "Tidying" a path here would
+/// strand every shipped user's save, cache and dex (moving data is `SaveTransfer`'s job, not this
+/// seam's). So the macOS branch is a fixed contract, not a refactoring target.
+///
+/// Linux follows the XDG Base Directory spec. It computes the paths itself rather than trusting
+/// corelibs-foundation's `.applicationSupportDirectory` mapping, because that mapping varies by
+/// distribution and version — the same machine could resolve to a different directory after an
+/// update, which is not a risk worth taking with save data.
+enum PlatformPaths {
+    #if os(macOS)
+    /// The **parent** of the app's data directory. Callers append `PokeTokenBar/…`.
+    static let appSupportRoot: URL =
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+
+    /// Log directory (callers are responsible for creating it — preserves existing behaviour).
+    static let logsDirectory: URL =
+        FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Logs")
+
+    /// State that only means anything while the process is alive (the single-instance lock).
+    static let runtimeDirectory: URL = FileManager.default.temporaryDirectory
+    #else
+    static let appSupportRoot: URL = xdg("XDG_DATA_HOME", default: ".local/share")
+    static let logsDirectory: URL = xdg("XDG_STATE_HOME", default: ".local/state")
+        .appendingPathComponent("PokeTokenBar")
+    static let runtimeDirectory: URL = {
+        // XDG_RUNTIME_DIR only exists inside a login session (it is absent under cron or
+        // `systemd --system`). Falling back to /tmp is better than losing the lock entirely.
+        if let raw = ProcessInfo.processInfo.environment["XDG_RUNTIME_DIR"], !raw.isEmpty {
+            return URL(fileURLWithPath: raw, isDirectory: true)
+        }
+        return FileManager.default.temporaryDirectory
+    }()
+
+    /// `$VAR` when it is absolute, otherwise `$HOME/<fallback>`. The XDG spec says to ignore
+    /// relative values.
+    private static func xdg(_ variable: String, default fallback: String) -> URL {
+        let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        guard let raw = ProcessInfo.processInfo.environment[variable],
+              raw.hasPrefix("/") else {
+            return home.appendingPathComponent(fallback)
+        }
+        return URL(fileURLWithPath: raw, isDirectory: true)
+    }
+    #endif
+
+    /// The app's own data directory, created if missing.
+    /// `…/Application Support/PokeTokenBar` on macOS, `…/.local/share/PokeTokenBar` on Linux.
+    static func appDirectory(_ subpath: String? = nil) -> URL {
+        var dir = appSupportRoot.appendingPathComponent("PokeTokenBar")
+        if let subpath { dir = dir.appendingPathComponent(subpath) }
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: Other apps' data directories (the usage logs we read)
+
+    /// An Electron app's `userData` directory — Claude Desktop, Cursor and friends.
+    ///
+    /// Electron picks a different location per platform (`app.getPath("userData")`):
+    /// `~/Library/Application Support/<app>` on macOS, `$XDG_CONFIG_HOME/<app>` on Linux.
+    /// This is **the app we are reading from** dictating the convention, not ours — changing it
+    /// means finding no logs at all.
+    static func electronAppData(_ name: String) -> URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        #if os(macOS)
+        return home.appendingPathComponent("Library/Application Support/\(name)")
+        #else
+        if let raw = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"], raw.hasPrefix("/") {
+            return URL(fileURLWithPath: raw, isDirectory: true).appendingPathComponent(name)
+        }
+        return home.appendingPathComponent(".config/\(name)")
+        #endif
+    }
+
+    /// The data directory of a **CLI tool** that follows XDG (kiro-cli and similar).
+    /// Unlike Electron this is `$XDG_DATA_HOME` (`~/.local/share`) — folding the two into one
+    /// helper would put one of them in the wrong place.
+    static func cliToolData(_ name: String) -> URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        #if os(macOS)
+        return home.appendingPathComponent("Library/Application Support/\(name)")
+        #else
+        if let raw = ProcessInfo.processInfo.environment["XDG_DATA_HOME"], raw.hasPrefix("/") {
+            return URL(fileURLWithPath: raw, isDirectory: true).appendingPathComponent(name)
+        }
+        return home.appendingPathComponent(".local/share/\(name)")
+        #endif
+    }
+}

--- a/Sources/PokeTokenBar/Core/Platform/PlatformPowerEvents.swift
+++ b/Sources/PokeTokenBar/Core/Platform/PlatformPowerEvents.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+#if os(macOS)
+import AppKit
+#endif
+
+/// Sleep and display-off events — used to pause polling (which spawns subprocesses) and save battery.
+enum PlatformPowerEvents {
+    /// - Parameters:
+    ///   - onWake: resumed from system sleep — refresh immediately.
+    ///   - onScreenSleep: display turned off — stop polling.
+    ///   - onScreenWake: display turned on — resume polling and refresh.
+    static func observe(
+        onWake: @escaping () -> Void,
+        onScreenSleep: @escaping () -> Void,
+        onScreenWake: @escaping () -> Void
+    ) {
+        #if os(macOS)
+        let center = NSWorkspace.shared.notificationCenter
+        center.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: .main) { _ in
+            onWake()
+        }
+        center.addObserver(
+            forName: NSWorkspace.screensDidSleepNotification, object: nil, queue: .main
+        ) { _ in onScreenSleep() }
+        center.addObserver(
+            forName: NSWorkspace.screensDidWakeNotification, object: nil, queue: .main
+        ) { _ in onScreenWake() }
+        #else
+        // The subscription itself lives in the Linux frontend, which owns the GLib main loop GDBus
+        // needs to deliver signals. Keeping it out of Core is what stops Core depending on GTK.
+        // If nothing installed an observer (tests, headless), polling simply never pauses.
+        linuxObserver?(onWake, onScreenSleep, onScreenWake)
+        #endif
+    }
+
+    #if !os(macOS)
+    /// Installed by the Linux frontend at startup, before any store is built.
+    nonisolated(unsafe) static var linuxObserver: (
+        (@escaping () -> Void, @escaping () -> Void, @escaping () -> Void) -> Void
+    )?
+    #endif
+}

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking   // Linux: URLSession/URLRequest live in this separate module
+#endif
 
 /// 부화 후보 — 진화라인 시작점(base) 종과 공식 희귀도.
 struct BaseSpecies: Sendable, Codable {
@@ -56,9 +59,7 @@ actor PokeAPIClient: PokeProviding {
     private var restBuildInFlight = false
     private var restBuildTried = false   // 세션당 1회 (GraphQL 다운 시 REST 인덱스 구축 트리거)
     private static let baseIndexFile: URL = {
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("PokeTokenBar")
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dir = PlatformPaths.appDirectory()
         return dir.appendingPathComponent("base-index.json")
     }()
     private struct BaseIndexSnapshot: Codable { let fetchedAt: Date; let entries: [BaseSpecies] }

--- a/Sources/PokeTokenBar/Core/PopoverNavigation.swift
+++ b/Sources/PokeTokenBar/Core/PopoverNavigation.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Observation
+
+/// The popover's tabs. Shared by both frontends — the macOS popover and the Linux window show the
+/// same four, and a tab that exists on one platform only is a parity bug waiting to happen.
+enum PopoverTab: String, CaseIterable {
+    case home, shop, bag, collection
+
+    /// Parse a tab from a command-line name; nil for anything unrecognised.
+    init?(name: String) {
+        guard let match = PopoverTab(rawValue: name.lowercased()) else { return nil }
+        self = match
+    }
+}
+
+/// Navigation state inside the popover (current tab / whether settings is showing).
+///
+/// On macOS `NSHostingController` survives the popover closing, so `@State` would persist; the
+/// screen state is split into this Observable and `AppDelegate` calls `reset()` on each open, which
+/// is what makes reopening always land on Home.
+@MainActor
+@Observable
+final class PopoverNavigation {
+    var showSettings = false
+    var tab: PopoverTab = .home
+    /// Selected provider tab — deliberately *not* reset, so reopening keeps the service you were on.
+    var providerID: String?
+
+    func reset() {
+        showSettings = false
+        tab = .home
+    }
+}

--- a/Sources/PokeTokenBar/Core/ProviderStatusChecker.swift
+++ b/Sources/PokeTokenBar/Core/ProviderStatusChecker.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking   // Linux: URLSession/URLRequest live in this separate module
+#endif
 
 /// 프로바이더 상태 페이지(statuspage.io)의 인시던트 지표.
 /// 목적: Claude/OpenAI API 장애 시 stale·0·에러 표시를 "앱 고장"으로 오인하지 않도록 **표시 전용** 신호.

--- a/Sources/PokeTokenBar/Core/SingleInstance.swift
+++ b/Sources/PokeTokenBar/Core/SingleInstance.swift
@@ -1,5 +1,10 @@
+#if os(macOS)
 import AppKit
 import Darwin
+#else
+import Foundation
+import Glibc
+#endif
 
 /// 같은 앱이 두 번 뜨는 것을 막는 가드 — **나중에 뜬 인스턴스가 물러난다**.
 ///
@@ -41,6 +46,7 @@ enum SingleInstance {
     /// 프로세스라, launchDate 로 판정하면 가드가 통째로 무효가 된다(실측: 로그인 에이전트가 띄운
     /// 인스턴스는 `launchDate == nil`, 같은 pid 의 `p_starttime` 은 정상). 커널 값은 두 경로 모두에
     /// 남고 프로세스 간 비교도 성립한다.
+    #if os(macOS)
     static func processStartTime(_ pid: pid_t) -> Date? {
         var info = kinfo_proc()
         var size = MemoryLayout<kinfo_proc>.stride
@@ -53,10 +59,10 @@ enum SingleInstance {
     }
 
     /// 위 판정을 실제 실행 중인 인스턴스에 적용한다. 실앱에서만 동작한다 —
-    /// `swift test`/로우 바이너리(dev 실행)는 번들이 아니라 항상 `false`(`AppEnv.isBundledApp`).
+    /// `swift test`/로우 바이너리(dev 실행)는 번들이 아니라 항상 `false`(`AppEnv.isProductionInstall`).
     @MainActor
     static func shouldYieldToRunningInstance() -> Bool {
-        guard AppEnv.isBundledApp, let bundleID = Bundle.main.bundleIdentifier else { return false }
+        guard AppEnv.isProductionInstall, let bundleID = Bundle.main.bundleIdentifier else { return false }
         let me = NSRunningApplication.current.processIdentifier
         let others = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
             .map(\.processIdentifier)
@@ -64,4 +70,33 @@ enum SingleInstance {
             .map(processStartTime)
         return shouldYield(myStartTime: processStartTime(me), otherStartTimes: others)
     }
+    #else
+    /// On Linux the decision is an **exclusive lock**, not a start-time comparison.
+    ///
+    /// macOS compares timestamps because of launchd's habit of exec'ing an already-running app a
+    /// second time, and that comparison has a known gap: if a time cannot be read, both instances
+    /// stay (see the doc above). Linux has no such constraint, so it uses `flock`, which the kernel
+    /// makes atomic — whoever takes it first stays, whoever cannot yields. The "the later instance
+    /// yields" contract is unchanged, and the tie / unreadable-clock edge cases disappear entirely.
+    ///
+    /// The fd is deliberately never closed (process lifetime = lock lifetime). On abnormal exit the
+    /// kernel reclaims it, so no stale lock is left behind — which a pidfile would have suffered.
+    nonisolated(unsafe) private static var lockFD: Int32 = -1
+
+    @MainActor
+    static func shouldYieldToRunningInstance() -> Bool {
+        guard AppEnv.isProductionInstall else { return false }
+        let path = PlatformPaths.runtimeDirectory
+            .appendingPathComponent("poketokenbar.lock").path
+        let fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0o644)
+        // If the lock cannot even be created, do not yield — losing the only instance is worse.
+        guard fd >= 0 else { return false }
+        if flock(fd, LOCK_EX | LOCK_NB) == 0 {
+            lockFD = fd
+            return false
+        }
+        close(fd)
+        return true
+    }
+    #endif
 }

--- a/Sources/PokeTokenBar/Core/SpriteAnimationPolicy.swift
+++ b/Sources/PokeTokenBar/Core/SpriteAnimationPolicy.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// How fast an always-on sprite is allowed to animate.
+///
+/// Gen-V sprites carry native delays as low as 0.02s. Honouring those on a surface that is on
+/// screen all day (the macOS menu bar, the Linux tray, the floating pet) means recompositing ~50
+/// times a second forever, and this repository has already paid for that once in idle wakeups
+/// (`defect-log` §에너지 / "Energy"). Transient surfaces — the popover, which is only open while
+/// someone is looking at it — keep the native rate by passing a floor of 0.
+enum SpriteAnimationPolicy {
+    /// ≈2.5fps. Slow enough to cost nothing at idle, fast enough to still read as movement.
+    static let idleFrameFloor: TimeInterval = 0.4
+
+    /// The delay to actually wait for a frame, given its native delay and a floor.
+    static func frameDelay(base: TimeInterval, floor: TimeInterval) -> TimeInterval {
+        max(base, floor)
+    }
+}

--- a/Sources/PokeTokenBar/Core/SpriteCrop.swift
+++ b/Sources/PokeTokenBar/Core/SpriteCrop.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Where the visible content of a sprite sits inside its canvas.
+///
+/// PokéAPI sprites are drawn on a fixed 96×96 canvas and the subject rarely fills it — the egg
+/// occupies 28×30, about 29% of the area. Anything that scales the whole canvas into a small fixed
+/// box (the macOS menu bar, the Linux tray icon) therefore renders a subject a third of the size it
+/// could be. Cropping to content is what fixes that.
+///
+/// The geometry lives here, apart from any image API, because both frontends need the same answer
+/// and it is the part worth testing: the pixel access differs (NSBitmapImageRep vs GdkPixbuf) but
+/// the rectangle must not.
+enum SpriteCrop {
+    struct Rect: Equatable {
+        let x: Int, y: Int, side: Int
+    }
+
+    /// The opaque bounding box, grown into a centred square and clamped to the canvas.
+    ///
+    /// Square, not the raw bounding box: the egg's content is 28×30 (taller than wide), and
+    /// cropping to that would stretch it sideways in a square frame. Squaring first preserves the
+    /// aspect ratio.
+    ///
+    /// Returns nil for a fully transparent canvas — the caller keeps the original rather than
+    /// cropping to nothing.
+    static func squareContentRect(
+        width: Int, height: Int, isOpaque: (Int, Int) -> Bool
+    ) -> Rect? {
+        guard width > 0, height > 0 else { return nil }
+        var minX = width, minY = height, maxX = -1, maxY = -1
+        for y in 0..<height {
+            for x in 0..<width where isOpaque(x, y) {
+                if x < minX { minX = x }
+                if x > maxX { maxX = x }
+                if y < minY { minY = y }
+                if y > maxY { maxY = y }
+            }
+        }
+        guard maxX >= minX, maxY >= minY else { return nil }
+
+        let boxWidth = maxX - minX + 1
+        let boxHeight = maxY - minY + 1
+        let side = min(max(boxWidth, boxHeight), min(width, height))
+        let x = max(0, min(minX - (side - boxWidth) / 2, width - side))
+        let y = max(0, min(minY - (side - boxHeight) / 2, height - side))
+        return Rect(x: x, y: y, side: side)
+    }
+
+    /// Alpha above which a pixel counts as content. Matches the macOS implementation this was
+    /// extracted from — sprites are hard-edged, so anything above "numerically nonzero" is subject.
+    static let opaqueAlphaThreshold = 0.01
+}

--- a/Sources/PokeTokenBar/Core/SpriteStore.swift
+++ b/Sources/PokeTokenBar/Core/SpriteStore.swift
@@ -1,0 +1,90 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking   // Linux: URLSession/URLRequest live in this separate module
+#endif
+
+
+/// 포켓몬 스프라이트를 런타임에 받아 로컬(Application Support)에 캐시. 레포/번들에 미포함.
+actor SpriteStore {
+    static let shared = SpriteStore()
+    private let base = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon"
+    private let itemBase = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/items"
+    private var mem: [String: Data] = [:]
+    private var memOrder: [String] = []   // LRU 순서(최근 접근이 뒤). 상한 초과 시 앞(오래된 것)부터 evict
+    // in-memory 스프라이트 캐시 상한 — 세션 중 종 변경 누적 무한증가 방지(#H1).
+    // 도감 한 페이지가 24칸이라 상한 24 는 LRU 가 매 페이지 전환마다 완전 회전했다(돌아올 때 디스크
+    // 동기 재읽기 24회). 정적 PNG 는 종당 0.5~1KB 라 64 로 올려도 메모리 비용이 무의미하다.
+    private let memLimit = 64
+    private let dir: URL = PlatformPaths.appDirectory("sprites")
+
+    /// 캐시 파일명 키 — 기존 "\(id)-a"/"\(id)-s" 유지, shiny 는 "sh" 접두(구캐시 그대로 유효).
+    static func cacheKey(speciesID: Int, animated: Bool, shiny: Bool) -> String {
+        "\(speciesID)-\(shiny ? "sh" : "")\(animated ? "a" : "s")"
+    }
+
+    func data(speciesID: Int, animated: Bool, shiny: Bool = false) async -> Data? {
+        if animated, !PokemonAssets.hasAnimatedSprite(speciesID: speciesID) { return nil }
+        let key = Self.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny)
+        if let d = mem[key] { touch(key); return d }
+        let ext = animated ? "gif" : "png"
+        let file = dir.appendingPathComponent("\(key).\(ext)")
+        if let d = try? Data(contentsOf: file) { remember(key, d); return d }
+        let urlStr: String
+        switch (animated, shiny) {
+        case (true, false):  urlStr = "\(base)/versions/generation-v/black-white/animated/\(speciesID).gif"
+        case (true, true):   urlStr = "\(base)/versions/generation-v/black-white/animated/shiny/\(speciesID).gif"
+        case (false, false): urlStr = "\(base)/\(speciesID).png"
+        case (false, true):  urlStr = "\(base)/shiny/\(speciesID).png"
+        }
+        guard let url = URL(string: urlStr),
+              let (d, resp) = try? await URLSession.shared.data(from: url),
+              (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
+        try? d.write(to: file, options: .atomic)   // torn write 방지 — 크래시/강제종료 시 손상 캐시가 남지 않게
+        remember(key, d)
+        return d
+    }
+
+    /// 아이템 스프라이트(정적 PNG, 이름 기반). 포켓몬과 같은 메모리/디스크 캐시 사용(키 "item-<name>",
+    /// 포켓몬 파일 "<id>-..." 과 안 겹침). 미제공(404)/오프라인이면 nil → 뷰가 이모지로 폴백.
+    func data(itemName: String) async -> Data? {
+        let key = "item-\(itemName)"
+        if let d = mem[key] { touch(key); return d }
+        let file = dir.appendingPathComponent("\(key).png")
+        if let d = try? Data(contentsOf: file) { remember(key, d); return d }
+        guard let url = URL(string: "\(itemBase)/\(itemName).png"),
+              let (d, resp) = try? await URLSession.shared.data(from: url),
+              (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
+        try? d.write(to: file, options: .atomic)
+        remember(key, d)
+        return d
+    }
+
+    /// 알 스프라이트(정적, pokemon/egg.png) — 애니메이션 알은 없음. 포켓몬/아이템과 같은 메모리·디스크 캐시(키 "egg").
+    func eggData() async -> Data? {
+        let key = "egg"
+        if let d = mem[key] { touch(key); return d }
+        let file = dir.appendingPathComponent("egg.png")
+        if let d = try? Data(contentsOf: file) { remember(key, d); return d }
+        guard let url = URL(string: "\(base)/egg.png"),
+              let (d, resp) = try? await URLSession.shared.data(from: url),
+              (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
+        try? d.write(to: file, options: .atomic)
+        remember(key, d)
+        return d
+    }
+
+    /// in-memory 캐시에 넣고 LRU 상한 유지(#H1) — 세션 중 종이 여러 번 바뀌어도 무한 성장 방지.
+    private func remember(_ key: String, _ data: Data) {
+        mem[key] = data
+        touch(key)
+        while memOrder.count > memLimit {
+            let old = memOrder.removeFirst()
+            mem.removeValue(forKey: old)
+        }
+    }
+    /// 접근/삽입 키를 최근(뒤)으로 이동 — 활성 종이 evict 되지 않게 하는 LRU.
+    private func touch(_ key: String) {
+        if let i = memOrder.firstIndex(of: key) { memOrder.remove(at: i) }
+        memOrder.append(key)
+    }
+}

--- a/Sources/PokeTokenBar/Core/UpdateChecker.swift
+++ b/Sources/PokeTokenBar/Core/UpdateChecker.swift
@@ -1,4 +1,10 @@
+#if os(macOS)
 import AppKit
+#endif
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking   // Linux: URLSession/URLRequest live in this separate module
+#endif
 import Observation
 
 /// GitHub 릴리스 최신 버전을 확인해 새 버전이 있으면 팝오버에 알린다.
@@ -18,7 +24,7 @@ final class UpdateChecker {
 
     init(currentVersion: String? = nil, clock: @escaping () -> Date = Date.init) {
         self.currentVersion = currentVersion
-            ?? (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "0"
+            ?? AppVersion.current
         self.clock = clock
     }
 
@@ -39,7 +45,7 @@ final class UpdateChecker {
               let htmlURL = URL(string: html), htmlURL.scheme == "https", htmlURL.host == "github.com"
         else { return }
         let latest = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
-        let skipped = UserDefaults.standard.string(forKey: "skippedUpdateVersion")
+        let skipped = PlatformDefaults.standard.string(forKey: "skippedUpdateVersion")
         if Self.isNewer(latest, than: currentVersion), latest != skipped {
             available = Available(version: latest, url: html)
         } else {
@@ -49,7 +55,7 @@ final class UpdateChecker {
 
     /// 이 버전은 다시 알리지 않음.
     func skipCurrent() {
-        if let v = available?.version { UserDefaults.standard.set(v, forKey: "skippedUpdateVersion") }
+        if let v = available?.version { PlatformDefaults.standard.set(v, forKey: "skippedUpdateVersion") }
         available = nil
     }
 
@@ -58,17 +64,22 @@ final class UpdateChecker {
         guard let update = available, !isUpdating else { return }
         isUpdating = true
         Task { @MainActor in
+            #if os(macOS)
             // brew cask 설치본이면 분리(detached) 스크립트가 앱 종료 후 tap 갱신→업그레이드→재오픈.
             // 그 외(brew 미설치/비-cask 설치)면 릴리스 페이지를 연다.
             let brew = await Task.detached { Self.brewCaskPath() }.value
             if let brew {
                 Self.launchDetachedUpgrade(brew: brew)
                 NSApp.terminate(nil)
-            } else {
-                isUpdating = false
-                AppLog.write("update: brew cask 아님/brew 미설치 → 릴리스 페이지 열기")
-                if let u = URL(string: update.url) { NSWorkspace.shared.open(u) }
+                return
             }
+            #endif
+            // Linux has no self-apply path: the app cannot tell how it was installed (distro
+            // package, manual build), and guessing wrong means damaging the user's installation.
+            // It stops at opening the release page.
+            isUpdating = false
+            AppLog.write("update: no self-apply path — opening the release page")
+            if let u = URL(string: update.url) { PlatformOpener.open(u) }
         }
     }
 
@@ -86,7 +97,9 @@ final class UpdateChecker {
         return false
     }
 
-    // MARK: brew 적용 (nonisolated — 블로킹 Process 는 detached 에서)
+    // MARK: brew 적용 (nonisolated — 블로킹 Process 는 detached 에서). macOS only.
+
+    #if os(macOS)
 
     /// poke-token-bar 가 brew cask 로 설치돼 있으면 brew 경로 반환, 아니면 nil(→ 릴리스 페이지 폴백).
     private nonisolated static func brewCaskPath() -> String? {
@@ -137,4 +150,5 @@ final class UpdateChecker {
         task.arguments = ["-c", script, "sh", brew, bundlePath]
         try? task.run()
     }
+    #endif
 }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -1,7 +1,5 @@
-import AppKit
 import Foundation
 import Observation
-import UserNotifications
 
 /// burn rate 단계 — companion 표시 상태(작업/집중) 판정에 사용.
 enum BurnTier: Sendable {
@@ -403,7 +401,7 @@ final class UsageStore {
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),
          statusProvider: any ProviderStatusProviding = StatuspageStatusProvider(),
          autoRefresh: Bool = true,
-         defaults: UserDefaults = .standard) {
+         defaults: UserDefaults = PlatformDefaults.standard) {
         self.providers = providers
         self.limitsProvider = claudeLimitsProvider
         self.codexLimitsProvider = codexLimitsProvider
@@ -434,23 +432,12 @@ final class UsageStore {
         ) { [weak self] _ in
             Task { @MainActor in await self?.refresh() }
         }
-        // 슬립 복귀 시 즉시 갱신
-        NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in await self?.refresh() }
-        }
-        // 디스플레이 꺼짐 → 폴링(ccusage 서브프로세스 spawn) 일시정지, 켜짐 → 재개 + 즉시 갱신 (배터리)
-        NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.screensDidSleepNotification, object: nil, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in self?.suspendPolling() }
-        }
-        NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.screensDidWakeNotification, object: nil, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in self?.resumePolling() }
-        }
+        // Refresh on wake; pause polling (which spawns ccusage subprocesses) when the display
+        // sleeps and resume plus refresh when it wakes — battery.
+        PlatformPowerEvents.observe(
+            onWake: { [weak self] in Task { @MainActor in await self?.refresh() } },
+            onScreenSleep: { [weak self] in Task { @MainActor in self?.suspendPolling() } },
+            onScreenWake: { [weak self] in Task { @MainActor in self?.resumePolling() } })
 
         // 알림 권한은 기동 즉시 묻지 않는다 — 앱을 이해하기 전 콜드 프롬프트는 거부율이 높고
         // 거부 시 재요청 경로가 없다. 팝오버 첫 오픈(사용자 의도)에 requestNotificationAuthorizationIfNeeded 로 1회 요청.
@@ -493,10 +480,11 @@ final class UsageStore {
         if isRefreshing { refreshPending = true; return }
         isRefreshing = true
         // App Nap 방지 — 백그라운드 스로틀로 ccusage 가 타임아웃되는 것을 막는다 (시스템 슬립은 허용)
-        let activity = ProcessInfo.processInfo.beginActivity(
-            options: .userInitiatedAllowingIdleSystemSleep, reason: "PokeTokenBar usage refresh")
+        // Spelled out because Token is Void on Linux, where inference would warn about a Void constant.
+        let activity: PlatformActivity.Token =
+            PlatformActivity.beginUserInitiated(reason: "PokeTokenBar usage refresh")
         defer {
-            ProcessInfo.processInfo.endActivity(activity)
+            PlatformActivity.end(activity)
             isRefreshing = false
             // 진행 중 겹쳐 들어온 요청을 1회 반영. 요청 도착률이 유한하므로 무한 재실행 없음.
             if refreshPending {
@@ -813,9 +801,9 @@ final class UsageStore {
     /// 팝오버 첫 오픈 등 사용자 의도 시점에 1회만 알림 권한 요청(멱등).
     func requestNotificationAuthorizationIfNeeded() {
         guard !notifAuthRequested else { return }
-        guard AppEnv.isBundledApp else { return }
+        guard AppEnv.isProductionInstall else { return }
         notifAuthRequested = true
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        PlatformNotifier.requestAuthorization()
     }
 
     /// 한도 알림 1건의 발화 지시(순수 판정 결과). 부수효과와 분리해 테스트 가능하게.
@@ -876,7 +864,7 @@ final class UsageStore {
             windows: windows, warn: warnThreshold, crit: critThreshold, tiers: &notifiedTier)
         guard !alerts.isEmpty else { return }
 
-        if limitNotifications, AppEnv.isBundledApp {
+        if limitNotifications, AppEnv.isProductionInstall {
             postLimitNotifications(alerts)
         }
         if floatingPetEnabled, floatingPetBubbleAlerts {
@@ -934,14 +922,11 @@ final class UsageStore {
     private func postLimitNotifications(_ alerts: [LimitAlert]) {
         let l = L(localizationLanguage)
         for alert in alerts {
-            let content = UNMutableNotificationContent()
-            content.title = alert.isCritical ? l.notifCritical : l.notifWarning
-            content.body = l.notifBody(alert.window, TokenFormatter.percent(alert.utilization))
-            content.sound = alert.isCritical ? .default : nil
-            UNUserNotificationCenter.current().add(
-                UNNotificationRequest(
-                    identifier: "\(alert.key)-\(alert.isCritical ? "critical" : "warning")",
-                    content: content, trigger: nil))
+            PlatformNotifier.post(
+                identifier: "\(alert.key)-\(alert.isCritical ? "critical" : "warning")",
+                title: alert.isCritical ? l.notifCritical : l.notifWarning,
+                body: l.notifBody(alert.window, TokenFormatter.percent(alert.utilization)),
+                sound: alert.isCritical, critical: alert.isCritical)
         }
     }
 
@@ -962,10 +947,8 @@ final class UsageStore {
 
     private func writeParitySnapshot() {
         // .app 번들에서만 기록 — 테스트가 실제 사용자 데이터 디렉토리의 스냅샷을 덮어쓰지 않도록.
-        guard AppEnv.isBundledApp else { return }
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("PokeTokenBar")
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        guard AppEnv.isProductionInstall else { return }
+        let dir = PlatformPaths.appDirectory()
         var providerEntries: [[String: Any]] = []
         for snapshot in snapshots {
             providerEntries.append([

--- a/Sources/PokeTokenBar/Linux/FloatingPetWindow.swift
+++ b/Sources/PokeTokenBar/Linux/FloatingPetWindow.swift
@@ -1,0 +1,90 @@
+#if os(Linux)
+import CGtk
+import Foundation
+
+/// The opt-in desktop companion — a small always-on-top window showing the sprite.
+///
+/// **Wayland limits what this can be.** The macOS panel remembers where you dragged it and reopens
+/// there; Wayland deliberately denies clients both their own surface position and the ability to set
+/// one, so the saved origin cannot be honoured and the compositor places the window. Positioning is
+/// therefore the user's job via a KWin window rule. Everything else — always on top, no decorations,
+/// transparent background, click to open the popover — works as on macOS.
+///
+/// The origin is still persisted through `UsageStore`, so nothing is lost if a future protocol
+/// (or an X11 session, where it does work) can place it.
+@MainActor
+final class FloatingPetWindow {
+    private let store: UsageStore
+    private let companion: CompanionStore
+    private let window: Widget
+    private let image: Widget
+    private var currentKey: String?
+    private var isVisible = false
+
+    init(store: UsageStore, companion: CompanionStore, onActivate: @escaping () -> Void) {
+        self.store = store
+        self.companion = companion
+
+        window = gtk_window_new(GTK_WINDOW_TOPLEVEL)!
+        gtk_window_set_title(asWindow(window), "PokeTokenBar pet")
+        gtk_window_set_decorated(asWindow(window), 0)
+        gtk_window_set_keep_above(asWindow(window), 1)
+        gtk_window_set_skip_taskbar_hint(asWindow(window), 1)
+        gtk_window_set_skip_pager_hint(asWindow(window), 1)
+        gtk_window_set_resizable(asWindow(window), 0)
+        // A utility type keeps most compositors from giving it a titlebar or a task-switcher entry.
+        gtk_window_set_type_hint(asWindow(window), GDK_WINDOW_TYPE_HINT_UTILITY)
+
+        // A button rather than a bare image: it gives keyboard focus, a hover cursor and a click
+        // signal for free, and `RELIEF_NONE` keeps it from drawing a button frame around the sprite.
+        let button = gtk_button_new()!
+        gtk_button_set_relief(
+            UnsafeMutableRawPointer(button).assumingMemoryBound(to: GtkButton.self), GTK_RELIEF_NONE)
+        image = gtk_image_new()!
+        gtk_container_add(asContainer(button), image)
+        gtkConnect(UnsafeMutableRawPointer(button), signal: "clicked", box: GtkCallbackBox(onActivate))
+        gtk_container_add(asContainer(window), button)
+        enableTransparency()
+
+        gtkConnectDeleteEvent(UnsafeMutableRawPointer(window), box: GtkCallbackBox { [weak self] in
+            // Closing the pet is the same as switching it off, so the setting matches what is on
+            // screen — otherwise it reappears at next launch and reads as a bug.
+            self?.store.floatingPetEnabled = false
+            self?.hide()
+        })
+    }
+
+    /// Give the window an RGBA visual so the area around the sprite is see-through rather than a
+    /// grey square. Compositor-dependent: without compositing the background falls back to opaque.
+    private func enableTransparency() {
+        guard let screen = gtk_widget_get_screen(window),
+              let visual = gdk_screen_get_rgba_visual(screen) else { return }
+        gtk_widget_set_visual(window, visual)
+        gtk_widget_set_app_paintable(window, 1)
+    }
+
+    func setVisible(_ visible: Bool) {
+        visible ? show() : hide()
+    }
+
+    private func show() {
+        isVisible = true
+        gtk_widget_show_all(window)
+    }
+
+    private func hide() {
+        isVisible = false
+        gtk_widget_hide(window)
+    }
+
+    /// Swap in the current companion sprite at the configured size.
+    func update(spriteData: Data?, key: String) {
+        guard isVisible, key != currentKey, let spriteData else { return }
+        let size = Int(store.floatingPetSize)
+        guard let pixbuf = SpriteRenderer.render(spriteData, size: size) else { return }
+        defer { g_object_unref(UnsafeMutableRawPointer(pixbuf)) }
+        gtk_image_set_from_pixbuf(asImage(image), pixbuf)
+        currentKey = key
+    }
+}
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/Linux/GtkRuntime.swift
+++ b/Sources/PokeTokenBar/Linux/GtkRuntime.swift
@@ -1,0 +1,158 @@
+#if os(Linux)
+import CGtk
+import Dispatch
+import Foundation
+
+/// Lets the GTK main loop and Swift concurrency (MainActor) share one thread.
+///
+/// **The problem.** Both want to be "the loop that owns the main thread". Calling `gtk_main()`
+/// blocks inside it, so libdispatch's main queue never runs and none of the `@MainActor` work in
+/// `UsageStore` / `CompanionStore` executes. Running only `dispatchMain()` has the mirror problem:
+/// GTK events go unprocessed and the tray menu stops responding. Taking Core off MainActor
+/// entirely was rejected — that splits code shared with macOS.
+///
+/// **What we do.** libdispatch is the primary loop (`dispatchMain()`), and GTK is pumped from a
+/// repeating timer on the main queue. Given that one of the two loops has to yield, keeping Swift
+/// concurrency alive is what lets the shared code stay shared.
+///
+/// **The cost — idle wakeups.** The pump wakes the CPU at its interval. This repository has
+/// already been burned once by wakeup amplification from an always-on animation
+/// (`defect-log` §에너지 / "Energy"), so the default is deliberately slack and only tightens when a window is
+/// up: 50ms (20Hz) for the tray alone, 16ms (60Hz) with a window. 50ms is imperceptible on a
+/// menu click.
+///
+/// The better fix is Swift 6's custom main executor, putting MainActor directly on the GLib
+/// context and removing the pump altogether — worth revisiting once the tray is settled
+/// (roadmap Phase 8).
+enum GtkRuntime {
+    /// Pump interval with no window open. Only the tray menu has to respond, so it runs slack.
+    private static let idleInterval: DispatchTimeInterval = .milliseconds(50)
+    /// Interval while a window (popover, floating pet) is visible.
+    private static let activeInterval: DispatchTimeInterval = .milliseconds(16)
+
+    @MainActor private static var pumping = false
+
+    /// True while a window is up, which tightens the pump. The frontend updates it on show/hide.
+    @MainActor static var hasVisibleWindow = false
+
+    /// `gtk_init` — false when there is no display (TTY, SSH). The caller explains and exits.
+    static func initialize() -> Bool {
+        // The desktop matches a window to its `.desktop` file by app id / WM_CLASS, and that is what
+        // gives the task bar an icon and a name. GTK derives it from the executable's filename by
+        // default, so a dev run (`PokeTokenBar`) and the installed binary (`poketokenbar`) would
+        // claim different identities and only one of them would match `poketokenbar.desktop`.
+        // Pinning it makes both resolve.
+        g_set_prgname("poketokenbar")
+        gdk_set_program_class("poketokenbar")
+        guard gtk_init_check(nil, nil) != 0 else { return false }
+        applyDefaultWindowIcon()
+        return true
+    }
+
+    /// Give every window the app icon.
+    ///
+    /// Falls back to the sprite the tray already generated when the themed icon is not installed
+    /// (a dev run out of the build directory), because a blank task-bar entry reads as a broken app.
+    private static func applyDefaultWindowIcon() {
+        if let theme = gtk_icon_theme_get_default(),
+           gtk_icon_theme_has_icon(theme, "poketokenbar") != 0 {
+            gtk_window_set_default_icon_name("poketokenbar")
+            return
+        }
+        let fallback = PlatformPaths.appDirectory("tray").appendingPathComponent("companion-egg.png")
+        if FileManager.default.fileExists(atPath: fallback.path) {
+            gtk_window_set_default_icon_from_file(fallback.path, nil)
+        }
+    }
+
+    /// Starts pumping GTK events on the main queue. Call once, before `dispatchMain()`.
+    static func startPumpFromMainQueue() {
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                guard !pumping else { return }
+                pumping = true
+                schedule()
+            }
+        }
+    }
+
+    @MainActor private static func schedule() {
+        let interval = hasVisibleWindow ? activeInterval : idleInterval
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval) {
+            MainActor.assumeIsolated {
+                // Drain only what is pending; never block. Passing `true` would stall the main
+                // queue whenever GTK has no events.
+                while gtk_events_pending() != 0 {
+                    _ = gtk_main_iteration_do(0)
+                }
+                schedule()
+            }
+        }
+    }
+}
+
+/// A box that carries a Swift closure through a C callback.
+///
+/// GTK signals hand back a single `gpointer`. A closure cannot cross into C directly, so it is
+/// wrapped in a class whose lifetime we hold manually via `Unmanaged` — the box has to outlive the
+/// widget, and leaving it to ARC means the first click calls into freed memory.
+final class GtkCallbackBox {
+    let run: () -> Void
+    init(_ run: @escaping () -> Void) { self.run = run }
+
+    /// An opaque pointer holding a +1 retain. GTK calls the matching release when the widget dies.
+    var opaque: UnsafeMutableRawPointer { Unmanaged.passRetained(self).toOpaque() }
+}
+
+/// Connect one signal. `g_signal_connect` is a C macro and unavailable to Swift, so this calls
+/// the real function underneath it.
+@discardableResult
+func gtkConnect(
+    _ instance: UnsafeMutableRawPointer,
+    signal: String,
+    box: GtkCallbackBox
+) -> gulong {
+    let callback: @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Void = {
+        _, data in
+        guard let data else { return }
+        Unmanaged<GtkCallbackBox>.fromOpaque(data).takeUnretainedValue().run()
+    }
+    let destroy: @convention(c) (UnsafeMutableRawPointer?, UnsafeMutablePointer<GClosure>?) -> Void = {
+        data, _ in
+        guard let data else { return }
+        Unmanaged<GtkCallbackBox>.fromOpaque(data).release()
+    }
+    return g_signal_connect_data(
+        instance, signal,
+        unsafeBitCast(callback, to: GCallback.self),
+        box.opaque,
+        destroy,
+        GConnectFlags(rawValue: 0))
+}
+/// Connect a window's `delete-event` (the close button).
+///
+/// Separate from `gtkConnect` because this signal's handler returns `gboolean`, and returning TRUE
+/// is what tells GTK "handled — do not destroy". A tray app must hide rather than destroy: the
+/// process outlives the window, and a destroyed one leaves every later `show()` pointing at freed
+/// widgets.
+@discardableResult
+func gtkConnectDeleteEvent(_ instance: UnsafeMutableRawPointer, box: GtkCallbackBox) -> gulong {
+    let callback: @convention(c) (
+        UnsafeMutableRawPointer?, UnsafeMutableRawPointer?, UnsafeMutableRawPointer?
+    ) -> gboolean = { _, _, data in
+        guard let data else { return 0 }
+        Unmanaged<GtkCallbackBox>.fromOpaque(data).takeUnretainedValue().run()
+        return 1   // handled: suppress the default destroy
+    }
+    let destroy: @convention(c) (UnsafeMutableRawPointer?, UnsafeMutablePointer<GClosure>?) -> Void = {
+        data, _ in
+        guard let data else { return }
+        Unmanaged<GtkCallbackBox>.fromOpaque(data).release()
+    }
+    return g_signal_connect_data(
+        instance, "delete-event",
+        unsafeBitCast(callback, to: GCallback.self),
+        box.opaque, destroy, GConnectFlags(rawValue: 0))
+}
+
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/Linux/GtkWidgets.swift
+++ b/Sources/PokeTokenBar/Linux/GtkWidgets.swift
@@ -1,0 +1,126 @@
+#if os(Linux)
+import CGtk
+import Foundation
+
+// GTK is a C API built on GObject's single-inheritance casts. Swift sees every widget as
+// `UnsafeMutablePointer<GtkWidget>` and every upcast as a raw-pointer rebind, so without these
+// helpers the layout code is more cast than content.
+
+typealias Widget = UnsafeMutablePointer<GtkWidget>
+
+@inline(__always) func asContainer(_ w: Widget) -> UnsafeMutablePointer<GtkContainer> {
+    UnsafeMutableRawPointer(w).assumingMemoryBound(to: GtkContainer.self)
+}
+@inline(__always) func asBox(_ w: Widget) -> UnsafeMutablePointer<GtkBox> {
+    UnsafeMutableRawPointer(w).assumingMemoryBound(to: GtkBox.self)
+}
+@inline(__always) func asLabel(_ w: Widget) -> UnsafeMutablePointer<GtkLabel> {
+    UnsafeMutableRawPointer(w).assumingMemoryBound(to: GtkLabel.self)
+}
+@inline(__always) func asProgressBar(_ w: Widget) -> UnsafeMutablePointer<GtkProgressBar> {
+    UnsafeMutableRawPointer(w).assumingMemoryBound(to: GtkProgressBar.self)
+}
+@inline(__always) func asWindow(_ w: Widget) -> UnsafeMutablePointer<GtkWindow> {
+    UnsafeMutableRawPointer(w).assumingMemoryBound(to: GtkWindow.self)
+}
+@inline(__always) func asImage(_ w: Widget) -> UnsafeMutablePointer<GtkImage> {
+    UnsafeMutableRawPointer(w).assumingMemoryBound(to: GtkImage.self)
+}
+@inline(__always) func asStack(_ w: Widget) -> UnsafeMutablePointer<GtkStack> {
+    UnsafeMutableRawPointer(w).assumingMemoryBound(to: GtkStack.self)
+}
+
+enum Gtk {
+    /// A label carrying Pango markup. Everything styled — bold numbers, coloured percentages — goes
+    /// through markup rather than per-widget CSS, because the text is rebuilt on every refresh and
+    /// swapping one string is cheaper than reattaching style classes.
+    static func label(
+        _ markup: String = "", align: GtkAlign = GTK_ALIGN_START, wrap: Bool = false
+    ) -> Widget {
+        let widget = gtk_label_new(nil)!
+        setMarkup(widget, markup)
+        gtk_widget_set_halign(widget, align)
+        if wrap {
+            gtk_label_set_line_wrap(asLabel(widget), 1)
+            gtk_label_set_xalign(asLabel(widget), 0)
+        }
+        return widget
+    }
+
+    static func setMarkup(_ widget: Widget, _ markup: String) {
+        validate(markup)
+        gtk_label_set_markup(asLabel(widget), markup)
+    }
+
+    /// Complain loudly about markup Pango cannot parse.
+    ///
+    /// `gtk_label_set_markup` reports nothing on failure — it just leaves the label **blank**. A
+    /// stray attribute (`<span class='t'>`, which Pango has no concept of) therefore erases the text
+    /// silently, and the only symptom is a missing name in the UI. `pango_parse_markup` does return
+    /// an error, so every markup string is run past it and failures land in the log with the text
+    /// that caused them.
+    private static func validate(_ markup: String) {
+        var error: UnsafeMutablePointer<GError>?
+        let ok = pango_parse_markup(markup, -1, 0, nil, nil, nil, &error) != 0
+        guard !ok else { return }
+        let reason = error.flatMap { String(cString: $0.pointee.message) } ?? "unknown"
+        if let error { g_error_free(error) }
+        AppLog.write("invalid Pango markup (label will render blank): \(reason) — \(markup)")
+        assertionFailure("invalid Pango markup: \(reason) — \(markup)")
+    }
+
+    static func box(_ orientation: GtkOrientation, spacing: Int = 0) -> Widget {
+        gtk_box_new(orientation, Int32(spacing))!
+    }
+
+    static func pack(_ container: Widget, _ child: Widget, expand: Bool = false, padding: Int = 0) {
+        gtk_box_pack_start(asBox(container), child, expand ? 1 : 0, expand ? 1 : 0, guint(padding))
+    }
+
+    /// A thin horizontal meter. GTK's own progress bar carries a lot of theme padding, so the
+    /// height is pinned to keep the limit rows compact like the macOS popover.
+    static func meter(fraction: Double, cssClass: String? = nil) -> Widget {
+        let bar = gtk_progress_bar_new()!
+        gtk_progress_bar_set_fraction(asProgressBar(bar), max(0, min(1, fraction)))
+        gtk_widget_set_size_request(bar, -1, 6)
+        if let cssClass { addClass(bar, cssClass) }
+        return bar
+    }
+
+    static func addClass(_ widget: Widget, _ name: String) {
+        gtk_style_context_add_class(gtk_widget_get_style_context(widget), name)
+    }
+
+    static func removeClass(_ widget: Widget, _ name: String) {
+        gtk_style_context_remove_class(gtk_widget_get_style_context(widget), name)
+    }
+
+    static func margins(_ widget: Widget, top: Int = 0, bottom: Int = 0, start: Int = 0, end: Int = 0) {
+        gtk_widget_set_margin_top(widget, Int32(top))
+        gtk_widget_set_margin_bottom(widget, Int32(bottom))
+        gtk_widget_set_margin_start(widget, Int32(start))
+        gtk_widget_set_margin_end(widget, Int32(end))
+    }
+
+    /// Remove and destroy every child — the panels are rebuilt wholesale on refresh.
+    static func clear(_ container: Widget) {
+        let children = gtk_container_get_children(asContainer(container))
+        var node = children
+        while let current = node {
+            if let child = current.pointee.data {
+                gtk_widget_destroy(child.assumingMemoryBound(to: GtkWidget.self))
+            }
+            node = current.pointee.next
+        }
+        g_list_free(children)
+    }
+
+    /// Pango markup escaping. Pokémon names and provider labels are data, and an unescaped `&`
+    /// makes `gtk_label_set_markup` reject the whole string, blanking the row.
+    static func escape(_ text: String) -> String {
+        guard let escaped = g_markup_escape_text(text, -1) else { return "" }
+        defer { g_free(escaped) }
+        return String(cString: escaped)
+    }
+}
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/Linux/LinuxApp.swift
+++ b/Sources/PokeTokenBar/Linux/LinuxApp.swift
@@ -1,0 +1,328 @@
+#if os(Linux)
+import CGtk
+import Dispatch
+import Foundation
+
+/// Linux entry point — puts usage and the companion Pokémon in the tray (AppIndicator).
+/// The popover, floating pet and shop/bag windows arrive in roadmap phases 5–7.
+@main
+struct PokeTokenBarLinux {
+    static func main() {
+        // A few one-shot flags so autostart is reachable before the settings window exists
+        // (roadmap Phase 7). They call straight into `LoginItem`, so the systemd unit has exactly
+        // one definition — a Makefile target writing its own copy would drift from it.
+        var openTab: PopoverTab?
+        var openWindowAtLaunch = false
+
+        switch CommandLine.arguments.dropFirst().first {
+        case "--enable-autostart":  exit(setAutostart(true))
+        case "--disable-autostart": exit(setAutostart(false))
+        case "--autostart-status":
+            print(MainActor.assumeIsolated { LoginItem.isEnabled } ? "enabled" : "disabled")
+            exit(0)
+        case "--window":
+            // Not only a convenience: GNOME ships no tray at all without an extension, so on those
+            // desktops this is the only way to reach the window.
+            openWindowAtLaunch = true
+            openTab = CommandLine.arguments.dropFirst(2).first.flatMap(PopoverTab.init(name:))
+        case "--version":
+            print(AppVersion.current)
+            exit(0)
+        case .some(let unknown) where unknown.hasPrefix("-"):
+            FileHandle.standardError.write(Data("PokeTokenBar: unknown option \(unknown)\n".utf8))
+            exit(2)
+        default:
+            break   // no arguments: run the tray
+        }
+
+        // Keep a subprocess pipe closing early (codex app-server and friends) from killing us —
+        // same reason and same position as the macOS AppDelegate.
+        signal(SIGPIPE, SIG_IGN)
+
+        // The duplicate-instance guard runs **before** the tray is built. Afterwards, the icon of
+        // the instance that yields would flash onto the panel and vanish (macOS puts it ahead of
+        // creating the status item for the same reason).
+        if SingleInstance.shouldYieldToRunningInstance() {
+            AppLog.write("duplicate instance: yielding to the instance already running")
+            AppLog.flush()
+            exit(0)
+        }
+        CrashReporter.install(version: AppVersion.current)
+        // Must be installed before any store exists: `UsageStore.init` calls
+        // `PlatformPowerEvents.observe`, and an observer registered later would never be asked.
+        PowerEvents.install()
+
+        guard GtkRuntime.initialize() else {
+            // English, not localised: this fires before the companion store (and therefore the
+            // language setting) has loaded, and it goes to stderr for someone running the binary
+            // from a shell.
+            FileHandle.standardError.write(Data(
+                "PokeTokenBar: cannot open a display, which the tray requires. Run it inside a GUI session.\n"
+                    .utf8))
+            exit(1)
+        }
+
+        // From here on, MainActor work only runs once the main queue is turning (dispatchMain),
+        // so setup is queued too and the loop is handed to dispatchMain last.
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated { App.shared.start(showingWindow: openWindowAtLaunch, tab: openTab) }
+        }
+        GtkRuntime.startPumpFromMainQueue()
+        dispatchMain()
+    }
+}
+
+/// Toggle "launch at login" and report the outcome. Returns a process exit code.
+private func setAutostart(_ enabled: Bool) -> Int32 {
+    MainActor.assumeIsolated {
+        do {
+            try LoginItem.setEnabled(enabled)
+            print("autostart \(enabled ? "enabled" : "disabled")")
+            return 0
+        } catch {
+            FileHandle.standardError.write(Data("PokeTokenBar: \(error)\n".utf8))
+            return 1
+        }
+    }
+}
+
+/// One tray item and the polling loop that feeds it.
+@MainActor
+final class App {
+    static let shared = App()
+
+    private let store = UsageStore()
+    private let companion = CompanionStore()
+    private var tray: TrayIndicator?
+    private var popover: PopoverWindow?
+    private var settings: SettingsWindow?
+    private var pet: FloatingPetWindow?
+    /// The sprite key currently on the tray ("<species>-<shiny>") — skip rewrites for the same one.
+    private var iconKey: String?
+
+    /// Frames of the current animated sprite, and where in the loop we are. Empty means the
+    /// companion has no animated sprite (only Gen-V mons do) and the static icon stands.
+    private var animationFrames: [SpriteRenderer.Frame] = []
+    private var animationIndex = 0
+    /// Bumped whenever the subject changes, so a timer belonging to the previous species stops
+    /// instead of cycling frames of a Pokémon that is no longer the companion.
+    private var animationGeneration = 0
+    /// Paused while the screen is off — see PlatformPowerEvents.
+    private var animationPaused = false
+
+    func start(showingWindow: Bool = false, tab: PopoverTab? = nil) {
+        let iconDirectory = PlatformPaths.appDirectory("tray")
+        // Start from a system-theme icon: sprites are fetched over the network, so on a first run
+        // or offline there is none yet. Some panels do not draw a blank for a missing icon name —
+        // they hide the item entirely. So begin with a name that certainly exists and swap later.
+        // Menu text follows the app's language setting. Hardcoding it would leave the language
+        // preference half-working — applying everywhere except the tray. (A fresh install defaults
+        // to the system locale: `AppLanguage.systemDefault`.)
+        let l = L(companion.language)
+        PopoverStyle.install()
+        popover = PopoverWindow(store: store, companion: companion, onClose: {})
+        let settingsWindow = SettingsWindow(store: store, companion: companion)
+        settingsWindow.onLanguageChange = { [weak self] in self?.relabel() }
+        settingsWindow.onFloatingPetChange = { [weak self] in self?.syncFloatingPet() }
+        settings = settingsWindow
+        pet = FloatingPetWindow(store: store, companion: companion) { [weak self] in
+            self?.popover?.show()
+            guard let self else { return }
+            Task { @MainActor in await self.popover?.loadSpritesAndRefresh() }
+        }
+        let tray = TrayIndicator(
+            id: "poketokenbar", iconThemePath: iconDirectory.path, iconName: "applications-games",
+            summaryPlaceholder: l.loading)
+        self.tray = tray
+
+        tray.addItem(l.openWindow, localized: { $0.openWindow }) { [weak self] in
+            guard let self else { return }
+            self.popover?.show()
+            Task { @MainActor in await self.popover?.loadSpritesAndRefresh() }
+        }
+        tray.addItem(l.refreshNow, localized: { $0.refreshNow }) { [weak self] in
+            Task { @MainActor in await self?.refresh() }
+        }
+        tray.addItem(l.settings, localized: { $0.settings }) { [weak self] in
+            self?.settings?.show()
+        }
+        tray.addItem(l.showLogFile, localized: { $0.showLogFile }) {
+            PlatformOpener.reveal(AppLog.logFileURL)
+        }
+        tray.appendSeparator()
+        tray.addItem(l.quit, localized: { $0.quit }) {
+            CrashReporter.markClean()
+            AppLog.flush()
+            exit(0)
+        }
+
+        store.localizationLanguage = companion.language
+        store.onRefresh = { [weak self] in self?.onStoreRefreshed() }
+        // The store pauses its own polling; the tray animation is ours to pause. Leaving a sprite
+        // cycling at 2.5fps against a blanked screen is exactly the idle drain the frame floor exists
+        // to avoid.
+        PlatformPowerEvents.observe(
+            onWake: {},
+            onScreenSleep: { [weak self] in self?.animationPaused = true },
+            onScreenWake: { [weak self] in self?.animationPaused = false })
+
+        syncFloatingPet()
+        if showingWindow {
+            popover?.show()
+            if let tab { popover?.select(tab) }
+        }
+        Task { @MainActor in await refresh() }
+        schedulePolling()
+    }
+
+    /// Show or hide the desktop pet to match the setting, and give it the current sprite.
+    private func syncFloatingPet() {
+        pet?.setVisible(store.floatingPetEnabled)
+        guard store.floatingPetEnabled else { return }
+        let key = companion.currentSpeciesID.map { "\($0)-\(companion.currentIsShiny)" } ?? "egg"
+        Task { @MainActor in
+            let data: Data?
+            if let species = companion.currentSpeciesID {
+                data = await SpriteStore.shared.data(
+                    speciesID: species, animated: false, shiny: companion.currentIsShiny)
+            } else {
+                data = await SpriteStore.shared.eggData()
+            }
+            pet?.update(spriteData: data, key: key)
+        }
+    }
+
+    /// Feed the refreshed usage into the companion, then hand out candy while the limits are fresh.
+    ///
+    /// **This is what makes the egg hatch.** `UsageStore` only counts tokens; the companion learns
+    /// about them solely through `update(...)`. Without this hook the app reports usage perfectly
+    /// and the companion never progresses — the hatch counter sits at its starting value forever,
+    /// which is exactly how it behaved before this existed.
+    private func onStoreRefreshed() {
+        updateCompanion()
+        companion.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        applyState()
+    }
+
+    private func updateCompanion() {
+        companion.update(
+            todayTokensByProvider: store.todayTokensByProvider,
+            todayDate: LocalUsageReader.todayKey(),
+            monthTotal: store.monthTotalTokens,
+            burnTier: store.burnTier,
+            limitWarning: store.isLimitWarning,
+            hasUsageData: store.hasUsageData)
+    }
+
+    /// Re-apply every label after a language change. The tray menu is built once at startup, so
+    /// without this the popover would switch language while the menu stayed on the old one.
+    private func relabel() {
+        store.localizationLanguage = companion.language
+        tray?.relabel(companion.l)
+        applyState()
+        Task { @MainActor in await popover?.loadSpritesAndRefresh() }
+    }
+
+    /// One usage refresh. The polling interval follows `store.refreshInterval` (a user setting).
+    private func refresh() async {
+        await store.refresh()
+        // `store.onRefresh` already fed the companion; hatching is checked afterwards so a refresh
+        // that crosses the threshold hatches in the same tick rather than one poll later.
+        await companion.hatchIfNeeded()
+        applyState()
+        await updateIcon()
+        syncFloatingPet()
+        // Only rebuilds when the window is actually up (see PopoverWindow.refresh).
+        await popover?.loadSpritesAndRefresh()
+    }
+
+    private func schedulePolling() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + store.refreshInterval) {
+            Task { @MainActor in
+                await self.refresh()
+                self.schedulePolling()   // schedule after completion so polls cannot pile up
+            }
+        }
+    }
+
+    private func applyState() {
+        // macOS stacks several lines vertically in the menu bar; an SNI label is a single line,
+        // so they are joined with " / ".
+        tray?.setUsageText(store.menuLines.joined(separator: " / "))
+    }
+
+    /// Put the companion sprite on the tray. Does nothing while the subject is unchanged, to
+    /// avoid pointless disk writes.
+    ///
+    /// Before the first hatch there is no species, and the subject is the egg — the same thing the
+    /// macOS menu bar shows. Returning early on a nil species instead would leave a fresh install
+    /// sitting on the placeholder system icon, which reads as "the app is broken" rather than
+    /// "your egg has not hatched yet".
+    private func updateIcon() async {
+        let key: String
+        let data: Data?
+        if let speciesID = companion.currentSpeciesID {
+            let shiny = companion.currentIsShiny
+            key = "\(speciesID)-\(shiny)"
+            guard key != iconKey else { return }
+            data = await SpriteStore.shared.data(
+                speciesID: speciesID, animated: false, shiny: shiny)
+        } else {
+            key = "egg"
+            guard key != iconKey else { return }
+            data = await SpriteStore.shared.eggData()
+        }
+        guard let data else { return }
+
+        // AppIndicator takes a **theme path plus a name**, not an image. Some panels keep using a
+        // cached pixmap when the same name is overwritten, so the key goes into the name and every
+        // change produces a fresh one.
+        let directory = PlatformPaths.appDirectory("tray")
+        let name = "companion-\(key)"
+        let file = directory.appendingPathComponent("\(name).png")
+        guard SpriteRenderer.write(data, to: file) else { return }
+        tray?.setIcon(named: name)
+        iconKey = key
+
+        // The static icon goes up first so something is showing immediately; the animated sprite is
+        // a second download and only exists for Gen-V species.
+        animationFrames = []
+        animationGeneration += 1
+        guard let speciesID = companion.currentSpeciesID,
+              PokemonAssets.hasAnimatedSprite(speciesID: speciesID),
+              let gif = await SpriteStore.shared.data(
+                speciesID: speciesID, animated: true, shiny: companion.currentIsShiny)
+        else { return }
+        let frames = SpriteRenderer.writeFrames(gif, directory: directory, prefix: name)
+        guard frames.count > 1 else { return }
+        animationFrames = frames
+        animationIndex = 0
+        scheduleAnimationTick(generation: animationGeneration)
+    }
+
+    /// Advance the tray sprite one frame, then schedule the next.
+    ///
+    /// A self-rescheduling timer rather than a fixed-interval one, because GIF frames have
+    /// individual delays. `generation` makes a stale chain die on its own once the subject changes.
+    private func scheduleAnimationTick(generation: Int) {
+        guard generation == animationGeneration, animationFrames.count > 1 else { return }
+        let frame = animationFrames[animationIndex % animationFrames.count]
+        let delay = SpriteAnimationPolicy.frameDelay(
+            base: frame.delay, floor: SpriteAnimationPolicy.idleFrameFloor)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, generation == self.animationGeneration else { return }
+                guard !self.animationPaused else {
+                    // Keep the chain alive but idle, so it resumes without re-extracting frames.
+                    self.scheduleAnimationTick(generation: generation)
+                    return
+                }
+                self.animationIndex += 1
+                let next = self.animationFrames[self.animationIndex % self.animationFrames.count]
+                self.tray?.setIcon(named: next.name)
+                self.scheduleAnimationTick(generation: generation)
+            }
+        }
+    }
+}
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/Linux/PopoverStyle.swift
+++ b/Sources/PokeTokenBar/Linux/PopoverStyle.swift
@@ -1,0 +1,65 @@
+#if os(Linux)
+import CGtk
+import Foundation
+
+/// The popover's stylesheet, installed once for the whole app.
+///
+/// GTK theming is CSS, and this deliberately does not hardcode a palette: colours come from the
+/// user's GTK theme via `@theme_fg_color` and friends, so the window follows their light/dark
+/// setting instead of fighting it. Only the accents that carry meaning — the limit colours — are
+/// fixed, because "over the warning threshold" has to read the same on every theme.
+enum PopoverStyle {
+    static func install() {
+        let css = """
+        .ptb-card {
+          background-color: alpha(@theme_fg_color, 0.05);
+          border-radius: 10px;
+          padding: 12px;
+        }
+        .ptb-title      { font-weight: bold; font-size: 13px; }
+        .ptb-huge       { font-size: 30px; font-weight: bold; }
+        .ptb-muted      { color: alpha(@theme_fg_color, 0.55); font-size: 11px; }
+        .ptb-section    { font-size: 11px; font-weight: bold; color: alpha(@theme_fg_color, 0.55); }
+        .ptb-badge {
+          background-color: alpha(@theme_fg_color, 0.12);
+          border-radius: 8px;
+          padding: 1px 7px;
+          font-size: 10px;
+          font-weight: bold;
+        }
+        .ptb-chip {
+          background-color: alpha(@theme_fg_color, 0.08);
+          border-radius: 12px;
+          padding: 3px 10px;
+          font-size: 11px;
+        }
+        /* A celebration should read as an event, not another data card. */
+        .ptb-celebration {
+          background-color: alpha(@theme_selected_bg_color, 0.30);
+          border: 1px solid @theme_selected_bg_color;
+        }
+        /* Evolution line: the current stage is ringed, later stages are faded back. */
+        .ptb-stage-current { border: 2px solid @theme_selected_bg_color; border-radius: 6px; }
+        .ptb-stage-future  { opacity: 0.35; }
+        .ptb-chip-on {
+          background-color: @theme_selected_bg_color;
+          color: @theme_selected_fg_color;
+        }
+        /* Limit meters. Green / amber / red are the same thresholds the menu bar uses, so a glance
+           at either surface means the same thing. */
+        progressbar.ptb-ok    trough progress { background-color: #35c759; }
+        progressbar.ptb-warn  trough progress { background-color: #ff9f0a; }
+        progressbar.ptb-crit  trough progress { background-color: #ff453a; }
+        progressbar trough { min-height: 6px; border-radius: 3px; }
+        progressbar progress { min-height: 6px; border-radius: 3px; }
+        """
+        guard let provider = gtk_css_provider_new() else { return }
+        gtk_css_provider_load_from_data(provider, css, -1, nil)
+        if let screen = gdk_screen_get_default() {
+            gtk_style_context_add_provider_for_screen(
+                screen, OpaquePointer(provider), guint(GTK_STYLE_PROVIDER_PRIORITY_APPLICATION))
+        }
+        g_object_unref(UnsafeMutableRawPointer(provider))
+    }
+}
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/Linux/PopoverWindow.swift
+++ b/Sources/PokeTokenBar/Linux/PopoverWindow.swift
@@ -1,0 +1,758 @@
+#if os(Linux)
+import CGtk
+import Foundation
+
+/// The main window — the Linux stand-in for the macOS popover.
+///
+/// It is a real window rather than a popover attached to the tray icon, because Wayland gives an
+/// application no way to position a surface next to a panel item it does not own. So it opens
+/// centred and stays on top; that is the closest honest equivalent.
+///
+/// Content is **rebuilt wholesale** on each refresh instead of diffed. The panel is a few dozen
+/// labels refreshed every couple of minutes, so rebuilding costs nothing measurable and removes a
+/// whole class of bug where a stale widget keeps showing an old number.
+@MainActor
+final class PopoverWindow {
+    private let store: UsageStore
+    private let companion: CompanionStore
+    private let window: Widget
+    private let stack: Widget
+    private let pages: [PopoverTab: Widget]
+    private var isVisible = false
+
+    /// Which provider's breakdown is expanded. nil = the first one.
+    private var selectedProviderID: String?
+
+    /// How many dex entries are drawn. The macOS Collection paginates; this caps the sprite
+    /// prefetch so a large dex does not fire hundreds of requests when the window opens.
+    private let dexPageSize = 60
+
+    /// Celebration currently on screen, and the sequence it came from. Held rather than read
+    /// straight off the store because the store's copy is consumed as soon as it is shown, while
+    /// the banner has to survive the rebuilds that tab switches and refreshes cause.
+    private var activeCelebration: String?
+    private var seenCelebrationSeq = -1
+
+    /// Live animation for the Home sprite: the frames, where we are, and a generation counter that
+    /// retires the timer when the subject changes. Pixbufs are owned here and unref'd on replace.
+    private var animationFrames: [(pixbuf: OpaquePointer, delay: TimeInterval)] = []
+    private var animationIndex = 0
+    private var animationGeneration = 0
+    private var animationImage: Widget?
+
+    /// Sprite bytes already fetched, keyed by "<species>-<shiny>" — avoids re-downloading on every
+    /// rebuild, which would otherwise hit the network once per refresh tick.
+    private var spriteCache: [String: Data] = [:]
+
+    init(store: UsageStore, companion: CompanionStore, onClose: @escaping () -> Void) {
+        self.store = store
+        self.companion = companion
+
+        window = gtk_window_new(GTK_WINDOW_TOPLEVEL)!
+        gtk_window_set_title(asWindow(window), "PokeTokenBar")
+        gtk_window_set_default_size(asWindow(window), 400, 620)
+        gtk_window_set_keep_above(asWindow(window), 1)
+        gtk_window_set_position(asWindow(window), GTK_WIN_POS_CENTER)
+
+        let root = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 8)
+        Gtk.margins(root, top: 10, bottom: 10, start: 10, end: 10)
+        gtk_container_add(asContainer(window), root)
+
+        stack = gtk_stack_new()!
+        let switcher = gtk_stack_switcher_new()!
+        gtk_stack_switcher_set_stack(
+            UnsafeMutableRawPointer(switcher).assumingMemoryBound(to: GtkStackSwitcher.self),
+            asStack(stack))
+        gtk_widget_set_halign(switcher, GTK_ALIGN_CENTER)
+        Gtk.pack(root, switcher)
+
+        var built: [PopoverTab: Widget] = [:]
+        let l = companion.l
+        for (tab, title) in [(PopoverTab.home, l.home), (.shop, l.shop), (.bag, l.bag),
+                             (.collection, l.collection)] {
+            let page = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 10)
+            let scroller = gtk_scrolled_window_new(nil, nil)!
+            gtk_scrolled_window_set_policy(
+                UnsafeMutableRawPointer(scroller).assumingMemoryBound(to: GtkScrolledWindow.self),
+                GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC)
+            gtk_container_add(asContainer(scroller), page)
+            gtk_stack_add_titled(asStack(stack), scroller, tab.identifier, title)
+            built[tab] = page
+        }
+        pages = built
+        Gtk.pack(root, stack, expand: true)
+
+        // Closing must hide, not destroy: the tray outlives the window, and destroying it would
+        // leave every later `show()` pointing at freed widgets. Returning true stops GTK's default
+        // destroy handler.
+        let box = GtkCallbackBox { [weak self] in
+            self?.hide()
+            onClose()
+        }
+        gtkConnectDeleteEvent(UnsafeMutableRawPointer(window), box: box)
+    }
+
+    // MARK: visibility
+
+    var visible: Bool { isVisible }
+
+    func toggle() { isVisible ? hide() : show() }
+
+    /// Switch tabs programmatically. Used by `--window <tab>`; the switcher drives it otherwise.
+    func select(_ tab: PopoverTab) {
+        gtk_stack_set_visible_child_name(asStack(stack), tab.identifier)
+    }
+
+    func show() {
+        isVisible = true
+        GtkRuntime.hasVisibleWindow = true
+        refresh()
+        gtk_widget_show_all(window)
+        gtk_window_present(asWindow(window))
+    }
+
+    func hide() {
+        isVisible = false
+        GtkRuntime.hasVisibleWindow = false
+        gtk_widget_hide(window)
+    }
+
+    /// Rebuild whatever is on screen. Cheap enough to call on every poll (see the type doc).
+    func refresh() {
+        guard isVisible else { return }
+        let l = companion.l
+        captureCelebrationIfNeeded(l)
+        for (tab, page) in pages {
+            Gtk.clear(page)
+            switch tab {
+            case .home:       buildHome(into: page)
+            case .shop:       buildShop(into: page, l)
+            case .bag:        buildBag(into: page, l)
+            case .collection: buildCollection(into: page, l)
+            }
+        }
+        gtk_widget_show_all(window)
+    }
+
+    /// Pull the sprites the visible tab needs, then rebuild. Async because the first paint may have
+    /// to download them.
+    func loadSpritesAndRefresh() async {
+        await cacheCompanionSprite()
+        for kind in ItemKind.allCases { await cacheItemSprite(kind) }
+        for item in companion.lineNodes {
+            if case .species(let speciesID) = item.content {
+                await cacheSprite(speciesID: speciesID, shiny: companion.currentIsShiny)
+            }
+        }
+        for entry in companion.dexEntriesSorted.prefix(dexPageSize) {
+            await cacheSprite(speciesID: entry.finalID, shiny: entry.isShiny)
+        }
+        refresh()
+    }
+
+    private func cacheCompanionSprite() async {
+        if let subject = companion.currentSpeciesID {
+            await cacheSprite(speciesID: subject, shiny: companion.currentIsShiny)
+        } else if spriteCache["egg"] == nil {
+            spriteCache["egg"] = await SpriteStore.shared.eggData()
+        }
+    }
+
+    private func cacheSprite(speciesID: Int, shiny: Bool) async {
+        let key = "\(speciesID)-\(shiny)"
+        guard spriteCache[key] == nil else { return }
+        spriteCache[key] = await SpriteStore.shared.data(
+            speciesID: speciesID, animated: false, shiny: shiny)
+    }
+
+    private func cacheItemSprite(_ kind: ItemKind) async {
+        guard let name = kind.spriteName else { return }   // no sprite upstream: emoji fallback
+        let key = "item-\(name)"
+        guard spriteCache[key] == nil else { return }
+        spriteCache[key] = await SpriteStore.shared.data(itemName: name)
+    }
+
+    /// A pixbuf image widget for a cached sprite, or nil if it has not arrived yet.
+    private func spriteImage(_ key: String, size: Int) -> Widget? {
+        guard let data = spriteCache[key], let pixbuf = SpriteRenderer.render(data, size: size)
+        else { return nil }
+        let image = gtk_image_new_from_pixbuf(pixbuf)!
+        g_object_unref(UnsafeMutableRawPointer(pixbuf))
+        return image
+    }
+
+    /// An item's sprite, falling back to its emoji — the same fallback the macOS shop uses when
+    /// PokéAPI has no artwork (mints are Gen-8 and simply absent).
+    private func itemIcon(_ kind: ItemKind, size: Int) -> Widget {
+        if let name = kind.spriteName, let image = spriteImage("item-\(name)", size: size) {
+            return image
+        }
+        let label = Gtk.label("<span size='x-large'>\(Gtk.escape(kind.fallbackEmoji))</span>")
+        gtk_widget_set_valign(label, GTK_ALIGN_CENTER)
+        return label
+    }
+
+    /// Take a newly fired celebration for display, exactly once.
+    ///
+    /// Keyed on `celebrationSeq` rather than on the optional itself, the way the macOS header does
+    /// it: consuming the store's copy immediately would otherwise let the same event replay every
+    /// time the panel rebuilt.
+    private func captureCelebrationIfNeeded(_ l: L) {
+        guard let celebration = companion.celebration,
+              companion.celebrationSeq != seenCelebrationSeq else { return }
+        seenCelebrationSeq = companion.celebrationSeq
+        let name = companion.displayName
+        switch celebration {
+        case .hatch(let shiny):
+            activeCelebration = "\(shiny ? l.notifShinyHatchTitle : l.notifHatchTitle)\n\(l.notifHatchBody(name))"
+        case .evolve:
+            activeCelebration = "\(l.notifEvolveTitle)\n\(l.notifEvolveBody(name))"
+        case .dittoReveal(let shiny):
+            activeCelebration = shiny ? l.notifShinyDittoRevealTitle : l.notifDittoRevealTitle
+        }
+        companion.consumeCelebration()
+
+        // Self-clearing: a congratulation still sitting there an hour later reads as stale UI.
+        let shown = seenCelebrationSeq
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30) { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, self.seenCelebrationSeq == shown else { return }
+                self.activeCelebration = nil
+                self.refresh()
+            }
+        }
+    }
+
+    private func celebrationBanner(_ text: String) -> Widget {
+        let banner = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 2)
+        Gtk.addClass(banner, "ptb-card")
+        Gtk.addClass(banner, "ptb-celebration")
+        let label = Gtk.label("<b>\(Gtk.escape(text))</b>", align: GTK_ALIGN_CENTER, wrap: true)
+        gtk_label_set_justify(asLabel(label), GTK_JUSTIFY_CENTER)
+        Gtk.pack(banner, label)
+        return banner
+    }
+
+    // MARK: companion animation
+
+    /// Animate the Home sprite if this species has a Gen-V animated sprite.
+    ///
+    /// The popover runs at the sprite's native rate (floor 0), unlike the tray: this surface only
+    /// exists while someone is looking at it, so the idle-wakeup argument that caps the tray at
+    /// 2.5fps does not apply here (`SpriteAnimationPolicy`).
+    private func startAnimation(on image: Widget, key: String) {
+        animationGeneration += 1
+        releaseAnimationFrames()
+        animationImage = image
+        animationIndex = 0
+
+        guard let speciesID = companion.currentSpeciesID,
+              PokemonAssets.hasAnimatedSprite(speciesID: speciesID) else { return }
+        let generation = animationGeneration
+        let shiny = companion.currentIsShiny
+        Task { @MainActor in
+            guard let gif = await SpriteStore.shared.data(
+                speciesID: speciesID, animated: true, shiny: shiny),
+                  generation == self.animationGeneration else { return }
+            let frames = SpriteRenderer.renderFrames(gif, size: 72)
+            guard frames.count > 1, generation == self.animationGeneration else {
+                for frame in frames { g_object_unref(UnsafeMutableRawPointer(frame.pixbuf)) }
+                return
+            }
+            self.animationFrames = frames
+            self.scheduleFrame(generation: generation)
+        }
+    }
+
+    private func scheduleFrame(generation: Int) {
+        guard generation == animationGeneration, animationFrames.count > 1, isVisible else { return }
+        let frame = animationFrames[animationIndex % animationFrames.count]
+        DispatchQueue.main.asyncAfter(deadline: .now() + max(frame.delay, 0.02)) { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, generation == self.animationGeneration, self.isVisible,
+                      let image = self.animationImage else { return }
+                self.animationIndex += 1
+                let next = self.animationFrames[self.animationIndex % self.animationFrames.count]
+                gtk_image_set_from_pixbuf(asImage(image), next.pixbuf)
+                self.scheduleFrame(generation: generation)
+            }
+        }
+    }
+
+    /// Frames are owned here, so replacing them has to unref the old ones or the pixbufs leak —
+    /// a species change every few minutes would otherwise accumulate megabytes over a long session.
+    private func releaseAnimationFrames() {
+        for frame in animationFrames { g_object_unref(UnsafeMutableRawPointer(frame.pixbuf)) }
+        animationFrames = []
+    }
+
+    // MARK: Shop
+
+    private func buildShop(into page: Widget, _ l: L) {
+        let wallet = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 2)
+        Gtk.addClass(wallet, "ptb-card")
+        let caption = Gtk.label(Gtk.escape(l.shop))
+        Gtk.addClass(caption, "ptb-section")
+        Gtk.pack(wallet, caption)
+        Gtk.pack(wallet, Gtk.label(
+            "<span size='large'><b>\(Gtk.escape(TokenFormatter.compact(companion.availableTokens)))</b></span>"))
+        let hint = Gtk.label("<span size='small'>\(Gtk.escape(l.shopHint))</span>", wrap: true)
+        Gtk.addClass(hint, "ptb-muted")
+        Gtk.pack(wallet, hint)
+        Gtk.pack(page, wallet)
+
+        for entry in companion.shopEntries {
+            Gtk.pack(page, shopRow(entry, l))
+        }
+    }
+
+    private func shopRow(_ entry: ShopEntry, _ l: L) -> Widget {
+        let row = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 10)
+        Gtk.addClass(row, "ptb-card")
+
+        let title: String
+        let subtitle: String
+        let affordable: Bool
+        let alreadyOwned: Bool
+        switch entry {
+        case .item(let kind):
+            Gtk.pack(row, itemIcon(kind, size: 32))
+            title = l.itemName(kind)
+            subtitle = l.itemDescription(kind)
+            affordable = companion.canBuy(kind)
+            alreadyOwned = kind.isPassive && companion.itemCount(kind) > 0
+        case .egg(let tier):
+            let icon = spriteImage("egg", size: 32) ?? Gtk.label("<span size='x-large'>🥚</span>")
+            Gtk.pack(row, icon)
+            title = l.eggName(tier)
+            subtitle = l.shopHint
+            affordable = companion.canBuyEgg(tier)
+            alreadyOwned = false
+        }
+
+        let text = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 2)
+        gtk_widget_set_valign(text, GTK_ALIGN_CENTER)
+        Gtk.pack(text, Gtk.label("<b>\(Gtk.escape(title))</b>"))
+        let desc = Gtk.label("<span size='small'>\(Gtk.escape(subtitle))</span>", wrap: true)
+        Gtk.addClass(desc, "ptb-muted")
+        Gtk.pack(text, desc)
+        let price = Gtk.label(
+            "<span size='small'>\(Gtk.escape(l.shopPriceLabel)) \(Gtk.escape(TokenFormatter.compact(entry.price)))</span>")
+        Gtk.addClass(price, "ptb-muted")
+        Gtk.pack(text, price)
+        Gtk.pack(row, text, expand: true)
+
+        if alreadyOwned {
+            let owned = Gtk.label("<span size='small'>\(Gtk.escape(l.ownedAlready))</span>")
+            gtk_widget_set_valign(owned, GTK_ALIGN_CENTER)
+            Gtk.pack(row, owned)
+            return row
+        }
+
+        let button = gtk_button_new_with_label(l.buy)!
+        gtk_widget_set_valign(button, GTK_ALIGN_CENTER)
+        // Insufficient balance disables the button rather than hiding it, so the price stays
+        // legible as a goal instead of the row silently losing its action.
+        gtk_widget_set_sensitive(button, affordable ? 1 : 0)
+        gtkConnect(UnsafeMutableRawPointer(button), signal: "clicked",
+                   box: GtkCallbackBox { [weak self] in
+                       guard let self else { return }
+                       switch entry {
+                       case .item(let kind): _ = self.companion.buy(kind)
+                       case .egg(let tier):  _ = self.companion.buyEgg(tier)
+                       }
+                       Task { @MainActor in await self.loadSpritesAndRefresh() }
+                   })
+        Gtk.pack(row, button)
+        return row
+    }
+
+    // MARK: Bag
+
+    private func buildBag(into page: Widget, _ l: L) {
+        let owned = companion.ownedItems
+        guard !owned.isEmpty else {
+            let empty = Gtk.label("<b>\(Gtk.escape(l.bagEmptyTitle))</b>", align: GTK_ALIGN_CENTER)
+            Gtk.margins(empty, top: 24)
+            Gtk.pack(page, empty)
+            return
+        }
+        for (kind, count) in owned {
+            Gtk.pack(page, bagRow(kind, count, l))
+        }
+    }
+
+    private func bagRow(_ kind: ItemKind, _ count: Int, _ l: L) -> Widget {
+        let row = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 10)
+        Gtk.addClass(row, "ptb-card")
+        Gtk.pack(row, itemIcon(kind, size: 32))
+
+        let text = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 2)
+        gtk_widget_set_valign(text, GTK_ALIGN_CENTER)
+        Gtk.pack(text, Gtk.label("<b>\(Gtk.escape(l.itemName(kind)))</b>"))
+        let countLabel = Gtk.label("<span size='small'>\(Gtk.escape(l.ownedCount(count)))</span>")
+        Gtk.addClass(countLabel, "ptb-muted")
+        Gtk.pack(text, countLabel)
+        Gtk.pack(row, text, expand: true)
+
+        // Passive items apply just by being owned — there is nothing to press, so no button.
+        guard !kind.isPassive else {
+            let applied = Gtk.label("<span size='small'>\(Gtk.escape(l.ownedAlready))</span>")
+            gtk_widget_set_valign(applied, GTK_ALIGN_CENTER)
+            Gtk.pack(row, applied)
+            return row
+        }
+
+        let button = gtk_button_new_with_label(l.useItem)!
+        gtk_widget_set_valign(button, GTK_ALIGN_CENTER)
+        // Consumables need something to act on; before the first hatch there is no companion.
+        gtk_widget_set_sensitive(button, companion.hasActive ? 1 : 0)
+        gtk_widget_set_tooltip_text(button, companion.hasActive ? nil : l.useAfterHatch)
+        gtkConnect(UnsafeMutableRawPointer(button), signal: "clicked",
+                   box: GtkCallbackBox { [weak self] in
+                       guard let self else { return }
+                       switch kind {
+                       case .rareCandy: _ = self.companion.useRareCandy()
+                       case .mint:      _ = self.companion.useMint()
+                       case .shinyCharm: break   // passive; handled above
+                       }
+                       Task { @MainActor in await self.loadSpritesAndRefresh() }
+                   })
+        Gtk.pack(row, button)
+        return row
+    }
+
+    // MARK: Collection
+
+    private func buildCollection(into page: Widget, _ l: L) {
+        let entries = companion.dexEntriesSorted
+        guard !entries.isEmpty else {
+            let empty = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 6)
+            Gtk.margins(empty, top: 24)
+            Gtk.pack(empty, Gtk.label("<b>\(Gtk.escape(l.dexEmptyTitle))</b>", align: GTK_ALIGN_CENTER))
+            let hint = Gtk.label("<span size='small'>\(Gtk.escape(l.dexEmptyHint))</span>",
+                                 align: GTK_ALIGN_CENTER)
+            Gtk.addClass(hint, "ptb-muted")
+            Gtk.pack(empty, hint)
+            Gtk.pack(page, empty)
+            return
+        }
+
+        let counts = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 8)
+        for rarity in [Rarity.common, .uncommon, .rare, .legendary] {
+            let count = companion.dexCount(rarity)
+            guard count > 0 else { continue }
+            let chip = Gtk.label(
+                "<span size='small'>\(Gtk.escape(rarity.rawValue)) <b>\(count)</b></span>")
+            Gtk.addClass(chip, "ptb-chip")
+            Gtk.pack(counts, chip)
+        }
+        Gtk.pack(page, counts)
+
+        // A flow grid keeps the sprites in rows that reflow with the window, which is closer to the
+        // macOS dex than a single long column.
+        let grid = gtk_flow_box_new()!
+        let flowBox = UnsafeMutableRawPointer(grid).assumingMemoryBound(to: GtkFlowBox.self)
+        gtk_flow_box_set_selection_mode(flowBox, GTK_SELECTION_NONE)
+        gtk_flow_box_set_max_children_per_line(flowBox, 4)
+        gtk_flow_box_set_homogeneous(flowBox, 1)
+        for entry in entries.prefix(dexPageSize) {
+            gtk_container_add(asContainer(grid), dexCell(entry))
+        }
+        Gtk.pack(page, grid)
+
+        if entries.count > dexPageSize {
+            // Say what is not shown. Silently truncating a collection reads as data loss.
+            let more = Gtk.label(
+                "<span size='small'>+\(entries.count - dexPageSize)</span>", align: GTK_ALIGN_CENTER)
+            Gtk.addClass(more, "ptb-muted")
+            Gtk.pack(page, more)
+        }
+    }
+
+    private func dexCell(_ entry: DexEntry) -> Widget {
+        let cell = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 2)
+        Gtk.addClass(cell, "ptb-card")
+        let key = "\(entry.finalID)-\(entry.isShiny)"
+        if let image = spriteImage(key, size: 56) {
+            Gtk.pack(cell, image)
+        }
+        let name = companion.dexStoredChainNames(entry)?[entry.finalID]
+            ?? "#\(entry.finalID)"
+        var markup = "<span size='small'>\(Gtk.escape(name))</span>"
+        if entry.isShiny { markup = "✨ " + markup }
+        let label = Gtk.label(markup, align: GTK_ALIGN_CENTER)
+        Gtk.pack(cell, label)
+        return cell
+    }
+
+    // MARK: Home
+
+    private func buildHome(into page: Widget) {
+        let l = companion.l
+        if let celebration = activeCelebration { Gtk.pack(page, celebrationBanner(celebration)) }
+        Gtk.pack(page, companionCard(l))
+        Gtk.pack(page, totalsCard(l))
+        if let line = evolutionLine() { Gtk.pack(page, line) }
+        if !store.snapshots.isEmpty { Gtk.pack(page, providerCard(l)) }
+        if let limits = store.limits { Gtk.pack(page, limitsCard(l, limits)) }
+        if store.snapshots.isEmpty {
+            Gtk.pack(page, Gtk.label("<span size='small'>\(Gtk.escape(l.dexEmptyHint))</span>",
+                                     align: GTK_ALIGN_CENTER))
+        }
+    }
+
+    /// Sprite + name + rarity + progress, matching the macOS home header.
+    private func companionCard(_ l: L) -> Widget {
+        let card = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 12)
+        Gtk.addClass(card, "ptb-card")
+
+        let key = companion.currentSpeciesID.map { "\($0)-\(companion.currentIsShiny)" } ?? "egg"
+        if let data = spriteCache[key], let pixbuf = SpriteRenderer.render(data, size: 72) {
+            let image = gtk_image_new_from_pixbuf(pixbuf)!
+            g_object_unref(UnsafeMutableRawPointer(pixbuf))
+            gtk_widget_set_valign(image, GTK_ALIGN_CENTER)
+            Gtk.pack(card, image)
+            // The static frame goes up first so the row never appears empty, then the animation
+            // takes over the same widget if this species has one.
+            startAnimation(on: image, key: key)
+        }
+
+        let text = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 4)
+        gtk_widget_set_valign(text, GTK_ALIGN_CENTER)
+
+        let heading = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 6)
+        Gtk.pack(heading, Gtk.label("<span size='large'><b>\(Gtk.escape(companion.displayName))</b></span>"))
+        if let rarity = companion.rarity {
+            let badge = Gtk.label(Gtk.escape(rarity.rawValue.uppercased()))
+            Gtk.addClass(badge, "ptb-badge")
+            gtk_widget_set_valign(badge, GTK_ALIGN_CENTER)
+            Gtk.pack(heading, badge)
+        }
+        Gtk.pack(text, heading)
+
+        // Egg and hatched companion track different quantities, so the subtitle, the meter and the
+        // remaining-amount line all switch together.
+        let stage = companion.isEgg ? l.eggIncubating
+            : (companion.isFinalStage ? l.finalForm : companion.stageText)
+        let stageLabel = Gtk.label("<span size='small'>\(Gtk.escape(stage))</span>")
+        Gtk.addClass(stageLabel, "ptb-muted")
+        Gtk.pack(text, stageLabel)
+
+        let fraction = companion.isEgg ? companion.eggProgress : companion.progress
+        Gtk.pack(text, Gtk.meter(fraction: fraction))
+
+        let remaining = companion.isEgg
+            ? l.eggToHatch(TokenFormatter.compact(companion.eggTokensToHatch))
+            : l.toGraduation(TokenFormatter.compact(companion.tokensToNext))
+        let remainingLabel = Gtk.label("<span size='small'>\(Gtk.escape(remaining))</span>")
+        Gtk.addClass(remainingLabel, "ptb-muted")
+        Gtk.pack(text, remainingLabel)
+
+        let status = Gtk.label("<span size='small'>\(Gtk.escape(companion.statusLine))</span>", wrap: true)
+        Gtk.addClass(status, "ptb-muted")
+        Gtk.pack(text, status)
+
+        Gtk.pack(card, text, expand: true)
+        return card
+    }
+
+    /// The evolution line: what this companion has been, is, and can still become.
+    ///
+    /// Stages already passed are shown at full strength, the current one is ringed, and future ones
+    /// are dimmed — an unresolved branch is a "?" because the line genuinely is not decided yet.
+    /// Returns nil for an egg, which has no line to show.
+    private func evolutionLine() -> Widget? {
+        let items = companion.lineNodes
+        guard items.count > 1 else { return nil }
+        let row = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 6)
+        Gtk.addClass(row, "ptb-card")
+        gtk_widget_set_halign(row, GTK_ALIGN_CENTER)
+
+        for (index, item) in items.enumerated() {
+            if index > 0 {
+                let arrow = Gtk.label("<span size='small'>→</span>")
+                Gtk.addClass(arrow, "ptb-muted")
+                gtk_widget_set_valign(arrow, GTK_ALIGN_CENTER)
+                Gtk.pack(row, arrow)
+            }
+            let cell: Widget
+            switch item.content {
+            case .species(let speciesID):
+                let key = "\(speciesID)-\(companion.currentIsShiny)"
+                cell = spriteImage(key, size: 40) ?? Gtk.label("<span size='small'>#\(speciesID)</span>")
+            case .mystery:
+                cell = Gtk.label("<span size='large'>?</span>")
+            }
+            switch item.state {
+            case .current: Gtk.addClass(cell, "ptb-stage-current")
+            case .future:  Gtk.addClass(cell, "ptb-stage-future")
+            case .done:    break
+            }
+            Gtk.pack(row, cell)
+        }
+        return row
+    }
+
+    /// Today's total, with week and month beneath it.
+    private func totalsCard(_ l: L) -> Widget {
+        let card = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 4)
+        Gtk.addClass(card, "ptb-card")
+
+        let caption = Gtk.label(Gtk.escape(l.todayTokens))
+        Gtk.addClass(caption, "ptb-section")
+        Gtk.pack(card, caption)
+
+        let headline = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 8)
+        let big = Gtk.label("<b>\(Gtk.escape(TokenFormatter.compact(store.todayTotalTokens)))</b>")
+        Gtk.addClass(big, "ptb-huge")
+        Gtk.pack(headline, big)
+
+        // The exact figure sits next to the abbreviated one, as on macOS — "319.9M" is for glancing,
+        // the grouped number is for anyone reconciling against a bill.
+        let exact = Gtk.label("<span size='small'>\(Gtk.escape(TokenFormatter.grouped(store.todayTotalTokens)))</span>")
+        Gtk.addClass(exact, "ptb-muted")
+        gtk_widget_set_valign(exact, GTK_ALIGN_END)
+        Gtk.pack(headline, exact)
+
+        if store.showsCost {
+            let cost = Gtk.label("<span size='small'>\(Gtk.escape(TokenFormatter.cost(store.todayCostTotal)))</span>")
+            Gtk.addClass(cost, "ptb-muted")
+            gtk_widget_set_valign(cost, GTK_ALIGN_END)
+            gtk_widget_set_hexpand(cost, 1)
+            gtk_widget_set_halign(cost, GTK_ALIGN_END)
+            Gtk.pack(headline, cost, expand: true)
+        }
+        Gtk.pack(card, headline)
+
+        let periods = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 16)
+        Gtk.pack(periods, periodLabel(l.thisWeek, store.weekTotalTokens, store.weekCostTotal))
+        Gtk.pack(periods, periodLabel(l.thisMonth, store.monthTotalTokens, store.monthCostTotal))
+        Gtk.pack(card, periods)
+        return card
+    }
+
+    private func periodLabel(_ title: String, _ tokens: Int, _ cost: Double) -> Widget {
+        var markup = "<span size='small'>\(Gtk.escape(title)) <b>\(Gtk.escape(TokenFormatter.compact(tokens)))</b>"
+        if store.showsCost { markup += " \(Gtk.escape(TokenFormatter.cost(cost)))" }
+        markup += "</span>"
+        let label = Gtk.label(markup)
+        Gtk.addClass(label, "ptb-muted")
+        return label
+    }
+
+    /// Provider chips plus the selected provider's token breakdown.
+    private func providerCard(_ l: L) -> Widget {
+        let card = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 8)
+        Gtk.addClass(card, "ptb-card")
+
+        let chips = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 6)
+        let selected = selectedProviderID ?? store.snapshots.first?.providerID
+        for snapshot in store.snapshots {
+            let button = gtk_button_new_with_label(snapshot.displayName)!
+            Gtk.addClass(button, "ptb-chip")
+            if snapshot.providerID == selected { Gtk.addClass(button, "ptb-chip-on") }
+            gtk_button_set_relief(
+                UnsafeMutableRawPointer(button).assumingMemoryBound(to: GtkButton.self),
+                GTK_RELIEF_NONE)
+            let id = snapshot.providerID
+            gtkConnect(UnsafeMutableRawPointer(button), signal: "clicked",
+                       box: GtkCallbackBox { [weak self] in
+                           self?.selectedProviderID = id
+                           self?.refresh()
+                       })
+            Gtk.pack(chips, button)
+        }
+        Gtk.pack(card, chips)
+
+        guard let snapshot = store.snapshots.first(where: { $0.providerID == selected }),
+              let today = snapshot.today
+        else { return card }
+
+        let heading = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 8)
+        Gtk.pack(heading, Gtk.label("<b>\(Gtk.escape(snapshot.displayName))</b>"))
+        let total = Gtk.label("<b>\(Gtk.escape(TokenFormatter.compact(today.totalTokens)))</b>")
+        gtk_widget_set_hexpand(total, 1)
+        gtk_widget_set_halign(total, GTK_ALIGN_END)
+        Gtk.pack(heading, total, expand: true)
+        if snapshot.reportsCost {
+            Gtk.pack(heading, Gtk.label("<span size='small'>\(Gtk.escape(TokenFormatter.cost(today.totalCost)))</span>"))
+        }
+        Gtk.pack(card, heading)
+
+        let parts = [
+            ("in", today.inputTokens), ("out", today.outputTokens),
+            ("cache w", today.cacheCreationTokens), ("cache r", today.cacheReadTokens),
+        ]
+        let breakdown = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 12)
+        for (name, value) in parts {
+            let label = Gtk.label(
+                "<span size='small'>\(name) <b>\(Gtk.escape(TokenFormatter.compact(value)))</b></span>")
+            Gtk.addClass(label, "ptb-muted")
+            Gtk.pack(breakdown, label)
+        }
+        Gtk.pack(card, breakdown)
+        return card
+    }
+
+    /// The official Claude limit windows with their reset countdowns.
+    private func limitsCard(_ l: L, _ limits: LimitStatus) -> Widget {
+        let card = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 8)
+        Gtk.addClass(card, "ptb-card")
+        let caption = Gtk.label(Gtk.escape(l.limitsOfficial))
+        Gtk.addClass(caption, "ptb-section")
+        Gtk.pack(card, caption)
+
+        let windows: [(String, LimitWindow?)] = [
+            (l.fiveHourSession, limits.fiveHour),
+            (l.weekly, limits.sevenDay),
+            (l.weeklyOpus, limits.sevenDayOpus),
+            (l.weeklySonnet, limits.sevenDaySonnet),
+        ]
+        for (title, window) in windows {
+            // A window with no utilisation has not been reported by the API — showing an empty
+            // meter would read as "0% used", which is the opposite of "unknown".
+            guard let window, let utilization = window.utilization else { continue }
+            Gtk.pack(card, limitRow(title, utilization))
+        }
+        return card
+    }
+
+    private func limitRow(_ title: String, _ utilization: Double) -> Widget {
+        let row = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 3)
+        let heading = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 8)
+        Gtk.pack(heading, Gtk.label("<span size='small'>\(Gtk.escape(title))</span>"))
+
+        let percent = Gtk.label(
+            "<span size='small'><b>\(Gtk.escape(TokenFormatter.percent(utilization)))</b></span>")
+        gtk_widget_set_hexpand(percent, 1)
+        gtk_widget_set_halign(percent, GTK_ALIGN_END)
+        Gtk.pack(heading, percent, expand: true)
+        Gtk.pack(row, heading)
+
+        // Same thresholds the menu bar and the limit notifications use, so one glance means one thing.
+        let meter = Gtk.meter(fraction: utilization)
+        if utilization >= store.critThreshold {
+            Gtk.addClass(meter, "ptb-crit")
+        } else if utilization >= store.warnThreshold {
+            Gtk.addClass(meter, "ptb-warn")
+        } else {
+            Gtk.addClass(meter, "ptb-ok")
+        }
+        Gtk.pack(row, meter)
+        return row
+    }
+}
+
+private extension PopoverTab {
+    /// Stable identifier for `gtk_stack_add_titled`; the visible title is localised separately.
+    var identifier: String {
+        switch self {
+        case .home: return "home"
+        case .shop: return "shop"
+        case .bag: return "bag"
+        case .collection: return "collection"
+        }
+    }
+}
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/Linux/PowerEvents.swift
+++ b/Sources/PokeTokenBar/Linux/PowerEvents.swift
@@ -1,0 +1,80 @@
+#if os(Linux)
+import CGtk
+import Foundation
+
+/// Sleep and screen-blank signals, over the session and system buses.
+///
+/// This is the Linux half of `PlatformPowerEvents`. It lives in the frontend because GDBus delivers
+/// signals through the GLib main context, which only exists once the GTK loop is running.
+///
+/// Two sources, because no single one covers both cases:
+/// - `org.freedesktop.login1.Manager.PrepareForSleep` (system bus) — suspend and resume. The signal
+///   carries `true` on the way down and `false` on the way back, so only the `false` edge is a wake.
+/// - `org.freedesktop.ScreenSaver.ActiveChanged` (session bus) — the screen blanking or unblanking,
+///   which is what macOS's `screensDidSleep` actually corresponds to. KDE and GNOME both implement it.
+enum PowerEvents {
+    /// Kept alive for the process lifetime — dropping the connections cancels the subscriptions.
+    nonisolated(unsafe) private static var connections: [OpaquePointer] = []
+    /// Retained callback boxes; GDBus keeps only the raw pointer.
+    nonisolated(unsafe) private static var boxes: [SignalBox] = []
+
+    final class SignalBox {
+        let handle: (Bool) -> Void
+        init(_ handle: @escaping (Bool) -> Void) { self.handle = handle }
+    }
+
+    static func install() {
+        PlatformPowerEvents.linuxObserver = { onWake, onScreenSleep, onScreenWake in
+            subscribe(
+                bus: G_BUS_TYPE_SYSTEM,
+                sender: "org.freedesktop.login1",
+                interface: "org.freedesktop.login1.Manager",
+                signal: "PrepareForSleep"
+            ) { goingToSleep in
+                // Only the resume edge matters: on the way down there is nothing left to refresh.
+                if !goingToSleep { onWake() }
+            }
+
+            subscribe(
+                bus: G_BUS_TYPE_SESSION,
+                sender: nil,   // KDE and GNOME own this name from different services
+                interface: "org.freedesktop.ScreenSaver",
+                signal: "ActiveChanged"
+            ) { screenSaverActive in
+                screenSaverActive ? onScreenSleep() : onScreenWake()
+            }
+        }
+    }
+
+    private static func subscribe(
+        bus: GBusType, sender: String?, interface: String, signal: String,
+        handler: @escaping (Bool) -> Void
+    ) {
+        guard let connection = g_bus_get_sync(bus, nil, nil) else {
+            AppLog.write("power events: no \(interface) bus — sleep/blank pauses disabled")
+            return
+        }
+        connections.append(connection)
+        let box = SignalBox(handler)
+        boxes.append(box)
+
+        let callback: @convention(c) (
+            OpaquePointer?, UnsafePointer<CChar>?, UnsafePointer<CChar>?, UnsafePointer<CChar>?,
+            UnsafePointer<CChar>?, OpaquePointer?, UnsafeMutableRawPointer?
+        ) -> Void = { _, _, _, _, _, parameters, data in
+            guard let data, let parameters else { return }
+            // Every signal we subscribe to is `(b)`. `g_variant_get_child` is variadic and out of
+            // reach from Swift, so the child is taken as a value and read directly.
+            guard let child = g_variant_get_child_value(parameters, 0) else { return }
+            defer { g_variant_unref(child) }
+            let flag = g_variant_get_boolean(child) != 0
+            Unmanaged<SignalBox>.fromOpaque(data).takeUnretainedValue().handle(flag)
+        }
+
+        g_dbus_connection_signal_subscribe(
+            connection, sender, interface, signal, nil, nil,
+            GDBusSignalFlags(rawValue: 0), callback,
+            Unmanaged.passUnretained(box).toOpaque(), nil)
+    }
+}
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/Linux/SettingsWindow.swift
+++ b/Sources/PokeTokenBar/Linux/SettingsWindow.swift
@@ -1,0 +1,212 @@
+#if os(Linux)
+import CGtk
+import Foundation
+
+/// Settings — the Linux counterpart of the macOS settings sheet.
+///
+/// Every control writes straight through to `UsageStore` / `CompanionStore`, which persist to
+/// `UserDefaults` on set. There is no apply/cancel step, matching macOS: a toggle that needs
+/// confirming is a toggle people leave in the wrong state.
+@MainActor
+final class SettingsWindow {
+    private let store: UsageStore
+    private let companion: CompanionStore
+    private let window: Widget
+    private let content: Widget
+    private var isVisible = false
+    /// Set while rebuilding, so programmatic widget updates do not echo back as user edits and
+    /// fight the value being restored.
+    private var isPopulating = false
+
+    init(store: UsageStore, companion: CompanionStore) {
+        self.store = store
+        self.companion = companion
+
+        window = gtk_window_new(GTK_WINDOW_TOPLEVEL)!
+        gtk_window_set_title(asWindow(window), "PokeTokenBar — Settings")
+        gtk_window_set_default_size(asWindow(window), 420, 620)
+        gtk_window_set_position(asWindow(window), GTK_WIN_POS_CENTER)
+
+        let scroller = gtk_scrolled_window_new(nil, nil)!
+        gtk_scrolled_window_set_policy(
+            UnsafeMutableRawPointer(scroller).assumingMemoryBound(to: GtkScrolledWindow.self),
+            GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC)
+        content = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 10)
+        Gtk.margins(content, top: 12, bottom: 12, start: 12, end: 12)
+        gtk_container_add(asContainer(scroller), content)
+        gtk_container_add(asContainer(window), scroller)
+
+        gtkConnectDeleteEvent(UnsafeMutableRawPointer(window),
+                              box: GtkCallbackBox { [weak self] in self?.hide() })
+    }
+
+    func show() {
+        isVisible = true
+        GtkRuntime.hasVisibleWindow = true
+        rebuild()
+        gtk_widget_show_all(window)
+        gtk_window_present(asWindow(window))
+    }
+
+    func hide() {
+        isVisible = false
+        GtkRuntime.hasVisibleWindow = false
+        gtk_widget_hide(window)
+    }
+
+    private func rebuild() {
+        isPopulating = true
+        defer { isPopulating = false }
+        Gtk.clear(content)
+        let l = companion.l
+
+        section(l.generalSectionTitle) { box in
+            self.dropdown(box, l.language, AppLanguage.allCases.map(\.label),
+                          selected: AppLanguage.allCases.firstIndex(of: self.companion.language) ?? 0) { index in
+                self.companion.setLanguage(AppLanguage.allCases[index])
+                // The whole UI is localised at build time, so a language change means rebuilding
+                // every visible surface — not just this window.
+                self.rebuild()
+                self.onLanguageChange?()
+            }
+            let presets = UsageStore.intervalPresets
+            self.dropdown(box, l.refreshInterval, presets.map { l.intervalLabel($0.value) },
+                          selected: presets.firstIndex { $0.value == self.store.refreshInterval } ?? 0) { index in
+                self.store.refreshInterval = presets[index].value
+            }
+            self.dropdown(box, l.limitDisplayModeLabel, [l.limitDisplayUsed, l.limitDisplayRemaining],
+                          selected: self.store.limitDisplayMode == .used ? 0 : 1) { index in
+                self.store.limitDisplayMode = index == 0 ? .used : .remaining
+            }
+            self.toggle(box, l.launchAtLogin, LoginItem.isEnabled) { on in
+                do { try LoginItem.setEnabled(on) } catch {
+                    AppLog.write("autostart toggle failed: \(error)")
+                }
+            }
+        }
+
+        section(l.menuBarSectionTitle) { box in
+            self.toggle(box, l.todayTokensShort, self.store.showTokensInMenu) { self.store.showTokensInMenu = $0 }
+            self.toggle(box, l.todayCost, self.store.showCostInMenu) { self.store.showCostInMenu = $0 }
+            self.toggle(box, l.limitPercent, self.store.showLimitInMenu) { self.store.showLimitInMenu = $0 }
+        }
+
+        section(l.floatingPetSectionTitle) { box in
+            self.toggle(box, l.floatingPetEnableLabel, self.store.floatingPetEnabled) {
+                self.store.floatingPetEnabled = $0
+                self.onFloatingPetChange?()
+            }
+            self.toggle(box, l.floatingPetBubbleAlertsLabel, self.store.floatingPetBubbleAlerts) {
+                self.store.floatingPetBubbleAlerts = $0
+            }
+        }
+
+        section(l.notificationsSection) { box in
+            self.toggle(box, l.limitNotificationsLabel, self.store.limitNotifications) {
+                self.store.limitNotifications = $0
+            }
+            self.toggle(box, l.companionNotificationsLabel, self.store.companionNotifications) {
+                self.store.companionNotifications = $0
+            }
+            self.toggle(box, l.statusChecksLabel, self.store.statusChecksEnabled) {
+                self.store.statusChecksEnabled = $0
+            }
+        }
+
+        section(l.updateSectionTitle) { box in
+            self.toggle(box, l.updateNotificationsLabel, self.store.updateNotificationsEnabled) {
+                self.store.updateNotificationsEnabled = $0
+            }
+        }
+
+        section(l.aboutSupportSectionTitle) { box in
+            let version = Gtk.label("<span size='small'>PokeTokenBar \(Gtk.escape(AppVersion.current))</span>")
+            Gtk.addClass(version, "ptb-muted")
+            Gtk.pack(box, version)
+            self.button(box, l.showLogFile) { PlatformOpener.reveal(AppLog.logFileURL) }
+            self.button(box, l.reportProblem) {
+                let body = l.reportMailBody(
+                    version: AppVersion.current,
+                    os: ProcessInfo.processInfo.operatingSystemVersionString)
+                if let url = SupportMail.mailtoURL(
+                    subject: l.reportMailSubject(AppVersion.current), body: body) {
+                    PlatformOpener.open(url)
+                }
+            }
+        }
+    }
+
+    /// Called after the language changes, so the tray and popover relabel too.
+    var onLanguageChange: (() -> Void)?
+    /// Called when the floating-pet toggle flips, so the pet window appears or goes away at once.
+    var onFloatingPetChange: (() -> Void)?
+
+    // MARK: building blocks
+
+    private func section(_ title: String, _ body: (Widget) -> Void) {
+        let card = Gtk.box(GTK_ORIENTATION_VERTICAL, spacing: 8)
+        Gtk.addClass(card, "ptb-card")
+        let heading = Gtk.label(Gtk.escape(title))
+        Gtk.addClass(heading, "ptb-section")
+        Gtk.pack(card, heading)
+        body(card)
+        Gtk.pack(content, card)
+    }
+
+    private func row(_ parent: Widget, _ title: String) -> Widget {
+        let row = Gtk.box(GTK_ORIENTATION_HORIZONTAL, spacing: 10)
+        let label = Gtk.label("<span size='small'>\(Gtk.escape(title))</span>", wrap: true)
+        gtk_widget_set_hexpand(label, 1)
+        Gtk.pack(row, label, expand: true)
+        Gtk.pack(parent, row)
+        return row
+    }
+
+    private func toggle(
+        _ parent: Widget, _ title: String, _ value: Bool, _ onChange: @escaping (Bool) -> Void
+    ) {
+        let container = row(parent, title)
+        let toggle = gtk_switch_new()!
+        gtk_switch_set_active(
+            UnsafeMutableRawPointer(toggle).assumingMemoryBound(to: GtkSwitch.self), value ? 1 : 0)
+        gtk_widget_set_valign(toggle, GTK_ALIGN_CENTER)
+        gtkConnect(UnsafeMutableRawPointer(toggle), signal: "notify::active",
+                   box: GtkCallbackBox { [weak self] in
+                       guard let self, !self.isPopulating else { return }
+                       let active = gtk_switch_get_active(
+                           UnsafeMutableRawPointer(toggle).assumingMemoryBound(to: GtkSwitch.self)) != 0
+                       onChange(active)
+                   })
+        Gtk.pack(container, toggle)
+    }
+
+    private func dropdown(
+        _ parent: Widget, _ title: String, _ options: [String], selected: Int,
+        _ onChange: @escaping (Int) -> Void
+    ) {
+        let container = row(parent, title)
+        let combo = gtk_combo_box_text_new()!
+        let comboText = UnsafeMutableRawPointer(combo).assumingMemoryBound(to: GtkComboBoxText.self)
+        for option in options { gtk_combo_box_text_append_text(comboText, option) }
+        gtk_combo_box_set_active(
+            UnsafeMutableRawPointer(combo).assumingMemoryBound(to: GtkComboBox.self), Int32(selected))
+        gtk_widget_set_valign(combo, GTK_ALIGN_CENTER)
+        gtkConnect(UnsafeMutableRawPointer(combo), signal: "changed",
+                   box: GtkCallbackBox { [weak self] in
+                       guard let self, !self.isPopulating else { return }
+                       let index = gtk_combo_box_get_active(
+                           UnsafeMutableRawPointer(combo).assumingMemoryBound(to: GtkComboBox.self))
+                       guard index >= 0 else { return }
+                       onChange(Int(index))
+                   })
+        Gtk.pack(container, combo)
+    }
+
+    private func button(_ parent: Widget, _ title: String, _ action: @escaping () -> Void) {
+        let button = gtk_button_new_with_label(title)!
+        gtk_widget_set_halign(button, GTK_ALIGN_START)
+        gtkConnect(UnsafeMutableRawPointer(button), signal: "clicked", box: GtkCallbackBox(action))
+        Gtk.pack(parent, button)
+    }
+}
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/Linux/SpriteRenderer.swift
+++ b/Sources/PokeTokenBar/Linux/SpriteRenderer.swift
@@ -1,0 +1,305 @@
+#if os(Linux)
+import CGtk
+import Foundation
+
+/// Turns downloaded sprite bytes into something GTK can show — a pixbuf for a window, or a PNG
+/// file for the tray (which takes icon *names* on disk, not images).
+///
+/// Two things have to happen that writing the PNG straight to disk does not do:
+///
+/// 1. **Crop the transparent padding.** PokéAPI draws on a 96×96 canvas and the egg fills 28×30 of
+///    it. The panel scales the whole canvas into its icon box, so an uncropped egg renders at about
+///    a third of the space and looks broken rather than small. `SpriteCrop` decides the rectangle;
+///    macOS applies the same one.
+/// 2. **Scale up with nearest-neighbour.** These are pixel-art sprites of about 30×30 after
+///    cropping. Letting the panel scale them up applies a smoothing filter and turns crisp pixels
+///    into mush, so they are pre-scaled here with `GDK_INTERP_NEAREST`.
+enum SpriteRenderer {
+    /// Rendered size. Larger than any panel asks for, so the panel only ever scales *down* — which
+    /// is the direction that stays sharp.
+    fileprivate static let renderedSize = 128
+
+    /// A cropped, nearest-scaled pixbuf at `size`. Caller owns the reference and must unref it.
+    /// Returns nil if the bytes are not a readable image.
+    static func render(_ data: Data, size: Int, crop: Bool = true) -> OpaquePointer? {
+        guard let source = pixbuf(from: data) else { return nil }
+        defer { g_object_unref(UnsafeMutableRawPointer(source)) }
+
+        let width = Int(gdk_pixbuf_get_width(source))
+        let height = Int(gdk_pixbuf_get_height(source))
+
+        var subject = source
+        var ownsSubject = false
+        if crop, let rect = contentRect(of: source, width: width, height: height),
+           let cropped = gdk_pixbuf_new_subpixbuf(
+            source, Int32(rect.x), Int32(rect.y), Int32(rect.side), Int32(rect.side)) {
+            subject = cropped
+            ownsSubject = true
+        }
+        defer { if ownsSubject { g_object_unref(UnsafeMutableRawPointer(subject)) } }
+
+        return gdk_pixbuf_scale_simple(subject, Int32(size), Int32(size), GDK_INTERP_NEAREST)
+    }
+
+    /// Write `data` to `file`, cropped and scaled — the tray takes a path, not an image.
+    /// Returns false if the bytes are not a readable image, in which case the caller keeps whatever
+    /// icon is already showing.
+    static func write(_ data: Data, to file: URL) -> Bool {
+        guard let scaled = render(data, size: renderedSize) else { return false }
+        defer { g_object_unref(UnsafeMutableRawPointer(scaled)) }
+        // `gdk_pixbuf_save` is variadic and unreachable from Swift; `savev` is the same call with
+        // the options passed as arrays instead.
+        return gdk_pixbuf_savev(scaled, file.path, "png", nil, nil, nil) != 0
+    }
+
+    /// Decode image bytes without touching the filesystem first.
+    private static func pixbuf(from data: Data) -> OpaquePointer? {
+        guard let loader = gdk_pixbuf_loader_new() else { return nil }
+        let ok = data.withUnsafeBytes { raw -> Bool in
+            guard let base = raw.baseAddress else { return false }
+            return gdk_pixbuf_loader_write(
+                loader, base.assumingMemoryBound(to: guchar.self), gsize(data.count), nil) != 0
+        }
+        // Close before reading: the pixbuf is only complete once the loader is told the stream ended.
+        let closed = gdk_pixbuf_loader_close(loader, nil) != 0
+        guard ok, closed, let pixbuf = gdk_pixbuf_loader_get_pixbuf(loader) else {
+            g_object_unref(UnsafeMutableRawPointer(loader))
+            return nil
+        }
+        // `get_pixbuf` returns a borrowed reference owned by the loader, so take one of our own
+        // before releasing it.
+        g_object_ref(UnsafeMutableRawPointer(pixbuf))
+        g_object_unref(UnsafeMutableRawPointer(loader))
+        return pixbuf
+    }
+
+    fileprivate static func contentRect(
+        of pixbuf: OpaquePointer, width: Int, height: Int
+    ) -> SpriteCrop.Rect? {
+        // Without an alpha channel every pixel is content, and the crop is the whole canvas.
+        guard gdk_pixbuf_get_has_alpha(pixbuf) != 0,
+              let pixels = gdk_pixbuf_get_pixels(pixbuf) else {
+            return SpriteCrop.squareContentRect(width: width, height: height) { _, _ in true }
+        }
+        let stride = Int(gdk_pixbuf_get_rowstride(pixbuf))
+        let channels = Int(gdk_pixbuf_get_n_channels(pixbuf))
+        let threshold = UInt8(SpriteCrop.opaqueAlphaThreshold * 255)
+        let alphaOffset: Int = channels - 1
+        return SpriteCrop.squareContentRect(width: width, height: height) { x, y in
+            let row: Int = y * stride
+            let column: Int = x * channels
+            let alpha: UInt8 = pixels[row + column + alphaOffset]
+            return alpha > threshold
+        }
+    }
+}
+
+extension SpriteRenderer {
+    /// One decoded frame of an animated sprite, already written to disk.
+    struct Frame {
+        /// Icon name (filename without extension) — what AppIndicator wants.
+        let name: String
+        /// How long to hold it, native delay before any floor is applied.
+        let delay: TimeInterval
+    }
+
+    /// Explode an animated GIF into numbered PNGs next to the static icons.
+    ///
+    /// The tray takes icon *names*, not images, so every frame has to exist as a file before it can
+    /// be shown. They are written once per species and then only cycled, which keeps the animation
+    /// loop free of disk work.
+    ///
+    /// Returns an empty array for a single-frame image, so callers fall back to the static icon
+    /// rather than "animating" one frame forever.
+    static func writeFrames(_ data: Data, directory: URL, prefix: String) -> [Frame] {
+        guard let loader = gdk_pixbuf_loader_new() else { return [] }
+        let wrote = data.withUnsafeBytes { raw -> Bool in
+            guard let base = raw.baseAddress else { return false }
+            return gdk_pixbuf_loader_write(
+                loader, base.assumingMemoryBound(to: guchar.self), gsize(data.count), nil) != 0
+        }
+        let closed = gdk_pixbuf_loader_close(loader, nil) != 0
+        guard wrote, closed, let animation = gdk_pixbuf_loader_get_animation(loader) else {
+            g_object_unref(UnsafeMutableRawPointer(loader))
+            return []
+        }
+        g_object_ref(UnsafeMutableRawPointer(animation))
+        g_object_unref(UnsafeMutableRawPointer(loader))
+        defer { g_object_unref(UnsafeMutableRawPointer(animation)) }
+
+        guard gdk_pixbuf_animation_is_static_image(animation) == 0 else { return [] }
+
+        // The iterator is driven by a clock we advance ourselves rather than by wall time, so the
+        // whole loop is extracted immediately instead of in real time.
+        var clock = GTimeVal(tv_sec: 0, tv_usec: 0)
+        guard let iterator = gdk_pixbuf_animation_get_iter(animation, &clock) else { return [] }
+        defer { g_object_unref(UnsafeMutableRawPointer(iterator)) }
+
+        var frames: [Frame] = []
+        var firstSignature: Int?
+        var lastSignature: Int?
+        // The cap is a backstop for a malformed animation; normal exit is loop detection below.
+        let maximumFrames = 120
+        while frames.count < maximumFrames {
+            let milliseconds = gdk_pixbuf_animation_iter_get_delay_time(iterator)
+            guard milliseconds >= 0 else { break }   // -1: not animated after all
+            guard let pixbuf = gdk_pixbuf_animation_iter_get_pixbuf(iterator) else { break }
+            let fingerprint = signature(of: pixbuf)
+
+            // The iterator hands back frame 0 twice before it starts moving, and some sprites
+            // repeat a frame mid-loop. Merge a repeat into the previous frame's delay instead of
+            // writing the same image again — and crucially, do not mistake it for the loop point.
+            if fingerprint == lastSignature {
+                if !frames.isEmpty {
+                    let previous = frames.removeLast()
+                    frames.append(Frame(name: previous.name,
+                                        delay: previous.delay + TimeInterval(milliseconds) / 1000))
+                }
+                advance(iterator, &clock, milliseconds)
+                continue
+            }
+            // Back to the first frame after at least two distinct ones: a full loop is captured.
+            if let firstSignature, fingerprint == firstSignature, frames.count >= 2 { break }
+            if firstSignature == nil { firstSignature = fingerprint }
+            lastSignature = fingerprint
+
+            let name = "\(prefix)-f\(frames.count)"
+            let file = directory.appendingPathComponent("\(name).png")
+            guard writeCroppedScaled(pixbuf, to: file) else { break }
+            frames.append(Frame(name: name, delay: TimeInterval(milliseconds) / 1000))
+
+            advance(iterator, &clock, milliseconds)
+        }
+        return frames.count > 1 ? frames : []
+    }
+
+    /// Crop, scale and save one already-decoded pixbuf.
+    private static func writeCroppedScaled(_ source: OpaquePointer, to file: URL) -> Bool {
+        let width = Int(gdk_pixbuf_get_width(source))
+        let height = Int(gdk_pixbuf_get_height(source))
+        var subject = source
+        var ownsSubject = false
+        if let rect = contentRect(of: source, width: width, height: height),
+           let cropped = gdk_pixbuf_new_subpixbuf(
+            source, Int32(rect.x), Int32(rect.y), Int32(rect.side), Int32(rect.side)) {
+            subject = cropped
+            ownsSubject = true
+        }
+        defer { if ownsSubject { g_object_unref(UnsafeMutableRawPointer(subject)) } }
+        guard let scaled = gdk_pixbuf_scale_simple(
+            subject, Int32(renderedSize), Int32(renderedSize), GDK_INTERP_NEAREST) else { return false }
+        defer { g_object_unref(UnsafeMutableRawPointer(scaled)) }
+        return gdk_pixbuf_savev(scaled, file.path, "png", nil, nil, nil) != 0
+    }
+}
+
+
+extension SpriteRenderer {
+    /// An animated sprite decoded into in-memory frames, cropped and scaled like the static path.
+    ///
+    /// Separate from `writeFrames` because the window can hold pixbufs directly — only the tray is
+    /// forced through files, and doing disk I/O for an on-screen animation would be silly.
+    /// **The caller owns every pixbuf and must unref them.**
+    static func renderFrames(_ data: Data, size: Int) -> [(pixbuf: OpaquePointer, delay: TimeInterval)] {
+        guard let loader = gdk_pixbuf_loader_new() else { return [] }
+        let wrote = data.withUnsafeBytes { raw -> Bool in
+            guard let base = raw.baseAddress else { return false }
+            return gdk_pixbuf_loader_write(
+                loader, base.assumingMemoryBound(to: guchar.self), gsize(data.count), nil) != 0
+        }
+        let closed = gdk_pixbuf_loader_close(loader, nil) != 0
+        guard wrote, closed, let animation = gdk_pixbuf_loader_get_animation(loader) else {
+            g_object_unref(UnsafeMutableRawPointer(loader))
+            return []
+        }
+        g_object_ref(UnsafeMutableRawPointer(animation))
+        g_object_unref(UnsafeMutableRawPointer(loader))
+        defer { g_object_unref(UnsafeMutableRawPointer(animation)) }
+        guard gdk_pixbuf_animation_is_static_image(animation) == 0 else { return [] }
+
+        var clock = GTimeVal(tv_sec: 0, tv_usec: 0)
+        guard let iterator = gdk_pixbuf_animation_get_iter(animation, &clock) else { return [] }
+        defer { g_object_unref(UnsafeMutableRawPointer(iterator)) }
+
+        var frames: [(OpaquePointer, TimeInterval)] = []
+        var firstSignature: Int?
+        var lastSignature: Int?
+        let maximumFrames = 120   // same runaway guard as writeFrames
+        while frames.count < maximumFrames {
+            let milliseconds = gdk_pixbuf_animation_iter_get_delay_time(iterator)
+            guard milliseconds >= 0, let source = gdk_pixbuf_animation_iter_get_pixbuf(iterator)
+            else { break }
+            let fingerprint = signature(of: source)
+            if fingerprint == lastSignature {   // repeat: extend the previous frame (see writeFrames)
+                if let last = frames.popLast() {
+                    frames.append((last.0, last.1 + TimeInterval(milliseconds) / 1000))
+                }
+                advance(iterator, &clock, milliseconds)
+                continue
+            }
+            if let firstSignature, fingerprint == firstSignature, frames.count >= 2 { break }
+            if firstSignature == nil { firstSignature = fingerprint }
+            lastSignature = fingerprint
+            if let scaled = croppedScaled(source, size: size) {
+                frames.append((scaled, TimeInterval(milliseconds) / 1000))
+            }
+            advance(iterator, &clock, milliseconds)
+        }
+        if frames.count > 1 { return frames }
+        for frame in frames { g_object_unref(UnsafeMutableRawPointer(frame.0)) }
+        return []
+    }
+
+    /// Crop to content and scale, returning a new pixbuf the caller owns.
+    fileprivate static func croppedScaled(_ source: OpaquePointer, size: Int) -> OpaquePointer? {
+        let width = Int(gdk_pixbuf_get_width(source))
+        let height = Int(gdk_pixbuf_get_height(source))
+        var subject = source
+        var ownsSubject = false
+        if let rect = contentRect(of: source, width: width, height: height),
+           let cropped = gdk_pixbuf_new_subpixbuf(
+            source, Int32(rect.x), Int32(rect.y), Int32(rect.side), Int32(rect.side)) {
+            subject = cropped
+            ownsSubject = true
+        }
+        defer { if ownsSubject { g_object_unref(UnsafeMutableRawPointer(subject)) } }
+        return gdk_pixbuf_scale_simple(subject, Int32(size), Int32(size), GDK_INTERP_NEAREST)
+    }
+}
+
+
+extension SpriteRenderer {
+    /// Step the iterator's synthetic clock forward by one frame's delay.
+    fileprivate static func advance(
+        _ iterator: OpaquePointer, _ clock: inout GTimeVal, _ milliseconds: Int32
+    ) {
+        clock.tv_usec += glong(milliseconds) * 1000
+        clock.tv_sec += glong(clock.tv_usec / 1_000_000)
+        clock.tv_usec %= 1_000_000
+        _ = gdk_pixbuf_animation_iter_advance(iterator, &clock)
+    }
+
+    /// A cheap fingerprint of a pixbuf's pixels, used to spot when a GIF has looped.
+    ///
+    /// A GIF has no end — the iterator happily cycles forever — so extraction needs its own stop
+    /// condition. Without one, a 20-frame sprite is written out to whatever cap the loop imposes,
+    /// duplicating frames on disk and in memory for no gain. When a later frame is byte-identical
+    /// to the first, one full loop has been captured and the rest is repetition.
+    fileprivate static func signature(of pixbuf: OpaquePointer) -> Int {
+        guard let pixels = gdk_pixbuf_get_pixels(pixbuf) else { return 0 }
+        let height = Int(gdk_pixbuf_get_height(pixbuf))
+        let stride = Int(gdk_pixbuf_get_rowstride(pixbuf))
+        let count = height * stride
+        var hash = 5381
+        // Sampling rather than hashing every byte: frames differ in whole regions, and a stride of
+        // 7 still separates them while keeping extraction off the critical path.
+        var index = 0
+        while index < count {
+            hash = (hash &* 33) &+ Int(pixels[index])
+            index += 7
+        }
+        return hash
+    }
+}
+
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/Linux/TrayIndicator.swift
+++ b/Sources/PokeTokenBar/Linux/TrayIndicator.swift
@@ -1,0 +1,84 @@
+#if os(Linux)
+import CGtk
+import Foundation
+
+/// The tray item — an AppIndicator (StatusNotifierItem) attached to the KDE/GNOME panel.
+///
+/// It stands in for macOS's `NSStatusItem` but is not as expressive:
+/// - Icons are set by **name within a theme directory**, not as images. So sprites are written to
+///   disk and swapped by name (`setIcon`).
+/// - The label (`app_indicator_set_label`) may not render at all, depending on the panel widget.
+///   Putting the numbers only in the label would leave the app mute on those panels, so **the same
+///   value is always written to the first menu row too.**
+@MainActor
+final class TrayIndicator {
+    private let indicator: UnsafeMutablePointer<AppIndicator>
+    private let menu: UnsafeMutablePointer<GtkWidget>
+    /// A disabled menu row showing the usage summary — the fallback for panels that hide labels.
+    private let summaryItem: UnsafeMutablePointer<GtkWidget>
+
+    /// - Parameters:
+    ///   - iconThemePath: the directory sprite PNGs are written to.
+    ///   - iconName: a filename inside that directory, without the extension.
+    init(id: String, iconThemePath: String, iconName: String, summaryPlaceholder: String) {
+        // GTK/AppIndicator constructors only return nil on allocation failure. Stopping here
+        // beats threading optionals through every later call — without a tray there is no app.
+        indicator = app_indicator_new_with_path(
+            id, iconName, APP_INDICATOR_CATEGORY_APPLICATION_STATUS, iconThemePath)!
+        menu = gtk_menu_new()!
+        summaryItem = gtk_menu_item_new_with_label(summaryPlaceholder)!
+        // Nothing to activate on the summary row — disable it so it does not read as an action.
+        gtk_widget_set_sensitive(summaryItem, 0)
+        gtk_menu_shell_append(UnsafeMutableRawPointer(menu).assumingMemoryBound(to: GtkMenuShell.self),
+                              summaryItem)
+        gtk_widget_show(summaryItem)
+        appendSeparator()
+        app_indicator_set_menu(indicator,
+                               UnsafeMutableRawPointer(menu).assumingMemoryBound(to: GtkMenu.self))
+        app_indicator_set_status(indicator, APP_INDICATOR_STATUS_ACTIVE)
+    }
+
+    /// Menu rows in insertion order, so a language change can relabel them in place. Rebuilding
+    /// the menu instead would drop the AppIndicator's reference and blank the tray on some panels.
+    private var items: [(widget: Widget, title: (L) -> String)] = []
+
+    /// Re-apply every menu label in the new language.
+    func relabel(_ l: L) {
+        for entry in items {
+            gtk_menu_item_set_label(
+                UnsafeMutableRawPointer(entry.widget).assumingMemoryBound(to: GtkMenuItem.self),
+                entry.title(l))
+        }
+    }
+
+    /// Append a menu item. The handler lives until GTK destroys the widget (`GtkCallbackBox`).
+    func addItem(_ title: String, localized: ((L) -> String)? = nil, action: @escaping () -> Void) {
+        guard let item = gtk_menu_item_new_with_label(title) else { return }
+        if let localized { items.append((item, localized)) }
+        gtkConnect(UnsafeMutableRawPointer(item), signal: "activate", box: GtkCallbackBox(action))
+        gtk_menu_shell_append(UnsafeMutableRawPointer(menu).assumingMemoryBound(to: GtkMenuShell.self),
+                              item)
+        gtk_widget_show(item)
+    }
+
+    func appendSeparator() {
+        guard let separator = gtk_separator_menu_item_new() else { return }
+        gtk_menu_shell_append(UnsafeMutableRawPointer(menu).assumingMemoryBound(to: GtkMenuShell.self),
+                              separator)
+        gtk_widget_show(separator)
+    }
+
+    /// The usage text shown on the panel. Written to **both** the label and the first menu row,
+    /// for the reason in the type doc above.
+    func setUsageText(_ text: String) {
+        app_indicator_set_label(indicator, text, text)
+        gtk_menu_item_set_label(
+            UnsafeMutableRawPointer(summaryItem).assumingMemoryBound(to: GtkMenuItem.self), text)
+    }
+
+    /// Swap the icon — a filename inside the theme directory, without the extension.
+    func setIcon(named name: String) {
+        app_indicator_set_icon_full(indicator, name, "PokeTokenBar")
+    }
+}
+#endif   // os(Linux)

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import AppKit
 import QuartzCore
 import SwiftUI
@@ -51,7 +52,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         signal(SIGPIPE, SIG_IGN)
         // 크래시·OOM·강제종료·런치실패를 로그에 남기는 전역 처리. 가능한 이르게(초기 크래시도 잡히게).
         CrashReporter.install(
-            version: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?")
+            version: AppVersion.current)
         NSApp.setActivationPolicy(.accessory)
         Self.migrateLegacyStorageIfNeeded()   // TokenMac → PokeTokenBar 리네임: 기존 companion/캐시 보존
         LoginItem.migrateFromLegacyLoginItemIfNeeded()   // 로그인아이템 → KeepAlive 에이전트(크래시 자동 재실행)
@@ -431,3 +432,4 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 }
+#endif   // os(macOS)

--- a/Sources/PokeTokenBar/UI/BagView.swift
+++ b/Sources/PokeTokenBar/UI/BagView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import SwiftUI
 
 /// 가방(인벤토리) — 소유 아이템 카드 + 사용. 빈 상태는 움직이는 잠만보(컬렉션의 피카츄 패턴).
@@ -136,3 +137,4 @@ private struct ItemCard: View {
         nav.tab = .home
     }
 }
+#endif   // os(macOS)

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import SwiftUI
 
 func rarityColor(_ r: Rarity?) -> Color {
@@ -112,7 +113,9 @@ struct SpriteView: View {
     }
 
     /// 프레임 지속(초) = max(원본 delay, 하한). 순수·테스트용 — fps 상한 회귀 가드.
-    static func frameDelay(base: TimeInterval, floor: TimeInterval) -> TimeInterval { max(base, floor) }
+    static func frameDelay(base: TimeInterval, floor: TimeInterval) -> TimeInterval {
+        SpriteAnimationPolicy.frameDelay(base: base, floor: floor)
+    }
 
     /// 디코드된 GIF 프레임 중 실제로 재생할 것 — 취소됐거나 2프레임 미만이면 빈 배열(정적 폴백).
     /// 취소 검사가 여기 있는 이유: `frames` 는 body 에서 `img` 보다 먼저 그려지므로, 취소된 로드가
@@ -616,18 +619,8 @@ struct CompanionHeader: View {
         }
     }
 
-    private var statusLine: String {
-        let l = store.l
-        switch store.displayState {
-        case .egg:     return l.statusEgg
-        case .idle:    return l.statusIdle
-        case .working: return l.statusWorking
-        case .focus:   return l.statusFocus
-        case .tired:   return l.statusTired
-        case .sleep:   return l.statusSleep
-        case .levelUp: return store.justEvolvedTo.map { l.statusEvolved($0) } ?? l.statusGrew
-        }
-    }
+    /// Moved to `CompanionStore.statusLine` so the Linux frontend shows the same sentence.
+    private var statusLine: String { store.statusLine }
 }
 
 /// 희귀도 1종 캡슐 — 색 점 + 라벨 + 개수. 선택 시 원색 링 + 체크마크로 강조.
@@ -1054,3 +1047,4 @@ private struct DexEntryRow: View {
         }
     }
 }
+#endif   // os(macOS)

--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import AppKit
 import SwiftUI
 
@@ -411,7 +412,8 @@ final class PetHostingView: NSHostingView<AnyView> {
 }
 
 struct FloatingPetView: View {
-    static let frameFloor: TimeInterval = 0.4
+    /// Shared with the Linux tray via `SpriteAnimationPolicy`.
+    static let frameFloor: TimeInterval = SpriteAnimationPolicy.idleFrameFloor
     var animated: Bool = true
     @Environment(UsageStore.self) private var store
     @Environment(CompanionStore.self) private var companion
@@ -484,3 +486,4 @@ private struct SpeechBubbleView: View {
         .padding(.bottom, 6)
     }
 }
+#endif   // os(macOS)

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -1,7 +1,6 @@
+#if os(macOS)
 import AppKit
 import SwiftUI
-
-enum PopoverTab { case home, shop, bag, collection }
 
 /// 팝오버 치수의 단일 소스. 자식이 쓸 수 있는 폭을 알아야 할 때 이 값을 쓴다 — 넘치는 자식이
 /// 부모 폭을 부풀리므로 GeometryReader 로 재면 순환한다.
@@ -10,23 +9,6 @@ enum PopoverMetrics {
     static let padding: CGFloat = 14
     /// 이 폭을 넘는 자식은 팝오버 창에 좌우로 잘린다.
     static let contentWidth: CGFloat = width - padding * 2
-}
-
-/// 팝오버 내부 내비게이션 상태(현재 탭 / 설정 표시 여부).
-/// NSHostingController 는 팝오버를 닫아도 재사용되어 @State 가 유지되므로, 화면 상태를 이
-/// Observable 로 분리해 AppDelegate 가 팝오버를 열 때마다 reset() 한다 — 닫혔다 열리면 항상 Home.
-@MainActor
-@Observable
-final class PopoverNavigation {
-    var showSettings = false
-    var tab: PopoverTab = .home
-    /// 프로바이더 탭 선택 — reset() 대상이 아님(팝오버를 다시 열어도 보던 서비스 유지).
-    var providerID: String?
-
-    func reset() {
-        showSettings = false
-        tab = .home
-    }
 }
 
 struct PopoverView: View {
@@ -639,3 +621,4 @@ struct ProviderTabBar: View {
         .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
     }
 }
+#endif   // os(macOS)

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -15,7 +16,7 @@ struct SettingsView: View {
     @State private var didCheckUpdate = false
     private var l: L { companion.l }
 
-    private var isBundledApp: Bool { AppEnv.isBundledApp }
+    private var isProductionInstall: Bool { AppEnv.isProductionInstall }
 
     /// 세이브 봉투에 남길 출처 표기 — 어느 Mac에서 내보낸 파일인지 나중에 알아보기 위한 것.
     private static var deviceName: String {
@@ -24,7 +25,7 @@ struct SettingsView: View {
 
     /// 현재 앱 버전 — 업데이트 적용 여부 확인용으로 설정창 하단에 표기.
     private static var appVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
+        AppVersion.current
     }
 
     // MARK: 레이아웃 — 헤더 고정 / 본문 스크롤 / 푸터 고정
@@ -131,7 +132,7 @@ struct SettingsView: View {
             groupRow {
                 VStack(alignment: .leading, spacing: 1) {
                     Text(l.launchAtLogin)
-                    if !isBundledApp {
+                    if !isProductionInstall {
                         Text(l.bundledOnly).font(.caption2).foregroundStyle(.tertiary)
                     }
                     if let launchAtLoginError {
@@ -141,7 +142,7 @@ struct SettingsView: View {
                 Spacer()
                 Toggle("", isOn: $launchAtLogin)
                     .labelsHidden().toggleStyle(.switch).controlSize(.small)
-                    .disabled(!isBundledApp)
+                    .disabled(!isProductionInstall)
                     .onChange(of: launchAtLogin) { _, newValue in
                         do {
                             try LoginItem.setEnabled(newValue)   // KeepAlive 에이전트(로그인 실행+크래시 재실행)
@@ -378,7 +379,7 @@ struct SettingsView: View {
                 Text(l.showLogFile)
                 Spacer()
                 Button("Finder") {
-                    NSWorkspace.shared.activateFileViewerSelecting([AppLog.logFileURL])
+                    PlatformOpener.reveal(AppLog.logFileURL)
                 }
             }
             if let reportError {
@@ -426,7 +427,7 @@ struct SettingsView: View {
     /// 푸터 링크 — 버전 표기와 동일한 크기·색을 상속하고 밑줄로만 구분.
     private func footerLink(_ title: String, _ urlString: String) -> some View {
         Button {
-            if let url = URL(string: urlString) { NSWorkspace.shared.open(url) }
+            if let url = URL(string: urlString) { PlatformOpener.open(url) }
         } label: {
             Text(title).underline()
         }
@@ -444,7 +445,7 @@ struct SettingsView: View {
             version: Self.appVersion,
             os: ProcessInfo.processInfo.operatingSystemVersionString)
         guard let url = SupportMail.mailtoURL(subject: subject, body: body),
-              NSWorkspace.shared.open(url) else {
+              PlatformOpener.open(url) else {
             reportError = l.reportMailFallback(SupportMail.address)
             return
         }
@@ -474,7 +475,7 @@ struct SettingsView: View {
         do {
             let data = try companion.exportedSaveData(appVersion: Self.appVersion, deviceName: Self.deviceName)
             try data.write(to: url, options: .atomic)
-            NSWorkspace.shared.activateFileViewerSelecting([url])
+            PlatformOpener.reveal(url)
         } catch {
             presentAlert(title: l.exportSaveLabel, message: error.localizedDescription, style: .warning)
         }
@@ -553,3 +554,4 @@ struct SettingsView: View {
         alert.runModal()
     }
 }
+#endif   // os(macOS)

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import SwiftUI
 
 /// 상점 — 사용한 토큰(재화 = usedSinceInstall − spentTokens)으로 아이템 구매(이상한 사탕·민트).
@@ -214,3 +215,4 @@ private struct EggCard: View {
         if store.buyEgg(tier) { nav.tab = .home }
     }
 }
+#endif   // os(macOS)

--- a/Sources/PokeTokenBar/UI/SpriteAnimation.swift
+++ b/Sources/PokeTokenBar/UI/SpriteAnimation.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import AppKit
 import ImageIO
 import UniformTypeIdentifiers
@@ -28,3 +29,4 @@ enum GIFDecoder {
         return d < 0.02 ? 0.1 : d
     }
 }
+#endif   // os(macOS)

--- a/Sources/PokeTokenBar/UI/SpriteLoader.swift
+++ b/Sources/PokeTokenBar/UI/SpriteLoader.swift
@@ -1,94 +1,5 @@
+#if os(macOS)
 import AppKit
-
-/// 포켓몬 스프라이트를 런타임에 받아 로컬(Application Support)에 캐시. 레포/번들에 미포함.
-actor SpriteStore {
-    static let shared = SpriteStore()
-    private let base = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon"
-    private let itemBase = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/items"
-    private var mem: [String: Data] = [:]
-    private var memOrder: [String] = []   // LRU 순서(최근 접근이 뒤). 상한 초과 시 앞(오래된 것)부터 evict
-    // in-memory 스프라이트 캐시 상한 — 세션 중 종 변경 누적 무한증가 방지(#H1).
-    // 도감 한 페이지가 24칸이라 상한 24 는 LRU 가 매 페이지 전환마다 완전 회전했다(돌아올 때 디스크
-    // 동기 재읽기 24회). 정적 PNG 는 종당 0.5~1KB 라 64 로 올려도 메모리 비용이 무의미하다.
-    private let memLimit = 64
-    private let dir: URL = {
-        let d = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("PokeTokenBar/sprites")
-        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
-        return d
-    }()
-
-    /// 캐시 파일명 키 — 기존 "\(id)-a"/"\(id)-s" 유지, shiny 는 "sh" 접두(구캐시 그대로 유효).
-    static func cacheKey(speciesID: Int, animated: Bool, shiny: Bool) -> String {
-        "\(speciesID)-\(shiny ? "sh" : "")\(animated ? "a" : "s")"
-    }
-
-    func data(speciesID: Int, animated: Bool, shiny: Bool = false) async -> Data? {
-        if animated, !PokemonAssets.hasAnimatedSprite(speciesID: speciesID) { return nil }
-        let key = Self.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny)
-        if let d = mem[key] { touch(key); return d }
-        let ext = animated ? "gif" : "png"
-        let file = dir.appendingPathComponent("\(key).\(ext)")
-        if let d = try? Data(contentsOf: file) { remember(key, d); return d }
-        let urlStr: String
-        switch (animated, shiny) {
-        case (true, false):  urlStr = "\(base)/versions/generation-v/black-white/animated/\(speciesID).gif"
-        case (true, true):   urlStr = "\(base)/versions/generation-v/black-white/animated/shiny/\(speciesID).gif"
-        case (false, false): urlStr = "\(base)/\(speciesID).png"
-        case (false, true):  urlStr = "\(base)/shiny/\(speciesID).png"
-        }
-        guard let url = URL(string: urlStr),
-              let (d, resp) = try? await URLSession.shared.data(from: url),
-              (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
-        try? d.write(to: file, options: .atomic)   // torn write 방지 — 크래시/강제종료 시 손상 캐시가 남지 않게
-        remember(key, d)
-        return d
-    }
-
-    /// 아이템 스프라이트(정적 PNG, 이름 기반). 포켓몬과 같은 메모리/디스크 캐시 사용(키 "item-<name>",
-    /// 포켓몬 파일 "<id>-..." 과 안 겹침). 미제공(404)/오프라인이면 nil → 뷰가 이모지로 폴백.
-    func data(itemName: String) async -> Data? {
-        let key = "item-\(itemName)"
-        if let d = mem[key] { touch(key); return d }
-        let file = dir.appendingPathComponent("\(key).png")
-        if let d = try? Data(contentsOf: file) { remember(key, d); return d }
-        guard let url = URL(string: "\(itemBase)/\(itemName).png"),
-              let (d, resp) = try? await URLSession.shared.data(from: url),
-              (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
-        try? d.write(to: file, options: .atomic)
-        remember(key, d)
-        return d
-    }
-
-    /// 알 스프라이트(정적, pokemon/egg.png) — 애니메이션 알은 없음. 포켓몬/아이템과 같은 메모리·디스크 캐시(키 "egg").
-    func eggData() async -> Data? {
-        let key = "egg"
-        if let d = mem[key] { touch(key); return d }
-        let file = dir.appendingPathComponent("egg.png")
-        if let d = try? Data(contentsOf: file) { remember(key, d); return d }
-        guard let url = URL(string: "\(base)/egg.png"),
-              let (d, resp) = try? await URLSession.shared.data(from: url),
-              (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
-        try? d.write(to: file, options: .atomic)
-        remember(key, d)
-        return d
-    }
-
-    /// in-memory 캐시에 넣고 LRU 상한 유지(#H1) — 세션 중 종이 여러 번 바뀌어도 무한 성장 방지.
-    private func remember(_ key: String, _ data: Data) {
-        mem[key] = data
-        touch(key)
-        while memOrder.count > memLimit {
-            let old = memOrder.removeFirst()
-            mem.removeValue(forKey: old)
-        }
-    }
-    /// 접근/삽입 키를 최근(뒤)으로 이동 — 활성 종이 evict 되지 않게 하는 LRU.
-    private func touch(_ key: String) {
-        if let i = memOrder.firstIndex(of: key) { memOrder.remove(at: i) }
-        memOrder.append(key)
-    }
-}
 
 @MainActor
 enum SpriteLoader {
@@ -156,23 +67,17 @@ enum SpriteLoader {
     /// 비투명(alpha>0) 콘텐츠 경계로 크롭 — 큰 투명 여백 제거. 96×96 1회만 수행(메모이즈).
     private static func cropToContent(_ image: NSImage) -> NSImage {
         guard let tiff = image.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff) else { return image }
-        let w = rep.pixelsWide, h = rep.pixelsHigh
-        var minX = w, minY = h, maxX = -1, maxY = -1
-        for y in 0..<h {
-            for x in 0..<w where (rep.colorAt(x: x, y: y)?.alphaComponent ?? 0) > 0.01 {
-                if x < minX { minX = x }; if x > maxX { maxX = x }
-                if y < minY { minY = y }; if y > maxY { maxY = y }
-            }
-        }
-        guard maxX >= minX, maxY >= minY else { return image }
-        // 콘텐츠 bbox 를 정사각(긴 변 기준)으로 확장해 중앙 정렬 — 알 콘텐츠는 28×30(세로가 김)이라 그대로
-        // 크롭하면 SpriteView 의 size×size 정사각 프레임에서 가로로 늘어나 뚱뚱해진다. 정사각 크롭이면 비율 보존.
-        let bw = maxX - minX + 1, bh = maxY - minY + 1
-        let side = min(max(bw, bh), min(w, h))
-        let sx = max(0, min(minX - (side - bw) / 2, w - side))
-        let sy = max(0, min(minY - (side - bh) / 2, h - side))
-        guard let cg = rep.cgImage?.cropping(to: CGRect(x: sx, y: sy, width: side, height: side))
+        // The geometry lives in `SpriteCrop` so the Linux tray computes the identical rectangle.
+        guard let rect = SpriteCrop.squareContentRect(
+            width: rep.pixelsWide, height: rep.pixelsHigh,
+            isOpaque: { x, y in
+                (rep.colorAt(x: x, y: y)?.alphaComponent ?? 0) > SpriteCrop.opaqueAlphaThreshold
+            })
+        else { return image }
+        guard let cg = rep.cgImage?.cropping(
+            to: CGRect(x: rect.x, y: rect.y, width: rect.side, height: rect.side))
         else { return image }
         return NSImage(cgImage: cg, size: NSSize(width: cg.width, height: cg.height))
     }
 }
+#endif   // os(macOS)

--- a/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
@@ -1,4 +1,8 @@
-import SQLite3
+#if canImport(SQLite3)
+import SQLite3   // Darwin-only module name
+#else
+import CSQLite   // Linux: the Sources/CSQLite module map
+#endif
 import XCTest
 @testable import PokeTokenBar
 
@@ -326,8 +330,16 @@ final class AntigravityUsageTests: XCTestCase {
 
         // Assert the condition the fallback exists for, so this test cannot pass through the
         // ordinary path and quietly stop covering it.
+        //
+        // macOS only: this precondition is a property of that platform's SQLite, which refuses to
+        // create the `-shm` file a checkpointed WAL store needs under `mode=ro`. Linux's SQLite
+        // opens the same database read-only without complaint, so asserting the failure there
+        // would be asserting someone else's bug. What the test actually guards — that the reader
+        // returns the rows — is checked on both.
+        #if os(macOS)
         XCTAssertNil(openReadOnlyWithoutFallback(database),
                      "mode=ro must fail here — otherwise this no longer exercises the fallback")
+        #endif
         XCTAssertEqual(readAll().count, 1)
     }
 

--- a/Tests/PokeTokenBarTests/BinaryLocatorTests.swift
+++ b/Tests/PokeTokenBarTests/BinaryLocatorTests.swift
@@ -2,6 +2,15 @@ import XCTest
 @testable import PokeTokenBar
 
 final class BinaryLocatorTests: XCTestCase {
+    /// The platform's Homebrew bin. The point is to lock in "a package-manager install is among
+    /// the candidates", so hardcoding the path string breaks on the other platform for reasons
+    /// that have nothing to do with the intent.
+    #if os(macOS)
+    private let brewBin = "/opt/homebrew/bin"
+    #else
+    private let brewBin = "/home/linuxbrew/.linuxbrew/bin"
+    #endif
+
     /// mise shim 이 버전매니저 본체를 찾을 수 있도록 PATH 가 보강되는지 (버그 리포트 시나리오).
     func testAugmentedEnvironmentPrependsToolPaths() {
         let home = NSHomeDirectory()
@@ -11,7 +20,7 @@ final class BinaryLocatorTests: XCTestCase {
         let paths = env["PATH"]!.split(separator: ":").map(String.init)
 
         XCTAssertEqual(paths.first, "\(home)/.local/share/mise/shims")   // 바이너리 디렉토리 최우선
-        XCTAssertTrue(paths.contains("/opt/homebrew/bin"))               // mise 본체 위치 후보
+        XCTAssertTrue(paths.contains(brewBin))                           // mise 본체 위치 후보
         XCTAssertTrue(paths.contains("\(home)/.local/bin"))
         XCTAssertTrue(paths.contains("/usr/bin"))                        // 기존 PATH 보존
         XCTAssertEqual(paths.filter { $0 == "\(home)/.local/share/mise/shims" }.count, 1)  // dedup
@@ -61,7 +70,7 @@ final class BinaryLocatorTests: XCTestCase {
 
     func testCommonPathsIncludeManagersForBinary() {
         let paths = BinaryLocator.commonNodeToolPaths("ccusage")
-        XCTAssertTrue(paths.contains("/opt/homebrew/bin/ccusage"))
+        XCTAssertTrue(paths.contains("\(brewBin)/ccusage"))
         XCTAssertTrue(paths.contains { $0.contains("/.local/share/mise/shims/ccusage") })
         XCTAssertTrue(paths.contains { $0.contains("/.asdf/shims/ccusage") })
         XCTAssertTrue(paths.contains { $0.contains("/.volta/bin/ccusage") })

--- a/Tests/PokeTokenBarTests/CompanionDisplayStateTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionDisplayStateTests.swift
@@ -28,7 +28,7 @@ final class CompanionDisplayStateTests: XCTestCase {
         return (s, clock)
     }
 
-    func testEggWhenNoUsageData() {
+    func testEggWhenNoUsageData() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-disp-\(UUID().uuidString).json")
         let s = CompanionStore(provider: StubProvider(value: dline(base: 1)),
                                clock: { dNow }, fileURL: url, rng: SeededRNG(seed: 1))
@@ -97,7 +97,7 @@ final class CompanionDisplayStateTests: XCTestCase {
 
     // MARK: 알(egg) 인큐베이션 파생값
 
-    func testEggProgressAndTokensToHatch() {
+    func testEggProgressAndTokensToHatch() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-disp-\(UUID().uuidString).json")
         let s = CompanionStore(provider: StubProvider(value: dline(base: 1)),
                                clock: { dNow }, fileURL: url, rng: SeededRNG(seed: 1))

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -186,7 +186,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] 도감 항목 하나가 손상돼도(구버전/필드 누락) 나머지 도감·companion·인벤토리를 지킨다 —
     /// 예전엔 `[DexEntry]` 배열 전체 decode 가 throw 돼 상태가 전면 초기화됐다(항목별 격리로 수정).
-    func testCorruptDexEntryDroppedWhileRestSurvives() throws {
+    func testCorruptDexEntryDroppedWhileRestSurvives() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-dex-\(UUID().uuidString).json")
         // 유효 2개 + 손상 1개(finalID/chainOrder 누락).
         let json = #"{"dex":[{"baseID":1,"finalID":3,"chainOrder":[1,2,3],"rarity":"common"},"#
@@ -204,7 +204,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] 전면 손상 상태 파일은 fresh 로 시작하되, 다음 save() 가 덮어써 영구 유실되기 전에
     /// 원본을 `.corrupt` 로 백업해 수동 복구 여지를 남긴다.
-    func testCorruptStateFileBackedUpBeforeReset() throws {
+    func testCorruptStateFileBackedUpBeforeReset() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-corrupt-\(UUID().uuidString).json")
         let garbage = "this is not valid json {{{ 손상"
         try Data(garbage.utf8).write(to: url)
@@ -225,7 +225,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] active(현재 포켓몬)가 손상돼도(pathIDs 누락 등) 알로 폴백하되 도감·인벤토리·누적은 보존한다 —
     /// 예전엔 active decode 실패가 CompanionState 전체를 throw 시켜 전면 초기화됐다(필드별 관대화로 수정).
-    func testCorruptActiveFallsBackToEggWhileRestSurvives() throws {
+    func testCorruptActiveFallsBackToEggWhileRestSurvives() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-active-corrupt-\(UUID().uuidString).json")
         // active 는 pathIDs 누락 → MonState decode 실패. dex/inventory/usedSinceInstall 은 유효.
         let json = #"{"active":{"baseID":1},"#
@@ -247,7 +247,7 @@ final class CompanionStoreTests: XCTestCase {
     // MARK: 도감 이름 (컬렉션 표시)
 
     /// 저장된 체인 종별 다국어 이름을 현재 언어로 해석 — 없으면 nil(뷰가 async 조회로 폴백).
-    func testDexStoredChainNamesResolvePerLanguage() {
+    func testDexStoredChainNamesResolvePerLanguage() async {
         let s = store(linear3)
         let named = DexEntry(baseID: 1, finalID: 3, chainOrder: [1, 2, 3], rarity: .common, caughtAt: nil,
                              names: [1: ["ko": "포1", "en": "P1"], 2: ["ko": "포2", "en": "P2"], 3: ["ko": "포3", "en": "P3"]])
@@ -302,7 +302,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// 같은 라인을 두 번 졸업해도 종은 한 칸으로 접힌다 — 로그가 2행인 게 정상이고, 중복은 도감
     /// 쪽에서 구조적으로 사라진다. 도감은 종 정보만 담으므로 성격·획득 횟수는 여기서 보지 않는다.
-    func testDexSpeciesFoldsDuplicateLinesToOneCellPerSpecies() throws {
+    func testDexSpeciesFoldsDuplicateLinesToOneCellPerSpecies() async throws {
         let entries = [
             DexEntry(baseID: 1, finalID: 3, chainOrder: [1, 2, 3], rarity: .common, caughtAt: fixedNow,
                      nature: .rash,
@@ -327,7 +327,7 @@ final class CompanionStoreTests: XCTestCase {
     /// 현재 개체는 **도달분**만 보유로 잡힌다. 졸업분을 비워 두면 누수가 종 목록에 그대로 드러난다 —
     /// pathIDs 전체를 쓰면 [1,2], plannedPathIDs(계획 경로)를 쓰면 [1,2,3] 이 되므로 한 상태로
     /// 두 오용을 동시에 가드한다.
-    func testDexSpeciesCountsOnlyReachedStagesOfActive() throws {
+    func testDexSpeciesCountsOnlyReachedStagesOfActive() async throws {
         let active = MonState(baseID: 1, pathIDs: [1, 2], plannedPathIDs: [1, 2, 3], stageIndex: 0,
                               usedAtStage: 0, rarity: .common, totalForms: 3, nature: .brave)
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
@@ -344,7 +344,7 @@ final class CompanionStoreTests: XCTestCase {
     /// 이로치는 종 단위 플래그다 — 개체 하나가 이로치면 그 개체가 지나온 체인 전 종에 표식이 선다.
     /// 일반 개체와 이로치 개체를 둘 다 가진 종도 한 칸으로 접히되 플래그가 서고, 칸은 기본 일반색으로
     /// 그려 두었다가 선택하면 이로치색으로 바꾼다(두 모습을 다 볼 수 있게).
-    func testDexSpeciesMarksShinyAcrossTheChain() throws {
+    func testDexSpeciesMarksShinyAcrossTheChain() async throws {
         let entries = [
             DexEntry(baseID: 1, finalID: 2, chainOrder: [1, 2], rarity: .common, caughtAt: fixedNow,
                      isShiny: false),
@@ -364,7 +364,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// 위장 메타몽은 리빌 전까지 이로치를 숨긴다 — 도감도 그 규칙을 따라야 한다
     /// (currentIsShiny 를 재사용하는 지점. 직접 isShiny 를 읽으면 정체가 미리 새어 나간다).
-    func testDexSpeciesHidesShinyWhileDittoIsDisguised() throws {
+    func testDexSpeciesHidesShinyWhileDittoIsDisguised() async throws {
         func store(revealed: Bool) throws -> CompanionStore {
             let active = MonState(baseID: 1, pathIDs: [1], stageIndex: 0, usedAtStage: 0,
                                   rarity: .common, totalForms: 3, isShiny: true,
@@ -465,7 +465,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// 트리거 브랜치 — 같은 라인을 졸업한 뒤 **다시 키우는 중**. 종은 이미 영구 보존분이라 사라지지 않으므로
     /// 표식이 서면 안 된다. "현재 개체에 속하면 표식"으로 판정하면 여기서 깨진다.
-    func testAlreadyGraduatedSpeciesIsNotMarkedWhileRaisedAgain() throws {
+    func testAlreadyGraduatedSpeciesIsNotMarkedWhileRaisedAgain() async throws {
         let graduated = DexEntry(baseID: 1, finalID: 3, chainOrder: [1, 2, 3], rarity: .common, caughtAt: fixedNow,
                                  names: [1: ["ko": "포1"], 2: ["ko": "포2"], 3: ["ko": "포3"]])
         let active = MonState(baseID: 1, pathIDs: [1, 2, 3], stageIndex: 1,
@@ -482,7 +482,7 @@ final class CompanionStoreTests: XCTestCase {
     }
 
     /// 졸업분만 있고 현재 개체가 없으면 표식은 하나도 없다(모두 영구 기록).
-    func testGraduatedOnlyDexHasNoRaisingMark() throws {
+    func testGraduatedOnlyDexHasNoRaisingMark() async throws {
         let s = try storeWithNamelessEntry()
         XCTAssertNil(s.state.active)
         XCTAssertEqual(s.dexSpecies.map(\.isRaising), [false, false, false])
@@ -508,7 +508,7 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(names, [1: "#1", 2: "#2", 3: "#3"])
     }
 
-    func testInstallBaselineExcludesPreInstallUsage() {
+    func testInstallBaselineExcludesPreInstallUsage() async {
         let s = store(linear3)
         // 데이터 도착 전 → baseline 미설정
         s.update(todayTokensByProvider: ["test": 0], todayDate: "d1", monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: false)
@@ -524,7 +524,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] 로컬 사용량 재집계가 기존 값보다 낮아진 뒤에도, 새 기준점 이후의 증가분은 알에 반영한다.
     /// 예전에는 aggregate high-water mark 로만 유지해 감소 후 증가가 영구히 무시됐다.
-    func testUsageIncreaseAfterValidDropContinuesEggProgress() {
+    func testUsageIncreaseAfterValidDropContinuesEggProgress() async {
         let s = store(linear3)
         base(s)
         use(s, 200)
@@ -543,7 +543,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] 데이터 공백/조회 실패로 today=0 이 들어와도 당일 기준점을 0으로 낮추지 않는다.
     /// 다음 정상 조회 때 당일 전체를 중복 지급하면 안 된다.
-    func testEmptyUsageSnapshotDoesNotRebaseDailyLedger() {
+    func testEmptyUsageSnapshotDoesNotRebaseDailyLedger() async {
         let s = store(linear3)
         base(s)
         use(s, 200)
@@ -559,7 +559,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] 프로바이더 하나가 일시적으로 snapshot을 내놓지 않아도 다른 프로바이더의
     /// 증가분만 적립하고, 사라졌던 프로바이더가 복구될 때 과거 사용량을 중복 지급하지 않는다.
-    func testProviderLedgerDoesNotRecreditMissingProviderAfterPartialSnapshotLoss() {
+    func testProviderLedgerDoesNotRecreditMissingProviderAfterPartialSnapshotLoss() async {
         let s = store(linear3)
         useMap(s, ["claude_code": 0, "codex": 0])
         useMap(s, ["claude_code": 1_000, "codex": 500])
@@ -580,7 +580,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] carrier만 남아 오늘 map이 비어도 프로바이더별 ledger를 0으로 낮추지 않는다.
     /// 정상 snapshot 복구 뒤에는 복구 시점 이후 증가분만 적립한다.
-    func testCarrierWithoutTodayDataDoesNotRebaseProviderLedger() {
+    func testCarrierWithoutTodayDataDoesNotRebaseProviderLedger() async {
         let s = store(linear3)
         useMap(s, ["codex": 0])
         useMap(s, ["codex": 2_000])
@@ -596,7 +596,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] 날짜가 바뀌면 이전 날짜의 provider별 기준값과 비교하지 않고,
     /// 새 날짜에 이미 사용한 누적값 전체를 적립한 뒤 이후 증가분을 이어서 적립한다.
-    func testDateRolloverCreditsCurrentDayUsage() {
+    func testDateRolloverCreditsCurrentDayUsage() async {
         let s = store(linear3)
         useMap(s, ["codex": 0], date: "d1")
         useMap(s, ["codex": 200], date: "d1")
@@ -613,7 +613,7 @@ final class CompanionStoreTests: XCTestCase {
     /// [회귀] 날짜 경계의 첫 refresh에서 provider 하나가 빠져도, 같은 날 복구된 현재 사용량을
     /// 누락하지 않는다. 이전 날짜의 ledger 값은 새 날짜와 비교할 수 없으므로 복구 provider의
     /// 새 날짜 기준은 0으로 열고, 그 날 처음 확인된 누적값을 적립한다.
-    func testLateProviderRecoveryAfterDateRolloverCreditsCurrentDayUsage() {
+    func testLateProviderRecoveryAfterDateRolloverCreditsCurrentDayUsage() async {
         let s = store(linear3)
         useMap(s, ["claude_code": 0, "codex": 0], date: "d1")
         useMap(s, ["claude_code": 1_000, "codex": 500], date: "d1")
@@ -636,7 +636,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] stale snapshot처럼 오늘 provider map이 비어 있는 refresh는 날짜 경계를 소비하지
     /// 않는다. 다음 유효한 새 날짜 snapshot이 들어오면 그 시점의 오늘 사용량을 적립한다.
-    func testStaleSnapshotDoesNotConsumeDateBoundary() {
+    func testStaleSnapshotDoesNotConsumeDateBoundary() async {
         let s = store(linear3)
         useMap(s, ["codex": 0], date: "d1")
         useMap(s, ["codex": 200], date: "d1")
@@ -652,7 +652,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [마이그레이션] aggregate high-water mark만 가진 구버전 세이브는 값을 프로바이더별로
     /// 추정하지 않고 첫 유효 snapshot을 seed한다. 이후 증가분은 새 ledger로 정상 적립한다.
-    func testLegacyAggregateLedgerSeedsProviderMapWithoutRetrospectiveCredit() throws {
+    func testLegacyAggregateLedgerSeedsProviderMapWithoutRetrospectiveCredit() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
         let legacy = #"{"installBaselineSet":true,"usedSinceInstall":10000,"claimedTodayTokens":9000,"lastDate":"d1"}"#
         try Data(legacy.utf8).write(to: url)
@@ -729,7 +729,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// 사용자 리포트와 같은 재시작 상태: active 는 저장돼 있지만 dex=[] 인 기존 상태 파일도
     /// 도감 빈 화면으로 떨어지지 않는다.
-    func testLoadedActiveCompanionPreventsEmptyDexState() throws {
+    func testLoadedActiveCompanionPreventsEmptyDexState() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-active-\(UUID().uuidString).json")
         let json = #"{"active":{"baseID":529,"pathIDs":[529],"stageIndex":0,"usedAtStage":148344233,"rarity":"uncommon","totalForms":2,"isShiny":false,"nature":"timid"},"dex":[]}"#
         try json.data(using: .utf8)!.write(to: url)
@@ -744,7 +744,7 @@ final class CompanionStoreTests: XCTestCase {
 
     /// [회귀] 현재 키우는 common 포켓몬은 더 희귀한 졸업 항목보다도 위에 고정된다.
     /// caughtAt 이 없는 구버전 졸업 항목은 active 로 오인하지 않는다.
-    func testActiveCompanionPinnedBeforeGraduatedEntries() throws {
+    func testActiveCompanionPinnedBeforeGraduatedEntries() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-active-sort-\(UUID().uuidString).json")
         let json = #"{"active":{"baseID":1,"pathIDs":[1],"stageIndex":0,"usedAtStage":5,"rarity":"common","totalForms":3},"dex":[{"id":"legacy-graduated","baseID":150,"finalID":150,"chainOrder":[150],"rarity":"legendary"}]}"#
         try json.data(using: .utf8)!.write(to: url)
@@ -758,13 +758,13 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertFalse(s.isActiveDexEntry(sorted[1]), "caughtAt=nil 만으로 active 를 판별하면 안 됨")
     }
 
-    func testDexRaisingLabelLocalized() {
+    func testDexRaisingLabelLocalized() async {
         XCTAssertEqual(L(.en).dexRaising, "Raising")
         XCTAssertEqual(L(.ko).dexRaising, "키우는 중")
         XCTAssertEqual(L(.ja).dexRaising, "育成中")
     }
 
-    func testUnknownNextEvolutionAccessibilityLabelLocalized() {
+    func testUnknownNextEvolutionAccessibilityLabelLocalized() async {
         XCTAssertEqual(L(.ko).unknownNextEvolution, "알 수 없는 다음 진화")
         XCTAssertEqual(L(.en).unknownNextEvolution, "Unknown next evolution")
         XCTAssertEqual(L(.ja).unknownNextEvolution, "次の進化先は不明")
@@ -803,7 +803,7 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertNil(s.state.active)
     }
 
-    func testStateDecodesWithoutEggUsage() throws {
+    func testStateDecodesWithoutEggUsage() async throws {
         // 기존 저장(필드 없음)도 깨지지 않고 eggUsage=0 으로 로드
         let json = #"{"installBaselineSet":true,"usedSinceInstall":5,"claimedTodayTokens":5,"lastDate":"d","active":null,"dex":[],"collectedFinals":[],"language":"ko"}"#
         let state = try JSONDecoder().decode(CompanionState.self, from: Data(json.utf8))
@@ -850,14 +850,14 @@ final class CompanionStoreTests: XCTestCase {
         ])
     }
 
-    func testRealizedLineItemsUsesStageIndexForCurrentMarker() {
+    func testRealizedLineItemsUsesStageIndexForCurrentMarker() async {
         XCTAssertEqual(CompanionStore.realizedLineItems(pathIDs: [1, 2], stageIndex: 0), [
             EvoLineItem(.species(1), .current),
             EvoLineItem(.species(2), .done),
         ])
     }
 
-    func testRepairedPlanAppendsFallbackRouteToCurrentPath() {
+    func testRepairedPlanAppendsFallbackRouteToCurrentPath() async {
         XCTAssertEqual(CompanionStore.repairedPlan(
             realizedPath: [265], stageIndex: 0, fallbackRoute: [265, 266, 267]),
             [265, 266, 267])
@@ -1129,13 +1129,17 @@ final class CompanionStoreTests: XCTestCase {
 /// 팝오버 루트가 `\.locale` 로 앱 언어를 내려주므로, 그 매핑이 실제로 해당 언어의 상대 시각을
 /// 만들어내는지까지 고정한다 — 코드만 비교하면 잘못 매핑해도 통과한다.
 final class DisplayLocaleTests: XCTestCase {
-    func testDisplayLocaleMatchesLanguageCode() {
+    func testDisplayLocaleMatchesLanguageCode() async {
         XCTAssertEqual(AppLanguage.ko.displayLocale.identifier, "ko")
         XCTAssertEqual(AppLanguage.en.displayLocale.identifier, "en")
         XCTAssertEqual(AppLanguage.ja.displayLocale.identifier, "ja")
     }
 
-    func testRelativeTimeFollowsAppLanguageNotSystem() {
+    // `RelativeDateTimeFormatter` does not exist in corelibs-foundation (Linux). What this test is
+    // really about is `AppLanguage.displayLocale`, but that platform offers no way to observe it,
+    // so the test goes with it.
+    #if os(macOS)
+    func testRelativeTimeFollowsAppLanguageNotSystem() async {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let past = now.addingTimeInterval(-3 * 3600)
 
@@ -1151,6 +1155,7 @@ final class DisplayLocaleTests: XCTestCase {
         // 세 언어가 서로 달라야 한다 — 하나로 고정돼 있으면 매핑이 죽은 것이다.
         XCTAssertEqual(Set([relative(.en), relative(.ko), relative(.ja)]).count, 3)
     }
+    #endif
 }
 
 // MARK: 포획 로그 정렬 / 요약
@@ -1160,7 +1165,7 @@ final class DexSortingTests: XCTestCase {
     /// sortRank 는 목록 정렬 키가 아니지만(로그는 시각순) 프리미엄 알의 등급 게이트가
     /// `line.rarity.sortRank < tier.sortRank` 로 쓴다 — 순서가 뒤집히면 고급/희귀 알이 조용히
     /// 낮은 등급을 통과시킨다. 그래서 순서 보증만 여기 남긴다.
-    func testSortRankOrdersRarityAscendingByValue() {
+    func testSortRankOrdersRarityAscendingByValue() async {
         XCTAssertLessThan(Rarity.common.sortRank, Rarity.uncommon.sortRank)
         XCTAssertLessThan(Rarity.uncommon.sortRank, Rarity.rare.sortRank)
         XCTAssertLessThan(Rarity.rare.sortRank, Rarity.legendary.sortRank)
@@ -1270,7 +1275,7 @@ final class CompanionIdentityTests: XCTestCase {
     }
 
     /// 구버전 저장(shiny/nature 키 없음) 디코딩 — 기본값(false/nil)으로 로드.
-    func testBackwardCompatibleDecode() throws {
+    func testBackwardCompatibleDecode() async throws {
         let old = """
         {"installBaselineSet":true,"usedSinceInstall":100,"eggUsage":0,
          "claimedTodayTokens":100,"lastDate":"d1",
@@ -1293,7 +1298,7 @@ final class CompanionIdentityTests: XCTestCase {
     /// [출시 안전] 손상된 상태 파일: active.pathIDs 가 비면 그 active 만 nil(알)로 폴백하되 나머지 상태는
     /// 보존한다(필드별 관대화). 깨진 active 를 살려두면 currentID out-of-bounds 위험이므로 nil 이어야 한다
     /// (예전엔 전체 디코드를 throw 시켜 상태 전면 초기화 → 도감·인벤토리까지 유실됐다).
-    func testEmptyPathIDsActiveFallsBackToNilPreservingRest() {
+    func testEmptyPathIDsActiveFallsBackToNilPreservingRest() async {
         let corrupt = """
         {"installBaselineSet":true,"eggUsage":0,"lastDate":"d1",
          "active":{"baseID":1,"pathIDs":[],"stageIndex":0,"usedAtStage":0,"rarity":"common","totalForms":3}}
@@ -1305,13 +1310,13 @@ final class CompanionIdentityTests: XCTestCase {
     }
 
     /// currentID 는 pathIDs 가 비어도(방어) baseID 로 폴백 — 크래시 없음.
-    func testCurrentIDFallsBackToBaseWhenPathEmpty() {
+    func testCurrentIDFallsBackToBaseWhenPathEmpty() async {
         let m = MonState(baseID: 42, pathIDs: [], stageIndex: 0, usedAtStage: 0, rarity: .common, totalForms: 1)
         XCTAssertEqual(m.currentID, 42)
     }
 
     /// 신규 설치 기본 언어는 시스템 로케일에서 유추 — 유효한 케이스이고 크래시 없음(한국어 강제 아님).
-    func testSystemDefaultLanguageResolves() {
+    func testSystemDefaultLanguageResolves() async {
         XCTAssertTrue(AppLanguage.allCases.contains(AppLanguage.systemDefault))
         XCTAssertEqual(CompanionState().language, AppLanguage.systemDefault)
     }
@@ -1550,7 +1555,7 @@ final class CompanionIdentityTests: XCTestCase {
     }
 
     /// 스프라이트 캐시 키 — 기존 키("25-a"/"25-s") 불변 + shiny 접두.
-    func testSpriteCacheKeyScheme() {
+    func testSpriteCacheKeyScheme() async {
         XCTAssertEqual(SpriteStore.cacheKey(speciesID: 25, animated: true, shiny: false), "25-a")
         XCTAssertEqual(SpriteStore.cacheKey(speciesID: 25, animated: false, shiny: false), "25-s")
         XCTAssertEqual(SpriteStore.cacheKey(speciesID: 25, animated: true, shiny: true), "25-sha")
@@ -1558,7 +1563,7 @@ final class CompanionIdentityTests: XCTestCase {
     }
 
     /// 성격 25종 — 3개 언어 명칭이 전부 비어있지 않고 중복 없는지.
-    func testNatureNamesComplete() {
+    func testNatureNamesComplete() async {
         XCTAssertEqual(PokemonNature.allCases.count, 25)
         for lang in AppLanguage.allCases {
             let names = PokemonNature.allCases.map { $0.name(lang) }
@@ -1571,10 +1576,10 @@ final class CompanionIdentityTests: XCTestCase {
 // MARK: PokéAPI SSRF 가드 (evolution_chain URL 검증 — 응답 변조 시 임의 호스트 fetch 방지)
 
 final class PokeAPIGuardTests: XCTestCase {
-    func testValidatedChainURLAcceptsPokeapiHttps() {
+    func testValidatedChainURLAcceptsPokeapiHttps() async {
         XCTAssertNotNil(PokeAPIClient.validatedChainURL("https://pokeapi.co/api/v2/evolution-chain/1/"))
     }
-    func testValidatedChainURLRejectsUntrusted() {
+    func testValidatedChainURLRejectsUntrusted() async {
         XCTAssertNil(PokeAPIClient.validatedChainURL("https://evil.example.com/x"), "임의 호스트 거부(SSRF)")
         XCTAssertNil(PokeAPIClient.validatedChainURL("https://pokeapi.co.evil.com/x"), "유사 호스트 거부")
         XCTAssertNil(PokeAPIClient.validatedChainURL("http://pokeapi.co/x"), "http 거부(https 고정)")

--- a/Tests/PokeTokenBarTests/CopilotUsageTests.swift
+++ b/Tests/PokeTokenBarTests/CopilotUsageTests.swift
@@ -1,4 +1,8 @@
-import SQLite3
+#if canImport(SQLite3)
+import SQLite3   // Darwin-only module name
+#else
+import CSQLite   // Linux: the Sources/CSQLite module map
+#endif
 import XCTest
 @testable import PokeTokenBar
 

--- a/Tests/PokeTokenBarTests/CursorUsageTests.swift
+++ b/Tests/PokeTokenBarTests/CursorUsageTests.swift
@@ -1,4 +1,8 @@
-import SQLite3
+#if canImport(SQLite3)
+import SQLite3   // Darwin-only module name
+#else
+import CSQLite   // Linux: the Sources/CSQLite module map
+#endif
 import XCTest
 @testable import PokeTokenBar
 

--- a/Tests/PokeTokenBarTests/DittoTests.swift
+++ b/Tests/PokeTokenBarTests/DittoTests.swift
@@ -105,7 +105,7 @@ final class DittoRevealTests: XCTestCase {
     }
 
     /// 위장 중엔 이로치가 표시상 숨겨진다(내부 isShiny 는 유지 — 리빌 때 공개).
-    func testShinyHiddenDuringDisguise() {
+    func testShinyHiddenDuringDisguise() async {
         let s = seedDisguise(shiny: true)
         XCTAssertTrue(s.state.active?.isShiny ?? false, "내부적으론 이로치")
         XCTAssertFalse(s.currentIsShiny, "위장 중엔 표시상 숨김")
@@ -225,7 +225,7 @@ final class DittoRevealTests: XCTestCase {
     }
 
     /// 구버전 저장(ditto 필드 없음) → nil/false, 일반 포켓몬으로 동작(이로치는 그대로 표시).
-    func testBackwardCompatDecodeNoDittoFields() {
+    func testBackwardCompatDecodeNoDittoFields() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("ditto-bc-\(UUID().uuidString).json")
         let active = "{\"baseID\":1,\"pathIDs\":[1],\"stageIndex\":0,\"usedAtStage\":0,"
             + "\"rarity\":\"common\",\"totalForms\":3,\"isShiny\":true}"   // ditto 필드 없음

--- a/Tests/PokeTokenBarTests/EvoLineLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/EvoLineLayoutTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)   // macOS frontend layout contracts (332pt popover, NSImage) — the Linux UI carries its own guards
 import XCTest
 import SwiftUI
 @testable import PokeTokenBar
@@ -32,7 +33,7 @@ final class EvoLineLayoutTests: XCTestCase {
     // MARK: 렌더 폭 — 실제 레이아웃 회귀
 
     /// 트리거 재현: 폭 제한이 없으면 긴 라인은 팝오버 콘텐츠 폭을 넘는다(= 버그 조건).
-    func testLongEvolutionLineWithoutMaxWidthOverflowsPopoverContent() {
+    func testLongEvolutionLineWithoutMaxWidthOverflowsPopoverContent() async {
         let w = renderedWidth(EvoLineView(nodes: longNodes, mysteryLabel: L(.en).unknownNextEvolution),
                               proposing: PopoverMetrics.contentWidth)
         XCTAssertGreaterThan(w, PopoverMetrics.contentWidth,
@@ -40,7 +41,7 @@ final class EvoLineLayoutTests: XCTestCase {
     }
 
     /// 수정 후: 팝오버가 주는 폭을 넘지 않는다(→ 부모 VStack 이 안 부풀고 팝오버가 안 잘린다).
-    func testLongEvolutionLineFitsPopoverContentWidth() {
+    func testLongEvolutionLineFitsPopoverContentWidth() async {
         let w = renderedWidth(EvoLineView(nodes: longNodes, mysteryLabel: L(.en).unknownNextEvolution,
                                           maxWidth: PopoverMetrics.contentWidth),
                               proposing: PopoverMetrics.contentWidth)
@@ -48,7 +49,7 @@ final class EvoLineLayoutTests: XCTestCase {
     }
 
     /// 도감 행(썸네일 56 + 이름 라벨)도 카드 안쪽 폭을 넘지 않는다.
-    func testLongDexChainFitsCardWidth() {
+    func testLongDexChainFitsCardWidth() async {
         let cardWidth = PopoverMetrics.contentWidth - 16   // DexEntryRow 카드 좌우 패딩 8pt
         let ids = [1, 2, 3, 4, 5]
         let nodes = ids.map { EvoLineItem(.species($0), .done) }
@@ -61,7 +62,7 @@ final class EvoLineLayoutTests: XCTestCase {
     }
 
     /// 짧은 라인은 스크롤 컨테이너 없이 예전과 똑같은 폭으로 그려진다(일반 라인 시각 회귀 방지).
-    func testShortChainRendersInlineAtNaturalWidth() {
+    func testShortChainRendersInlineAtNaturalWidth() async {
         // 3칸 = 40*3 + 화살표 10*2 + 간격 2*4 = 148pt
         let expected = EvoLineView.rowWidth(count: 3, thumb: 40, hasNames: false)
         XCTAssertEqual(expected, 148)
@@ -74,7 +75,7 @@ final class EvoLineLayoutTests: XCTestCase {
     // MARK: 순수 판정 — 스크롤 전환 경계
 
     /// rowWidth 는 레이아웃과 같은 식이어야 한다(측정값과 일치 — 어긋나면 스크롤 판정이 틀어진다).
-    func testRowWidthMatchesRenderedWidth() {
+    func testRowWidthMatchesRenderedWidth() async {
         for count in 1...9 {
             let nodes = (1...count).map { i in
                 i == count ? EvoLineItem(.mystery, .future) : EvoLineItem(.species(i), .done)
@@ -88,7 +89,7 @@ final class EvoLineLayoutTests: XCTestCase {
     }
 
     /// mystery 는 이름이 없더라도 도감 라인의 이름 열 폭을 예약해야 rowWidth 기반 스크롤 판정과 일치한다.
-    func testNamedMysteryCellReservesNameColumnWidth() {
+    func testNamedMysteryCellReservesNameColumnWidth() async {
         let nodes = [EvoLineItem(.species(1), .done), EvoLineItem(.mystery, .future)]
         let names = [1: String(repeating: "W", count: 20)]
         let rendered = renderedWidth(EvoLineView(nodes: nodes, mysteryLabel: L(.en).unknownNextEvolution, names: names),
@@ -100,7 +101,7 @@ final class EvoLineLayoutTests: XCTestCase {
     }
 
     /// 홈 라인(썸네일 40)은 6칸까지 그대로, 7칸부터 스크롤.
-    func testNeedsScrollBoundaryForHomeLine() {
+    func testNeedsScrollBoundaryForHomeLine() async {
         let w = PopoverMetrics.contentWidth
         XCTAssertFalse(EvoLineView.needsScroll(count: 6, thumb: 40, hasNames: false, maxWidth: w))
         XCTAssertTrue(EvoLineView.needsScroll(count: 7, thumb: 40, hasNames: false, maxWidth: w))
@@ -108,14 +109,14 @@ final class EvoLineLayoutTests: XCTestCase {
     }
 
     /// 도감 행(썸네일 56 + 이름)은 4칸까지 그대로, 5칸부터 스크롤.
-    func testNeedsScrollBoundaryForDexRow() {
+    func testNeedsScrollBoundaryForDexRow() async {
         let w = PopoverMetrics.contentWidth - 16
         XCTAssertFalse(EvoLineView.needsScroll(count: 4, thumb: 56, hasNames: true, maxWidth: w))
         XCTAssertTrue(EvoLineView.needsScroll(count: 5, thumb: 56, hasNames: true, maxWidth: w))
     }
 
     /// maxWidth 를 안 주면(기본 .infinity) 스크롤을 붙이지 않는다 — 폭이 고정되지 않은 호출부용 기본값.
-    func testUnboundedWidthNeverScrolls() {
+    func testUnboundedWidthNeverScrolls() async {
         XCTAssertFalse(EvoLineView.needsScroll(count: 99, thumb: 40, hasNames: false, maxWidth: .infinity))
     }
 
@@ -123,7 +124,7 @@ final class EvoLineLayoutTests: XCTestCase {
 
     /// 페이드·셰브론은 "그쪽에 더 있을 때만" 떠야 한다. 스냅샷으로는 첫 프레임(맨 왼쪽)밖에 못 봐서
     /// 스크롤 중간/끝 상태는 이 순수 판정으로 잠근다.
-    func testAffordanceShowsOnlyWhereContentRemains() {
+    func testAffordanceShowsOnlyWhereContentRemains() async {
         let content = EvoLineView.rowWidth(count: 9, thumb: 40, hasNames: false)   // 472
         let view = PopoverMetrics.contentWidth                                      // 332
 
@@ -142,7 +143,7 @@ final class EvoLineLayoutTests: XCTestCase {
 
     /// 셰브론은 누를 때마다 더 나아가야 한다 — 목표가 현재 위치에 따라 바뀌는지, 범위를 안 넘는지.
     /// (고정 목표로 두면 한 번 이동한 뒤 다시 눌러도 제자리가 된다.)
-    func testPageTargetAdvancesAndStaysInBounds() {
+    func testPageTargetAdvancesAndStaysInBounds() async {
         let w = PopoverMetrics.contentWidth
         func target(_ forward: Bool, at scrollX: CGFloat) -> Int {
             EvoLineView.pageTarget(forward: forward, scrollX: scrollX, count: 9,
@@ -160,9 +161,10 @@ final class EvoLineLayoutTests: XCTestCase {
     }
 
     /// 넘치지 않는 줄에는 어느 쪽 신호도 뜨지 않는다.
-    func testAffordanceHiddenWhenContentFits() {
+    func testAffordanceHiddenWhenContentFits() async {
         let a = EvoLineView.scrollAffordance(scrollX: 0, contentWidth: 148,
                                              maxWidth: PopoverMetrics.contentWidth)
         XCTAssertFalse(a.back); XCTAssertFalse(a.forward)
     }
 }
+#endif   // os(macOS)

--- a/Tests/PokeTokenBarTests/FreshEggTests.swift
+++ b/Tests/PokeTokenBarTests/FreshEggTests.swift
@@ -30,7 +30,7 @@ final class FreshEggTests: XCTestCase {
     func testPriceIsOneBillion() { XCTAssertEqual(FreshEgg.price, 1_000_000_000) }
 
     /// [핵심] 리롤 = 폐기: active 사라지고 새 알(eggUsage 0). **도감·확률(collectedFinals) 불변** = "뽑은 적 없던 것처럼".
-    func testBuyFreshEggDiscardsWithoutDexOrProbabilityImpact() {
+    func testBuyFreshEggDiscardsWithoutDexOrProbabilityImpact() async {
         let s = store(used: 5_000_000_000, spent: 0)
         let persistedDexBefore = s.state.dex
         let collectedBefore = s.state.collectedFinals
@@ -52,7 +52,7 @@ final class FreshEggTests: XCTestCase {
     }
 
     /// 폐기한 개체(baseID 10)의 종은 collectedFinals 에 들어가지 않는다(이후 부화 확률에 영향 없음).
-    func testDiscardedSpeciesNotCollected() {
+    func testDiscardedSpeciesNotCollected() async {
         let s = store()
         XCTAssertTrue(s.buyFreshEgg())
         XCTAssertFalse(s.state.collectedFinals.contains { $0.hasPrefix("10:") },
@@ -60,7 +60,7 @@ final class FreshEggTests: XCTestCase {
     }
 
     /// 알 상태(활성 없음)에선 리롤할 게 없어 불가.
-    func testCannotRerollWhenEgg() {
+    func testCannotRerollWhenEgg() async {
         let s = store(active: false, used: 5_000_000_000)
         XCTAssertFalse(s.hasActive)
         XCTAssertFalse(s.canBuyFreshEgg)
@@ -69,7 +69,7 @@ final class FreshEggTests: XCTestCase {
     }
 
     /// 잔액이 가격 미만이면 불가 — 활성 유지.
-    func testCannotRerollWithoutFunds() {
+    func testCannotRerollWithoutFunds() async {
         let s = store(used: 500_000_000)   // 1B 미만
         XCTAssertFalse(s.canBuyFreshEgg)
         XCTAssertFalse(s.buyFreshEgg())
@@ -78,7 +78,7 @@ final class FreshEggTests: XCTestCase {
     }
 
     /// 이로치도 폐기 가능(추가 경고는 UI 단계, 로직은 동일) — 리롤 후 흔적 없음.
-    func testShinyCanBeRerolled() {
+    func testShinyCanBeRerolled() async {
         let s = store(shiny: true)
         XCTAssertTrue(s.currentIsShiny)
         XCTAssertTrue(s.buyFreshEgg())

--- a/Tests/PokeTokenBarTests/GrokUsageTests.swift
+++ b/Tests/PokeTokenBarTests/GrokUsageTests.swift
@@ -472,11 +472,11 @@ final class GrokUsageTests: XCTestCase {
 
     private func rewriteSnapshot(_ mutate: (inout [String: Any]) throws -> Void) throws {
         let raw = try Data(contentsOf: cacheFile)
-        let plain = (try? (raw as NSData).decompressed(using: .zlib) as Data) ?? raw
+        let plain = PlatformCompression.decompress(raw) ?? raw
         var snapshot = try XCTUnwrap(JSONSerialization.jsonObject(with: plain) as? [String: Any])
         try mutate(&snapshot)
         let data = try JSONSerialization.data(withJSONObject: snapshot)
-        try ((data as NSData).compressed(using: .zlib) as Data).write(to: cacheFile, options: .atomic)
+        try XCTUnwrap(PlatformCompression.compress(data)).write(to: cacheFile, options: .atomic)
     }
 
     // MARK: 등록·집계 패리티

--- a/Tests/PokeTokenBarTests/IncrementalStoreScanTests.swift
+++ b/Tests/PokeTokenBarTests/IncrementalStoreScanTests.swift
@@ -1,4 +1,8 @@
-import SQLite3
+#if canImport(SQLite3)
+import SQLite3   // Darwin-only module name
+#else
+import CSQLite   // Linux: the Sources/CSQLite module map
+#endif
 import XCTest
 @testable import PokeTokenBar
 

--- a/Tests/PokeTokenBarTests/KiroUsageTests.swift
+++ b/Tests/PokeTokenBarTests/KiroUsageTests.swift
@@ -1,4 +1,8 @@
-import SQLite3
+#if canImport(SQLite3)
+import SQLite3   // Darwin-only module name
+#else
+import CSQLite   // Linux: the Sources/CSQLite module map
+#endif
 import XCTest
 @testable import PokeTokenBar
 
@@ -364,10 +368,23 @@ final class KiroUsageTests: XCTestCase {
     }
 
     func testDefaultRootIsTheKiroCliHome() {
+        // kiro-cli is a CLI tool, so the convention differs per platform: Application Support on
+        // macOS, the XDG data directory on Linux. Calling the implementation back would just
+        // compare it with itself, so the paths are spelled out — that is the contract under test.
+        #if os(macOS)
         let expected = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Application Support/kiro-cli")
+        let overridden = ProcessInfo.processInfo.environment["KIRO_CLI_HOME"] != nil
+        #else
+        let expected = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/kiro-cli")
+        // With XDG_DATA_HOME relocated the default is not under home — skipped for the same
+        // reason as KIRO_CLI_HOME.
+        let overridden = ProcessInfo.processInfo.environment["KIRO_CLI_HOME"] != nil
+            || ProcessInfo.processInfo.environment["XDG_DATA_HOME"]?.hasPrefix("/") == true
+        #endif
         let roots = LocalAdditionalUsageReader.defaultKiroRoots
-        if ProcessInfo.processInfo.environment["KIRO_CLI_HOME"] == nil {
+        if !overridden {
             XCTAssertEqual(roots, [expected])
         }
         XCTAssertFalse(roots.isEmpty)

--- a/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
+++ b/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
@@ -1,4 +1,8 @@
-import SQLite3
+#if canImport(SQLite3)
+import SQLite3   // Darwin-only module name
+#else
+import CSQLite   // Linux: the Sources/CSQLite module map
+#endif
 import XCTest
 @testable import PokeTokenBar
 
@@ -120,7 +124,15 @@ final class LocalAdditionalUsageTests: XCTestCase {
             modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [database])
 
         XCTAssertEqual(entries.count, 1)
-        XCTAssertEqual(entries.first?.localDay, "2026-01-02")
+        // `localDay` is exactly what the name says: a **local** date (localDayFormatter uses
+        // timeZone = .current). The fixture's 1767312000000ms is 2026-01-02T00:00:00**Z**, so a
+        // literal "2026-01-02" only breaks at negative UTC offsets (at UTC-03 it is
+        // 2026-01-01 21:00 → "2026-01-01"). What this test is actually about is whether ms are
+        // mistaken for seconds, so deriving the expectation from the same instant keeps all of its
+        // discriminating power — read as seconds it lands in the far future and fails immediately.
+        let expectedDay = LocalUsageReader.localDayFormatter()
+            .string(from: try date("2026-01-02T00:00:00Z"))
+        XCTAssertEqual(entries.first?.localDay, expectedDay)
         XCTAssertEqual(entries.first?.total, 15)
     }
 

--- a/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
@@ -280,7 +280,7 @@ final class LocalUsageCacheTests: XCTestCase {
 
     private func rewriteCodexCacheAsPriorParserVersion() throws {
         let raw = try Data(contentsOf: cacheFile)
-        let plain = (try? (raw as NSData).decompressed(using: .zlib) as Data) ?? raw
+        let plain = PlatformCompression.decompress(raw) ?? raw
         var snapshot = try XCTUnwrap(JSONSerialization.jsonObject(with: plain) as? [String: Any])
         var codex = try XCTUnwrap(snapshot["codex"] as? [String: Any])
 
@@ -302,7 +302,7 @@ final class LocalUsageCacheTests: XCTestCase {
         snapshot["codexParserVersion"] = 3
 
         let data = try JSONSerialization.data(withJSONObject: snapshot)
-        let compressed = try (data as NSData).compressed(using: .zlib) as Data
+        let compressed = try XCTUnwrap(PlatformCompression.compress(data))
         try compressed.write(to: cacheFile, options: .atomic)
     }
 
@@ -463,7 +463,7 @@ final class LocalUsageCacheTests: XCTestCase {
 
     private func downgradeCodexSessionIndexVersion() throws {
         let raw = try Data(contentsOf: cacheFile)
-        let plain = (try? (raw as NSData).decompressed(using: .zlib) as Data) ?? raw
+        let plain = PlatformCompression.decompress(raw) ?? raw
         var snapshot = try XCTUnwrap(JSONSerialization.jsonObject(with: plain) as? [String: Any])
         XCTAssertFalse(
             (snapshot["codexSessionIDs"] as? [String: Any] ?? [:]).isEmpty,
@@ -471,7 +471,7 @@ final class LocalUsageCacheTests: XCTestCase {
         snapshot["codexSessionIndexVersion"] = 1
 
         let data = try JSONSerialization.data(withJSONObject: snapshot)
-        let compressed = try (data as NSData).compressed(using: .zlib) as Data
+        let compressed = try XCTUnwrap(PlatformCompression.compress(data))
         try compressed.write(to: cacheFile, options: .atomic)
     }
 
@@ -636,7 +636,7 @@ final class LocalUsageCacheTests: XCTestCase {
         XCTAssertEqual(Set(entries.map(\.output)), [1, 2], "조회 자체는 둘 다 반환")
 
         let raw = try Data(contentsOf: cacheFile)
-        let plain = (try? (raw as NSData).decompressed(using: .zlib) as Data) ?? raw
+        let plain = PlatformCompression.decompress(raw) ?? raw
         let snap = String(decoding: plain, as: UTF8.self)
         XCTAssertFalse(snap.contains("old.jsonl"), "45일 지난 blob 은 스냅샷에서 prune")
         XCTAssertTrue(snap.contains("new.jsonl"))
@@ -681,7 +681,7 @@ final class LocalUsageCacheTests: XCTestCase {
 
         // 압축 해제해 평문으로 다운그레이드(구버전 캐시 파일 시뮬레이션)
         let raw = try Data(contentsOf: cacheFile)
-        let plain = try (raw as NSData).decompressed(using: .zlib) as Data
+        let plain = try XCTUnwrap(PlatformCompression.decompress(raw))
         try plain.write(to: cacheFile)
 
         // 내용을 몰래 바꿔도(길이·mtime 동일) 평문 스냅샷이 로드되면 42 유지
@@ -696,7 +696,7 @@ final class LocalUsageCacheTests: XCTestCase {
         try writeFile("a.jsonl", lines: (1...50).map { claudeLine(id: "\($0)", output: $0) }, mtime: t)
         _ = await makeCache().claudeEntries(modifiedSince: since)
         let raw = try Data(contentsOf: cacheFile)
-        let plain = try (raw as NSData).decompressed(using: .zlib) as Data   // zlib 아니면 throw
+        let plain = try XCTUnwrap(PlatformCompression.decompress(raw))   // zlib 아니면 throw
         XCTAssertLessThan(raw.count, plain.count, "압축본이 평문보다 작아야 한다")
     }
 

--- a/Tests/PokeTokenBarTests/MintTests.swift
+++ b/Tests/PokeTokenBarTests/MintTests.swift
@@ -32,7 +32,7 @@ final class MintTests: XCTestCase {
 
     // MARK: 사용
 
-    func testUseMintChangesNatureToDifferent() {
+    func testUseMintChangesNatureToDifferent() async {
         let s = store(nature: "adamant", mint: 1)
         XCTAssertEqual(s.state.active?.nature, .adamant)
         let new = s.useMint()
@@ -43,7 +43,7 @@ final class MintTests: XCTestCase {
     }
 
     /// 여러 번 써도 매번 '직전 성격과 다른' 값으로만 바뀐다(현재 제외 롤).
-    func testMintNeverRepeatsCurrentAcrossUses() {
+    func testMintNeverRepeatsCurrentAcrossUses() async {
         let s = store(nature: "adamant", mint: 6)
         for _ in 0..<6 {
             let before = s.state.active?.nature
@@ -54,7 +54,7 @@ final class MintTests: XCTestCase {
     }
 
     /// 성격 nil(구버전 개체) → 유효한 성격이 설정된다.
-    func testUseMintFromNilNatureSetsValid() {
+    func testUseMintFromNilNatureSetsValid() async {
         let s = store(nature: nil, mint: 1)
         XCTAssertNil(s.state.active?.nature)
         let new = s.useMint()
@@ -63,7 +63,7 @@ final class MintTests: XCTestCase {
     }
 
     /// 성장·종·shiny·usedAtStage·통계 전부 불변(순수 코스메틱).
-    func testUseMintDoesNotAffectGrowthOrIdentity() {
+    func testUseMintDoesNotAffectGrowthOrIdentity() async {
         let s = store(nature: "adamant", mint: 1, used: 1_000_000_000, usedAtStage: 50_000_000, shiny: true)
         let beforeStage = s.state.active?.stageIndex
         let beforeUsed = s.state.usedSinceInstall
@@ -78,7 +78,7 @@ final class MintTests: XCTestCase {
 
     // MARK: 게이트
 
-    func testCannotUseMintOnEgg() {
+    func testCannotUseMintOnEgg() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mint-egg-\(UUID().uuidString).json")
         let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":1,\"lastDate\":\"d\","
             + "\"dex\":[],\"collectedFinals\":[],\"inventory\":{\"mint\":2}}"
@@ -90,7 +90,7 @@ final class MintTests: XCTestCase {
         XCTAssertEqual(s.itemCount(.mint), 2, "알 상태에선 소모 안 됨")
     }
 
-    func testCannotUseMintWithoutStock() {
+    func testCannotUseMintWithoutStock() async {
         let s = store(nature: "adamant", mint: 0)
         XCTAssertFalse(s.canUseMint)
         XCTAssertNil(s.useMint())
@@ -98,7 +98,7 @@ final class MintTests: XCTestCase {
 
     // MARK: 피드백
 
-    func testMintFeedbackSetAndConsumed() {
+    func testMintFeedbackSetAndConsumed() async {
         let s = store(nature: "adamant", mint: 1)
         let before = s.mintFeedbackSeq
         let new = s.useMint()
@@ -110,7 +110,7 @@ final class MintTests: XCTestCase {
 
     // MARK: 영속
 
-    func testUseMintPersistsAcrossRestart() {
+    func testUseMintPersistsAcrossRestart() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mint-persist-\(UUID().uuidString).json")
         let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":1,\"lastDate\":\"d\","
             + "\"active\":{\"baseID\":1,\"pathIDs\":[1],\"stageIndex\":0,\"usedAtStage\":0,\"rarity\":\"common\",\"totalForms\":3,\"nature\":\"adamant\"},"
@@ -127,7 +127,7 @@ final class MintTests: XCTestCase {
 
     // MARK: 상점 구매
 
-    func testMintShopPriceAndPurchasable() {
+    func testMintShopPriceAndPurchasable() async {
         XCTAssertEqual(ItemKind.mint.shopPrice, Mint.price)
         XCTAssertEqual(ItemKind.mint.shopPrice, 100_000_000)
         let s = store(mint: 0)
@@ -135,7 +135,7 @@ final class MintTests: XCTestCase {
         XCTAssertTrue(s.purchasableItems.contains(.mint))
     }
 
-    func testBuyMintDebitsWalletAndCredits() {
+    func testBuyMintDebitsWalletAndCredits() async {
         let s = store(mint: 0, used: 300_000_000)
         XCTAssertTrue(s.canBuy(.mint))
         XCTAssertTrue(s.buy(.mint))
@@ -144,7 +144,7 @@ final class MintTests: XCTestCase {
         XCTAssertEqual(s.availableTokens, 300_000_000 - Mint.price)
     }
 
-    func testCannotBuyMintBelowPrice() {
+    func testCannotBuyMintBelowPrice() async {
         let s = store(mint: 0, used: Mint.price - 1)
         XCTAssertFalse(s.canBuy(.mint))
         XCTAssertFalse(s.buy(.mint))

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -73,7 +73,10 @@ final class StorePerformanceTests: XCTestCase {
                               clock: { pNow }, fileURL: url, rng: SeededRNG(seed: 1))
     }
 
-    func testLargeDexSortPerformanceAndCorrectness() throws {
+    // `async` is here not because this test is asynchronous, but because Linux's XCTest discovery
+    // generates an `[Any]` array — and fails to compile — when one class mixes `throws` and `async`
+    // test methods. testUpdateHotPath in this class is async, so this one matches it.
+    func testLargeDexSortPerformanceAndCorrectness() async throws {
         let s = try storeWithLargeDex(1000)
         XCTAssertEqual(s.dexEntries.count, 1000)
         measure {
@@ -121,6 +124,7 @@ final class StoreTerminationTests: XCTestCase {
     }
 }
 
+#if os(macOS)   // macOS frontend contracts (FloatingPetController, SpriteView) — the Linux UI carries its own guards
 // MARK: 플로팅 펫 / 스프라이트 idle 배터리 규율
 
 /// 항상 떠 있는 플로팅 펫은 두 번째 GIF 표면이라, 메뉴바에서 고친 idle wakeup 증폭이 재발하지 않게
@@ -129,32 +133,32 @@ final class StoreTerminationTests: XCTestCase {
 final class FloatingPetEnergyTests: XCTestCase {
     /// [회귀] 플로팅 펫 GIF 는 fps 하한(0.4s≈2.5fps)으로 캡 — 네이티브 fps 로 돌면 프레임마다
     /// 재합성(CA 커밋→디스플레이 사이클 wakeup)이 늘어 메뉴바 회귀를 그대로 반복한다.
-    func testPetFrameDelayHonorsFloor() {
+    func testPetFrameDelayHonorsFloor() async {
         XCTAssertEqual(SpriteView.frameDelay(base: 0.1, floor: 0.4), 0.4, accuracy: 1e-9)   // 빠른 프레임 → 캡
         XCTAssertEqual(SpriteView.frameDelay(base: 0.6, floor: 0.4), 0.6, accuracy: 1e-9)   // 이미 느리면 원본 유지
     }
 
     /// 팝오버 등 일시적 표시(floor=0)는 네이티브 delay 그대로 — 캡은 항상 뜬 펫에만 적용.
-    func testTransientSpriteKeepsNativeDelay() {
+    func testTransientSpriteKeepsNativeDelay() async {
         XCTAssertEqual(SpriteView.frameDelay(base: 0.1, floor: 0), 0.1, accuracy: 1e-9)
         XCTAssertEqual(SpriteView.frameDelay(base: 0.03, floor: 0), 0.03, accuracy: 1e-9)
     }
 
     /// 저전력 모드면 펫 애니메이션을 정지(정적)해 배터리를 아낀다. 정상 모드면 애니메이션.
-    func testPetFreezesUnderLowPower() {
+    func testPetFreezesUnderLowPower() async {
         XCTAssertFalse(FloatingPetController.shouldAnimate(lowPower: true))
         XCTAssertTrue(FloatingPetController.shouldAnimate(lowPower: false))
     }
 
     /// [회귀] 펫은 반드시 fps 캡이 걸려야 한다 — frameFloor 가 0 으로 돌아가면(네이티브 fps) 메뉴바에서
     /// 고친 wakeup 회귀가 재발한다. 뷰가 실제로 넘기는 상수를 그대로 가드한다(리터럴 유실 방지).
-    func testPetFrameFloorIsCapped() {
+    func testPetFrameFloorIsCapped() async {
         XCTAssertGreaterThan(FloatingPetView.frameFloor, 0, "펫 fps 캡이 해제되면 idle wakeup 회귀")
         XCTAssertEqual(FloatingPetView.frameFloor, 0.4, accuracy: 1e-9, "메뉴바와 동일한 0.4s≈2.5fps 캡")
     }
 
     /// Bubble needs headroom + width beyond the square pet size — otherwise content is clipped.
-    func testPanelGrowsForBubbleWithoutChangingPetOrigin() {
+    func testPanelGrowsForBubbleWithoutChangingPetOrigin() async {
         let pet: CGFloat = 96
         let idle = FloatingPetController.panelSize(petSize: pet, showingBubble: false)
         XCTAssertEqual(idle, NSSize(width: pet, height: pet))
@@ -174,7 +178,7 @@ final class FloatingPetEnergyTests: XCTestCase {
     }
 
     /// Click opens the popover only when the pointer barely moved; larger movement is a drag.
-    func testClickThresholdDistinguishesClickFromDrag() {
+    func testClickThresholdDistinguishesClickFromDrag() async {
         let a = NSPoint(x: 10, y: 10)
         XCTAssertTrue(FloatingPetController.isClick(from: a, to: NSPoint(x: 11, y: 12)))
         XCTAssertTrue(FloatingPetController.isClick(from: a, to: a))
@@ -183,7 +187,7 @@ final class FloatingPetEnergyTests: XCTestCase {
 
     /// Hover tooltip is localized and pure — tokens always; limit % only when provided.
     /// Remaining mode inverts the % and adds the self-describing suffix.
-    func testHoverTooltipBuilder() {
+    func testHoverTooltipBuilder() async {
         let l = L(.en)
         XCTAssertEqual(
             FloatingPetView.hoverTooltip(todayTokens: 12_345, limitUtilization: nil, mode: .used, l: l),
@@ -207,7 +211,7 @@ final class FloatingPetEnergyTests: XCTestCase {
     /// while the view truncates — so this guard fails on `wouldTruncate`, not only overflow.
     /// The tautological `measured.width ≤ panel.width` is gone: `measureSpeechBubble`
     /// clamps width to the column by construction, so that assert could never fail.
-    func testLocalizedAlertBubbleFitsDefaultPanel() {
+    func testLocalizedAlertBubbleFitsDefaultPanel() async {
         let pet: CGFloat = 96
         let panel = FloatingPetController.panelSize(petSize: pet, showingBubble: true)
         XCTAssertEqual(panel.width, FloatingPetController.bubbleMinWidth)
@@ -241,7 +245,7 @@ final class FloatingPetEnergyTests: XCTestCase {
     /// #167: 3-line copy that still fits the 70pt headroom must fail the guard.
     /// Height-only would stay green (owner's table: 3-line ≈69pt). Injected independently
     /// of Localization.swift so a green localized run can't hide a broken truncate check.
-    func testThreeLineBodyThatFitsHeadroomWouldTruncate() {
+    func testThreeLineBodyThatFitsHeadroomWouldTruncate() async {
         let title = "Límite inminente"
         let body = Self.bodyWrappingExtraLines(2, title: title)
         let layout = FloatingPetController.measureSpeechBubbleLayout(title: title, body: body)
@@ -255,7 +259,7 @@ final class FloatingPetEnergyTests: XCTestCase {
     }
 
     /// Two-line wrap is the view's designed capacity — must not trip truncation.
-    func testTwoLineBodyDoesNotTruncate() {
+    func testTwoLineBodyDoesNotTruncate() async {
         let title = "Límite inminente"
         let body = Self.bodyWrappingExtraLines(1, title: title)
         let layout = FloatingPetController.measureSpeechBubbleLayout(title: title, body: body)
@@ -265,7 +269,7 @@ final class FloatingPetEnergyTests: XCTestCase {
     }
 
     /// 4-line copy overflows the panel *and* truncates — the other threshold in the owner's table.
-    func testFourLineBodyExceedsHeadroomAndWouldTruncate() {
+    func testFourLineBodyExceedsHeadroomAndWouldTruncate() async {
         let title = "Límite inminente"
         let body = Self.bodyWrappingExtraLines(3, title: title)
         let layout = FloatingPetController.measureSpeechBubbleLayout(title: title, body: body)
@@ -279,7 +283,7 @@ final class FloatingPetEnergyTests: XCTestCase {
     /// Unclamped single-line width must be able to exceed the content column.
     /// `measureSpeechBubble` returns `min(contentWidth, …) + padding` (= panel width),
     /// so comparing that to `panel.width` can never fail (#167).
-    func testUnclampedBubbleTextWidthCanExceedContentColumn() {
+    func testUnclampedBubbleTextWidthCanExceedContentColumn() async {
         let title = "Límite inminente"
         let body = String(repeating: "M", count: 80)
         let layout = FloatingPetController.measureSpeechBubbleLayout(title: title, body: body)
@@ -329,3 +333,4 @@ final class FloatingPetEnergyTests: XCTestCase {
         return text
     }
 }
+#endif   // os(macOS)

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -1,4 +1,7 @@
 import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking   // Linux: HTTPURLResponse lives in this module
+#endif
 @testable import PokeTokenBar
 
 #if os(macOS)

--- a/Tests/PokeTokenBarTests/PopoverNavigationTests.swift
+++ b/Tests/PokeTokenBarTests/PopoverNavigationTests.swift
@@ -5,13 +5,13 @@ import XCTest
 // 항상 Home 으로 돌아가게 한다(설정 화면 잔류 방지).
 @MainActor
 final class PopoverNavigationTests: XCTestCase {
-    func testDefaultsToHome() {
+    func testDefaultsToHome() async {
         let nav = PopoverNavigation()
         XCTAssertFalse(nav.showSettings)
         XCTAssertEqual(nav.tab, .home)
     }
 
-    func testResetReturnsToHomeFromSettings() {
+    func testResetReturnsToHomeFromSettings() async {
         let nav = PopoverNavigation()
         nav.showSettings = true
         nav.tab = .collection

--- a/Tests/PokeTokenBarTests/PremiumEggTests.swift
+++ b/Tests/PokeTokenBarTests/PremiumEggTests.swift
@@ -97,7 +97,7 @@ final class PremiumEggTests: XCTestCase {
 
     /// capture_rate 전 구간 × 등급 전수. `includes(captureRate:)` 가 참인 것과 `from` 이 그 등급 이상으로
     /// 분류하는 것이 **정확히 일치**해야 한다. 한쪽 임계만 바꾸면 여기서 깨진다.
-    func testCaptureRateCeilingIsTheSameThresholdAsClassification() {
+    func testCaptureRateCeilingIsTheSameThresholdAsClassification() async {
         for cr in 0...255 {
             let classified = Rarity.from(captureRate: cr, isLegendary: false, isMythical: false)
             for tier in [Rarity.common, .uncommon, .rare] {
@@ -110,7 +110,7 @@ final class PremiumEggTests: XCTestCase {
 
     /// 전설은 capture_rate 로 판정할 수 없다(인덱스에 is_legendary 가 없음) → 필터 대상 아님.
     /// 동시에 전설은 전원 capture_rate ≤ 45 라 고급·희귀 필터에 **자연히 포함**된다("이상" 규칙 성립).
-    func testLegendaryHasNoCaptureRateCeilingButPassesLowerTierFilters() {
+    func testLegendaryHasNoCaptureRateCeilingButPassesLowerTierFilters() async {
         XCTAssertNil(Rarity.legendary.captureRateCeiling)
         XCTAssertFalse(Rarity.legendary.includes(captureRate: 3))
         // 실제 전설의 capture_rate 대역(3·30·45)은 고급/희귀 필터를 모두 통과한다.
@@ -123,7 +123,7 @@ final class PremiumEggTests: XCTestCase {
 
     // MARK: 가격 — 졸업 총량 배율(새 상수 금지)
 
-    func testPricesFollowGraduationTotalRatio() {
+    func testPricesFollowGraduationTotalRatio() async {
         XCTAssertEqual(FreshEgg.price(guaranteeing: nil), 1_000_000_000)
         XCTAssertEqual(FreshEgg.price(guaranteeing: .uncommon), 2_500_000_000)
         XCTAssertEqual(FreshEgg.price(guaranteeing: .rare), 4_000_000_000)
@@ -145,7 +145,7 @@ final class PremiumEggTests: XCTestCase {
     ///
     /// 출처: PokéAPI GraphQL v1beta2, `evolves_from_species_id IS NULL` · id ≤ 649 · 메타몽 제외,
     /// 2026-08-04 측정(base 328종). 풀이 크게 바뀌면 이 값을 다시 재고 결론을 재확인해야 한다.
-    func testRareEggIsNotDominatedAtMeasuredPoolComposition() {
+    func testRareEggIsNotDominatedAtMeasuredPoolComposition() async {
         let weight: [Rarity: Double] = [.common: 37_240, .uncommon: 3_135, .rare: 3_053, .legendary: 339]
         // 고급 알 = 고급 이상 풀(전설 포함). 그 안에서 희귀 이상이 나올 확률.
         let uncommonEggPool = weight[.uncommon]! + weight[.rare]! + weight[.legendary]!
@@ -173,7 +173,7 @@ final class PremiumEggTests: XCTestCase {
 
     // MARK: 구매 — 게이트·차감·보증 기록
 
-    func testBuyPremiumEggRecordsGuaranteeAndDebitsTierPrice() {
+    func testBuyPremiumEggRecordsGuaranteeAndDebitsTierPrice() async {
         let s = activeStore()
         XCTAssertTrue(s.canBuyEgg(.rare))
         XCTAssertTrue(s.buyEgg(.rare))
@@ -186,7 +186,7 @@ final class PremiumEggTests: XCTestCase {
     }
 
     /// 알 상태에선 등급 알도 못 산다 — 기존 새 알과 게이트 통일.
-    func testCannotBuyAnyEggWhileIncubating() {
+    func testCannotBuyAnyEggWhileIncubating() async {
         let s = eggStore(tier: nil, seed: 1, provider: TieredProvider())
         XCTAssertFalse(s.hasActive)
         for tier in FreshEgg.shopTiers {
@@ -197,7 +197,7 @@ final class PremiumEggTests: XCTestCase {
     }
 
     /// 잔액이 그 **티어의** 가격에 미달이면 불가 — 기본 알은 살 수 있어도 희귀 알은 못 산다.
-    func testFundsAreCheckedAgainstTierPrice() {
+    func testFundsAreCheckedAgainstTierPrice() async {
         let s = activeStore(used: 3_000_000_000)   // 1B·2.5B 는 되고 4B 는 안 되는 잔액
         XCTAssertTrue(s.canBuyEgg(nil))
         XCTAssertTrue(s.canBuyEgg(.uncommon))
@@ -213,7 +213,7 @@ final class PremiumEggTests: XCTestCase {
     /// (활성 포켓몬과 pre-roll 은 애초에 공존하지 않는다: 프리패치는 알 상태에서만 돌고 `hatchIfNeeded`
     /// 가 부화 직전 비운다. 그 불변식이 밖에서 들어온 파일에도 유지되는지는
     /// `testSanitizedDropsGuaranteeAndItsPreRollWhenActiveExists` 가 지킨다.)
-    func testPurchaseStartsFromCleanRollState() {
+    func testPurchaseStartsFromCleanRollState() async {
         let s = activeStore()
         XCTAssertNil(s.state.pendingHatchID, "활성 포켓몬이 있는 동안엔 pre-roll 이 없다")
         XCTAssertTrue(s.buyEgg(.rare))
@@ -223,7 +223,7 @@ final class PremiumEggTests: XCTestCase {
     }
 
     /// 보증은 재시작을 건너 살아남아야 한다 — 구매 시점엔 종을 못 정하기 때문(롤에 네트워크 필요).
-    func testGuaranteeSurvivesRestart() {
+    func testGuaranteeSurvivesRestart() async {
         let f = url()
         let s1 = activeStore(at: f)
         XCTAssertTrue(s1.buyEgg(.uncommon))
@@ -371,7 +371,7 @@ final class PremiumEggTests: XCTestCase {
     // MARK: 세이브 이전 / 정규화
 
     /// 보증은 산 물건이지 기기 장부가 아니다 — 기기를 옮겨도 따라간다.
-    func testGuaranteeTravelsWithSave() {
+    func testGuaranteeTravelsWithSave() async {
         var imported = CompanionState()
         imported.eggTier = .uncommon
         imported.usedSinceInstall = 1_000_000
@@ -384,7 +384,7 @@ final class PremiumEggTests: XCTestCase {
     /// 안 그러면 지금 개체가 졸업할 때 그 보증이 다음 알로 새어 영구 프리미엄이 된다.
     /// 그 보증으로 미리 뽑아둔 종(pendingHatchID)도 같이 버려야 한다: 보증만 지우면 졸업으로 받는 **무료**
     /// 알이 그 pre-roll 로 부화해 아무도 사지 않은 프리미엄 결과가 나온다.
-    func testSanitizedDropsGuaranteeAndItsPreRollWhenActiveExists() {
+    func testSanitizedDropsGuaranteeAndItsPreRollWhenActiveExists() async {
         var s = CompanionState()
         s.eggTier = .rare
         s.pendingHatchID = 3
@@ -416,7 +416,7 @@ final class PremiumEggTests: XCTestCase {
 
     /// 판매 목록에 없는 티어는 살 수 없다 — 가격만 계산되면(전설 8B) 호출부 하나가 실수했을 때 토큰이
     /// 통째로 사라지고 그 알은 영영 안 깨진다.
-    func testCannotBuyTierThatIsNotSold() {
+    func testCannotBuyTierThatIsNotSold() async {
         let s = activeStore()
         XCTAssertFalse(FreshEgg.shopTiers.contains(.legendary))
         XCTAssertFalse(s.canBuyEgg(.legendary))
@@ -427,7 +427,7 @@ final class PremiumEggTests: XCTestCase {
     }
 
     /// 모르는 등급 rawValue 는 nil(보증 없음)로 강등 — 관대 디코딩의 안전한 방향.
-    func testUnknownGuaranteeDecodesAsNoGuarantee() throws {
+    func testUnknownGuaranteeDecodesAsNoGuarantee() async throws {
         let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":0,\"spentTokens\":0,"
             + "\"lastDate\":\"d\",\"dex\":[],\"collectedFinals\":[],\"eggTier\":\"mythic\"}"
         let decoded = try JSONDecoder().decode(CompanionState.self, from: Data(json.utf8))

--- a/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)   // macOS frontend layout contracts (332pt popover, NSImage) — the Linux UI carries its own guards
 import XCTest
 import SwiftUI
 @testable import PokeTokenBar
@@ -27,7 +28,7 @@ final class ProviderTabLayoutTests: XCTestCase {
 
     /// 이 파일의 목록이 실제 레지스트리와 어긋나면 위 가드들은 배포되지 않는 탭 바를 재고 있는 것이다
     /// — Grok 추가 때 목록만 손대고 끝난 것과 같은 표류를 기계로 막는다.
-    func testTabListMatchesTheRegisteredProviders() {
+    func testTabListMatchesTheRegisteredProviders() async {
         let store = UsageStore(autoRefresh: false,
                                defaults: UserDefaults(suiteName: "ProviderTabLayoutTests.\(UUID().uuidString)")!)
         XCTAssertEqual(allProviders.map(\.providerID), store.registeredProviderIDs,
@@ -45,7 +46,7 @@ final class ProviderTabLayoutTests: XCTestCase {
 
     /// 트리거 재현: 스크롤 없이 나열하면 등록된 탭 전부는 팝오버 콘텐츠 폭을 넘는다(= 버그 조건).
     /// 넘치지 않으면 아래 단일 행 검증이 무의미해지므로 이 테스트가 먼저 실패해야 한다.
-    func testAllProviderTabsExceedPopoverContentWidthWhenLaidOutInOneRow() {
+    func testAllProviderTabsExceedPopoverContentWidthWhenLaidOutInOneRow() async {
         let natural = HStack(spacing: 6) {
             ForEach(allProviders) { snap in
                 Text(snap.displayName)
@@ -61,7 +62,7 @@ final class ProviderTabLayoutTests: XCTestCase {
 
     /// 수정 후: 탭이 다 붙어도 탭 바는 한 행 높이를 유지한다(= 캡슐 텍스트가 접히지 않는다).
     /// 기준선은 탭 2개짜리 바 — 넘치지 않는 대조군이다.
-    func testProviderTabBarStaysSingleRowWithAllProviders() {
+    func testProviderTabBarStaysSingleRowWithAllProviders() async {
         let baseline = rendered(bar(Array(allProviders.prefix(2))),
                                 proposing: PopoverMetrics.contentWidth).height
         let full = rendered(bar(allProviders), proposing: PopoverMetrics.contentWidth).height
@@ -70,13 +71,13 @@ final class ProviderTabLayoutTests: XCTestCase {
     }
 
     /// 탭 바 자체는 주어진 폭 안에 머문다(넘친 자식이 부모 VStack 을 부풀려 팝오버를 자르지 않게).
-    func testProviderTabBarFitsPopoverContentWidth() {
+    func testProviderTabBarFitsPopoverContentWidth() async {
         let w = rendered(bar(allProviders), proposing: PopoverMetrics.contentWidth).width
         XCTAssertLessThanOrEqual(w, PopoverMetrics.contentWidth)
     }
 
     /// 탭 하나가 단독으로 콘텐츠 폭을 넘으면 스크롤로도 못 구한다 — 새 프로바이더 이름 길이 가드.
-    func testNoSingleProviderTabExceedsContentWidth() {
+    func testNoSingleProviderTabExceedsContentWidth() async {
         for snap in allProviders {
             let w = rendered(bar([snap]), proposing: PopoverMetrics.contentWidth).width
             XCTAssertLessThanOrEqual(w, PopoverMetrics.contentWidth,
@@ -84,3 +85,4 @@ final class ProviderTabLayoutTests: XCTestCase {
         }
     }
 }
+#endif   // os(macOS)

--- a/Tests/PokeTokenBarTests/RareCandyTests.swift
+++ b/Tests/PokeTokenBarTests/RareCandyTests.swift
@@ -30,20 +30,20 @@ private struct RCLineThrows: PokeProviding {
 
 @MainActor
 final class CandyGrantEvaluationTests: XCTestCase {
-    func testSessionGrantsOne() {
+    func testSessionGrantsOne() async {
         var tier: [String: Int] = [:]
         let grants = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 100)], grantTier: &tier)
         XCTAssertEqual(grants.map(\.count), [1])
         XCTAssertEqual(tier["s"], 1)
     }
 
-    func testWeeklyGrantsFive() {
+    func testWeeklyGrantsFive() async {
         var tier: [String: Int] = [:]
         let grants = CompanionStore.evaluateCandyGrants(windows: [w("wk", .weekly, 100)], grantTier: &tier)
         XCTAssertEqual(grants.map(\.count), [RareCandy.weeklyGrant])
     }
 
-    func testBelow100NoGrant() {
+    func testBelow100NoGrant() async {
         var tier: [String: Int] = [:]
         let grants = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 99.9)], grantTier: &tier)
         XCTAssertTrue(grants.isEmpty)
@@ -51,7 +51,7 @@ final class CandyGrantEvaluationTests: XCTestCase {
     }
 
     /// 같은 tier 유지 중엔 재지급 안 함(80·81·84… 억제의 사탕 버전).
-    func testNoDoubleGrantWhileAt100() {
+    func testNoDoubleGrantWhileAt100() async {
         var tier: [String: Int] = [:]
         _ = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 100)], grantTier: &tier)
         let again = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 100)], grantTier: &tier)
@@ -59,7 +59,7 @@ final class CandyGrantEvaluationTests: XCTestCase {
     }
 
     /// 100% 아래로 내려가면 재무장(맵에서 제거) → 다시 채우면 재지급.
-    func testRearmAfterDropBelow100() {
+    func testRearmAfterDropBelow100() async {
         var tier: [String: Int] = [:]
         _ = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 100)], grantTier: &tier)
         _ = CompanionStore.evaluateCandyGrants(windows: [w("s", .session, 40)], grantTier: &tier)
@@ -69,7 +69,7 @@ final class CandyGrantEvaluationTests: XCTestCase {
     }
 
     /// 세션+주간+미달 혼합 — 세션 1 + 주간 5, 미달 창은 무시.
-    func testMixedWindows() {
+    func testMixedWindows() async {
         var tier: [String: Int] = [:]
         let grants = CompanionStore.evaluateCandyGrants(windows: [
             w("claude.fiveHour", .session, 100),
@@ -80,7 +80,7 @@ final class CandyGrantEvaluationTests: XCTestCase {
     }
 
     /// 지급 grant 는 발화 창 이름을 담는다(알림 "왜 받는지").
-    func testGrantCarriesWindowName() {
+    func testGrantCarriesWindowName() async {
         var tier: [String: Int] = [:]
         let grants = CompanionStore.evaluateCandyGrants(
             windows: [w("claude.fiveHour", .session, 100, name: "Claude 5시간 세션")], grantTier: &tier)
@@ -88,7 +88,7 @@ final class CandyGrantEvaluationTests: XCTestCase {
     }
 
     /// Codex 창 분류 — ≤24h=세션, 초과=주간, 미상=세션.
-    func testCodexWindowClassification() {
+    func testCodexWindowClassification() async {
         XCTAssertEqual(UsageStore.windowClass(minutes: 300), .session)     // 5h
         XCTAssertEqual(UsageStore.windowClass(minutes: 1440), .session)    // 24h 경계
         XCTAssertEqual(UsageStore.windowClass(minutes: 10_080), .weekly)   // 7d
@@ -140,7 +140,7 @@ final class RareCandyStoreTests: XCTestCase {
     // MARK: 지급
 
     /// 첫 실행: 이미 100%인 창은 소급 지급 안 하고 tier 시드만(candyFeatureSeeded=true).
-    func testFirstRunSeedsWithoutGranting() {
+    func testFirstRunSeedsWithoutGranting() async {
         let s = store(rcLinear3)
         s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)
         XCTAssertEqual(s.rareCandyCount, 0, "첫 실행 100% 창은 소급 지급 안 함")
@@ -149,7 +149,7 @@ final class RareCandyStoreTests: XCTestCase {
     }
 
     /// 시드 후 같은 창이 계속 100%여도 재지급 없음.
-    func testNoGrantForAlreadySeededWindow() {
+    func testNoGrantForAlreadySeededWindow() async {
         let s = store(rcLinear3)
         s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)   // 시드
         s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)   // 재호출
@@ -157,7 +157,7 @@ final class RareCandyStoreTests: XCTestCase {
     }
 
     /// 한도 미로딩(limitsReady=false)이면 시드조차 하지 않는다(다음 refresh 재시도).
-    func testNoSeedWhenLimitsNotReady() {
+    func testNoSeedWhenLimitsNotReady() async {
         let s = store(rcLinear3)
         s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: false)
         XCTAssertFalse(s.state.candyFeatureSeeded)
@@ -165,7 +165,7 @@ final class RareCandyStoreTests: XCTestCase {
     }
 
     /// 시드 후 새 창이 100%를 새로 넘으면 지급 — 세션 1개.
-    func testSessionGrantAfterSeed() {
+    func testSessionGrantAfterSeed() async {
         let s = store(rcLinear3)
         s.grantCandies(from: [], limitsReady: true)   // 시드
         s.grantCandies(from: [w("claude.fiveHour", .session, 100)], limitsReady: true)
@@ -173,7 +173,7 @@ final class RareCandyStoreTests: XCTestCase {
     }
 
     /// 주간 창은 5개.
-    func testWeeklyGrantsFiveCandies() {
+    func testWeeklyGrantsFiveCandies() async {
         let s = store(rcLinear3)
         s.grantCandies(from: [], limitsReady: true)
         s.grantCandies(from: [w("claude.sevenDay", .weekly, 100)], limitsReady: true)
@@ -182,7 +182,7 @@ final class RareCandyStoreTests: XCTestCase {
 
     /// [핵심 회귀] 지급 tier 는 영속 — 재시작(같은 파일 재로드) 후 같은 100% 창이 재지급되지 않는다.
     /// (notifiedTier 인메모리와 달리 candyGrantTier 는 파일에 저장돼야 함.)
-    func testGrantTierPersistsAcrossRestartNoDoubleGrant() {
+    func testGrantTierPersistsAcrossRestartNoDoubleGrant() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rc-persist-\(UUID().uuidString).json")
         let s1 = CompanionStore(provider: StubProvider(value: rcLinear3), clock: { rcNow }, fileURL: url, rng: SeededRNG(seed: 1))
         s1.grantCandies(from: [], limitsReady: true)                                        // 시드
@@ -200,7 +200,7 @@ final class RareCandyStoreTests: XCTestCase {
 
     /// [회귀] 재무장(100%→아래로)으로 grantTier 에서 제거된 것이 영속돼야 재시작 후 지급 누락이 없다.
     /// 지급 없이 재무장만 발생한 경우에도 save() 돼야 한다(과거: grants 비면 save 스킵 → stale tier 잔존).
-    func testRearmPersistsAcrossRestart() {
+    func testRearmPersistsAcrossRestart() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rc-rearm-\(UUID().uuidString).json")
         let s1 = CompanionStore(provider: StubProvider(value: rcLinear3), clock: { rcNow }, fileURL: url, rng: SeededRNG(seed: 1))
         s1.grantCandies(from: [], limitsReady: true)                                      // 시드
@@ -288,7 +288,7 @@ final class RareCandyStoreTests: XCTestCase {
     }
 
     /// 알(부화 전)에는 사용 불가 — 재고가 있어도 소모되지 않는다.
-    func testCannotUseOnEgg() {
+    func testCannotUseOnEgg() async {
         let s = store(rcLinear3)
         giveCandies(s, 2)
         XCTAssertTrue(s.isEgg)
@@ -308,7 +308,7 @@ final class RareCandyStoreTests: XCTestCase {
 
     /// [회귀 가드] 활성 포켓몬이 있어도 라인 미로딩(재시작 직후·오프라인)이면 사용 불가 —
     /// 진화 없이 XP만 적립되는 것 방지. 재고가 있어도 소모되지 않는다.
-    func testCannotUseWhileLineUnloaded() {
+    func testCannotUseWhileLineUnloaded() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rc-unloaded-\(UUID().uuidString).json")
         // 활성 포켓몬 + 사탕 1 + 시드완료 상태를 저장 → RCLineThrows 로 로드하면 currentLine 이 nil.
         let json = #"{"installBaselineSet":true,"lastDate":"d1","active":{"baseID":1,"pathIDs":[1],"stageIndex":0,"usedAtStage":0,"rarity":"common","totalForms":3},"inventory":{"rareCandy":1},"candyFeatureSeeded":true,"dex":[],"collectedFinals":[]}"#

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -95,7 +95,7 @@ final class SaveTransferTests: XCTestCase {
 
     // MARK: 봉투
 
-    func testRoundTripPreservesProgress() throws {
+    func testRoundTripPreservesProgress() async throws {
         let original = oldMacState(today: "2026-08-03")
         let data = try SaveTransfer.encode(state: original, appVersion: "2.5.0",
                                            deviceName: "Old Mac", now: transferNow)
@@ -112,7 +112,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [핵심] 봉투가 없으면 `CompanionState` 의 관대 디코딩이 아무 JSON 이나 빈 상태로 흡수해
     /// "불러오기 성공 → 도감이 사라짐"이 된다. 포맷 id 로 먼저 거른다.
-    func testForeignJSONIsRejectedRatherThanImportedAsEmptyState() throws {
+    func testForeignJSONIsRejectedRatherThanImportedAsEmptyState() async throws {
         // 관대 디코딩이면 통째로 통과해 버릴 모양의 JSON.
         let foreign = Data(#"{"some":"other app","dex":123}"#.utf8)
         XCTAssertThrowsError(try SaveTransfer.decode(foreign)) { error in
@@ -130,7 +130,7 @@ final class SaveTransferTests: XCTestCase {
     /// 기존 두 케이스는 모두 필수 키 누락이라 A 로만 통과했다 — `format` 비교를 통째로 삭제해도
     /// 전체 스위트가 그대로 통과했다(뮤테이션으로 확인). 여기서 **B 단독**을 고정한다:
     /// 6개 필드가 전부 유효하고 `format` 값만 다른 완전한 봉투.
-    func testValidEnvelopeWithWrongFormatIDIsRejected() throws {
+    func testValidEnvelopeWithWrongFormatIDIsRejected() async throws {
         let data = try SaveTransfer.encode(state: oldMacState(today: "2026-08-03"),
                                            appVersion: "2.5.0", deviceName: "Other App", now: transferNow)
         var json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -148,7 +148,7 @@ final class SaveTransferTests: XCTestCase {
         }
     }
 
-    func testNewerSchemaIsRejected() throws {
+    func testNewerSchemaIsRejected() async throws {
         var data = try SaveTransfer.encode(state: CompanionState(), appVersion: "2.5.0",
                                            deviceName: "Future Mac", now: transferNow)
         var json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -169,7 +169,7 @@ final class SaveTransferTests: XCTestCase {
     /// `claimedTodayTokensByProvider` 는 "이 기기가 프로바이더별로 오늘 어디까지 적립했나"인데 옛 기기 값(56.8M)이 그대로
     /// 따라오면 `update` 의 `todayTokens > claimedTodayTokens` 게이트가 하루 종일 거짓이 된다.
     /// 대조군(재정렬 없음)을 같이 돌려 트리거 브랜치를 실제로 밟는지 확인한다.
-    func testTransferDayTokensStillCountAfterRebase() throws {
+    func testTransferDayTokensStillCountAfterRebase() async throws {
         let today = "2026-08-03"
         let imported = oldMacState(today: today)
         let newMacTodaySoFar = 5_000_000
@@ -206,7 +206,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// 불러올 때 이 기기의 오늘 사용량을 아직 모르면(파싱 전·프로바이더 없음) baseline 판정을
     /// 신규 설치 경로에 넘긴다 — 여기서 0 으로 잡으면 첫 파싱 때 하루치가 통째로 델타가 된다.
-    func testImportWithoutUsageDataDefersBaselineInsteadOfCreditingWholeDay() throws {
+    func testImportWithoutUsageDataDefersBaselineInsteadOfCreditingWholeDay() async throws {
         let today = "2026-08-03"
         let url = tempURL("nodata")
         let s = store(at: url)
@@ -232,7 +232,7 @@ final class SaveTransferTests: XCTestCase {
     /// [회귀] stale snapshot만 남아 `hasUsageData`는 true인데 오늘 map은 비어 있는 상태로
     /// 세이브를 불러와도, 빈 provider ledger를 유효한 기준점으로 저장하면 안 된다.
     /// 첫 정상 snapshot은 baseline으로만 잡고, 그 이후 증가분부터 적립해야 한다.
-    func testImportWithStaleOnlyUsageDefersBaselineInsteadOfSeedingEmptyLedger() throws {
+    func testImportWithStaleOnlyUsageDefersBaselineInsteadOfSeedingEmptyLedger() async throws {
         let today = "2026-08-03"
         let url = tempURL("stale-only")
         let s = store(at: url)
@@ -262,7 +262,7 @@ final class SaveTransferTests: XCTestCase {
 
     // MARK: 진행 보존 · 가드레일
 
-    func testImportKeepsProgressAndCandyGrantLedger() throws {
+    func testImportKeepsProgressAndCandyGrantLedger() async throws {
         let today = "2026-08-03"
         var imported = oldMacState(today: today)
         // 한도는 계정 전역이라 같은 창 key 가 새 기기에서도 유효하다 — 원장을 버리면 사탕이 중복 지급된다.
@@ -285,7 +285,7 @@ final class SaveTransferTests: XCTestCase {
     }
 
     /// 덮어쓰기 전 직전 상태를 남긴다 — 잘못 불러왔을 때 손으로 되돌릴 수단.
-    func testPreviousStateIsBackedUpBeforeOverwrite() throws {
+    func testPreviousStateIsBackedUpBeforeOverwrite() async throws {
         let today = "2026-08-03"
         let url = tempURL("backup")
 
@@ -416,7 +416,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [회귀·딥리뷰 H1] 새 Mac 에서 AI CLI 를 아직 안 쓴 시점(hasUsageData=false)에 불러오면,
     /// 개체가 있는데도 알로 표시되고 진화 라인 로드 재시도가 도달 불가였다.
-    func testImportedCompanionIsNotShownAsEggBeforeUsageArrives() throws {
+    func testImportedCompanionIsNotShownAsEggBeforeUsageArrives() async throws {
         let today = "2026-08-03"
         let url = tempURL("noegg")
         let s = store(at: url)
@@ -445,7 +445,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [회귀·딥리뷰 H2] 극단값 세이브가 그대로 저장되면 이후 산술이 오버플로 트랩으로 프로세스를 죽이고,
     /// 재기동해도 같은 파일을 읽어 다시 죽는다(수동 삭제 전까지 복구 불가).
-    func testExtremeValuesAreClampedAtTheTrustBoundary() throws {
+    func testExtremeValuesAreClampedAtTheTrustBoundary() async throws {
         var evil = CompanionState()
         evil.installBaselineSet = true
         evil.usedSinceInstall = Int.max
@@ -482,7 +482,7 @@ final class SaveTransferTests: XCTestCase {
     /// [회귀·딥리뷰 H2 후속] 불러오기 경계만 막으면 **이미 디스크에 있는** 극단값은 남아, 매 기동마다
     /// 같은 값을 읽어 산술 트랩으로 죽는 상태를 벗어나지 못한다(디코드가 성공하므로 `.corrupt` 복구도
     /// 발동 안 함). 상태 파일을 읽는 경로에서도 같은 정규화가 걸려야 자가 복구된다.
-    func testCorruptStateOnDiskIsClampedOnLoadNotJustOnImport() throws {
+    func testCorruptStateOnDiskIsClampedOnLoadNotJustOnImport() async throws {
         let url = tempURL("diskclamp")
         // 앱이 아니라 손편집·이전 버전이 남긴 것처럼 극단값을 직접 파일에 심는다.
         let json = #"{"installBaselineSet":true,"usedSinceInstall":9223372036854775807,"#
@@ -507,7 +507,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [딥리뷰 M-g] 이전 시 필드 분류가 산문 규약뿐이라, 새 필드가 추가되면 아무 판단 없이 "진행"으로
     /// 딸려 들어간다(`language` 가 실제로 그랬다). 필드 목록을 테스트로 고정해 **분류를 강제**한다.
-    func testEveryCompanionStateFieldIsClassifiedForTransfer() {
+    func testEveryCompanionStateFieldIsClassifiedForTransfer() async {
         // eggTier(알 등급 보증) = 진행 — 산 물건이지 이 기기의 장부가 아니라 기기를 옮겨도 따라간다.
         let progress: Set<String> = ["usedSinceInstall", "spentTokens", "eggUsage", "eggTier",
                                      "pendingHatchID", "active", "dex", "collectedFinals", "inventory"]
@@ -525,7 +525,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [딥리뷰 M-c] `language` 는 진행이 아니라 이 기기에서 보는 방식이다. 일본어 Mac 의 세이브가
     /// 영어 Mac 의 UI 언어를 조용히 바꾸면 안 된다.
-    func testImportKeepsThisDevicesLanguage() throws {
+    func testImportKeepsThisDevicesLanguage() async throws {
         let today = "2026-08-03"
         let url = tempURL("lang")
         var mine = CompanionState()
@@ -548,7 +548,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [딥리뷰 M-e] 사탕 지급 원장은 계정 전역(한도 창 key)이라 통째 교체하면 안 된다.
     /// **더 오래된** 세이브를 불러오면 이미 지급한 창의 기록이 사라져 같은 창에서 재지급된다.
-    func testCandyGrantLedgerMergesInsteadOfBeingReplacedByAnOlderSave() throws {
+    func testCandyGrantLedgerMergesInsteadOfBeingReplacedByAnOlderSave() async throws {
         let today = "2026-08-03"
         let url = tempURL("candy")
         var mine = CompanionState()
@@ -574,7 +574,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [딥리뷰 M-a] 확인창은 3개 언어로 "직전 상태가 남는다"고 약속한다. 백업을 못 남기면 그 약속을
     /// 못 지키는 것이므로 **덮어쓰지 않고 중단**해야 한다(예전엔 `try?` 로 삼키고 그냥 진행했다).
-    func testImportAbortsWhenBackupCannotBeWritten() throws {
+    func testImportAbortsWhenBackupCannotBeWritten() async throws {
         let today = "2026-08-03"
         let url = tempURL("nobackup")
         var mine = CompanionState()
@@ -601,7 +601,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [딥리뷰 M-b] 백업 슬롯이 하나면 두 번째 불러오기가 **원본**을 덮어써, 되돌리려는 바로 그
     /// 순간 되돌릴 대상이 사라진다. 불러올 때마다 새 슬롯이어야 한다.
-    func testSecondImportDoesNotDestroyTheOriginalBackup() throws {
+    func testSecondImportDoesNotDestroyTheOriginalBackup() async throws {
         let today = "2026-08-03"
         let url = tempURL("twoimports")
         var original = CompanionState()
@@ -637,7 +637,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [딥리뷰 M-f] 파괴적 버튼이 기본이면 Return 한 키로 진행이 대체된다. `NSAlert` 구성은 XCTest 에서
     /// 도달 불가라 규칙만 순수 함수로 빼 고정한다.
-    func testCancelIsTheDefaultButtonOnTheImportConfirmation() {
+    func testCancelIsTheDefaultButtonOnTheImportConfirmation() async {
         XCTAssertEqual(ImportConfirmPolicy.keyEquivalent(forButtonAt: ImportConfirmPolicy.cancelButtonIndex), "\r")
         XCTAssertEqual(ImportConfirmPolicy.keyEquivalent(forButtonAt: ImportConfirmPolicy.replaceButtonIndex), "",
                        "대체(파괴적) 버튼이 기본이면 안 된다")
@@ -645,7 +645,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// [딥리뷰 M-h] `applySave` 가 정하는 표시 상태가 어떤 테스트에서도 단언되지 않아, 삼항을 뒤집어도
     /// 통과했다.
-    func testApplySaveSetsDisplayStateFromWhetherACompanionCameIn() throws {
+    func testApplySaveSetsDisplayStateFromWhetherACompanionCameIn() async throws {
         let today = "2026-08-03"
         var withMon = oldMacState(today: today)
         withMon.active = MonState(baseID: 403, pathIDs: [403], plannedPathIDs: [403],
@@ -667,7 +667,7 @@ final class SaveTransferTests: XCTestCase {
     // MARK: 파일 경계 (딥리뷰 LOW)
 
     /// 거대한 JSON 은 메인스레드 파싱을 수 초간 잡는다(실측 39MB ≈ 1.8초). 세이브는 수 KB 라 상한이 안전하다.
-    func testOversizedFileIsRejectedBeforeParsing() {
+    func testOversizedFileIsRejectedBeforeParsing() async {
         let huge = Data(count: SaveTransfer.maxFileBytes + 1)
         XCTAssertThrowsError(try SaveTransfer.decode(huge)) { error in
             XCTAssertEqual(error as? SaveTransferError,
@@ -677,7 +677,7 @@ final class SaveTransferTests: XCTestCase {
 
     /// 상위 스키마 세이브는 본문 모양이 달라 전체 디코드가 실패할 수 있다. 그래도 "세이브 파일이
     /// 아니에요"가 아니라 "앱을 업데이트하라"로 안내해야 한다 — 헤더를 먼저 읽는 이유다.
-    func testNewerSchemaIsReportedEvenWhenTheBodyIsUnreadable() throws {
+    func testNewerSchemaIsReportedEvenWhenTheBodyIsUnreadable() async throws {
         let json = #"{"format":"poketokenbar.save","schema":99,"whatever":{"unknown":true}}"#
         XCTAssertThrowsError(try SaveTransfer.decode(Data(json.utf8))) { error in
             XCTAssertEqual(error as? SaveTransferError,
@@ -690,7 +690,7 @@ final class SaveTransferTests: XCTestCase {
     /// 매핑이 어긋나면 `SaveTransferError` 는 LocalizedError 가 아니라 "The operation couldn't be
     /// completed. (PokeTokenBar.SaveTransferError error 0.)" 가 그대로 사용자에게 뜬다.
     /// 언어는 `allCases` 로 돈다 — 리터럴 목록은 언어가 늘어난 순간 조용히 커버를 멈춘다.
-    func testImportErrorMessagesAreLocalizedNotRawSwiftText() {
+    func testImportErrorMessagesAreLocalizedNotRawSwiftText() async {
         for lang in AppLanguage.allCases {
             let l = L(lang)
             let notSave = l.importErrorMessage(SaveTransferError.notASaveFile)
@@ -707,7 +707,7 @@ final class SaveTransferTests: XCTestCase {
         XCTAssertEqual(L(.en).importErrorMessage(other), other.localizedDescription)
     }
 
-    func testSuggestedFileNameCarriesDate() {
+    func testSuggestedFileNameCarriesDate() async {
         // 2026-08-03 12:00 UTC — 정오라 표준시대가 달라도 날짜 경계를 넘지 않는다(파일명은 로컬 날짜).
         let name = SaveTransfer.suggestedFileName(date: Date(timeIntervalSince1970: 1_785_758_400))
         XCTAssertTrue(name.hasPrefix("PokeTokenBar-Save-"))

--- a/Tests/PokeTokenBarTests/ShinyCharmTests.swift
+++ b/Tests/PokeTokenBarTests/ShinyCharmTests.swift
@@ -29,7 +29,7 @@ final class ShinyCharmTests: XCTestCase {
 
     // MARK: 순수 판정 — 부적 유무로 분모가 48/64 로 바뀌며 판정이 뒤집힌다
 
-    func testRollsShinyFlipsWithCharm() {
+    func testRollsShinyFlipsWithCharm() async {
         // roll=48: 부적 있으면 shiny(48%48==0), 없으면 아님(48%64≠0)
         XCTAssertTrue(CompanionStore.rollsShiny(roll: 48, charmOwned: true))
         XCTAssertFalse(CompanionStore.rollsShiny(roll: 48, charmOwned: false))
@@ -46,7 +46,7 @@ final class ShinyCharmTests: XCTestCase {
         XCTAssertFalse(CompanionStore.rollsShiny(roll: 1, charmOwned: false))
     }
 
-    func testConstantsAndPassiveFlag() {
+    func testConstantsAndPassiveFlag() async {
         XCTAssertEqual(ShinyCharm.price, 3_000_000_000)
         XCTAssertEqual(ShinyCharm.shinyDenominator, 48)
         XCTAssertTrue(ItemKind.shinyCharm.isPassive)
@@ -57,7 +57,7 @@ final class ShinyCharmTests: XCTestCase {
 
     // MARK: 구매 / 보유 (보유형 = 1회 구매)
 
-    func testBuyDeductsAndOwns() {
+    func testBuyDeductsAndOwns() async {
         let s = store(used: 5_000_000_000, spent: 0, charm: false)
         XCTAssertFalse(s.ownsShinyCharm)
         XCTAssertTrue(s.purchasableItems.contains(.shinyCharm), "상점에 노출")
@@ -70,7 +70,7 @@ final class ShinyCharmTests: XCTestCase {
     }
 
     /// 보유형은 재구매 불가 — canBuy false, buy no-op, 지출/개수 불변.
-    func testBuyOnceNoRepurchase() {
+    func testBuyOnceNoRepurchase() async {
         let s = store(used: 10_000_000_000, charm: true)
         XCTAssertTrue(s.ownsShinyCharm)
         XCTAssertFalse(s.canBuy(.shinyCharm), "보유형은 재구매 불가")
@@ -80,14 +80,14 @@ final class ShinyCharmTests: XCTestCase {
         XCTAssertEqual(s.itemCount(.shinyCharm), 1, "개수 1 유지(2 안 됨)")
     }
 
-    func testCanBuyNeedsEnoughTokens() {
+    func testCanBuyNeedsEnoughTokens() async {
         let s = store(used: 2_000_000_000)   // 3B 미만
         XCTAssertFalse(s.canBuy(.shinyCharm))
         XCTAssertFalse(s.buy(.shinyCharm))
         XCTAssertFalse(s.ownsShinyCharm)
     }
 
-    func testOwnsReflectsInventory() {
+    func testOwnsReflectsInventory() async {
         XCTAssertFalse(store(charm: false).ownsShinyCharm)
         XCTAssertTrue(store(charm: true).ownsShinyCharm)
     }
@@ -102,6 +102,7 @@ final class ShinyCharmTests: XCTestCase {
     }
 }
 
+#if os(macOS)   // macOS frontend contracts (FloatingPetController, SpriteView) — the Linux UI carries its own guards
 // MARK: 이로치 스프라이트 갱신 (도감 이로치 토글)
 
 /// 도감은 이로치를 잡은 종을 기본 일반색으로 그리고, 탭하면 같은 종을 이로치색으로 바꾼다 —
@@ -109,7 +110,7 @@ final class ShinyCharmTests: XCTestCase {
 /// "이미 그 종을 로드했다"로 빠져나가 색이 바뀌지 않는다(플래시 방지 가드가 토글을 삼킨다).
 @MainActor
 final class SpriteShinyReloadTests: XCTestCase {
-    func testShinyFlipReloadsSpriteForSameSpecies() {
+    func testShinyFlipReloadsSpriteForSameSpecies() async {
         // 도감 토글의 두 방향 — 이 두 줄이 회귀의 본체다.
         XCTAssertTrue(SpriteView.needsReload(loadedID: 1, loadedShiny: false, id: 1, shiny: true),
                       "일반 → 이로치 토글이 갱신을 트리거해야 한다")
@@ -117,15 +118,16 @@ final class SpriteShinyReloadTests: XCTestCase {
                       "이로치 → 일반 토글도 마찬가지")
     }
 
-    func testUnchangedSpriteSkipsReload() {
+    func testUnchangedSpriteSkipsReload() async {
         // 같은 종·같은 이로치 여부면 재요청하지 않는다(재렌더 플래시 방지 가드 유지).
         XCTAssertFalse(SpriteView.needsReload(loadedID: 1, loadedShiny: false, id: 1, shiny: false))
         XCTAssertFalse(SpriteView.needsReload(loadedID: 1, loadedShiny: true, id: 1, shiny: true))
     }
 
-    func testSpeciesChangeReloadsRegardlessOfShiny() {
+    func testSpeciesChangeReloadsRegardlessOfShiny() async {
         XCTAssertTrue(SpriteView.needsReload(loadedID: 1, loadedShiny: false, id: 2, shiny: false))
         XCTAssertTrue(SpriteView.needsReload(loadedID: nil, loadedShiny: false, id: 1, shiny: false),
                       "미로드(캐시 미스) 상태에서는 항상 불러온다")
     }
 }
+#endif   // os(macOS)

--- a/Tests/PokeTokenBarTests/ShopTests.swift
+++ b/Tests/PokeTokenBarTests/ShopTests.swift
@@ -28,28 +28,28 @@ final class ShopTests: XCTestCase {
 
     // MARK: 잔액 계산
 
-    func testAvailableEqualsUsedWhenNothingSpent() {
+    func testAvailableEqualsUsedWhenNothingSpent() async {
         XCTAssertEqual(store(used: 1_000_000_000).availableTokens, 1_000_000_000)
     }
 
-    func testAvailableSubtractsSpent() {
+    func testAvailableSubtractsSpent() async {
         XCTAssertEqual(store(used: 1_000_000_000, spent: 300_000_000).availableTokens, 700_000_000)
     }
 
     /// spent > used(비정상 상태 파일)이어도 음수로 새지 않는다(max 가드).
-    func testAvailableNeverNegative() {
+    func testAvailableNeverNegative() async {
         XCTAssertEqual(store(used: 100_000_000, spent: 500_000_000).availableTokens, 0)
     }
 
     /// 하위호환: spentTokens 키 없는 구버전 저장 → 0 으로 로드(잔액 = used).
-    func testDecodesWithoutSpentTokens() throws {
+    func testDecodesWithoutSpentTokens() async throws {
         let json = #"{"installBaselineSet":true,"usedSinceInstall":900,"lastDate":"d","dex":[]}"#
         let s = try JSONDecoder().decode(CompanionState.self, from: Data(json.utf8))
         XCTAssertEqual(s.spentTokens, 0)
         XCTAssertEqual(s.usedSinceInstall, 900)
     }
 
-    func testSpentTokensRoundTrip() throws {
+    func testSpentTokensRoundTrip() async throws {
         var st = CompanionState()
         st.usedSinceInstall = 1000
         st.spentTokens = 400
@@ -59,17 +59,17 @@ final class ShopTests: XCTestCase {
 
     // MARK: 구매 가능 판정 (경계)
 
-    func testCanBuyAtExactPrice() {
+    func testCanBuyAtExactPrice() async {
         XCTAssertTrue(store(used: RareCandy.price).canBuyRareCandy)
     }
 
-    func testCannotBuyOneBelowPrice() {
+    func testCannotBuyOneBelowPrice() async {
         XCTAssertFalse(store(used: RareCandy.price - 1).canBuyRareCandy)
     }
 
     // MARK: 구매 (차감 + 적립 + 영속)
 
-    func testBuyDebitsWalletAndCreditsInventory() {
+    func testBuyDebitsWalletAndCreditsInventory() async {
         let s = store(used: 1_000_000_000)
         XCTAssertTrue(s.buyRareCandy())
         XCTAssertEqual(s.rareCandyCount, 1)
@@ -79,7 +79,7 @@ final class ShopTests: XCTestCase {
     }
 
     /// 잔액 부족이면 no-op — 인벤토리·지출 원장 불변, false 반환.
-    func testBuyInsufficientIsNoOp() {
+    func testBuyInsufficientIsNoOp() async {
         let s = store(used: 400_000_000)
         XCTAssertFalse(s.buyRareCandy())
         XCTAssertEqual(s.rareCandyCount, 0)
@@ -87,7 +87,7 @@ final class ShopTests: XCTestCase {
     }
 
     /// 여러 번 구매하면 잔액이 바닥날 때까지만 성공(가드가 매번 재평가).
-    func testMultipleBuysUntilBroke() {
+    func testMultipleBuysUntilBroke() async {
         let s = store(used: 1_200_000_000)          // 2개까지 가능(1B), 3번째 실패(잔액 200M)
         XCTAssertTrue(s.buyRareCandy())
         XCTAssertTrue(s.buyRareCandy())
@@ -98,7 +98,7 @@ final class ShopTests: XCTestCase {
     }
 
     /// 구매는 이미 가진 사탕에 합산된다(무료 지급분과 같은 인벤토리).
-    func testBuyAddsToExistingStock() {
+    func testBuyAddsToExistingStock() async {
         let s = store(used: 1_000_000_000, rareCandy: 3)
         XCTAssertTrue(s.buyRareCandy())
         XCTAssertEqual(s.rareCandyCount, 4)
@@ -107,7 +107,7 @@ final class ShopTests: XCTestCase {
     }
 
     /// [영속] 재시작(같은 파일 재로드) 후 지출·재고가 유지된다.
-    func testBuyPersistsAcrossRestart() {
+    func testBuyPersistsAcrossRestart() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("shop-persist-\(UUID().uuidString).json")
         let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":1000000000,\"spentTokens\":0,"
             + "\"lastDate\":\"d\",\"dex\":[],\"collectedFinals\":[]}"
@@ -124,7 +124,7 @@ final class ShopTests: XCTestCase {
     // MARK: 정렬 (가격 저렴한 순 + 구매 완료 보유형 맨 아래)
 
     /// 상점 목록은 가격 오름차순(민트 100M < 사탕 500M < 이로치 부적 3B).
-    func testItemsSortedByPriceAscending() {
+    func testItemsSortedByPriceAscending() async {
         let items = store(used: 0).purchasableItems
         XCTAssertEqual(items, [.mint, .rareCandy, .shinyCharm])
         let prices = items.compactMap(\.shopPrice)
@@ -133,7 +133,7 @@ final class ShopTests: XCTestCase {
 
     /// 구매 완료한 보유형(이로치 부적)은 맨 아래로. 재구매 불가라 상단에 둘 이유 없음.
     /// (현재 부적이 최고가라 가격순 결과와 일치하지만, 향후 저가 보유형이 생겨도 규칙이 유지되도록 게이트.)
-    func testOwnedPassiveSinksToBottom() {
+    func testOwnedPassiveSinksToBottom() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("shop-sort-\(UUID().uuidString).json")
         let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":0,\"spentTokens\":0,"
             + "\"lastDate\":\"d\",\"dex\":[],\"collectedFinals\":[],\"inventory\":{\"shinyCharm\":1}}"
@@ -149,7 +149,7 @@ final class ShopTests: XCTestCase {
     /// (회귀: 알이 ForEach 밖에서 무조건 맨 아래로 append 돼 3B 부적보다 아래에 놓이던 표시.)
     /// 등급 알을 인접 그룹으로 묶지 **않는** 것이 의도다 — 그러면 4B 희귀 알이 3B 부적 위로 올라가
     /// 위 회귀를 부분적으로 되살린다. 티어 관계는 카드의 등급 배지로 읽힌다.
-    func testShopEntriesInterleavesFreshEggByPrice() {
+    func testShopEntriesInterleavesFreshEggByPrice() async {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("shop-entries-\(UUID().uuidString).json")
         let mon = "{\"baseID\":10,\"pathIDs\":[10],\"stageIndex\":0,\"usedAtStage\":200000000,"
             + "\"rarity\":\"common\",\"totalForms\":3,\"isShiny\":false}"
@@ -171,7 +171,7 @@ final class ShopTests: XCTestCase {
 
     /// 활성 포켓몬이 없으면(알 상태) 리롤 대상이 없어 알은 **등급 알까지 전부** 목록에서 빠진다.
     /// 프리미엄 알만 알 상태에서 살 수 있게 하는 안은 채택하지 않았다 — 기존 새 알과 게이트를 통일한다.
-    func testShopEntriesOmitsFreshEggWhenNoActive() {
+    func testShopEntriesOmitsFreshEggWhenNoActive() async {
         let s = store(used: 5_000_000_000)   // active 없음
         XCTAssertFalse(s.hasActive)
         XCTAssertEqual(s.shopEntries, [.item(.mint), .item(.rareCandy), .item(.shinyCharm)])

--- a/Tests/PokeTokenBarTests/SingleInstanceTests.swift
+++ b/Tests/PokeTokenBarTests/SingleInstanceTests.swift
@@ -57,6 +57,11 @@ final class SingleInstanceTests: XCTestCase {
     }
 
     // MARK: 입력 — 시작 시각을 실제로 읽어내는가
+    //
+    // macOS only — the Linux decision never reads start times at all; it uses `flock`
+    // (see SingleInstance). That path has no "the guard is void because a time could not be read"
+    // failure mode, so there is no regression guard to carry over.
+    #if os(macOS)
 
     /// 회귀 가드(핵심). 첫 구현은 `NSRunningApplication.launchDate` 로 판정했는데, 그 값은 launchd 가
     /// 직접 exec 한 프로세스에서 nil 이라 정작 물러나야 할 인스턴스가 판정에서 빠져나가 가드가 통째로
@@ -79,4 +84,5 @@ final class SingleInstanceTests: XCTestCase {
     func testProcessStartTimeIsNilForAnUnknownProcess() {
         XCTAssertNil(SingleInstance.processStartTime(pid_t(Int32.max)))
     }
+    #endif
 }

--- a/Tests/PokeTokenBarTests/SpriteCropTests.swift
+++ b/Tests/PokeTokenBarTests/SpriteCropTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// Sprite content cropping — the geometry both frontends share.
+///
+/// The defect this guards is visible, not crashy: without cropping, a 96×96 canvas holding a 28×30
+/// egg is scaled whole into the tray, so the egg draws at roughly a third of the available box and
+/// reads as "the icon is broken". That is exactly how it shipped on Linux before this existed.
+final class SpriteCropTests: XCTestCase {
+    /// Treats a rectangle of content at a known offset as opaque.
+    private func box(x: Int, y: Int, w: Int, h: Int) -> (Int, Int) -> Bool {
+        { px, py in px >= x && px < x + w && py >= y && py < y + h }
+    }
+
+    func testCropsAwayTransparentPadding() {
+        // The real egg case: 28×30 of content on a 96×96 canvas.
+        let rect = SpriteCrop.squareContentRect(
+            width: 96, height: 96, isOpaque: box(x: 34, y: 33, w: 28, h: 30))
+        // The square takes the longer edge, so the subject fills the frame instead of ~29% of it.
+        XCTAssertEqual(rect, SpriteCrop.Rect(x: 33, y: 33, side: 30))
+    }
+
+    /// Squaring is the whole reason a taller-than-wide subject does not come out stretched.
+    func testExpandsToSquareOnTheLongerEdge() {
+        let rect = try? XCTUnwrap(SpriteCrop.squareContentRect(
+            width: 100, height: 100, isOpaque: box(x: 40, y: 10, w: 10, h: 40)))
+        XCTAssertEqual(rect?.side, 40)
+    }
+
+    /// A square must never hang off the canvas, or the crop reads out of bounds.
+    func testClampsToCanvasWhenContentSitsOnTheEdge() {
+        let rect = try? XCTUnwrap(SpriteCrop.squareContentRect(
+            width: 50, height: 50, isOpaque: box(x: 0, y: 45, w: 4, h: 5)))
+        guard let rect else { return XCTFail("expected a rect") }
+        XCTAssertGreaterThanOrEqual(rect.x, 0)
+        XCTAssertGreaterThanOrEqual(rect.y, 0)
+        XCTAssertLessThanOrEqual(rect.x + rect.side, 50)
+        XCTAssertLessThanOrEqual(rect.y + rect.side, 50)
+    }
+
+    /// Fully transparent → nil, so the caller keeps the original image instead of cropping to nothing.
+    func testFullyTransparentCanvasHasNoContentRect() {
+        XCTAssertNil(SpriteCrop.squareContentRect(width: 32, height: 32, isOpaque: { _, _ in false }))
+    }
+
+    func testRejectsAnEmptyCanvas() {
+        XCTAssertNil(SpriteCrop.squareContentRect(width: 0, height: 0, isOpaque: { _, _ in true }))
+    }
+
+    /// Content filling the canvas is already square — cropping must be a no-op, not a shrink.
+    func testFullCanvasIsUnchanged() {
+        let rect = SpriteCrop.squareContentRect(
+            width: 64, height: 64, isOpaque: { _, _ in true })
+        XCTAssertEqual(rect, SpriteCrop.Rect(x: 0, y: 0, side: 64))
+    }
+}

--- a/Tests/PokeTokenBarTests/SpriteSubjectTests.swift
+++ b/Tests/PokeTokenBarTests/SpriteSubjectTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)   // macOS frontend layout contracts (332pt popover, NSImage) — the Linux UI carries its own guards
 import XCTest
 import AppKit
 @testable import PokeTokenBar
@@ -53,7 +54,7 @@ final class SpriteSubjectTests: XCTestCase {
     // MARK: 주체가 알로 바뀔 때 (#135)
 
     /// 졸업·Fresh Egg — 이전 개체의 픽셀은 다른 주체의 것이라 버리고 알로 교체한다.
-    func testBecomingEggDropsPreviousSpeciesPixels() {
+    func testBecomingEggDropsPreviousSpeciesPixels() async {
         let species = image(4), egg = image(2)
         let next = SpriteSubject(image: species, loadedID: 25).becomingEgg(cachedEgg: egg)
         XCTAssertTrue(next.image === egg, "옛 개체 이미지가 남으면 플로팅 펫이 졸업 후에도 그 포켓몬을 그린다")
@@ -61,14 +62,14 @@ final class SpriteSubjectTests: XCTestCase {
     }
 
     /// 알 이미지가 아직 캐시에 없으면(콜드) 옛 개체를 남기는 대신 글리프로 떨어뜨린다.
-    func testBecomingEggWithColdCacheClearsToGlyph() {
+    func testBecomingEggWithColdCacheClearsToGlyph() async {
         let next = SpriteSubject(image: image(4), loadedID: 25).becomingEgg(cachedEgg: nil)
         XCTAssertNil(next.image, "캐시가 없다고 옛 개체를 남기면 안 된다 — 🥚 글리프가 옳다")
         XCTAssertNil(next.loadedID)
     }
 
     /// 이미 알이던 주체는 건드리지 않는다 — 시드된 알 이미지를 지우면 글리프로 한 번 깜빡인다.
-    func testBecomingEggLeavesAnExistingEggAlone() {
+    func testBecomingEggLeavesAnExistingEggAlone() async {
         let egg = image(2)
         let next = SpriteSubject(image: egg, loadedID: nil).becomingEgg(cachedEgg: nil)
         XCTAssertTrue(next.image === egg)
@@ -80,14 +81,14 @@ final class SpriteSubjectTests: XCTestCase {
     /// [트리거] 취소된 정적 로드는 이미지도 loadedID 도 건드리지 않는다.
     /// 반영하면 (a) 알 위에 옛 개체가 되살아나고 (b) loadedID 가 오염돼 다음에 그 종이 활성일 때
     /// "이미 로드됨"으로 판단해 살아있는 포켓몬 자리에 🥚 글리프가 고정된다.
-    func testCancelledLoadLeavesSubjectUntouched() {
+    func testCancelledLoadLeavesSubjectUntouched() async {
         let species = image(4)
         XCTAssertNil(SpriteSubject(image: image(2), loadedID: nil).applyingLoad(species, for: 26, cancelled: true),
                      "취소된 로드는 상태를 아예 건드리면 안 된다 — 이미지 복원과 loadedID 오염이 여기서 갈린다")
     }
 
     /// 취소되지 않은 로드는 그대로 반영한다(가드가 과잉 차단하지 않는지).
-    func testAcceptedLoadUpdatesImageAndID() throws {
+    func testAcceptedLoadUpdatesImageAndID() async throws {
         let species = image(4)
         let next = try XCTUnwrap(SpriteSubject(image: nil, loadedID: nil)
             .applyingLoad(species, for: 26, cancelled: false))
@@ -96,7 +97,7 @@ final class SpriteSubjectTests: XCTestCase {
     }
 
     /// 로드 실패(오프라인)는 기존 동작대로 "시도했음"을 남긴다 — 같은 id 재요청 폭주 방지.
-    func testFailedButNotCancelledLoadStillMarksTheAttempt() throws {
+    func testFailedButNotCancelledLoadStillMarksTheAttempt() async throws {
         let next = try XCTUnwrap(SpriteSubject(image: image(4), loadedID: 25)
             .applyingLoad(nil, for: 26, cancelled: false))
         XCTAssertNil(next.image)
@@ -104,7 +105,7 @@ final class SpriteSubjectTests: XCTestCase {
     }
 
     /// 알 이미지 로드도 같은 규칙 — 취소면 무시, 아니면 반영하되 loadedID 는 알(nil) 그대로.
-    func testEggImageAppliesOnlyWhenNotCancelled() throws {
+    func testEggImageAppliesOnlyWhenNotCancelled() async throws {
         let egg = image(2)
         XCTAssertNil(SpriteSubject(image: nil, loadedID: nil).applyingEgg(egg, cancelled: true))
 
@@ -117,18 +118,18 @@ final class SpriteSubjectTests: XCTestCase {
 
     /// [트리거] 취소된 GIF 는 반영하지 않는다 — body 가 frames 를 img 보다 먼저 그리므로,
     /// 뒤늦게 대입되면 알 위에 옛 개체의 프레임이 정지 상태로 올라온다(#135 와 같은 증상).
-    func testFramesDroppedWhenCancelled() {
+    func testFramesDroppedWhenCancelled() async {
         let decoded = [frame(image(4)), frame(image(4))]
         XCTAssertTrue(SpriteView.framesToApply(decoded, cancelled: true).isEmpty)
     }
 
     /// 2프레임 미만은 애니메이션이 아니다 → 정적 폴백(기존 규칙 보존).
-    func testSingleFrameFallsBackToStatic() {
+    func testSingleFrameFallsBackToStatic() async {
         XCTAssertTrue(SpriteView.framesToApply([frame(image(4))], cancelled: false).isEmpty)
         XCTAssertTrue(SpriteView.framesToApply([], cancelled: false).isEmpty)
     }
 
-    func testMultiFrameAcceptedWhenNotCancelled() {
+    func testMultiFrameAcceptedWhenNotCancelled() async {
         let first = image(4), second = image(4)
         let ready = SpriteView.framesToApply([frame(first), frame(second)], cancelled: false)
         XCTAssertEqual(ready.count, 2)
@@ -199,3 +200,4 @@ final class SpriteSubjectTests: XCTestCase {
         XCTAssertNil(box.subject.loadedID)
     }
 }
+#endif   // os(macOS)

--- a/Tests/PokeTokenBarTests/UsageEnvironmentTests.swift
+++ b/Tests/PokeTokenBarTests/UsageEnvironmentTests.swift
@@ -125,12 +125,18 @@ final class UsageEnvironmentTests: XCTestCase {
     /// - `CompanionStore`: `PTB_STATE_DIR` 은 개발/QA 격리용
     /// - `OAuthLimitsProvider`: 의도적으로 프로세스 환경만 본다(자동 폴링 경로에서 셸 spawn 금지 —
     ///   해당 함수 주석 참조). 값이 필요한 사용량 스캔 쪽이 이미 셸 조회를 한다.
+    /// - `PlatformPaths`: XDG variables address **our own storage location, not a usage-log
+    ///   location**, and they are not values a user exports from a shell rc — the login session
+    ///   (systemd/PAM) puts them into the process directly. So the "a GUI app does not inherit the
+    ///   shell environment" hazard does not apply. Routing them through `UsageEnvironment` would in
+    ///   fact spawn a login shell just to locate a save directory.
     func testNoProviderReadsUsageLocationEnvDirectly() throws {
         let allowed: Set<String> = [
             "UsageEnvironment.swift",
             "BinaryLocator.swift",
             "CompanionStore.swift",
             "OAuthLimitsProvider.swift",
+            "PlatformPaths.swift",
         ]
         let sources = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()    // PokeTokenBarTests

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -222,7 +222,7 @@ final class UsageStoreTests: XCTestCase {
 
     /// 플로팅 펫은 기본 꺼짐(96px). 토글·크기 변경은 defaults 에 영속돼 재시작 후 유지된다.
     /// Bubble alerts default ON (opt-out), nested under the pet — independent of Notification Center.
-    func testFloatingPetSettingsDefaultAndPersistence() {
+    func testFloatingPetSettingsDefaultAndPersistence() async {
         let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(1_000))
         let store = makeStore(providers: [claude])
         XCTAssertFalse(store.floatingPetEnabled, "옵트인 기능 — 기본은 꺼짐")
@@ -240,7 +240,7 @@ final class UsageStoreTests: XCTestCase {
     }
 
     /// Bubble picker is pure: critical beats warn; within a tier higher utilization wins (stable choice).
-    func testBubbleAlertPicksHighestSeverityThenUtilization() {
+    func testBubbleAlertPicksHighestSeverityThenUtilization() async {
         let warnLow = UsageStore.LimitAlert(key: "a", window: "A", isCritical: false, utilization: 81)
         let warnHigh = UsageStore.LimitAlert(key: "b", window: "B", isCritical: false, utilization: 90)
         let critLow = UsageStore.LimitAlert(key: "c", window: "C", isCritical: true, utilization: 95)
@@ -252,7 +252,7 @@ final class UsageStoreTests: XCTestCase {
     }
 
     /// 6s auto-dismiss is a pure time check — testable without AppKit / Task.sleep.
-    func testBubbleDismissUsesTTL() {
+    func testBubbleDismissUsesTTL() async {
         let shown = Date(timeIntervalSince1970: 1_000)
         XCTAssertFalse(UsageStore.shouldDismissBubble(shownAt: shown, now: shown.addingTimeInterval(5.9)))
         XCTAssertTrue(UsageStore.shouldDismissBubble(shownAt: shown, now: shown.addingTimeInterval(6)))
@@ -291,7 +291,7 @@ final class UsageStoreTests: XCTestCase {
     // MARK: 프로바이더 상태(인시던트) 표시
 
     /// statuspage.io status.json 파싱(순수) — indicator/description 매핑 + 미지값 unknown + malformed nil.
-    func testProviderStatusParse() {
+    func testProviderStatusParse() async {
         let s = StatuspageStatusProvider.parse(Data(#"{"page":{"name":"Claude"},"status":{"indicator":"minor","description":"Partially Degraded Service"}}"#.utf8))
         XCTAssertEqual(s?.indicator, .minor)
         XCTAssertEqual(s?.description, "Partially Degraded Service")
@@ -306,7 +306,7 @@ final class UsageStoreTests: XCTestCase {
 
     /// [회귀] OpenAI 전역 상태가 이미지 생성 장애로 minor 여도 Codex API 구성요소가 정상이면
     /// Codex 탭에 "일부 장애"를 표시하면 안 된다.
-    func testCodexStatusIgnoresUnrelatedGlobalIncident() {
+    func testCodexStatusIgnoresUnrelatedGlobalIncident() async {
         let data = Data(#"""
         {
           "status":{"indicator":"minor","description":"Partial System Degradation"},
@@ -323,7 +323,7 @@ final class UsageStoreTests: XCTestCase {
     }
 
     /// 실제 해당 구성요소가 저하됐을 때는 경고를 유지한다.
-    func testProviderComponentDegradationMapsToIssue() {
+    func testProviderComponentDegradationMapsToIssue() async {
         let data = Data(#"{"components":[{"name":"Claude Code","status":"degraded_performance"}]}"#.utf8)
         let status = StatuspageStatusProvider.parseComponent(data, named: "Claude Code")
         XCTAssertEqual(status?.indicator, .minor)
@@ -361,7 +361,7 @@ final class UsageStoreTests: XCTestCase {
 
     /// 회귀(#사용자리포트): 경고선 80% 로 두면 80·81·84·90·94 매 갱신마다 반복 알림되던 문제.
     /// 이제 같은 tier 유지 중엔 재알림하지 않고, 위험선 통과 시에만 1회 추가 발화.
-    func testLimitAlertFiresOncePerTierNotEveryRefresh() {
+    func testLimitAlertFiresOncePerTierNotEveryRefresh() async {
         var tiers: [String: Int] = [:]
         func eval(_ util: Double) -> [UsageStore.LimitAlert] {
             UsageStore.evaluateLimitAlerts(windows: [("주간", "주간", util)], warn: 80, crit: 95, tiers: &tiers)
@@ -378,7 +378,7 @@ final class UsageStoreTests: XCTestCase {
 
     /// 휘발성 resets_at 회귀 직접 재현: 같은 utilization 을 여러 번(= 매 fetch resets_at 만 달라지던
     /// 상황) 평가해도, 판정이 resets_at 를 아예 받지 않으므로 최초 1회만 발화.
-    func testLimitAlertDoesNotRefireOnRepeatedSameUtilization() {
+    func testLimitAlertDoesNotRefireOnRepeatedSameUtilization() async {
         var tiers: [String: Int] = [:]
         XCTAssertEqual(UsageStore.evaluateLimitAlerts(windows: [("주간", "주간", 90)], warn: 80, crit: 95, tiers: &tiers).count, 1)
         XCTAssertTrue(UsageStore.evaluateLimitAlerts(windows: [("주간", "주간", 90)], warn: 80, crit: 95, tiers: &tiers).isEmpty)
@@ -386,7 +386,7 @@ final class UsageStoreTests: XCTestCase {
     }
 
     /// 경고선 아래로 내려가면(창 리셋 등) 재무장 — 다음 상승 시 새 에피소드로 다시 1회 발화.
-    func testLimitAlertRearmsAfterDroppingBelowWarn() {
+    func testLimitAlertRearmsAfterDroppingBelowWarn() async {
         var tiers: [String: Int] = [:]
         _ = UsageStore.evaluateLimitAlerts(windows: [("주간", "주간", 82)], warn: 80, crit: 95, tiers: &tiers)
         XCTAssertTrue(UsageStore.evaluateLimitAlerts(windows: [("주간", "주간", 40)], warn: 80, crit: 95, tiers: &tiers).isEmpty)
@@ -396,7 +396,7 @@ final class UsageStoreTests: XCTestCase {
     }
 
     /// 여러 창은 독립 추적 — 5h 가 이미 위험 발화해도 주간은 자기 임계값에서 별도 1회.
-    func testLimitAlertTracksWindowsIndependently() {
+    func testLimitAlertTracksWindowsIndependently() async {
         var tiers: [String: Int] = [:]
         let first = UsageStore.evaluateLimitAlerts(
             windows: [("5시간", "5시간", 96), ("주간", "주간", 50)], warn: 80, crit: 95, tiers: &tiers)
@@ -410,7 +410,7 @@ final class UsageStoreTests: XCTestCase {
     /// 과거엔 표시명을 식별자로 써서 Codex 다중 bucket 의 개인 한도(둘 다 "Codex 개인 한도")나
     /// legacy opus 필드 vs weekly_scoped Opus 엔트리가 서로의 tier 를 덮어써 한쪽 알림이 억제됐다.
     /// 이제 key 가 다르면 표시명이 같아도 각자 1회씩 발화한다.
-    func testLimitAlertKeyDisambiguatesDuplicateDisplayNames() {
+    func testLimitAlertKeyDisambiguatesDuplicateDisplayNames() async {
         var tiers: [String: Int] = [:]
         // 같은 표시명("Codex 개인 한도"), 다른 key — 두 bucket 이 동시에 경고선을 넘음.
         let alerts = UsageStore.evaluateLimitAlerts(
@@ -526,7 +526,7 @@ final class UsageStoreTests: XCTestCase {
     // MARK: 한도 표시 방식 (used / remaining)
 
     /// 표시 변환 순수 판정 — remaining = 100−사용률, 0 하한(사용률 100 초과 시 음수 금지), 경계 포함.
-    func testLimitDisplayPercentModes() {
+    func testLimitDisplayPercentModes() async {
         XCTAssertEqual(UsageStore.displayPercent(40, mode: .used), 40)
         XCTAssertEqual(UsageStore.displayPercent(40, mode: .remaining), 60)
         XCTAssertEqual(UsageStore.displayPercent(0, mode: .remaining), 100)
@@ -556,7 +556,7 @@ final class UsageStoreTests: XCTestCase {
     }
 
     /// 설정 영속 — 기본은 used(기존 사용자 무변화), remaining 선택은 재시작(같은 defaults 재로드) 후 유지.
-    func testLimitDisplayModePersistsAcrossRestart() {
+    func testLimitDisplayModePersistsAcrossRestart() async {
         let s1 = makeStore(providers: [])
         XCTAssertEqual(s1.limitDisplayMode, .used, "기본값 = used(현행 표시 유지)")
         s1.limitDisplayMode = .remaining
@@ -834,7 +834,7 @@ final class UsageStoreTests: XCTestCase {
 
     /// 기본 등록 프로바이더 레지스트리 무결성 — 비어 있지 않고 id 가 유일.
     /// (새 프로바이더를 배열에 등록하는 단일 지점이 살아있는지 최소 보증.)
-    func testDefaultProviderRegistryHasUniqueIds() {
+    func testDefaultProviderRegistryHasUniqueIds() async {
         let store = UsageStore(autoRefresh: false, defaults: testDefaults)
         let ids = store.registeredProviderIDs
         XCTAssertFalse(ids.isEmpty)
@@ -915,7 +915,7 @@ final class UsageStoreTests: XCTestCase {
 
     // MARK: friendlyLimitError 매핑
 
-    func testFriendlyLimitErrorMapping() {
+    func testFriendlyLimitErrorMapping() async {
         let l = L(.en)
         XCTAssertEqual(UsageStore.friendlyLimitError(LimitsError.httpStatus(401), l), l.limitRefreshHTTPError(401))
         XCTAssertEqual(UsageStore.friendlyLimitError(LimitsError.httpStatus(500), l), l.limitRefreshHTTPError(500))
@@ -930,7 +930,7 @@ final class UsageStoreTests: XCTestCase {
 
     /// 자격증명 항목이 MCP 서버 OAuth 상태만 담고 계정 토큰(`claudeAiOauth`)은 없는 경우
     /// (Claude Code 2.1.x 에서 관측) — 형식 오류로 뭉뚱그리면 "재로그인하면 된다"를 안내 못 한다.
-    func testAccountOAuthMissingIsDistinguishedFromMalformedCredential() {
+    func testAccountOAuthMissingIsDistinguishedFromMalformedCredential() async {
         func data(_ json: String) -> Data { Data(json.utf8) }
 
         XCTAssertTrue(OAuthCredentialData.isAccountOAuthMissing(

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -5,6 +5,7 @@ read_when:
   - 동시성/await·옵셔널 판정·캐시 무효화·외부 로그 포맷을 건드릴 때
   - 메뉴바·플로팅 펫 등 상시 표시 애니메이션의 성능을 손볼 때
   - 세이브 이전/병합·외부 파일 입력 경로를 만들 때
+  - 테스트가 실행 환경(타임존·로케일·플랫폼)을 전제하고 있지 않은지 볼 때 / checking whether a test assumes its environment
 ---
 
 # 결함 대응 축적 규칙
@@ -342,3 +343,34 @@ read_when:
   넣어 보고, 로컬 장부만 새 기기 기준으로 다시 잡는다(`SaveTransfer.rebasedForThisDevice`). 회귀 가드:
   `testTransferDayTokensStillCountAfterRebase` — 재정렬 없는 대조군을 같이 돌려 결함 조건이 살아 있는지도
   함께 확인한다(테스트가 트리거 브랜치를 실제로 밟는지 보증).
+
+## Test environment assumptions
+
+> This section is written in English — see `CLAUDE.md` §기여 언어 규약 (English-first).
+
+- **Never compare a UTC instant against a local-date literal.** `LocalUsageReader.localDayFormatter()`
+  sets `timeZone = .current`, so `localDay` is exactly what its name says: a *local* date.
+  `testHermesAcceptsMillisecondStartedAt` put `1767312000000`ms (= 2026-01-02T00:00:00**Z**) in the
+  fixture and asserted the literal `"2026-01-02"`, so it **only broke at negative UTC offsets**
+  (UTC-03 → local 2026-01-01 21:00 → `"2026-01-01"`). This is not a platform defect — it fails on a
+  Mac in the same timezone. Development and CI simply sit at UTC+9, so nobody stepped on it.
+  The fix is not a different literal but **deriving the expectation from the same instant**
+  (`localDayFormatter().string(from:)`). It looks like comparing the code with itself, yet it keeps
+  all of its discriminating power: the subject of that test is "are ms mistaken for seconds", and if
+  they were, the date lands in the year 57973 and fails instantly.
+  Class sweep (2026-08-17): of the 15 `yyyy-MM-dd` literals in the tests, **this was the only place
+  asserting an instant→local-date conversion**. The rest are fixture *inputs* (`Entry(localDay:)`)
+  or plain JSON string comparisons, where no timezone is involved. Same class as pinning the locale
+  (#166) — **do not drag the environment into an assertion.**
+- **Inject the defect at the layer the defect lives in.** To check the guard above actually bites, the
+  fixture was changed from `1767312000000` to `1767312000` — and **the test still passed**, because ms
+  and seconds there are *the same instant*, so the injection changed nothing. The real injection is
+  removing the reader's discriminator (`raw >= 100_000_000_000 ? raw / 1_000 : raw` in `dateValue`),
+  and only then did it fail with `57973-11-20`. Do not read "injected and still passing" as "the guard
+  is useless" — **first check the injection reproduced the defect at all.**
+- **Asserting platform-specific behaviour as a precondition means asserting someone else's bug
+  elsewhere.** `testCheckpointedWalDatabaseIsStillReadable` first asserts that opening with `mode=ro`
+  must fail, to prove the fallback is really exercised. That is a property of macOS's SQLite (it
+  cannot create the `-shm` a checkpointed WAL store needs); Linux's SQLite opens the same file
+  without complaint. Narrow the precondition to that platform (`#if os(macOS)`) and check **what the
+  test actually guards** — that the reader returns the rows — on both.

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -35,7 +35,22 @@ swift test --enable-code-coverage
 
 PROF=$(find .build -name 'default.profdata' | head -1)
 # dSYM 안에도 같은 이름의 DWARF 바이너리가 있어 head -1 이 그걸 집으면 llvm-cov 가 실패한다 → 제외.
-BIN=$(find .build -name 'PokeTokenBarPackageTests' -type f ! -path '*.dSYM/*' | head -1)
+# Linux 의 테스트 산출물은 `.xctest` 접미사를 달고 나오므로 두 이름을 모두 받는다.
+BIN=$(find .build \( -name 'PokeTokenBarPackageTests' -o -name 'PokeTokenBarPackageTests.xctest' \) \
+  -type f ! -path '*.dSYM/*' | head -1)
+
+# 커버리지 도구 — macOS 는 xcrun, Linux 는 스위프트 툴체인 안의 llvm-cov(보통 PATH 에 없다).
+# 하드코딩하면 한쪽 플랫폼에서 게이트가 통째로 안 돈다.
+if command -v xcrun >/dev/null 2>&1; then
+  LLVM_COV=(xcrun llvm-cov)
+elif [[ -x "$(dirname "$(readlink -f "$(command -v swift)")")/llvm-cov" ]]; then
+  LLVM_COV=("$(dirname "$(readlink -f "$(command -v swift)")")/llvm-cov")
+elif command -v llvm-cov >/dev/null 2>&1; then
+  LLVM_COV=(llvm-cov)
+else
+  echo "✗ llvm-cov 를 찾지 못했습니다(커버리지 게이트 실행 불가)." >&2
+  exit 1
+fi
 if [[ -z "$PROF" || -z "$BIN" ]]; then
   echo "✗ 커버리지 산출물(profdata/binary)을 찾지 못했습니다." >&2
   exit 1
@@ -43,7 +58,7 @@ fi
 
 echo
 echo "▶ 로직 코어 커버리지 (임계값 ${THRESHOLD}%)"
-REPORT=$(xcrun llvm-cov report "$BIN" -instr-profile="$PROF" "${LOGIC_CORE[@]}" 2>/dev/null)
+REPORT=$("${LLVM_COV[@]}" report "$BIN" -instr-profile="$PROF" "${LOGIC_CORE[@]}" 2>/dev/null)
 echo "$REPORT"
 
 # TOTAL 행의 라인 커버리지(%) 추출 — 컬럼: ... Lines MissedLines Cover(=$10)


### PR DESCRIPTION
…DE Plasma

Runs the same companion and usage tracker in the Linux system tray, sharing all parsing, progression and save code with macOS. Built and verified on Arch Linux, KDE Plasma 6, Wayland.

Structure: one target with platform-conditional sources and dependencies rather than a Core/UI target split. Splitting would have forced ~9,500 lines of Core from internal to public purely to reach the UI and broken `@testable import PokeTokenBar` in all 33 test files; wrapping the macOS UI in `#if os(macOS)` gives the same isolation and leaves test-gate.sh and build-app.sh paths valid.

Platform seams (Core/Platform), each with both branches:
- PlatformPaths      ~/Library -> XDG; macOS expressions kept byte-identical so
                     existing saves are not stranded
- PlatformNotifier   UserNotifications -> libnotify, with sound split from
                     urgency (Linux CRITICAL means "stays until dismissed")
- PlatformOpener     NSWorkspace -> xdg-open, FileManager1.ShowItems for reveal
- PlatformDefaults   corelibs-foundation keys UserDefaults on the executable
                     filename, so a dev run and an installed binary kept separate
                     settings; pinned to a named suite
- PlatformCompression NSData zlib -> zlib directly
- PlatformCompat     autoreleasepool no-op, App Nap token
- PlatformPowerEvents logind PrepareForSleep + ScreenSaver ActiveChanged
- SingleInstance     start-time comparison -> flock (atomic; no tie/unreadable
                     -clock gaps)
- LoginItem          SMAppService -> systemd --user, Restart=on-failure mapping
                     KeepAlive.SuccessfulExit=false

Shared display logic moved out of the macOS-only UI so both frontends agree: SpriteStore, SpriteCrop (+6 tests), SpriteAnimationPolicy, CompanionStore .statusLine, PopoverTab/PopoverNavigation.

Linux frontend: tray with animated companion sprite and usage text, main window (Home / Shop / Bag / Collection), evolution line, official limit meters, celebration banner, settings window, floating pet. GTK is pumped from the dispatch main queue so Swift concurrency keeps working.

Also: Makefile as the canonical runbook (build/run/test/install/autostart, version-sync tying AppVersion to build-app.sh), test-gate.sh made portable (resolves llvm-cov without xcrun, accepts the .xctest artifact), and a Pango markup validator — invalid markup renders a blank label with no error, which is how a missing companion name went unnoticed.

Tests: 633 passing on Linux (7 skipped). macOS is unverified here (no Mac); dual-platform support rests on conditional compilation and review, not a build.

Fixes found on the way:
- The companion never received usage, so the egg could never hatch: the update()/grantCandies() hook that macOS runs on every refresh was missing.
- testHermesAcceptsMillisecondStartedAt compared a UTC instant against a local date literal and only passed at non-negative UTC offsets (see defect-log).


Claude-Session: https://claude.ai/code/session_01CvZta6Dnph52EruyNeXuEA

<!-- Write the PR title and this description in English (see CONTRIBUTING.md). -->

## Summary

<!-- What does this PR do, and why? Keep it focused. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

<!--
When this PR changes anything under `Sources/PokeTokenBar/UI/`, describe the
before/after below. Images (screenshots or GIFs) are welcome but optional — a
clear text description is fine. The canonical app screenshots in `assets/` are
regenerated at release, so they don't need updating per PR. Remove this section
only if there are no UI changes.
-->

| Before | After |
| ------ | ----- |
|        |       |

## Checklist

- [ ] `swift build` and `swift test` pass locally
- [ ] PR title and description are written in English
- [ ] UI changes are described above (before/after — images optional)
- [ ] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] Tests were added or updated for this change
