### PR TITLE
perf: bound memory while parsing large Codex rollouts

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -386,7 +386,7 @@ enum LocalUsageReader {
 
     /// 파일 내부 정보만 파싱. fork replay 여부는 다른 rollout과 대조.
     static func parseCodexRollout(_ url: URL, fmt: DateFormatter) -> CodexParsedRollout {
-        guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+        func emptyRollout() -> CodexParsedRollout {
             return CodexParsedRollout(
                 path: url.path,
                 sessionID: nil,
@@ -396,6 +396,7 @@ enum LocalUsageReader {
                 events: []
             )
         }
+
         var events: [CodexUsageEvent] = []
         var turn = 0
         var sessionID: String?
@@ -407,52 +408,55 @@ enum LocalUsageReader {
         // 실모델은 아래 codexModel 이 로그에서 동적 추출(신모델 자동 대응). 이 값은 세션에 model 라인이
         // 아예 없을 때만 쓰는 버전무관 폴백 — Codex 비용은 항상 0이라 표시 숫자엔 영향 없다(업데이트 불필요).
         var model = "codex"
-        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
-            autoreleasepool {   // JSONSerialization 의 autoreleased 객체를 라인마다 배출(콜드 파싱 피크 억제)
-                let record = String(line)
-                // NOTE: 여기에 `line.contains("session_meta")` prefilter 를 넣으면 **느려진다**.
-                // 실측(실기기 57 rollout, release 빌드, best of 3 × 2회): 없음 1.80/1.84s vs 있음 2.17/2.19s.
-                // Swift `String.contains(_:)` 는 grapheme 단위 탐색이라 라인마다 훑는 비용이
-                // JSONSerialization 의 파싱보다 크다 — "파싱 줄 수를 줄이면 빨라진다"는 직관이 틀린 자리다.
-                if let meta = codexSessionMeta(record) {
-                    if sessionID == nil {
-                        // subagent meta는 `id`가 child이고 `session_id`가 parent일 수 있으므로 id 우선.
-                        sessionID = meta.id
-                        parentSessionID = meta.parentID
-                        forkedAt = meta.date
-                        isSubagent = meta.isSubagent
+        do {
+            try forEachCodexLine(in: url) { line in
+                autoreleasepool {   // JSONSerialization 의 autoreleased 객체를 라인마다 배출(콜드 파싱 피크 억제)
+                    // Data.range 는 바이트 탐색이라 String.contains 의 grapheme 스캔과 달리
+                    // 비대상 라인을 값싼 비용으로 건너뛸 수 있다. 대형 rollout 의 대부분은
+                    // response_item/delta 이며, 사용량 집계에 필요한 세 종류만 JSON 파싱한다.
+                    if line.range(of: codexSessionMetaMarker) != nil,
+                       let meta = codexSessionMeta(line) {
+                        if sessionID == nil {
+                            // subagent meta는 `id`가 child이고 `session_id`가 parent일 수 있으므로 id 우선.
+                            sessionID = meta.id
+                            parentSessionID = meta.parentID
+                            forkedAt = meta.date
+                            isSubagent = meta.isSubagent
+                        }
+                        if let id = meta.id, id != currentSessionID {
+                            currentSessionID = id
+                            previousUsageState = nil
+                        }
                     }
-                    if let id = meta.id, id != currentSessionID {
-                        currentSessionID = id
+                    if line.range(of: codexModelMarker) != nil, let m = codexModel(line) { model = m }
+                    guard line.range(of: codexTokenCountMarker) != nil else { return }
+                    guard let parsed = parseCodexLine(
+                        line, file: url.lastPathComponent, turn: turn, model: model, fmt: fmt
+                    ) else { return }
+                    defer { turn += 1 }
+
+                    // Codex는 같은 cumulative/last usage 상태를 그대로 다시 기록할 수 있음. replay trimming을
+                    // 하기 전에 파일 내부에서 정규화한다. 같은 세션의 연속 token_count 상태가 full vector까지
+                    // 같으면 새 토큰 기여가 없는 동일 snapshot이므로 한 번만 남긴다.
+                    if let state = parsed.usageState, let sessionID = currentSessionID {
+                        if let previous = previousUsageState,
+                           previous.sessionID == sessionID,
+                           previous.state == state {
+                            return
+                        }
+                        previousUsageState = (sessionID, state)
+                    } else {
                         previousUsageState = nil
                     }
+                    events.append(CodexUsageEvent(
+                        entry: parsed.entry,
+                        usageState: parsed.usageState,
+                        sessionID: currentSessionID
+                    ))
                 }
-                if line.contains("\"model\""), let m = codexModel(record) { model = m }
-                guard line.contains("token_count") else { return }
-                guard let parsed = parseCodexLine(
-                    record, file: url.lastPathComponent, turn: turn, model: model, fmt: fmt
-                ) else { return }
-                defer { turn += 1 }
-
-                // Codex는 같은 cumulative/last usage 상태를 그대로 다시 기록할 수 있음. replay trimming을
-                // 하기 전에 파일 내부에서 정규화한다. 같은 세션의 연속 token_count 상태가 full vector까지
-                // 같으면 새 토큰 기여가 없는 동일 snapshot이므로 한 번만 남긴다.
-                if let state = parsed.usageState, let sessionID = currentSessionID {
-                    if let previous = previousUsageState,
-                       previous.sessionID == sessionID,
-                       previous.state == state {
-                        return
-                    }
-                    previousUsageState = (sessionID, state)
-                } else {
-                    previousUsageState = nil
-                }
-                events.append(CodexUsageEvent(
-                    entry: parsed.entry,
-                    usageState: parsed.usageState,
-                    sessionID: currentSessionID
-                ))
             }
+        } catch {
+            return emptyRollout()
         }
         return CodexParsedRollout(
             path: url.path,
@@ -463,6 +467,48 @@ enum LocalUsageReader {
             events: events
         )
     }
+
+    /// 대형 JSONL 을 파일 크기와 무관한 메모리로 순회한다. 완성된 한 줄만
+    /// 소유하므로 피크는 파일 전체가 아니라 가장 긴 라인 + 청크 크기에 비례한다.
+    private static func forEachCodexLine(in url: URL, body: (Data) -> Void) throws {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        let chunkSize = 1024 * 1024
+        var buffer = Data()
+        buffer.reserveCapacity(chunkSize)
+
+        while true {
+            let readChunk = try autoreleasepool { () throws -> Bool in
+                guard let chunk = try handle.read(upToCount: chunkSize), !chunk.isEmpty else {
+                    return false
+                }
+
+                buffer.append(chunk)
+                var lineStart = buffer.startIndex
+                while lineStart < buffer.endIndex,
+                      let newline = buffer[lineStart...].firstIndex(of: 0x0A) {
+                    if lineStart < newline {
+                        body(Data(buffer[lineStart..<newline]))
+                    }
+                    lineStart = buffer.index(after: newline)
+                }
+                if lineStart != buffer.startIndex {
+                    buffer.removeSubrange(buffer.startIndex..<lineStart)
+                }
+                // FileHandle 의 Data bridge가 만든 autoreleased backing storage도 청크마다 배출한다.
+                // 이 경계가 없으면 청크 크기는 작아도 전체 파일을 다 읽을 때까지 RSS가 누적될 수 있다.
+                return true
+            }
+            if !readChunk { break }
+        }
+
+        if !buffer.isEmpty { body(buffer) }
+    }
+
+    private static let codexSessionMetaMarker = Data("session_meta".utf8)
+    private static let codexModelMarker = Data("\"model\"".utf8)
+    private static let codexTokenCountMarker = Data("token_count".utf8)
 
     /// 부모 탐색이 다루는 rollout 파일. 캐시는 `(path, mtime, size)` 로 blob 을 무효화하고 reader 는
     /// mtime 으로 조회 윈도우만 나누므로, 두 경로가 같은 표현을 공유한다.
@@ -588,9 +634,8 @@ enum LocalUsageReader {
         id.count >= 4 && id.contains { $0.isLetter || $0.isNumber }
     }
 
-    private static func codexSessionMeta(_ line: String) -> CodexSessionMeta? {
-        guard let data = line.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+    private static func codexSessionMeta(_ line: Data) -> CodexSessionMeta? {
+        guard let obj = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
               (obj["type"] as? String) == "session_meta",
               let payload = obj["payload"] as? [String: Any] else { return nil }
         let id = (payload["id"] as? String).flatMap { $0.isEmpty ? nil : $0 }
@@ -678,10 +723,12 @@ enum LocalUsageReader {
 
     private static func codexProbeOutcome(of line: Data) -> CodexProbeOutcome {
         guard !line.isEmpty else { return .keepScanning }
-        // 손상된 줄을 건너뛰면 뒤에 재삽입된 parent meta를 이 파일의 id로 오인할 수 있으므로 중단한다.
-        guard let text = String(data: line, encoding: .utf8) else { return .invalid }
-        if let meta = codexSessionMeta(text) { return .sessionID(meta.id) }
-        if text.contains("token_count") { return .stop }
+        // 손상된 줄을 건너뛰면 뒤에 재삽입된 parent meta를 이 파일의 id로
+        // 오인할 수 있으므로 중단한다. probe 는 1MiB 상한이 있어 UTF-8 검증 비용이 제한된다.
+        guard String(data: line, encoding: .utf8) != nil else { return .invalid }
+        if line.range(of: codexSessionMetaMarker) != nil,
+           let meta = codexSessionMeta(line) { return .sessionID(meta.id) }
+        if line.range(of: codexTokenCountMarker) != nil { return .stop }
         return .keepScanning
     }
 
@@ -867,10 +914,9 @@ enum LocalUsageReader {
     }
 
     private static func parseCodexLine(
-        _ line: String, file: String, turn: Int, model: String, fmt: DateFormatter
+        _ line: Data, file: String, turn: Int, model: String, fmt: DateFormatter
     ) -> ParsedCodexToken? {
-        guard let data = line.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        guard let obj = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
               let payload = obj["payload"] as? [String: Any],
               (payload["type"] as? String) == "token_count",
               let info = payload["info"] as? [String: Any],
@@ -1138,9 +1184,8 @@ enum LocalUsageReader {
         return nil
     }
 
-    private static func codexModel(_ line: String) -> String? {
-        guard let data = line.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+    private static func codexModel(_ line: Data) -> String? {
+        guard let obj = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
               let payload = obj["payload"] as? [String: Any] else { return nil }
         if let m = payload["model"] as? String { return m }
         if let tc = payload["turn_context"] as? [String: Any], let m = tc["model"] as? String { return m }

--- a/Tests/PokeTokenBarTests/CodexLargeRolloutPerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/CodexLargeRolloutPerformanceTests.swift
@@ -1,0 +1,206 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import PokeTokenBar
+
+final class CodexLargeRolloutPerformanceTests: XCTestCase {
+    private let targetBytes = 512 * 1024 * 1024
+    private let rssBudgetBytes: UInt64 = 700 * 1024 * 1024
+    private let rssGrowthBudgetBytes: UInt64 = 192 * 1024 * 1024
+
+    func testCodexLargeRolloutStaysWithinMemoryBudget() throws {
+        guard ProcessInfo.processInfo.environment["POKETOKENBAR_RUN_LARGE_PERF"] == "1" else {
+            throw XCTSkip("Set POKETOKENBAR_RUN_LARGE_PERF=1 or run scripts/perf-codex-large-rollout.sh")
+        }
+
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let fixture = try writeLargeCodexRollout(to: root)
+        XCTAssertGreaterThanOrEqual(fixture.fileSize, targetBytes)
+        XCTAssertLessThan(fixture.fileSize, targetBytes + 16 * 1024)
+        XCTAssertGreaterThan(fixture.expectedEventCount, 10)
+
+        let baselineRSS = PeakResidentSampler.currentResidentBytes()
+        let sampler = PeakResidentSampler()
+        sampler.start()
+        let started = Date()
+        let entries = LocalUsageReader.codexEntries(modifiedSince: .distantPast, root: root)
+        let elapsed = Date().timeIntervalSince(started)
+        let peakRSS = sampler.stop()
+        let rssGrowth = peakRSS >= baselineRSS ? peakRSS - baselineRSS : 0
+
+        let elapsedText = String(format: "%.3f", elapsed)
+        print(
+            "PERF_RESULT size_mib=512 baseline_rss_mib=\(Self.mib(baselineRSS)) "
+                + "peak_rss_mib=\(Self.mib(peakRSS)) rss_growth_mib=\(Self.mib(rssGrowth)) "
+                + "elapsed_seconds=\(elapsedText)"
+        )
+
+        XCTAssertEqual(entries.count, fixture.expectedEventCount)
+        XCTAssertEqual(entries.reduce(0) { $0 + $1.input }, fixture.expectedInput)
+        XCTAssertEqual(entries.reduce(0) { $0 + $1.cacheRead }, fixture.expectedCacheRead)
+        XCTAssertEqual(entries.reduce(0) { $0 + $1.output }, fixture.expectedOutput)
+        XCTAssertEqual(entries.reduce(0) { $0 + $1.total }, fixture.expectedTotal)
+        XCTAssertLessThan(
+            peakRSS,
+            rssBudgetBytes,
+            "Peak RSS \(Self.mib(peakRSS)) MiB must stay below \(Self.mib(rssBudgetBytes)) MiB for a 512 MiB Codex rollout"
+        )
+        XCTAssertLessThan(
+            rssGrowth,
+            rssGrowthBudgetBytes,
+            "Parsing RSS growth \(Self.mib(rssGrowth)) MiB must stay below \(Self.mib(rssGrowthBudgetBytes)) MiB"
+        )
+        XCTAssertLessThan(elapsed, 20, "512 MiB Codex rollout parse took \(elapsed)s")
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ptb-codex-large-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private struct FixtureStats {
+        let fileSize: Int
+        let expectedEventCount: Int
+        let expectedInput: Int
+        let expectedCacheRead: Int
+        let expectedOutput: Int
+        let expectedTotal: Int
+    }
+
+    private func writeLargeCodexRollout(to root: URL) throws -> FixtureStats {
+        let file = root.appendingPathComponent("rollout-large.jsonl")
+        _ = FileManager.default.createFile(atPath: file.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: file)
+        defer { try? handle.close() }
+
+        func write(_ line: String) {
+            handle.write(Data((line + "\n").utf8))
+        }
+
+        var written = 0
+        func writeAndCount(_ line: String) {
+            let data = Data((line + "\n").utf8)
+            handle.write(data)
+            written += data.count
+        }
+
+        writeAndCount("""
+        {"type":"session_meta","timestamp":"2026-08-01T00:00:00.000Z","payload":{"id":"large-rollout","session_id":"large-rollout"}}
+        """)
+
+        let payload = String(repeating: "x", count: 8 * 1024)
+        let noise = """
+        {"type":"event_msg","timestamp":"2026-08-01T00:00:00.001Z","payload":{"type":"agent_message_delta","delta":"\(payload)"}}
+        """
+        let noiseBytes = Data((noise + "\n").utf8).count
+
+        var eventCount = 0
+        var expectedInput = 0
+        var expectedCacheRead = 0
+        var expectedOutput = 0
+        var cumulativeInput = 0
+        var cumulativeCached = 0
+        var cumulativeOutput = 0
+        var noiseSinceLastToken = 0
+
+        while written < targetBytes {
+            if eventCount < 64 && noiseSinceLastToken >= 1024 {
+                eventCount += 1
+                noiseSinceLastToken = 0
+
+                let lastInput = 1_000 + eventCount
+                let lastCached = 100 + eventCount
+                let lastOutput = 50 + eventCount
+                cumulativeInput += lastInput
+                cumulativeCached += lastCached
+                cumulativeOutput += lastOutput
+
+                expectedInput += lastInput - lastCached
+                expectedCacheRead += lastCached
+                expectedOutput += lastOutput
+
+                let second = String(format: "%02d", eventCount % 60)
+                writeAndCount("""
+                {"type":"event_msg","timestamp":"2026-08-01T00:00:\(second).000Z","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":\(cumulativeInput),"cached_input_tokens":\(cumulativeCached),"cache_write_input_tokens":0,"output_tokens":\(cumulativeOutput),"reasoning_output_tokens":0,"total_tokens":\(cumulativeInput + cumulativeOutput)},"last_token_usage":{"input_tokens":\(lastInput),"cached_input_tokens":\(lastCached),"cache_write_input_tokens":0,"output_tokens":\(lastOutput),"reasoning_output_tokens":0,"total_tokens":\(lastInput + lastOutput)}}}}
+                """)
+            } else {
+                write(noise)
+                written += noiseBytes
+                noiseSinceLastToken += 1
+            }
+        }
+
+        return FixtureStats(
+            fileSize: written,
+            expectedEventCount: eventCount,
+            expectedInput: expectedInput,
+            expectedCacheRead: expectedCacheRead,
+            expectedOutput: expectedOutput,
+            expectedTotal: expectedInput + expectedCacheRead + expectedOutput
+        )
+    }
+
+    private static func mib(_ bytes: UInt64) -> UInt64 {
+        bytes / 1024 / 1024
+    }
+}
+
+private final class PeakResidentSampler: @unchecked Sendable {
+    private let lock = NSLock()
+    private var peak: UInt64 = 0
+    private var shouldStop = false
+    private lazy var thread = Thread { [weak self] in
+        self?.run()
+    }
+
+    func start() {
+        sample()
+        thread.start()
+    }
+
+    func stop() -> UInt64 {
+        lock.lock()
+        shouldStop = true
+        lock.unlock()
+
+        while !thread.isFinished {
+            Thread.sleep(forTimeInterval: 0.005)
+        }
+        return peak
+    }
+
+    private func run() {
+        while true {
+            lock.lock()
+            let done = shouldStop
+            lock.unlock()
+            if done { return }
+
+            sample()
+            usleep(10_000)
+        }
+    }
+
+    private func sample() {
+        let resident = Self.currentResidentBytes()
+        lock.lock()
+        peak = max(peak, resident)
+        lock.unlock()
+    }
+
+    static func currentResidentBytes() -> UInt64 {
+        var info = mach_task_basic_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info_data_t>.stride / MemoryLayout<natural_t>.stride)
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return 0 }
+        return UInt64(info.resident_size)
+    }
+}

--- a/scripts/perf-codex-large-rollout.sh
+++ b/scripts/perf-codex-large-rollout.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ -d /Applications/Xcode.app/Contents/Developer ]]; then
+  export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+fi
+
+SCRATCH_PATH="$(mktemp -d "${TMPDIR:-/tmp}/poketokenbar-perf.XXXXXX")"
+trap 'rm -rf "$SCRATCH_PATH"' EXIT
+
+swift build --scratch-path "$SCRATCH_PATH" -c release
+
+POKETOKENBAR_RUN_LARGE_PERF=1 /usr/bin/time -l \
+  swift test --scratch-path "$SCRATCH_PATH" -c release \
+  --filter 'CodexLargeRolloutPerformanceTests/testCodexLargeRolloutStaysWithinMemoryBudget'
+
+swift test --scratch-path "$SCRATCH_PATH" --filter 'LocalUsageReaderTests|LocalUsageCacheTests'
+swift test --scratch-path "$SCRATCH_PATH"


### PR DESCRIPTION
## Summary

Bound Codex rollout parsing memory independently of the rollout file size.

- Replace the whole-file `String(contentsOf:)` read with a 1 MiB `FileHandle` line stream.
- Use byte markers to JSON-decode only `session_meta`, model, and `token_count` records.
- Drain `FileHandle`'s bridged `Data` backing storage once per chunk, in addition to the existing per-record JSON autorelease pool.
- Add an opt-in 512 MiB performance regression test and a reproducible local gate.

This is a focused follow-up to #94. That PR bounded autoreleased JSON objects but intentionally retained whole-file reads after a generic streaming experiment regressed memory. This PR addresses a different scale case: a single multi-GiB Codex rollout.

## Root cause

A real 21 GiB Codex rollout made the installed app approach 20 GiB of physical footprint while keeping a CPU core busy. The failure chain was:

1. `parseCodexRollout` decoded the entire JSONL file into one `String`.
2. Splitting that string created additional file-sized storage before line-level parsing began.
3. The per-line autorelease pool from #94 could release `JSONSerialization` objects, but it could not release the whole source string or its split storage.
4. A first chunked implementation still accumulated roughly one file's worth of RSS because `FileHandle.read(upToCount:)` bridged backing storage remained autoreleased until the outer pool drained. A chunk-level autorelease boundary reduced parse growth from 516 MiB to 5 MiB on the 512 MiB fixture.
5. Existing tests used small semantic fixtures, so token correctness was covered but file-sized RSS growth had no regression guard.

## Behavior preservation

The change leaves rollout ownership and accounting after parsing unchanged:

- session and model discovery retain their existing precedence;
- cumulative/last usage vectors, repeated-state normalization, fork replay trimming, and subagent ownership are unchanged;
- file read failures still discard the rollout rather than returning a partial result;
- all existing Codex reader and cache tests pass.

## Performance

Release build, same generated 512 MiB Codex rollout with 64 usage events:

| | Whole-file parser | Streaming parser |
| --- | ---: | ---: |
| Peak RSS | 1,052 MiB | 28 MiB |
| RSS growth during parse | not separately recorded | 5 MiB |
| Parse time | 34.156 s | 2.798 s |

The opt-in test enforces:

- peak RSS below 700 MiB;
- parse-time RSS growth below 192 MiB;
- elapsed time below 20 seconds;
- exact event count and input/cache-read/output/total token sums.

Run it with:

```bash
./scripts/perf-codex-large-rollout.sh
```

The large fixture is generated at runtime and is not committed.

## Class sweep and scope

I searched the remaining usage readers for whole-file reads. Claude, Gemini, and Grok still have provider-specific whole-file paths. They are intentionally unchanged here:

- only Codex reproduced a single multi-GiB rollout on the measured machine;
- #94 documented that a generic streaming conversion regressed settled memory;
- changing every provider would broaden the token-accuracy risk without matching provider-specific evidence.

This PR also does not add incremental append parsing. A changed large rollout still requires a cold sequential scan; the goal here is to bound memory and remove unnecessary JSON parsing. Incremental checkpoints can be evaluated separately.

Open PR #181 changes Codex scan roots but not rollout parsing. This parser change is orthogonal and should compose after a rebase if #181 lands first.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Other: performance

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] No UI changes
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change

## Validation

- `./scripts/perf-codex-large-rollout.sh`
  - 512 MiB: baseline RSS 22 MiB, peak RSS 28 MiB, growth 5 MiB, 2.798 s
  - 84 targeted `LocalUsageReaderTests` / `LocalUsageCacheTests`, 0 failures
  - full suite: 677 tests, 8 skipped, 0 failures
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/test-gate.sh`
  - 677 tests, 8 skipped, 0 failures
  - logic-core line coverage: 90.01% (75% required)
- `git diff --check`
- `bash -n scripts/perf-codex-large-rollout.sh`
