### PR TITLE
feat: add French (fr) UI language

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -7,7 +7,7 @@ enum CompanionStateKind: String, Sendable {
 
 /// 앱 언어. 포켓몬 이름은 PokéAPI 다국어 names 에서 가져온다.
 enum AppLanguage: String, Codable, Sendable, CaseIterable {
-    case ko, en, ja, es
+    case ko, en, ja, es, fr
     /// PokéAPI language.name 후보(첫 매칭 사용)
     var apiCodes: [String] {
         switch self {
@@ -15,10 +15,11 @@ enum AppLanguage: String, Codable, Sendable, CaseIterable {
         case .en: return ["en"]
         case .ja: return ["ja-Hrkt", "ja"]
         case .es: return ["es"]
+        case .fr: return ["fr"]
         }
     }
     var label: String {
-        switch self { case .ko: return "한국어"; case .en: return "English"; case .ja: return "日本語"; case .es: return "Español" }
+        switch self { case .ko: return "한국어"; case .en: return "English"; case .ja: return "日本語"; case .es: return "Español"; case .fr: return "Français" }
     }
 
     var displayLocale: Locale { Locale(identifier: rawValue) }
@@ -30,12 +31,13 @@ enum AppLanguage: String, Codable, Sendable, CaseIterable {
     }
 
     /// 신규 설치 기본 언어 — 시스템 선호 언어에서 유추(글로벌 출시: 한국어 강제 금지).
-    /// ko/ja/es 만 매칭, 그 외 전부 영어(fallback-of-fallback). 기존 사용자는 저장된 언어를 그대로 쓴다.
+    /// ko/ja/es/fr 만 매칭, 그 외 전부 영어(fallback-of-fallback). 기존 사용자는 저장된 언어를 그대로 쓴다.
     static var systemDefault: AppLanguage {
         switch Locale.preferredLanguages.first?.prefix(2).lowercased() {
         case "ko": return .ko
         case "ja": return .ja
         case "es": return .es
+        case "fr": return .fr
         default:   return .en
         }
     }
@@ -324,37 +326,37 @@ enum PokemonNature: String, Codable, Sendable, CaseIterable {
     case modest, mild, quiet, bashful, rash
     case calm, gentle, sassy, careful, quirky
 
-    /// 본가 공식 번역 명칭 (ko/en/ja/es).
+    /// 본가 공식 번역 명칭 (ko/en/ja/es/fr).
     func name(_ lang: AppLanguage) -> String {
-        let names: (String, String, String, String)
+        let names: (String, String, String, String, String)
         switch self {
-        case .hardy:   names = ("노력", "Hardy", "がんばりや", "Fuerte")
-        case .lonely:  names = ("외로움", "Lonely", "さみしがり", "Huraña")
-        case .brave:   names = ("용감", "Brave", "ゆうかん", "Audaz")
-        case .adamant: names = ("고집", "Adamant", "いじっぱり", "Firme")
-        case .naughty: names = ("개구쟁이", "Naughty", "やんちゃ", "Pícara")
-        case .bold:    names = ("대담", "Bold", "ずぶとい", "Osada")
-        case .docile:  names = ("온순", "Docile", "すなお", "Dócil")
-        case .relaxed: names = ("무사태평", "Relaxed", "のんき", "Plácida")
-        case .impish:  names = ("장난꾸러기", "Impish", "わんぱく", "Agitada")
-        case .lax:     names = ("촐랑", "Lax", "のうてんき", "Floja")
-        case .timid:   names = ("겁쟁이", "Timid", "おくびょう", "Miedosa")
-        case .hasty:   names = ("성급", "Hasty", "せっかち", "Activa")
-        case .serious: names = ("성실", "Serious", "まじめ", "Seria")
-        case .jolly:   names = ("명랑", "Jolly", "ようき", "Alegre")
-        case .naive:   names = ("천진난만", "Naive", "むじゃき", "Ingenua")
-        case .modest:  names = ("조심", "Modest", "ひかえめ", "Modesta")
-        case .mild:    names = ("의젓", "Mild", "おっとり", "Afable")
-        case .quiet:   names = ("냉정", "Quiet", "れいせい", "Mansa")
-        case .bashful: names = ("수줍음", "Bashful", "てれや", "Tímida")
-        case .rash:    names = ("덜렁", "Rash", "うっかりや", "Alocada")
-        case .calm:    names = ("차분", "Calm", "おだやか", "Serena")
-        case .gentle:  names = ("얌전", "Gentle", "おとなしい", "Amable")
-        case .sassy:   names = ("건방", "Sassy", "なまいき", "Grosera")
-        case .careful: names = ("신중", "Careful", "しんちょう", "Cauta")
-        case .quirky:  names = ("변덕", "Quirky", "きまぐれ", "Rara")
+        case .hardy:   names = ("노력", "Hardy", "がんばりや", "Fuerte", "Hardi")
+        case .lonely:  names = ("외로움", "Lonely", "さみしがり", "Huraña", "Solo")
+        case .brave:   names = ("용감", "Brave", "ゆうかん", "Audaz", "Brave")
+        case .adamant: names = ("고집", "Adamant", "いじっぱり", "Firme", "Rigide")
+        case .naughty: names = ("개구쟁이", "Naughty", "やんちゃ", "Pícara", "Mauvais")
+        case .bold:    names = ("대담", "Bold", "ずぶとい", "Osada", "Assuré")
+        case .docile:  names = ("온순", "Docile", "すなお", "Dócil", "Docile")
+        case .relaxed: names = ("무사태평", "Relaxed", "のんき", "Plácida", "Relax")
+        case .impish:  names = ("장난꾸러기", "Impish", "わんぱく", "Agitada", "Malin")
+        case .lax:     names = ("촐랑", "Lax", "のうてんき", "Floja", "Lâche")
+        case .timid:   names = ("겁쟁이", "Timid", "おくびょう", "Miedosa", "Timide")
+        case .hasty:   names = ("성급", "Hasty", "せっかち", "Activa", "Pressé")
+        case .serious: names = ("성실", "Serious", "まじめ", "Seria", "Sérieux")
+        case .jolly:   names = ("명랑", "Jolly", "ようき", "Alegre", "Jovial")
+        case .naive:   names = ("천진난만", "Naive", "むじゃき", "Ingenua", "Naïf")
+        case .modest:  names = ("조심", "Modest", "ひかえめ", "Modesta", "Modeste")
+        case .mild:    names = ("의젓", "Mild", "おっとり", "Afable", "Doux")
+        case .quiet:   names = ("냉정", "Quiet", "れいせい", "Mansa", "Discret")
+        case .bashful: names = ("수줍음", "Bashful", "てれや", "Tímida", "Pudique")
+        case .rash:    names = ("덜렁", "Rash", "うっかりや", "Alocada", "Foufou")
+        case .calm:    names = ("차분", "Calm", "おだやか", "Serena", "Calme")
+        case .gentle:  names = ("얌전", "Gentle", "おとなしい", "Amable", "Gentil")
+        case .sassy:   names = ("건방", "Sassy", "なまいき", "Grosera", "Malpoli")
+        case .careful: names = ("신중", "Careful", "しんちょう", "Cauta", "Prudent")
+        case .quirky:  names = ("변덕", "Quirky", "きまぐれ", "Rara", "Bizarre")
         }
-        switch lang { case .ko: return names.0; case .en: return names.1; case .ja: return names.2; case .es: return names.3 }
+        switch lang { case .ko: return names.0; case .en: return names.1; case .ja: return names.2; case .es: return names.3; case .fr: return names.4 }
     }
 }
 

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -7,57 +7,58 @@ struct L {
     let lang: AppLanguage
     init(_ lang: AppLanguage) { self.lang = lang }
 
-    private func t(_ ko: String, _ en: String, _ ja: String, _ es: String) -> String {
+    private func t(_ ko: String, _ en: String, _ ja: String, _ es: String, _ fr: String) -> String {
         switch lang {
         case .ko: return ko
         case .en: return en
         case .ja: return ja
         case .es: return es
+        case .fr: return fr
         }
     }
 
     // MARK: 탭
-    var home: String { t("홈", "Home", "ホーム", "Inicio") }
+    var home: String { t("홈", "Home", "ホーム", "Inicio", "Accueil") }
     /// 상위 탭 이름 — 안에서 도감/포획 로그를 세그먼트로 전환하므로 둘을 아우르는 말이어야 한다.
     /// (ko 가 "도감"이면 탭과 세그먼트가 같은 이름이 돼 en/ja 의 Collection/コレクション 과도 어긋난다.)
-    var collection: String { t("컬렉션", "Collection", "コレクション", "Colección") }
+    var collection: String { t("컬렉션", "Collection", "コレクション", "Colección", "Collection") }
 
     // MARK: 헤더 (오늘/주/월)
-    var todayTokens: String { t("오늘 사용한 토큰", "Today's tokens", "本日のトークン", "Tokens de hoy") }
-    var thisWeek: String { t("이번 주", "This week", "今週", "Esta semana") }
-    var thisMonth: String { t("이번 달", "This month", "今月", "Este mes") }
+    var todayTokens: String { t("오늘 사용한 토큰", "Today's tokens", "本日のトークン", "Tokens de hoy", "Tokens du jour") }
+    var thisWeek: String { t("이번 주", "This week", "今週", "Esta semana", "Cette semaine") }
+    var thisMonth: String { t("이번 달", "This month", "今月", "Este mes", "Ce mois-ci") }
 
     // MARK: 한도 섹션
-    var limitsOfficial: String { t("한도 (공식)", "Limits (official)", "上限（公式）", "Límites (oficial)") }
-    var fiveHourSession: String { t("5시간 세션", "5-hour session", "5時間セッション", "Sesión de 5 horas") }
-    var weekly: String { t("주간", "Weekly", "週間", "Semanal") }
-    var weeklyOpus: String { t("주간 Opus", "Weekly Opus", "週間 Opus", "Opus semanal") }
-    var weeklySonnet: String { t("주간 Sonnet", "Weekly Sonnet", "週間 Sonnet", "Sonnet semanal") }
-    var claudeCurrentBlock: String { t("Claude 현재 5h 블록", "Claude current 5h block", "Claude 現在の5hブロック", "Bloque actual de 5h de Claude") }
-    var reset: String { t("리셋", "Reset", "リセット", "Reinicio") }
-    var limitReached: String { t("한도 도달", "Limit reached", "上限到達", "Límite alcanzado") }
-    var personalSpendLimit: String { t("개인 사용 한도", "Personal spend limit", "個人利用上限", "Límite de gasto personal") }
-    var staleLimits: String { t("갱신 지연", "Stale", "更新遅延", "Desactualizado") }
-    var refresh: String { t("갱신", "Refresh", "更新", "Actualizar") }
-    var limitsTapToLoad: String { t("공식 한도 불러오기", "Load official limits", "公式上限を読み込む", "Cargar límites oficiales") }
+    var limitsOfficial: String { t("한도 (공식)", "Limits (official)", "上限（公式）", "Límites (oficial)", "Limites (officiel)") }
+    var fiveHourSession: String { t("5시간 세션", "5-hour session", "5時間セッション", "Sesión de 5 horas", "Session de 5 h") }
+    var weekly: String { t("주간", "Weekly", "週間", "Semanal", "Hebdo") }
+    var weeklyOpus: String { t("주간 Opus", "Weekly Opus", "週間 Opus", "Opus semanal", "Opus hebdo") }
+    var weeklySonnet: String { t("주간 Sonnet", "Weekly Sonnet", "週間 Sonnet", "Sonnet semanal", "Sonnet hebdo") }
+    var claudeCurrentBlock: String { t("Claude 현재 5h 블록", "Claude current 5h block", "Claude 現在の5hブロック", "Bloque actual de 5h de Claude", "Bloc 5 h actuel de Claude") }
+    var reset: String { t("리셋", "Reset", "リセット", "Reinicio", "Réinit.") }
+    var limitReached: String { t("한도 도달", "Limit reached", "上限到達", "Límite alcanzado", "Limite atteinte") }
+    var personalSpendLimit: String { t("개인 사용 한도", "Personal spend limit", "個人利用上限", "Límite de gasto personal", "Limite de dépense personnelle") }
+    var staleLimits: String { t("갱신 지연", "Stale", "更新遅延", "Desactualizado", "Périmé") }
+    var refresh: String { t("갱신", "Refresh", "更新", "Actualizar", "Actualiser") }
+    var limitsTapToLoad: String { t("공식 한도 불러오기", "Load official limits", "公式上限を読み込む", "Cargar límites oficiales", "Charger les limites officielles") }
 
     /// 프로바이더 상태 페이지 인시던트 지표 → 현지화 라벨(표시 전용).
     func providerStatusLabel(_ indicator: ProviderStatusIndicator) -> String {
         switch indicator {
-        case .operational: return t("정상", "Operational", "正常", "Operativo")
-        case .minor:       return t("일부 장애", "Minor issues", "一部障害", "Problemas menores")
-        case .major:       return t("장애", "Major outage", "障害", "Interrupción grave")
-        case .critical:    return t("심각한 장애", "Critical outage", "重大障害", "Interrupción crítica")
-        case .maintenance: return t("점검 중", "Maintenance", "メンテナンス", "Mantenimiento")
-        case .unknown:     return t("상태 불명", "Status unknown", "状態不明", "Estado desconocido")
+        case .operational: return t("정상", "Operational", "正常", "Operativo", "Opérationnel")
+        case .minor:       return t("일부 장애", "Minor issues", "一部障害", "Problemas menores", "Problèmes mineurs")
+        case .major:       return t("장애", "Major outage", "障害", "Interrupción grave", "Panne majeure")
+        case .critical:    return t("심각한 장애", "Critical outage", "重大障害", "Interrupción crítica", "Panne critique")
+        case .maintenance: return t("점검 중", "Maintenance", "メンテナンス", "Mantenimiento", "Maintenance")
+        case .unknown:     return t("상태 불명", "Status unknown", "状態不明", "Estado desconocido", "État inconnu")
         }
     }
-    func plan(_ p: String) -> String { t("플랜 \(p)", "Plan \(p)", "プラン \(p)", "Plan \(p)") }
+    func plan(_ p: String) -> String { t("플랜 \(p)", "Plan \(p)", "プラン \(p)", "Plan \(p)", "Forfait \(p)") }
     func forecastReach(_ time: String) -> String {
-        t("현재 속도면 \(time) 한도 도달", "At current rate, limit hit at \(time)", "現在のペースで \(time) に上限到達", "Al ritmo actual, límite alcanzado a las \(time)")
+        t("현재 속도면 \(time) 한도 도달", "At current rate, limit hit at \(time)", "現在のペースで \(time) に上限到達", "Al ritmo actual, límite alcanzado a las \(time)", "À ce rythme, limite atteinte à \(time)")
     }
     var forecastNoReach: String {
-        t("현재 속도로는 리셋 전 한도 도달 없음", "Won't hit limit before reset at current rate", "現在のペースではリセット前に上限到達なし", "Al ritmo actual, no alcanzarás el límite antes del reinicio")
+        t("현재 속도로는 리셋 전 한도 도달 없음", "Won't hit limit before reset at current rate", "現在のペースではリセット前に上限到達なし", "Al ritmo actual, no alcanzarás el límite antes del reinicio", "À ce rythme, tu n'atteindras pas la limite avant la réinit.")
     }
 
     /// Claude oauth/usage 신형 limits[] 엔트리 이름 — kind + 모델 스코프 기반.
@@ -67,8 +68,8 @@ struct L {
         case "weekly_all": return weekly
         case "weekly_scoped":
             // 모델명이 없으면 레거시 "주간" 행과 이름이 겹치므로 scoped 임을 구분 표기
-            guard let model else { return t("주간 (모델별)", "Weekly (scoped)", "週間（モデル別）", "Semanal (por modelo)") }
-            return t("주간 \(model)", "Weekly \(model)", "週間 \(model)", "Semanal \(model)")
+            guard let model else { return t("주간 (모델별)", "Weekly (scoped)", "週間（モデル別）", "Semanal (por modelo)", "Hebdo (par modèle)") }
+            return t("주간 \(model)", "Weekly \(model)", "週間 \(model)", "Semanal \(model)", "Hebdo \(model)")
         default:
             let base = kind ?? "limit"
             let name = model.map { " \($0)" } ?? ""
@@ -83,117 +84,121 @@ struct L {
         case 10_080: return weekly
         case let m? where m >= 60 && m % 60 == 0:
             let h = m / 60
-            return t("\(h)시간", "\(h)h", "\(h)時間", "\(h)h")
-        case let m?: return t("\(m)분", "\(m)m", "\(m)分", "\(m)m")
-        case nil: return t("한도", "Limit", "上限", "Límite")
+            return t("\(h)시간", "\(h)h", "\(h)時間", "\(h)h", "\(h) h")
+        case let m?: return t("\(m)분", "\(m)m", "\(m)分", "\(m)m", "\(m) min")
+        case nil: return t("한도", "Limit", "上限", "Límite", "Limite")
         }
     }
 
     // MARK: 푸터
-    var refreshNow: String { t("지금 새로고침", "Refresh now", "今すぐ更新", "Actualizar ahora") }
-    var updated: String { t("갱신", "Updated", "更新", "Actualizado") }
-    var settings: String { t("설정", "Settings", "設定", "Ajustes") }
-    var back: String { t("뒤로", "Back", "戻る", "Atrás") }
-    var generalSectionTitle: String { t("일반", "General", "一般", "General") }
-    var menuBarSectionTitle: String { t("메뉴바에 표시", "Show in menu bar", "メニューバーに表示", "Mostrar en la barra de menús") }
-    var advancedSectionTitle: String { t("고급", "Advanced", "詳細", "Avanzado") }
-    var advancedDisclosureLabel: String { t("고급 설정 · 진단", "Advanced · diagnostics", "詳細設定・診断", "Avanzado · diagnóstico") }
-    var aboutSupportSectionTitle: String { t("정보 & 지원", "About & Support", "情報とサポート", "Acerca de y soporte") }
-    var quit: String { t("종료", "Quit", "終了", "Salir") }
+    var refreshNow: String { t("지금 새로고침", "Refresh now", "今すぐ更新", "Actualizar ahora", "Actualiser maintenant") }
+    var updated: String { t("갱신", "Updated", "更新", "Actualizado", "Mis à jour") }
+    var settings: String { t("설정", "Settings", "設定", "Ajustes", "Réglages") }
+    var back: String { t("뒤로", "Back", "戻る", "Atrás", "Retour") }
+    var generalSectionTitle: String { t("일반", "General", "一般", "General", "Général") }
+    var menuBarSectionTitle: String { t("메뉴바에 표시", "Show in menu bar", "メニューバーに表示", "Mostrar en la barra de menús", "Afficher dans la barre des menus") }
+    var advancedSectionTitle: String { t("고급", "Advanced", "詳細", "Avanzado", "Avancé") }
+    var advancedDisclosureLabel: String { t("고급 설정 · 진단", "Advanced · diagnostics", "詳細設定・診断", "Avanzado · diagnóstico", "Avancé · diagnostics") }
+    var aboutSupportSectionTitle: String { t("정보 & 지원", "About & Support", "情報とサポート", "Acerca de y soporte", "À propos et assistance") }
+    var quit: String { t("종료", "Quit", "終了", "Salir", "Quitter") }
 
     // MARK: 설정
-    var refreshInterval: String { t("새로고침 간격", "Refresh interval", "更新間隔", "Intervalo de actualización") }
-    var language: String { t("언어", "Language", "言語", "Idioma") }
-    var menuBarItems: String { t("메뉴바 표시 항목 (복수 선택)", "Menu bar items (multi-select)", "メニューバー表示項目（複数選択）", "Elementos de la barra de menús (selección múltiple)") }
-    var todayTokensShort: String { t("오늘 토큰", "Today's tokens", "本日のトークン", "Tokens de hoy") }
-    var todayCost: String { t("오늘 비용 ($)", "Today's cost ($)", "本日のコスト ($)", "Coste de hoy ($)") }
-    var limitPercent: String { t("한도 %", "Limit %", "上限 %", "Límite %") }
-    var limitDisplayModeLabel: String { t("한도 표시 방식", "Limit display", "上限の表示", "Visualización del límite") }
-    var limitDisplayUsed: String { t("사용량", "Used", "使用量", "Usado") }
-    var limitDisplayRemaining: String { t("남은 양", "Remaining", "残量", "Restante") }
+    var refreshInterval: String { t("새로고침 간격", "Refresh interval", "更新間隔", "Intervalo de actualización", "Intervalle d'actualisation") }
+    var language: String { t("언어", "Language", "言語", "Idioma", "Langue") }
+    var menuBarItems: String { t("메뉴바 표시 항목 (복수 선택)", "Menu bar items (multi-select)", "メニューバー表示項目（複数選択）", "Elementos de la barra de menús (selección múltiple)", "Éléments de la barre des menus (sélection multiple)") }
+    var todayTokensShort: String { t("오늘 토큰", "Today's tokens", "本日のトークン", "Tokens de hoy", "Tokens du jour") }
+    var todayCost: String { t("오늘 비용 ($)", "Today's cost ($)", "本日のコスト ($)", "Coste de hoy ($)", "Coût du jour ($)") }
+    var limitPercent: String { t("한도 %", "Limit %", "上限 %", "Límite %", "Limite %") }
+    var limitDisplayModeLabel: String { t("한도 표시 방식", "Limit display", "上限の表示", "Visualización del límite", "Affichage de la limite") }
+    var limitDisplayUsed: String { t("사용량", "Used", "使用量", "Usado", "Utilisé") }
+    var limitDisplayRemaining: String { t("남은 양", "Remaining", "残量", "Restante", "Restant") }
     /// 팝오버 한도 행의 remaining 모드 표시 — %에 자기설명 접미사를 붙인다.
     func percentRemaining(_ percent: String) -> String {
-        t("\(percent) 남음", "\(percent) left", "残り\(percent)", "\(percent) restante")
+        t("\(percent) 남음", "\(percent) left", "残り\(percent)", "\(percent) restante", "\(percent) restant")
     }
-    var allOffHint: String { t("전부 끄면 캐릭터만 표시됩니다", "All off shows only the character", "すべてオフにするとキャラクターのみ表示", "Si desactivas todo, solo se mostrará el personaje") }
+    var allOffHint: String { t("전부 끄면 캐릭터만 표시됩니다", "All off shows only the character", "すべてオフにするとキャラクターのみ表示", "Si desactivas todo, solo se mostrará el personaje", "Tout désactiver n'affiche que le personnage") }
     // MARK: 대표 포켓몬
     var representativePokemonLabel: String {
-        t("대표 포켓몬", "Representative Pokémon", "代表ポケモン", "Pokémon representativo")
+        t("대표 포켓몬", "Representative Pokémon", "代表ポケモン", "Pokémon representativo", "Pokémon représentatif")
     }
     var representativeFollowCurrent: String {
-        t("현재 포켓몬 따라가기", "Follow current companion", "現在のポケモンに合わせる", "Seguir al compañero actual")
+        t("현재 포켓몬 따라가기", "Follow current companion", "現在のポケモンに合わせる", "Seguir al compañero actual", "Suivre le compagnon actuel")
     }
     var representativeChooseFromDex: String {
-        t("도감에서 선택…", "Choose in Pokédex…", "図鑑で選ぶ…", "Elegir en la Pokédex…")
+        t("도감에서 선택…", "Choose in Pokédex…", "図鑑で選ぶ…", "Elegir en la Pokédex…", "Choisir dans le Pokédex…")
     }
     var representativeSet: String {
-        t("대표로 설정", "Set as representative", "代表ポケモンに設定", "Establecer como representante")
+        t("대표로 설정", "Set as representative", "代表ポケモンに設定", "Establecer como representante", "Définir comme représentatif")
     }
-    var representativeBadge: String { t("대표", "Representative", "代表", "Representante") }
+    var representativeBadge: String { t("대표", "Representative", "代表", "Representante", "Représentatif") }
     // MARK: 플로팅 펫
-    var floatingPetSectionTitle: String { t("플로팅 펫", "Floating Pet", "フローティングペット", "Mascota flotante") }
-    var floatingPetEnableLabel: String { t("플로팅 펫 표시", "Show floating pet", "フローティングペットを表示", "Mostrar mascota flotante") }
+    var floatingPetSectionTitle: String { t("플로팅 펫", "Floating Pet", "フローティングペット", "Mascota flotante", "Compagnon flottant") }
+    var floatingPetEnableLabel: String { t("플로팅 펫 표시", "Show floating pet", "フローティングペットを表示", "Mostrar mascota flotante", "Afficher le compagnon flottant") }
     var floatingPetHint: String {
         t("포켓몬이 화면 위에 떠 있어요 — 드래그로 위치를 옮길 수 있어요",
           "Your Pokémon floats over the screen — drag to reposition",
           "ポケモンが画面の上に浮かびます — ドラッグで移動できます",
-          "Tu Pokémon flota sobre la pantalla — arrástralo para moverlo")
+          "Tu Pokémon flota sobre la pantalla — arrástralo para moverlo",
+          "Ton Pokémon flotte au-dessus de l'écran — fais-le glisser pour le déplacer")
     }
-    var floatingPetSizeLabel: String { t("크기", "Size", "サイズ", "Tamaño") }
+    var floatingPetSizeLabel: String { t("크기", "Size", "サイズ", "Tamaño", "Taille") }
     /// 지금은 한도 알림만 말풍선으로 뜨지만, 알림 종류가 늘어도 이 라벨은 그대로 쓴다.
     var floatingPetBubbleAlertsLabel: String {
-        t("말풍선으로 알림 받기", "Show notifications as bubbles", "通知を吹き出しで表示", "Mostrar notificaciones como globos")
+        t("말풍선으로 알림 받기", "Show notifications as bubbles", "通知を吹き出しで表示", "Mostrar notificaciones como globos", "Afficher les notifications en bulles")
     }
-    var floatingPetMenuOpen: String { t("토큰 바 열기", "Open Token Bar", "トークンバーを開く", "Abrir Token Bar") }
+    var floatingPetMenuOpen: String { t("토큰 바 열기", "Open Token Bar", "トークンバーを開く", "Abrir Token Bar", "Ouvrir Token Bar") }
     var floatingPetMenuHide: String {
-        t("플로팅 펫 끄기", "Turn off floating pet", "フローティングペットをオフ", "Desactivar mascota flotante")
+        t("플로팅 펫 끄기", "Turn off floating pet", "フローティングペットをオフ", "Desactivar mascota flotante", "Désactiver le compagnon flottant")
     }
     func floatingPetHoverTokensOnly(_ tokens: String) -> String {
-        t("오늘 \(tokens) 토큰", "Today: \(tokens) tokens", "今日: \(tokens) トークン", "Hoy: \(tokens) tokens")
+        t("오늘 \(tokens) 토큰", "Today: \(tokens) tokens", "今日: \(tokens) トークン", "Hoy: \(tokens) tokens", "Aujourd'hui : \(tokens) tokens")
     }
     func floatingPetHoverWithLimit(_ tokens: String, _ percent: String) -> String {
         t("오늘 \(tokens) 토큰 (한도 \(percent))",
           "Today: \(tokens) tokens (limit \(percent))",
           "今日: \(tokens) トークン（上限 \(percent)）",
-          "Hoy: \(tokens) tokens (límite \(percent))")
+          "Hoy: \(tokens) tokens (límite \(percent))",
+          "Aujourd'hui : \(tokens) tokens (limite \(percent))")
     }
 
-    var disableKeychain: String { t("Keychain 접근 끄기", "Disable Keychain access", "Keychainアクセスを無効化", "Desactivar acceso a Keychain") }
-    var disableKeychainHint: String { t("켜면 Keychain 접근 허용 팝업이 더 안 뜹니다 — 공식 한도(%)만 숨겨지고 토큰·비용은 그대로", "When on, no more Keychain permission pop-ups — only official limits (%) are hidden; tokens/cost stay", "オンにするとKeychain許可のポップアップが出なくなります — 公式上限(%)のみ非表示、トークン・費用はそのまま", "Al activarlo, ya no aparecerán los avisos de permiso de Keychain — solo se ocultan los límites oficiales (%), los tokens y el coste se mantienen") }
-    var refreshLimitToken: String { t("한도 토큰 캐시 갱신", "Refresh limit token cache", "上限トークンキャッシュを更新", "Actualizar caché del token de límite") }
-    var onlyOnPress: String { t("누를 때만 Keychain 을 읽어요 — 자동 폴링은 안 읽어 팝업이 안 떠요. 토큰 만료 후 이 버튼으로 한도 갱신", "Reads Keychain only when pressed — auto-polling never does, so no pop-ups. Refresh limits here after the token expires", "押した時のみKeychainを読みます — 自動更新では読まずポップアップも出ません。トークン期限切れ後はこのボタンで上限を更新", "Solo lee Keychain al pulsar — el sondeo automático nunca lo hace, así que no aparecen avisos. Usa este botón para actualizar los límites tras la expiración del token") }
-    var launchAtLogin: String { t("로그인 시 자동 시작", "Launch at login", "ログイン時に自動起動", "Iniciar al arrancar sesión") }
-    var bundledOnly: String { t(".app 번들로 설치된 경우에만 사용 가능 (scripts/build-app.sh)", "Available only when installed as an .app bundle (scripts/build-app.sh)", ".appバンドルでインストールした場合のみ利用可能 (scripts/build-app.sh)", "Disponible solo si se instaló como paquete .app (scripts/build-app.sh)") }
-    var notificationsSection: String { t("알림", "Notifications", "通知", "Notificaciones") }
-    var limitNotificationsLabel: String { t("한도 알림", "Limit alerts", "上限通知", "Alertas de límite") }
-    var companionNotificationsLabel: String { t("Companion 이벤트 (부화·진화·졸업)", "Companion events (hatch / evolve / graduate)", "コンパニオンイベント（孵化・進化・卒業）", "Eventos del compañero (eclosión / evolución / graduación)") }
-    var statusChecksLabel: String { t("프로바이더 상태 확인", "Provider status checks", "プロバイダー状態チェック", "Comprobación de estado de proveedores") }
-    var statusChecksHint: String { t("Claude·OpenAI 장애를 팝오버에 표시 (알림 아님)", "Show Claude / OpenAI incidents in the popover (not a notification)", "Claude・OpenAIの障害をポップオーバーに表示（通知ではない）", "Muestra incidentes de Claude/OpenAI en el popover (no es una notificación)") }
-    var warning: String { t("경고", "Warning", "警告", "Aviso") }
-    var critical: String { t("임박", "Critical", "切迫", "Crítico") }
-    var aggregationNote: String { t("토큰 집계 기준: totalTokens (input + output + cache, 로컬 날짜)", "Token basis: totalTokens (input + output + cache, local date)", "集計基準: totalTokens (input + output + cache, ローカル日付)", "Base de cálculo: totalTokens (input + output + cache, fecha local)") }
-    var close: String { t("닫기", "Close", "閉じる", "Cerrar") }
+    var disableKeychain: String { t("Keychain 접근 끄기", "Disable Keychain access", "Keychainアクセスを無効化", "Desactivar acceso a Keychain", "Désactiver l'accès au Keychain") }
+    var disableKeychainHint: String { t("켜면 Keychain 접근 허용 팝업이 더 안 뜹니다 — 공식 한도(%)만 숨겨지고 토큰·비용은 그대로", "When on, no more Keychain permission pop-ups — only official limits (%) are hidden; tokens/cost stay", "オンにするとKeychain許可のポップアップが出なくなります — 公式上限(%)のみ非表示、トークン・費用はそのまま", "Al activarlo, ya no aparecerán los avisos de permiso de Keychain — solo se ocultan los límites oficiales (%), los tokens y el coste se mantienen", "Une fois activé, plus de pop-ups d'autorisation Keychain — seules les limites officielles (%) sont masquées ; les tokens et le coût restent visibles") }
+    var refreshLimitToken: String { t("한도 토큰 캐시 갱신", "Refresh limit token cache", "上限トークンキャッシュを更新", "Actualizar caché del token de límite", "Actualiser le cache du token de limite") }
+    var onlyOnPress: String { t("누를 때만 Keychain 을 읽어요 — 자동 폴링은 안 읽어 팝업이 안 떠요. 토큰 만료 후 이 버튼으로 한도 갱신", "Reads Keychain only when pressed — auto-polling never does, so no pop-ups. Refresh limits here after the token expires", "押した時のみKeychainを読みます — 自動更新では読まずポップアップも出ません。トークン期限切れ後はこのボタンで上限を更新", "Solo lee Keychain al pulsar — el sondeo automático nunca lo hace, así que no aparecen avisos. Usa este botón para actualizar los límites tras la expiración del token", "Lit le Keychain uniquement sur appui — le polling automatique ne le fait jamais, donc pas de pop-up. Actualise les limites ici après l'expiration du token") }
+    var launchAtLogin: String { t("로그인 시 자동 시작", "Launch at login", "ログイン時に自動起動", "Iniciar al arrancar sesión", "Lancer à l'ouverture de session") }
+    var bundledOnly: String { t(".app 번들로 설치된 경우에만 사용 가능 (scripts/build-app.sh)", "Available only when installed as an .app bundle (scripts/build-app.sh)", ".appバンドルでインストールした場合のみ利用可能 (scripts/build-app.sh)", "Disponible solo si se instaló como paquete .app (scripts/build-app.sh)", "Disponible uniquement si installé comme paquet .app (scripts/build-app.sh)") }
+    var notificationsSection: String { t("알림", "Notifications", "通知", "Notificaciones", "Notifications") }
+    var limitNotificationsLabel: String { t("한도 알림", "Limit alerts", "上限通知", "Alertas de límite", "Alertes de limite") }
+    var companionNotificationsLabel: String { t("Companion 이벤트 (부화·진화·졸업)", "Companion events (hatch / evolve / graduate)", "コンパニオンイベント（孵化・進化・卒業）", "Eventos del compañero (eclosión / evolución / graduación)", "Événements du compagnon (éclosion / évolution / diplôme)") }
+    var statusChecksLabel: String { t("프로바이더 상태 확인", "Provider status checks", "プロバイダー状態チェック", "Comprobación de estado de proveedores", "Vérification de l'état des fournisseurs") }
+    var statusChecksHint: String { t("Claude·OpenAI 장애를 팝오버에 표시 (알림 아님)", "Show Claude / OpenAI incidents in the popover (not a notification)", "Claude・OpenAIの障害をポップオーバーに表示（通知ではない）", "Muestra incidentes de Claude/OpenAI en el popover (no es una notificación)", "Affiche les incidents Claude / OpenAI dans le popover (pas une notification)") }
+    var warning: String { t("경고", "Warning", "警告", "Aviso", "Avertissement") }
+    var critical: String { t("임박", "Critical", "切迫", "Crítico", "Critique") }
+    var aggregationNote: String { t("토큰 집계 기준: totalTokens (input + output + cache, 로컬 날짜)", "Token basis: totalTokens (input + output + cache, local date)", "集計基準: totalTokens (input + output + cache, ローカル日付)", "Base de cálculo: totalTokens (input + output + cache, fecha local)", "Base de calcul : totalTokens (input + output + cache, date locale)") }
+    var close: String { t("닫기", "Close", "閉じる", "Cerrar", "Fermer") }
 
     // MARK: 세이브 이전 (설정 → 백업 & 이전)
-    var transferSectionTitle: String { t("백업 & 이전", "Backup & Transfer", "バックアップと移行", "Copia de seguridad y transferencia") }
-    var exportSaveLabel: String { t("세이브 내보내기", "Export save", "セーブを書き出す", "Exportar partida") }
+    var transferSectionTitle: String { t("백업 & 이전", "Backup & Transfer", "バックアップと移行", "Copia de seguridad y transferencia", "Sauvegarde et transfert") }
+    var exportSaveLabel: String { t("세이브 내보내기", "Export save", "セーブを書き出す", "Exportar partida", "Exporter la sauvegarde") }
     var exportSaveHint: String {
         t("도감·누적 토큰·가방·현재 포켓몬을 파일 하나로 저장해요",
           "Saves your Pokédex, lifetime tokens, Bag, and current Pokémon as one file",
           "図鑑・累計トークン・バッグ・現在のポケモンを1つのファイルに保存します",
-          "Guarda tu Pokédex, tokens acumulados, Bolsa y Pokémon actual en un solo archivo")
+          "Guarda tu Pokédex, tokens acumulados, Bolsa y Pokémon actual en un solo archivo",
+          "Enregistre ton Pokédex, tes tokens cumulés, ton Sac et ton Pokémon actuel dans un seul fichier")
     }
-    var exportSaveButton: String { t("내보내기…", "Export…", "書き出す…", "Exportar…") }
-    var importSaveLabel: String { t("세이브 불러오기", "Import save", "セーブを読み込む", "Importar partida") }
+    var exportSaveButton: String { t("내보내기…", "Export…", "書き出す…", "Exportar…", "Exporter…") }
+    var importSaveLabel: String { t("세이브 불러오기", "Import save", "セーブを読み込む", "Importar partida", "Importer une sauvegarde") }
     var importSaveHint: String {
         t("다른 Mac에서 내보낸 파일을 골라 이 Mac으로 이어서 키워요",
           "Pick a file exported from another Mac and continue here",
           "他のMacから書き出したファイルを選んでこのMacで続けます",
-          "Elige un archivo exportado desde otro Mac y continúa aquí")
+          "Elige un archivo exportado desde otro Mac y continúa aquí",
+          "Choisis un fichier exporté depuis un autre Mac et continue ici")
     }
-    var importSaveButton: String { t("불러오기…", "Import…", "読み込む…", "Importar…") }
+    var importSaveButton: String { t("불러오기…", "Import…", "読み込む…", "Importar…", "Importer…") }
     var importConfirmTitle: String {
-        t("이 Mac의 진행을 대체할까요?", "Replace this Mac's progress?", "このMacの進行を置き換えますか？", "¿Reemplazar el progreso de este Mac?")
+        t("이 Mac의 진행을 대체할까요?", "Replace this Mac's progress?", "このMacの進行を置き換えますか？", "¿Reemplazar el progreso de este Mac?", "Remplacer la progression de ce Mac ?")
     }
     /// 무엇이 사라지는지 수치로 적는다 — 일반적인 "정말 진행할까요?" 보다 판단에 실제로 쓸모 있다.
     /// 내보낸 시각·출처 기기를 함께 보여주는 이유: 도감 수가 같으면 3주 전 세이브도 문구가 똑같아,
@@ -228,26 +233,36 @@ struct L {
           Este Mac ahora: Pokédex \(currentDex) · \(currentTokens) acumulados
 
           El progreso actual de este Mac será reemplazado. El estado anterior se guarda como copia de seguridad en la carpeta de estado (últimas 5).
+          """,
+          """
+          Sauvegarde à importer : Pokédex \(incomingDex) · \(incomingTokens) cumulés
+          Exportée : \(exportedAt) · \(sourceDevice)
+          Ce Mac actuellement : Pokédex \(currentDex) · \(currentTokens) cumulés
+
+          La progression actuelle de ce Mac sera remplacée. L'état précédent est conservé en sauvegarde dans le dossier d'état (5 derniers).
           """)
     }
-    var importConfirmReplace: String { t("대체", "Replace", "置き換える", "Reemplazar") }
+    var importConfirmReplace: String { t("대체", "Replace", "置き換える", "Reemplazar", "Remplacer") }
     func importSaveDone(dex: Int, tokens: String) -> String {
         t("불러왔어요 — 도감 \(dex)마리 · 누적 \(tokens)",
           "Imported — \(dex) in Pokédex · \(tokens) lifetime",
           "読み込みました — 図鑑 \(dex)匹 · 累計 \(tokens)",
-          "Importado — Pokédex \(dex) · \(tokens) acumulados")
+          "Importado — Pokédex \(dex) · \(tokens) acumulados",
+          "Importé — Pokédex \(dex) · \(tokens) cumulés")
     }
     var importErrorNotSaveFile: String {
         t("PokeTokenBar 세이브 파일이 아니에요.",
           "That isn't a PokeTokenBar save file.",
           "PokeTokenBar のセーブファイルではありません。",
-          "Ese no es un archivo de partida de PokeTokenBar.")
+          "Ese no es un archivo de partida de PokeTokenBar.",
+          "Ce n'est pas un fichier de sauvegarde PokeTokenBar.")
     }
     var importErrorNewerSchema: String {
         t("더 새로운 버전에서 만든 세이브예요 — 앱을 업데이트한 뒤 다시 시도해 주세요.",
           "This save was made by a newer version — update the app and try again.",
           "より新しいバージョンで作成されたセーブです — アプリを更新してから再試行してください。",
-          "Esta partida se creó con una versión más reciente — actualiza la app e inténtalo de nuevo.")
+          "Esta partida se creó con una versión más reciente — actualiza la app e inténtalo de nuevo.",
+          "Cette sauvegarde a été créée par une version plus récente — mets l'app à jour et réessaie.")
     }
     /// 불러오기 실패 사유 → 사용자 문구. 뷰가 아니라 여기 두는 이유는 이 매핑이 테스트 가능해야 하기
     /// 때문이다 — 매핑이 어긋나면 `SaveTransferError` 는 LocalizedError 가 아니라서 "The operation
@@ -265,36 +280,41 @@ struct L {
         t("세이브 파일이라기엔 너무 커요 — 다른 파일을 고른 것 같아요.",
           "That file is too large to be a save — it looks like the wrong file.",
           "セーブファイルにしては大きすぎます — 別のファイルを選んだようです。",
-          "Ese archivo es demasiado grande para ser una partida — parece que elegiste el archivo equivocado.")
+          "Ese archivo es demasiado grande para ser una partida — parece que elegiste el archivo equivocado.",
+          "Ce fichier est trop volumineux pour être une sauvegarde — ce n'est sans doute pas le bon fichier.")
     }
     /// 백업을 못 남기면 불러오기를 중단한다 — 되돌릴 수단 없이 진행을 대체하지 않기 위해서다.
     var importErrorBackupFailed: String {
         t("현재 상태를 백업하지 못해 불러오기를 중단했어요 — 진행은 그대로예요. 디스크 여유 공간을 확인해 주세요.",
           "Import stopped because the current state couldn't be backed up — your progress is untouched. Check free disk space.",
           "現在の状態をバックアップできなかったため読み込みを中止しました — 進行はそのままです。ディスクの空き容量を確認してください。",
-          "Se detuvo la importación porque no se pudo hacer una copia de seguridad del estado actual — tu progreso no se ha tocado. Comprueba el espacio libre en disco.")
+          "Se detuvo la importación porque no se pudo hacer una copia de seguridad del estado actual — tu progreso no se ha tocado. Comprueba el espacio libre en disco.",
+          "Import interrompu car l'état actuel n'a pas pu être sauvegardé — ta progression est intacte. Vérifie l'espace disque disponible.")
     }
 
     // MARK: 문제점 알리기 (설정 → 메일 리포트)
-    var reportProblem: String { t("문제점 알리기", "Report a problem", "問題を報告", "Reportar un problema") }
-    var showLogFile: String { t("로그 파일 보기", "Show log file", "ログファイルを表示", "Mostrar archivo de registro") }
+    var reportProblem: String { t("문제점 알리기", "Report a problem", "問題を報告", "Reportar un problema", "Signaler un problème") }
+    var showLogFile: String { t("로그 파일 보기", "Show log file", "ログファイルを表示", "Mostrar archivo de registro", "Afficher le fichier journal") }
     var reportAttachHint: String {
         t("메일에 로그 파일을 첨부해 주시면 원인 파악에 큰 도움이 돼요.",
           "Attaching the log file to the email helps a lot with diagnosis.",
           "メールにログファイルを添付していただくと原因の特定に役立ちます。",
-          "Adjuntar el archivo de registro al correo ayuda mucho a diagnosticar el problema.")
+          "Adjuntar el archivo de registro al correo ayuda mucho a diagnosticar el problema.",
+          "Joindre le fichier journal au mail aide beaucoup au diagnostic.")
     }
     func reportMailFallback(_ address: String) -> String {
         t("메일 앱을 열 수 없어요. \(address) 로 직접 보내주세요.",
           "Couldn't open a mail app. Please email \(address) directly.",
           "メールアプリを開けません。\(address) 宛に直接お送りください。",
-          "No se pudo abrir una app de correo. Escribe directamente a \(address).")
+          "No se pudo abrir una app de correo. Escribe directamente a \(address).",
+          "Impossible d'ouvrir une app de messagerie. Écris directement à \(address).")
     }
     func reportMailSubject(_ version: String) -> String {
         t("[PokeTokenBar] 문제 리포트 (v\(version))",
           "[PokeTokenBar] Problem report (v\(version))",
           "[PokeTokenBar] 問題レポート (v\(version))",
-          "[PokeTokenBar] Reporte de problema (v\(version))")
+          "[PokeTokenBar] Reporte de problema (v\(version))",
+          "[PokeTokenBar] Rapport de problème (v\(version))")
     }
     func reportMailBody(version: String, os: String) -> String {
         t("""
@@ -336,53 +356,64 @@ struct L {
         Versión de la app: v\(version)
         macOS: \(os)
         Archivo de registro (se recomienda adjuntar): ~/Library/Logs/PokeTokenBar.log
+        """,
+        """
+        Ce qui s'est passé :
+        (Décris le problème — quand, sur quel écran, et ce que tu as vu)
+
+
+        ---
+        Version de l'app : v\(version)
+        macOS: \(os)
+        Fichier journal (à joindre de préférence) : ~/Library/Logs/PokeTokenBar.log
         """)
     }
 
     /// 새로고침 간격 라벨 (초 단위 값 → 표시). 0 = 수동.
     func intervalLabel(_ seconds: TimeInterval) -> String {
-        if seconds == 0 { return t("수동", "Manual", "手動", "Manual") }
+        if seconds == 0 { return t("수동", "Manual", "手動", "Manual", "Manuel") }
         let m = Int(seconds / 60)
-        return t("\(m)분", "\(m) min", "\(m)分", "\(m) min")
+        return t("\(m)분", "\(m) min", "\(m)分", "\(m) min", "\(m) min")
     }
 
     // MARK: 컴패니언
-    var finalForm: String { t("최종 진화체", "Final form", "最終進化", "Forma final") }
-    func stage(_ i: Int, _ k: Int) -> String { t("진화 단계 \(i) / \(k)", "Stage \(i) / \(k)", "進化段階 \(i) / \(k)", "Etapa \(i) / \(k)") }
-    var unknownNextEvolution: String { t("알 수 없는 다음 진화", "Unknown next evolution", "次の進化先は不明", "Próxima evolución desconocida") }
-    var eggIncubating: String { t("🥚 부화 준비 중", "🥚 Incubating", "🥚 孵化の準備中", "🥚 Incubando") }
-    func eggToHatch(_ amount: String) -> String { t("부화까지 \(amount)", "\(amount) to hatch", "孵化まで \(amount)", "\(amount) para eclosionar") }
-    func toNextEvolution(_ amount: String) -> String { t("다음 진화까지 \(amount)", "\(amount) to next evolution", "次の進化まで \(amount)", "\(amount) para la siguiente evolución") }
-    func toGraduation(_ amount: String) -> String { t("졸업까지 \(amount)", "\(amount) to graduation", "卒業まで \(amount)", "\(amount) para graduarse") }
+    var finalForm: String { t("최종 진화체", "Final form", "最終進化", "Forma final", "Forme finale") }
+    func stage(_ i: Int, _ k: Int) -> String { t("진화 단계 \(i) / \(k)", "Stage \(i) / \(k)", "進化段階 \(i) / \(k)", "Etapa \(i) / \(k)", "Stade \(i) / \(k)") }
+    var unknownNextEvolution: String { t("알 수 없는 다음 진화", "Unknown next evolution", "次の進化先は不明", "Próxima evolución desconocida", "Prochaine évolution inconnue") }
+    var eggIncubating: String { t("🥚 부화 준비 중", "🥚 Incubating", "🥚 孵化の準備中", "🥚 Incubando", "🥚 En incubation") }
+    func eggToHatch(_ amount: String) -> String { t("부화까지 \(amount)", "\(amount) to hatch", "孵化まで \(amount)", "\(amount) para eclosionar", "\(amount) avant l'éclosion") }
+    func toNextEvolution(_ amount: String) -> String { t("다음 진화까지 \(amount)", "\(amount) to next evolution", "次の進化まで \(amount)", "\(amount) para la siguiente evolución", "\(amount) avant la prochaine évolution") }
+    func toGraduation(_ amount: String) -> String { t("졸업까지 \(amount)", "\(amount) to graduation", "卒業まで \(amount)", "\(amount) para graduarse", "\(amount) avant le diplôme") }
     func graduated(_ name: String) -> String {
         t("\(name) 졸업 → 도감에 보존. 새 Token Egg가 도착했어요!",
           "\(name) graduated → saved to the dex. A new Token Egg has arrived!",
           "\(name) 卒業 → 図鑑に保存。新しいToken Eggが届きました！",
-          "\(name) se graduó → guardado en la Pokédex. ¡Ha llegado un nuevo Token Egg!")
+          "\(name) se graduó → guardado en la Pokédex. ¡Ha llegado un nuevo Token Egg!",
+          "\(name) a été diplômé → conservé dans le Pokédex. Un nouveau Token Egg est arrivé !")
     }
-    var dexEmptyTitle: String { t("아직 잡은 포켓몬이 없어요!", "No Pokémon caught yet!", "まだ捕まえたポケモンがいません！", "¡Todavía no has capturado ningún Pokémon!") }
-    var dexEmptyHint: String { t("토큰을 써서 첫 포켓몬을 부화시켜 보세요.", "Spend tokens to hatch your first Pokémon.", "トークンを使って最初のポケモンを孵化させましょう。", "Usa tokens para eclosionar tu primer Pokémon.") }
+    var dexEmptyTitle: String { t("아직 잡은 포켓몬이 없어요!", "No Pokémon caught yet!", "まだ捕まえたポケモンがいません！", "¡Todavía no has capturado ningún Pokémon!", "Aucun Pokémon capturé pour l'instant !") }
+    var dexEmptyHint: String { t("토큰을 써서 첫 포켓몬을 부화시켜 보세요.", "Spend tokens to hatch your first Pokémon.", "トークンを使って最初のポケモンを孵化させましょう。", "Usa tokens para eclosionar tu primer Pokémon.", "Dépense des tokens pour faire éclore ton premier Pokémon.") }
 
     // MARK: 도감 요약 헤더
-    var dexTitle: String { t("도감", "Pokédex", "図鑑", "Pokédex") }
-    func dexTotal(_ n: Int) -> String { t("총 \(n)마리", "\(n) total", "全\(n)匹", "\(n) en total") }
+    var dexTitle: String { t("도감", "Pokédex", "図鑑", "Pokédex", "Pokédex") }
+    func dexTotal(_ n: Int) -> String { t("총 \(n)마리", "\(n) total", "全\(n)匹", "\(n) en total", "\(n) au total") }
     /// 포획 로그 = 개체 단위 기록(같은 라인 중복이 정상). 도감 = 종 단위 집계.
-    var catchLogTitle: String { t("포획 로그", "Catch log", "捕獲ログ", "Registro de capturas") }
+    var catchLogTitle: String { t("포획 로그", "Catch log", "捕獲ログ", "Registro de capturas", "Journal de captures") }
     /// 도감 총계는 개체가 아니라 종 수 — 로그의 dexTotal("총 N마리")과 단위가 다르다.
-    func dexSpeciesTotal(_ n: Int) -> String { t("\(n)종", "\(n) species", "\(n)種", "\(n) especies") }
+    func dexSpeciesTotal(_ n: Int) -> String { t("\(n)종", "\(n) species", "\(n)種", "\(n) especies", "\(n) espèces") }
     func dexPageLabel(_ page: Int, _ total: Int) -> String {
-        t("\(total)페이지 중 \(page)페이지", "Page \(page) of \(total)", "\(total)ページ中 \(page)ページ", "Página \(page) de \(total)")
+        t("\(total)페이지 중 \(page)페이지", "Page \(page) of \(total)", "\(total)ページ中 \(page)ページ", "Página \(page) de \(total)", "Page \(page) sur \(total)")
     }
-    var dexPagePrev: String { t("이전 페이지", "Previous page", "前のページ", "Página anterior") }
-    var dexPageNext: String { t("다음 페이지", "Next page", "次のページ", "Página siguiente") }
-    var dexRaising: String { t("키우는 중", "Raising", "育成中", "Criando") }
-    var rarityCommon: String { t("일반", "Common", "ノーマル", "Común") }
-    var rarityUncommon: String { t("고급", "Uncommon", "アンコモン", "Poco común") }
-    var rarityRare: String { t("희귀", "Rare", "レア", "Raro") }
-    var rarityLegendary: String { t("전설", "Legendary", "伝説", "Legendario") }
-    var dexFilterHint: String { t("탭하면 이 희귀도만 보기 · 다시 탭하면 전체", "Tap to show only this rarity · tap again to clear", "タップでこの希少度のみ表示・再タップで全体", "Toca para ver solo esta rareza · toca de nuevo para ver todo") }
+    var dexPagePrev: String { t("이전 페이지", "Previous page", "前のページ", "Página anterior", "Page précédente") }
+    var dexPageNext: String { t("다음 페이지", "Next page", "次のページ", "Página siguiente", "Page suivante") }
+    var dexRaising: String { t("키우는 중", "Raising", "育成中", "Criando", "En élevage") }
+    var rarityCommon: String { t("일반", "Common", "ノーマル", "Común", "Commun") }
+    var rarityUncommon: String { t("고급", "Uncommon", "アンコモン", "Poco común", "Peu commun") }
+    var rarityRare: String { t("희귀", "Rare", "レア", "Raro", "Rare") }
+    var rarityLegendary: String { t("전설", "Legendary", "伝説", "Legendario", "Légendaire") }
+    var dexFilterHint: String { t("탭하면 이 희귀도만 보기 · 다시 탭하면 전체", "Tap to show only this rarity · tap again to clear", "タップでこの希少度のみ表示・再タップで全体", "Toca para ver solo esta rareza · toca de nuevo para ver todo", "Touche pour n'afficher que cette rareté · touche à nouveau pour tout afficher") }
     /// 도감 칸의 ✨ 를 읽어주는 명사 — 이모지는 스크린리더가 일관되게 읽지 못한다.
-    var dexShinyLabel: String { t("이로치", "Shiny", "色違い", "Variocolor") }
+    var dexShinyLabel: String { t("이로치", "Shiny", "色違い", "Variocolor", "Chromatique") }
     func rarityLabel(_ r: Rarity) -> String {
         switch r {
         case .common:    return rarityCommon
@@ -393,36 +424,37 @@ struct L {
     }
 
     // 상태 한 줄
-    var statusEgg: String { t("곧 깨어나요.", "Hatching soon.", "もうすぐ孵化します。", "Está a punto de eclosionar.") }
-    var statusIdle: String { t("오늘은 조용히 자리를 지켜요.", "Keeping quiet today.", "今日は静かにしています。", "Hoy se mantiene tranquilo.") }
-    var statusWorking: String { t("오늘의 작업 흔적이 쌓이고 있어요.", "Today's work is piling up.", "本日の作業が積み重なっています。", "El trabajo de hoy se va acumulando.") }
-    var statusFocus: String { t("지금은 집중 모드예요.", "In focus mode now.", "今は集中モードです。", "Ahora está en modo concentración.") }
-    var statusTired: String { t("한도에 가까워요. 잠깐 쉬어도 괜찮아요.", "Close to the limit. A short break is fine.", "上限が近いです。少し休んでも大丈夫。", "Está cerca del límite. Un pequeño descanso no vendría mal.") }
-    var statusSleep: String { t("지금은 자고 있어요.", "Sleeping now.", "今は眠っています。", "Ahora está durmiendo.") }
-    func statusEvolved(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！", "¡Evolucionó a \(name)!") }
-    var statusGrew: String { t("성장했어요!", "It grew!", "成長しました！", "¡Ha crecido!") }
+    var statusEgg: String { t("곧 깨어나요.", "Hatching soon.", "もうすぐ孵化します。", "Está a punto de eclosionar.", "Bientôt l'éclosion.") }
+    var statusIdle: String { t("오늘은 조용히 자리를 지켜요.", "Keeping quiet today.", "今日は静かにしています。", "Hoy se mantiene tranquilo.", "Tranquille aujourd'hui.") }
+    var statusWorking: String { t("오늘의 작업 흔적이 쌓이고 있어요.", "Today's work is piling up.", "本日の作業が積み重なっています。", "El trabajo de hoy se va acumulando.", "Le travail du jour s'accumule.") }
+    var statusFocus: String { t("지금은 집중 모드예요.", "In focus mode now.", "今は集中モードです。", "Ahora está en modo concentración.", "En mode concentration.") }
+    var statusTired: String { t("한도에 가까워요. 잠깐 쉬어도 괜찮아요.", "Close to the limit. A short break is fine.", "上限が近いです。少し休んでも大丈夫。", "Está cerca del límite. Un pequeño descanso no vendría mal.", "Proche de la limite. Une petite pause ne fait pas de mal.") }
+    var statusSleep: String { t("지금은 자고 있어요.", "Sleeping now.", "今は眠っています。", "Ahora está durmiendo.", "En train de dormir.") }
+    func statusEvolved(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！", "¡Evolucionó a \(name)!", "A évolué en \(name) !") }
+    var statusGrew: String { t("성장했어요!", "It grew!", "成長しました！", "¡Ha crecido!", "Il a grandi !") }
 
     // MARK: companion 이벤트 시스템 알림
-    var notifHatchTitle: String { t("🥚 부화!", "🥚 Hatched!", "🥚 孵化！", "🥚 ¡Eclosionó!") }
-    func notifHatchBody(_ name: String) -> String { t("알에서 \(name)이(가) 나왔어요!", "\(name) hatched from the egg!", "タマゴから \(name) が生まれました！", "¡\(name) salió del huevo!") }
-    var notifShinyHatchTitle: String { t("✨ 이로치 포켓몬!", "✨ Shiny Pokémon!", "✨ 色違いポケモン！", "✨ ¡Pokémon variocolor!") }
-    func notifShinyHatchBody(_ name: String) -> String { t("이로치 \(name)이(가) 태어났어요! (1/64)", "A shiny \(name) hatched! (1 in 64)", "色違いの \(name) が生まれました！(1/64)", "¡Nació un \(name) variocolor! (1 entre 64)") }
-    var eggImminent: String { t("곧 부화해요!", "About to hatch!", "もうすぐ孵化！", "¡Está a punto de eclosionar!") }
+    var notifHatchTitle: String { t("🥚 부화!", "🥚 Hatched!", "🥚 孵化！", "🥚 ¡Eclosionó!", "🥚 Éclosion !") }
+    func notifHatchBody(_ name: String) -> String { t("알에서 \(name)이(가) 나왔어요!", "\(name) hatched from the egg!", "タマゴから \(name) が生まれました！", "¡\(name) salió del huevo!", "\(name) est sorti de l'œuf !") }
+    var notifShinyHatchTitle: String { t("✨ 이로치 포켓몬!", "✨ Shiny Pokémon!", "✨ 色違いポケモン！", "✨ ¡Pokémon variocolor!", "✨ Pokémon chromatique !") }
+    func notifShinyHatchBody(_ name: String) -> String { t("이로치 \(name)이(가) 태어났어요! (1/64)", "A shiny \(name) hatched! (1 in 64)", "色違いの \(name) が生まれました！(1/64)", "¡Nació un \(name) variocolor! (1 entre 64)", "Un \(name) chromatique est né ! (1 sur 64)") }
+    var eggImminent: String { t("곧 부화해요!", "About to hatch!", "もうすぐ孵化！", "¡Está a punto de eclosionar!", "Sur le point d'éclore !") }
     /// 첫 실행(아직 토큰 적립 0) 안내 — "왜 아무 일도 안 일어나지"를 방지.
     var eggFirstRunHint: String {
         t("로컬 AI 코딩 도구의 사용량으로 자라요. 약 5M 토큰을 쓰면 알이 부화해요.",
           "Grows from your local AI coding usage. Your egg hatches after ~5M tokens.",
           "ローカルの AI コーディング使用量で育ちます。約5Mトークンでタマゴが孵化します。",
-          "Crece con el uso de tus herramientas locales de programación con IA. Tu huevo eclosiona tras unos 5M de tokens.") }
-    var notifEvolveTitle: String { t("✨ 진화!", "✨ Evolved!", "✨ 進化！", "✨ ¡Evolucionó!") }
-    func notifEvolveBody(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！", "¡Evolucionó a \(name)!") }
+          "Crece con el uso de tus herramientas locales de programación con IA. Tu huevo eclosiona tras unos 5M de tokens.",
+          "Il grandit avec l'usage de tes outils de code IA locaux. Ton œuf éclôt après environ 5M de tokens.") }
+    var notifEvolveTitle: String { t("✨ 진화!", "✨ Evolved!", "✨ 進化！", "✨ ¡Evolucionó!", "✨ Évolution !") }
+    func notifEvolveBody(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！", "¡Evolucionó a \(name)!", "A évolué en \(name) !") }
     // 메타몽 위장 리빌 — 진화 못 하는 메타몽이 첫 진화 순간 정체를 드러낸다.
-    var notifDittoRevealTitle: String { t("🎭 어라? 메타몽!", "🎭 Huh? It's Ditto!", "🎭 あれ？メタモン！", "🎭 ¿Eh? ¡Es Ditto!") }
-    func notifDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 사실은 메타몽이었어요!", "You thought it was \(disguise) — it was Ditto all along!", "\(disguise) だと思ってた… 実はメタモンでした！", "Pensabas que era \(disguise) — ¡en realidad era Ditto!") }
-    var notifShinyDittoRevealTitle: String { t("🎭✨ 어라? 이로치 메타몽!", "🎭✨ Huh? A shiny Ditto!", "🎭✨ あれ？色違いメタモン！", "🎭✨ ¿Eh? ¡Un Ditto variocolor!") }
-    func notifShinyDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 이로치 메타몽이었어요! (1/64)", "You thought it was \(disguise) — it was a shiny Ditto! (1 in 64)", "\(disguise) だと思ってた… 色違いのメタモンでした！(1/64)", "Pensabas que era \(disguise) — ¡era un Ditto variocolor! (1 entre 64)") }
-    var notifGraduateTitle: String { t("🎓 졸업!", "🎓 Graduated!", "🎓 卒業！", "🎓 ¡Graduado!") }
-    func notifGraduateBody(_ name: String) -> String { t("\(name) — 도감에 보존! 새 알이 도착했어요.", "\(name) — saved to your Pokédex! A new egg has arrived.", "\(name) — 図鑑に保存！新しいタマゴが届きました。", "\(name) — ¡guardado en tu Pokédex! Ha llegado un nuevo huevo.") }
+    var notifDittoRevealTitle: String { t("🎭 어라? 메타몽!", "🎭 Huh? It's Ditto!", "🎭 あれ？メタモン！", "🎭 ¿Eh? ¡Es Ditto!", "🎭 Hein ? C'est Métamorph !") }
+    func notifDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 사실은 메타몽이었어요!", "You thought it was \(disguise) — it was Ditto all along!", "\(disguise) だと思ってた… 実はメタモンでした！", "Pensabas que era \(disguise) — ¡en realidad era Ditto!", "Tu croyais que c'était \(disguise) — c'était Métamorph depuis le début !") }
+    var notifShinyDittoRevealTitle: String { t("🎭✨ 어라? 이로치 메타몽!", "🎭✨ Huh? A shiny Ditto!", "🎭✨ あれ？色違いメタモン！", "🎭✨ ¿Eh? ¡Un Ditto variocolor!", "🎭✨ Hein ? Un Métamorph chromatique !") }
+    func notifShinyDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 이로치 메타몽이었어요! (1/64)", "You thought it was \(disguise) — it was a shiny Ditto! (1 in 64)", "\(disguise) だと思ってた… 色違いのメタモンでした！(1/64)", "Pensabas que era \(disguise) — ¡era un Ditto variocolor! (1 entre 64)", "Tu croyais que c'était \(disguise) — c'était un Métamorph chromatique ! (1 sur 64)") }
+    var notifGraduateTitle: String { t("🎓 졸업!", "🎓 Graduated!", "🎓 卒業！", "🎓 ¡Graduado!", "🎓 Diplômé !") }
+    func notifGraduateBody(_ name: String) -> String { t("\(name) — 도감에 보존! 새 알이 도착했어요.", "\(name) — saved to your Pokédex! A new egg has arrived.", "\(name) — 図鑑に保存！新しいタマゴが届きました。", "\(name) — ¡guardado en tu Pokédex! Ha llegado un nuevo huevo.", "\(name) — conservé dans ton Pokédex ! Un nouvel œuf est arrivé.") }
 
     // MARK: Claude 한도 토큰 갱신 오류 (친절 안내)
     func limitRefreshHTTPError(_ status: Int) -> String {
@@ -431,33 +463,38 @@ struct L {
                 "Claude 자격증명이 만료됐거나 권한이 없어요 (\(status)). Claude Code 로그인을 확인하세요. Codex만 쓴다면 무시해도 됩니다 — Codex 한도는 따로 표시돼요.",
                 "Claude credential is expired or unauthorized (\(status)). Check that you're signed in to Claude Code. If you only use Codex you can ignore this — Codex limits show separately.",
                 "Claude の認証情報が期限切れか権限がありません (\(status))。Claude Code にサインインしているか確認してください。Codex のみ使用する場合は無視できます — Codex の上限は別に表示されます。",
-                "La credencial de Claude expiró o no tiene permisos (\(status)). Comprueba que has iniciado sesión en Claude Code. Si solo usas Codex, puedes ignorar esto — los límites de Codex se muestran aparte.")
+                "La credencial de Claude expiró o no tiene permisos (\(status)). Comprueba que has iniciado sesión en Claude Code. Si solo usas Codex, puedes ignorar esto — los límites de Codex se muestran aparte.",
+                "L'identifiant Claude a expiré ou n'est pas autorisé (\(status)). Vérifie que tu es connecté à Claude Code. Si tu n'utilises que Codex, ignore ceci — les limites Codex s'affichent séparément.")
         }
-        return t("Claude 한도 조회 실패 (\(status)).", "Failed to fetch Claude limits (\(status)).", "Claude の上限取得に失敗しました (\(status))。", "No se pudieron obtener los límites de Claude (\(status)).")
+        return t("Claude 한도 조회 실패 (\(status)).", "Failed to fetch Claude limits (\(status)).", "Claude の上限取得に失敗しました (\(status))。", "No se pudieron obtener los límites de Claude (\(status)).", "Échec de récupération des limites Claude (\(status)).")
     }
     var limitRefreshNoCredential: String {
         t("Claude 자격증명을 찾지 못했어요. Claude Code 에 로그인하면 한도가 표시됩니다. Codex만 쓴다면 무시해도 돼요.",
           "No Claude credential found. Sign in to Claude Code to see limits. If you only use Codex you can ignore this.",
           "Claude の認証情報が見つかりません。Claude Code にサインインすると上限が表示されます。Codex のみなら無視して構いません。",
-          "No se encontró ninguna credencial de Claude. Inicia sesión en Claude Code para ver los límites. Si solo usas Codex, puedes ignorar esto.")
+          "No se encontró ninguna credencial de Claude. Inicia sesión en Claude Code para ver los límites. Si solo usas Codex, puedes ignorar esto.",
+          "Aucun identifiant Claude trouvé. Connecte-toi à Claude Code pour voir les limites. Si tu n'utilises que Codex, ignore ceci.")
     }
     var limitRefreshReauthNeeded: String {
         t("Claude 자격증명에 계정 로그인 정보가 없어요. Claude Code 에서 `/login` 으로 다시 로그인하면 한도가 표시됩니다.",
           "Your Claude credential has no account sign-in. Run `/login` in Claude Code to sign in again and limits will appear.",
           "Claude の認証情報にアカウントのサインインが含まれていません。Claude Code で `/login` を実行して再度サインインすると上限が表示されます。",
-          "Tu credencial de Claude no tiene una sesión de cuenta asociada. Ejecuta `/login` en Claude Code para volver a iniciar sesión y ver los límites.")
+          "Tu credencial de Claude no tiene una sesión de cuenta asociada. Ejecuta `/login` en Claude Code para volver a iniciar sesión y ver los límites.",
+          "Ton identifiant Claude n'a pas de connexion de compte. Lance `/login` dans Claude Code pour te reconnecter et les limites apparaîtront.")
     }
     var limitRefreshGeneric: String {
         t("Claude 한도 조회에 실패했어요. 잠시 후 다시 시도하세요.",
           "Couldn't fetch Claude limits. Please try again shortly.",
           "Claude の上限取得に失敗しました。しばらくして再試行してください。",
-          "No se pudieron obtener los límites de Claude. Inténtalo de nuevo en unos momentos.")
+          "No se pudieron obtener los límites de Claude. Inténtalo de nuevo en unos momentos.",
+          "Impossible de récupérer les limites Claude. Réessaie dans un instant.")
     }
     var limitRefreshRateLimited: String {
         t("Claude 한도 조회가 일시 제한됐어요 (429). 잠시 쉬었다가 자동으로 재시도합니다.",
           "Claude limit checks are temporarily rate-limited (429). Backing off and retrying automatically.",
           "Claude の上限取得が一時的に制限されています (429)。少し待って自動的に再試行します。",
-          "Las comprobaciones de límites de Claude están temporalmente limitadas (429). Se reintentará automáticamente en breve.")
+          "Las comprobaciones de límites de Claude están temporalmente limitadas (429). Se reintentará automáticamente en breve.",
+          "Les vérifications de limites Claude sont temporairement restreintes (429). Pause puis nouvelle tentative automatique.")
     }
 
     // MARK: Claude 세션 만료(401) 안내
@@ -465,61 +502,64 @@ struct L {
         t("Claude 세션 만료 — 한도가 갱신 안 돼요",
           "Claude session expired — limits can't refresh",
           "Claude セッション期限切れ — 上限を更新できません",
-          "Sesión de Claude expirada — los límites no se pueden actualizar")
+          "Sesión de Claude expirada — los límites no se pueden actualizar",
+          "Session Claude expirée — les limites ne s'actualisent pas")
     }
     var claudeAuthExpiredHint: String {
         t("표시된 값은 만료 전 기준이에요. 다시 시도하거나, Claude Code 를 한 번 실행하면 자동 갱신됩니다.",
           "Values shown are from before expiry. Retry, or run Claude Code once to refresh automatically.",
           "表示値は期限切れ前のものです。再試行するか、Claude Code を一度実行すると自動更新されます。",
-          "Los valores mostrados son de antes de la expiración. Reinténtalo, o ejecuta Claude Code una vez para actualizarlos automáticamente.")
+          "Los valores mostrados son de antes de la expiración. Reinténtalo, o ejecuta Claude Code una vez para actualizarlos automáticamente.",
+          "Les valeurs affichées datent d'avant l'expiration. Réessaie, ou lance Claude Code une fois pour actualiser automatiquement.")
     }
-    var retry: String { t("다시 시도", "Retry", "再試行", "Reintentar") }
+    var retry: String { t("다시 시도", "Retry", "再試行", "Reintentar", "Réessayer") }
 
     // MARK: 업데이트 알림
     func updateAvailable(_ version: String, current: String) -> String {
         t("🆕 v\(version) 사용 가능 (현재 \(current))",
           "🆕 v\(version) available (you have \(current))",
           "🆕 v\(version) が利用可能（現在 \(current)）",
-          "🆕 v\(version) disponible (tienes \(current))")
+          "🆕 v\(version) disponible (tienes \(current))",
+          "🆕 v\(version) disponible (tu as \(current))")
     }
-    var updateButton: String { t("업데이트", "Update", "更新", "Actualizar") }
-    var updateLater: String { t("나중에", "Later", "後で", "Más tarde") }
-    var updating: String { t("업데이트 중…", "Updating…", "更新中…", "Actualizando…") }
-    var updateSectionTitle: String { t("업데이트", "Updates", "アップデート", "Actualizaciones") }
-    var updateNotificationsLabel: String { t("업데이트 알림", "Update notifications", "アップデート通知", "Notificaciones de actualización") }
-    var checkForUpdatesLabel: String { t("업데이트 확인", "Check for updates", "アップデートを確認", "Buscar actualizaciones") }
-    var checkNowButton: String { t("지금 확인", "Check now", "今すぐ確認", "Comprobar ahora") }
-    func updateFound(_ version: String) -> String { t("새 버전 v\(version) 있어요", "Version \(version) is available", "バージョン \(version) が利用可能です", "La versión \(version) está disponible") }
-    func upToDate(_ version: String) -> String { t("최신 버전이에요 (v\(version))", "You're on the latest (v\(version))", "最新です (v\(version))", "Tienes la última versión (v\(version))") }
+    var updateButton: String { t("업데이트", "Update", "更新", "Actualizar", "Mettre à jour") }
+    var updateLater: String { t("나중에", "Later", "後で", "Más tarde", "Plus tard") }
+    var updating: String { t("업데이트 중…", "Updating…", "更新中…", "Actualizando…", "Mise à jour…") }
+    var updateSectionTitle: String { t("업데이트", "Updates", "アップデート", "Actualizaciones", "Mises à jour") }
+    var updateNotificationsLabel: String { t("업데이트 알림", "Update notifications", "アップデート通知", "Notificaciones de actualización", "Notifications de mise à jour") }
+    var checkForUpdatesLabel: String { t("업데이트 확인", "Check for updates", "アップデートを確認", "Buscar actualizaciones", "Rechercher des mises à jour") }
+    var checkNowButton: String { t("지금 확인", "Check now", "今すぐ確認", "Comprobar ahora", "Vérifier maintenant") }
+    func updateFound(_ version: String) -> String { t("새 버전 v\(version) 있어요", "Version \(version) is available", "バージョン \(version) が利用可能です", "La versión \(version) está disponible", "La version \(version) est disponible") }
+    func upToDate(_ version: String) -> String { t("최신 버전이에요 (v\(version))", "You're on the latest (v\(version))", "最新です (v\(version))", "Tienes la última versión (v\(version))", "Tu as la dernière version (v\(version))") }
 
     // MARK: 알림
-    var notifCritical: String { t("한도 임박", "Limit imminent", "上限切迫", "Límite inminente") }
-    var notifWarning: String { t("한도 경고", "Limit warning", "上限警告", "Aviso de límite") }
+    var notifCritical: String { t("한도 임박", "Limit imminent", "上限切迫", "Límite inminente", "Limite imminente") }
+    var notifWarning: String { t("한도 경고", "Limit warning", "上限警告", "Aviso de límite", "Alerte de limite") }
     func notifBody(_ name: String, _ percent: String) -> String {
-        t("\(name) 한도 \(percent) 사용", "\(name) at \(percent)", "\(name) 上限 \(percent) 使用", "\(name) al \(percent)")
+        t("\(name) 한도 \(percent) 사용", "\(name) at \(percent)", "\(name) 上限 \(percent) 使用", "\(name) al \(percent)", "\(name) à \(percent)")
     }
-    var claudeFiveHour: String { t("Claude 5시간 세션", "Claude 5-hour session", "Claude 5時間セッション", "Sesión de 5 horas de Claude") }
-    var claudeWeekly: String { t("Claude 주간", "Claude weekly", "Claude 週間", "Semanal de Claude") }
-    var codexPersonalLimit: String { t("Codex 개인 한도", "Codex personal limit", "Codex 個人上限", "Límite personal de Codex") }
+    var claudeFiveHour: String { t("Claude 5시간 세션", "Claude 5-hour session", "Claude 5時間セッション", "Sesión de 5 horas de Claude", "Session de 5 h de Claude") }
+    var claudeWeekly: String { t("Claude 주간", "Claude weekly", "Claude 週間", "Semanal de Claude", "Claude hebdo") }
+    var codexPersonalLimit: String { t("Codex 개인 한도", "Codex personal limit", "Codex 個人上限", "Límite personal de Codex", "Limite personnelle Codex") }
 
     // MARK: 가방 / 아이템
-    var bag: String { t("가방", "Bag", "バッグ", "Bolsa") }
-    var bagEmptyTitle: String { t("아직 가방이 비어있어요!", "Your bag is empty!", "バッグはまだ空っぽです！", "¡Tu bolsa todavía está vacía!") }
-    var useItem: String { t("사용하기", "Use", "つかう", "Usar") }
-    var use: String { t("사용", "Use", "つかう", "Usar") }
-    var cancel: String { t("취소", "Cancel", "キャンセル", "Cancelar") }
+    var bag: String { t("가방", "Bag", "バッグ", "Bolsa", "Sac") }
+    var bagEmptyTitle: String { t("아직 가방이 비어있어요!", "Your bag is empty!", "バッグはまだ空っぽです！", "¡Tu bolsa todavía está vacía!", "Ton sac est encore vide !") }
+    var useItem: String { t("사용하기", "Use", "つかう", "Usar", "Utiliser") }
+    var use: String { t("사용", "Use", "つかう", "Usar", "Utiliser") }
+    var cancel: String { t("취소", "Cancel", "キャンセル", "Cancelar", "Annuler") }
     func useOnCurrent(_ name: String) -> String {
-        t("\(name)에게 사용할까요?", "Use on \(name)?", "\(name) に使いますか？", "¿Usar en \(name)?")
+        t("\(name)에게 사용할까요?", "Use on \(name)?", "\(name) に使いますか？", "¿Usar en \(name)?", "Utiliser sur \(name) ?")
     }
-    var useAfterHatch: String { t("부화 후 사용할 수 있어요", "Usable after hatching", "孵化後に使えます", "Se puede usar después de eclosionar") }
-    var useNeedsPokemon: String { t("사용할 포켓몬이 없어요", "No Pokémon to use it on", "使えるポケモンがいません", "No hay ningún Pokémon en quien usarlo") }
+    var useAfterHatch: String { t("부화 후 사용할 수 있어요", "Usable after hatching", "孵化後に使えます", "Se puede usar después de eclosionar", "Utilisable après l'éclosion") }
+    var useNeedsPokemon: String { t("사용할 포켓몬이 없어요", "No Pokémon to use it on", "使えるポケモンがいません", "No hay ningún Pokémon en quien usarlo", "Aucun Pokémon sur qui l'utiliser") }
 
     /// 아이템 표시명 — species 처럼 공식 현지명.
     func itemName(_ kind: ItemKind) -> String {
         switch kind {
-        case .rareCandy: return t("이상한 사탕", "Rare Candy", "ふしぎなアメ", "Caramelo Raro")
-        case .mint:      return t("민트", "Mint", "ミント", "Menta")
-        case .shinyCharm: return t("이로치 부적", "Shiny Charm", "ひかるおまもり", "Amuleto Iris")
+        case .rareCandy: return t("이상한 사탕", "Rare Candy", "ふしぎなアメ", "Caramelo Raro", "Super Bonbon")
+        case .mint:      return t("민트", "Mint", "ミント", "Menta", "Menthe")
+        case .shinyCharm: return t("이로치 부적", "Shiny Charm", "ひかるおまもり", "Amuleto Iris", "Charme Chroma")
         }
     }
     func itemDescription(_ kind: ItemKind) -> String {
@@ -529,42 +569,45 @@ struct L {
             return t("현재 포켓몬의 경험치를 \(xp) 올려줘요.",
                      "Raises your Pokémon's EXP by \(xp).",
                      "ポケモンの経験値を\(xp)上げます。",
-                     "Aumenta la experiencia de tu Pokémon en \(xp).")
+                     "Aumenta la experiencia de tu Pokémon en \(xp).",
+                     "Augmente l'EXP de ton Pokémon de \(xp).")
         case .mint:
             return t("현재 포켓몬의 성격을 랜덤으로 바꿔줘요.",
                      "Randomly changes your Pokémon's nature.",
                      "ポケモンのせいかくをランダムに変えます。",
-                     "Cambia aleatoriamente la naturaleza de tu Pokémon.")
+                     "Cambia aleatoriamente la naturaleza de tu Pokémon.",
+                     "Change aléatoirement la nature de ton Pokémon.")
         case .shinyCharm:
             return t("보유하면 이로치 포켓몬이 태어날 확률이 올라가요.",
                      "While owned, raises the chance of hatching a shiny.",
                      "持っていると色違いが生まれる確率が上がります。",
-                     "Mientras lo tengas, aumenta la probabilidad de que nazca un Pokémon variocolor.")
+                     "Mientras lo tengas, aumenta la probabilidad de que nazca un Pokémon variocolor.",
+                     "Tant que tu le possèdes, augmente les chances qu'un Pokémon chromatique éclose.")
         }
     }
     /// 가방 사용 컨트롤의 효과 힌트 — 민트("성격 랜덤 변경", 사탕의 "+XP" 자리).
-    var mintEffectHint: String { t("성격 랜덤 변경", "Random nature", "せいかくランダム変更", "Naturaleza aleatoria") }
+    var mintEffectHint: String { t("성격 랜덤 변경", "Random nature", "せいかくランダム変更", "Naturaleza aleatoria", "Nature aléatoire") }
 
     // MARK: 상점 (재화 = 사용한 토큰)
-    var shop: String { t("상점", "Shop", "ショップ", "Tienda") }
-    var spendableTokens: String { t("쓸 수 있는 토큰", "Spendable tokens", "使えるトークン", "Tokens disponibles") }
-    var shopHint: String { t("사용한 토큰으로 아이템을 살 수 있어요.", "Spend the tokens you've used on items.", "使ったトークンでアイテムを購入できます。", "Usa los tokens que has consumido para comprar objetos.") }
-    var buy: String { t("구매", "Buy", "購入", "Comprar") }
-    func buyConfirm(_ name: String) -> String { t("\(name) 구매할까요?", "Buy \(name)?", "\(name) を購入しますか？", "¿Comprar \(name)?") }
-    var notEnoughTokens: String { t("토큰이 부족해요", "Not enough tokens", "トークンが足りません", "No tienes suficientes tokens") }
-    func ownedCount(_ n: Int) -> String { t("보유 ×\(n)", "Owned ×\(n)", "所持 ×\(n)", "En posesión ×\(n)") }
-    var shopPriceLabel: String { t("가격", "Price", "価格", "Precio") }
-    var ownedAlready: String { t("보유 중", "Owned", "所持済み", "En posesión") }
-    var shinyCharmEffectHint: String { t("이로치 확률 ↑ · 적용 중", "Shiny rate ↑ · active", "色違い率↑ · 適用中", "Prob. variocolor ↑ · activo") }
+    var shop: String { t("상점", "Shop", "ショップ", "Tienda", "Boutique") }
+    var spendableTokens: String { t("쓸 수 있는 토큰", "Spendable tokens", "使えるトークン", "Tokens disponibles", "Tokens disponibles") }
+    var shopHint: String { t("사용한 토큰으로 아이템을 살 수 있어요.", "Spend the tokens you've used on items.", "使ったトークンでアイテムを購入できます。", "Usa los tokens que has consumido para comprar objetos.", "Dépense les tokens que tu as consommés pour acheter des objets.") }
+    var buy: String { t("구매", "Buy", "購入", "Comprar", "Acheter") }
+    func buyConfirm(_ name: String) -> String { t("\(name) 구매할까요?", "Buy \(name)?", "\(name) を購入しますか？", "¿Comprar \(name)?", "Acheter \(name) ?") }
+    var notEnoughTokens: String { t("토큰이 부족해요", "Not enough tokens", "トークンが足りません", "No tienes suficientes tokens", "Pas assez de tokens") }
+    func ownedCount(_ n: Int) -> String { t("보유 ×\(n)", "Owned ×\(n)", "所持 ×\(n)", "En posesión ×\(n)", "Possédés ×\(n)") }
+    var shopPriceLabel: String { t("가격", "Price", "価格", "Precio", "Prix") }
+    var ownedAlready: String { t("보유 중", "Owned", "所持済み", "En posesión", "Possédé") }
+    var shinyCharmEffectHint: String { t("이로치 확률 ↑ · 적용 중", "Shiny rate ↑ · active", "色違い率↑ · 適用中", "Prob. variocolor ↑ · activo", "Taux chromatique ↑ · actif") }
     // 알 (리롤) — tier = 보증 등급 하한(nil = 보증 없는 기본 알).
     // 이름은 `rarityLabel(r) + " 알"` 식 조합으로 만들지 않는다: 한국어·영어는 맞아떨어져도 일본어에서
     // 조사가 어긋난다(レアのタマゴ vs 자연스러운 レアなタマゴ). 세 언어를 명시 트리플로 적는다.
     func eggName(_ tier: Rarity?) -> String {
         switch tier {
-        case nil, .common?: return t("포켓몬 알", "Pokémon Egg", "ポケモンのタマゴ", "Huevo Pokémon")
-        case .uncommon?:  return t("고급 알", "Uncommon Egg", "アンコモンのタマゴ", "Huevo poco común")
-        case .rare?:      return t("희귀 알", "Rare Egg", "レアのタマゴ", "Huevo raro")
-        case .legendary?: return t("전설 알", "Legendary Egg", "でんせつのタマゴ", "Huevo legendario")   // 미판매(FreshEgg.shopTiers)
+        case nil, .common?: return t("포켓몬 알", "Pokémon Egg", "ポケモンのタマゴ", "Huevo Pokémon", "Œuf Pokémon")
+        case .uncommon?:  return t("고급 알", "Uncommon Egg", "アンコモンのタマゴ", "Huevo poco común", "Œuf peu commun")
+        case .rare?:      return t("희귀 알", "Rare Egg", "レアのタマゴ", "Huevo raro", "Œuf rare")
+        case .legendary?: return t("전설 알", "Legendary Egg", "でんせつのタマゴ", "Huevo legendario", "Œuf légendaire")   // 미판매(FreshEgg.shopTiers)
         }
     }
     func eggDescription(_ tier: Rarity?) -> String {
@@ -572,39 +615,44 @@ struct L {
             return t("지금 포켓몬을 놓아주고 새 알로 다시 시작해요.",
                      "Send off your current Pokémon and start fresh with a new egg.",
                      "いまのポケモンを手放して新しいタマゴからやり直します。",
-                     "Suelta a tu Pokémon actual y empieza de nuevo con un huevo nuevo.")
+                     "Suelta a tu Pokémon actual y empieza de nuevo con un huevo nuevo.",
+                     "Laisse partir ton Pokémon actuel et repars de zéro avec un nouvel œuf.")
         }
         let r = rarityLabel(tier)
         return t("지금 포켓몬을 놓아주고 \(r) 이상이 확정으로 나오는 알을 받아요.",
                  "Send off your current Pokémon for an egg guaranteed to hatch \(r) or better.",
                  "いまのポケモンを手放して \(r) 以上が確定で孵るタマゴをもらいます。",
-                 "Suelta a tu Pokémon actual y consigue un huevo garantizado de \(r) o superior.")
+                 "Suelta a tu Pokémon actual y consigue un huevo garantizado de \(r) o superior.",
+                 "Laisse partir ton Pokémon actuel pour un œuf garanti \(r) ou mieux.")
     }
     /// 인큐베이션 중 표시하는 보증 배지 — 어떤 알을 품고 있는지 한 줄로.
     func eggGuaranteeHint(_ tier: Rarity) -> String {
         let r = rarityLabel(tier)
-        return t("\(r) 이상 확정", "\(r) or better", "\(r) 以上確定", "\(r) o superior garantizado")
+        return t("\(r) 이상 확정", "\(r) or better", "\(r) 以上確定", "\(r) o superior garantizado", "\(r) ou mieux garanti")
     }
     func eggConfirm(_ monName: String, _ eggName: String) -> String {
         t("\(monName)을(를) 놓아주고 \(eggName)(으)로 바꿀까요?",
           "Send off \(monName) for the \(eggName)?",
           "\(monName) を手放して \(eggName) にしますか？",
-          "¿Soltar a \(monName) y cambiarlo por \(eggName)?")
+          "¿Soltar a \(monName) y cambiarlo por \(eggName)?",
+          "Laisser partir \(monName) pour le \(eggName) ?")
     }
-    var freshEggShinyWarning: String { t("⚠️ 이로치 포켓몬이에요! 정말 놓아줄까요?", "⚠️ This one is shiny! Really send it off?", "⚠️ 色違いです！本当に手放しますか？", "⚠️ ¡Este es variocolor! ¿Seguro que quieres soltarlo?") }
-    var freshEggDiscardShiny: String { t("이로치 놓아주기", "Send shiny off", "手放す", "Soltar variocolor") }
+    var freshEggShinyWarning: String { t("⚠️ 이로치 포켓몬이에요! 정말 놓아줄까요?", "⚠️ This one is shiny! Really send it off?", "⚠️ 色違いです！本当に手放しますか？", "⚠️ ¡Este es variocolor! ¿Seguro que quieres soltarlo?", "⚠️ Celui-ci est chromatique ! Vraiment le laisser partir ?") }
+    var freshEggDiscardShiny: String { t("이로치 놓아주기", "Send shiny off", "手放す", "Soltar variocolor", "Laisser partir le chromatique") }
 
     // MARK: 사탕 획득 알림 ("왜 받는지" = 토큰 한도를 다 채운 수고에 대한 보상)
     func notifCandyTitle(item: String, count: Int) -> String {
         t("🍬 \(item) \(count)개를 받았어요!",
           "🍬 You got \(count)× \(item)!",
           "🍬 \(item)を\(count)個もらいました！",
-          "🍬 ¡Has recibido \(count)× \(item)!")
+          "🍬 ¡Has recibido \(count)× \(item)!",
+          "🍬 Tu as reçu \(count)× \(item) !")
     }
     func notifCandyBody(window: String) -> String {
         t("\(window) 토큰 한도를 다 채웠어요. 열심히 쓴 만큼 사탕을 드려요 — 포켓몬에게 써서 진화시켜 보세요!",
           "You maxed out your \(window) token limit. A treat for the effort — use it to evolve your Pokémon!",
           "\(window)のトークン上限を使い切りました。がんばったごほうびです — ポケモンに使って進化させよう！",
-          "Has agotado tu límite de tokens \(window). Un premio por el esfuerzo — ¡úsalo para evolucionar a tu Pokémon!")
+          "Has agotado tu límite de tokens \(window). Un premio por el esfuerzo — ¡úsalo para evolucionar a tu Pokémon!",
+          "Tu as atteint ta limite de tokens \(window). Une récompense pour l'effort — utilise-la pour faire évoluer ton Pokémon !")
     }
 }

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -21,7 +21,7 @@ protocol PokeProviding: Sendable {
 actor PokeAPIClient: PokeProviding {
     static let shared = PokeAPIClient()
     private let base = URL(string: "https://pokeapi.co/api/v2")!
-    private let langCodes = ["ko", "en", "ja-Hrkt", "ja", "es"]
+    private let langCodes = ["ko", "en", "ja-Hrkt", "ja", "es", "fr"]
     private var speciesCache: [Int: SpeciesDTO] = [:]
     private var lineCache: [Int: EvoLine] = [:]   // 프리패칭 → 부화 순간 네트워크 0
 

--- a/Tests/PokeTokenBarTests/LocalizationInterpolationTests.swift
+++ b/Tests/PokeTokenBarTests/LocalizationInterpolationTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// Interpolation-parity guard: the compiler enforces only the `t(...)` arg count, not that a
+/// translation kept its `\(...)` placeholders — a dropped one still compiles. Sentinels catch it.
+final class LocalizationInterpolationTests: XCTestCase {
+    func testStringArgInterpolationsSurviveEveryLanguage() {
+        let A = "SNTA"
+        let B = "SNTB"
+        for lang in AppLanguage.allCases {
+            let l = L(lang)
+            func check(_ label: String, _ produced: String, _ expected: String...) {
+                for e in expected {
+                    XCTAssertTrue(produced.contains(e),
+                                  "\(lang.rawValue) \(label): '\(e)' missing → '\(produced)'")
+                }
+            }
+            check("forecastReach", l.forecastReach(A), A)
+            check("claudeLimitEntry", l.claudeLimitEntry(kind: "weekly_scoped", model: A), A)
+            check("percentRemaining", l.percentRemaining(A), A)
+            check("floatingPetHoverTokensOnly", l.floatingPetHoverTokensOnly(A), A)
+            check("floatingPetHoverWithLimit", l.floatingPetHoverWithLimit(A, B), A, B)
+            check("importSaveDone", l.importSaveDone(dex: 4242, tokens: A), "4242", A)
+            check("reportMailFallback", l.reportMailFallback(A), A)
+            check("reportMailSubject", l.reportMailSubject(A), A)
+            check("reportMailBody", l.reportMailBody(version: A, os: B), A, B)
+            check("eggToHatch", l.eggToHatch(A), A)
+            check("toNextEvolution", l.toNextEvolution(A), A)
+            check("toGraduation", l.toGraduation(A), A)
+            check("graduated", l.graduated(A), A)
+            check("statusEvolved", l.statusEvolved(A), A)
+            check("notifHatchBody", l.notifHatchBody(A), A)
+            check("notifShinyHatchBody", l.notifShinyHatchBody(A), A)
+            check("notifEvolveBody", l.notifEvolveBody(A), A)
+            check("notifDittoRevealBody", l.notifDittoRevealBody(A), A)
+            check("notifShinyDittoRevealBody", l.notifShinyDittoRevealBody(A), A)
+            check("notifGraduateBody", l.notifGraduateBody(A), A)
+            check("limitRefreshHTTPError401", l.limitRefreshHTTPError(401), "401")
+            check("limitRefreshHTTPError404", l.limitRefreshHTTPError(404), "404")
+            check("updateAvailable", l.updateAvailable(A, current: B), A, B)
+            check("updateFound", l.updateFound(A), A)
+            check("upToDate", l.upToDate(A), A)
+            check("notifBody", l.notifBody(A, B), A, B)
+            check("useOnCurrent", l.useOnCurrent(A), A)
+            check("buyConfirm", l.buyConfirm(A), A)
+            check("eggConfirm", l.eggConfirm(A, B), A, B)
+            check("notifCandyTitle", l.notifCandyTitle(item: A, count: 4242), A, "4242")
+            check("notifCandyBody", l.notifCandyBody(window: A), A)
+            check("plan", l.plan(A), A)
+            check("stage", l.stage(4242, 1717), "4242", "1717")
+            check("dexTotal", l.dexTotal(4242), "4242")
+            check("dexSpeciesTotal", l.dexSpeciesTotal(4242), "4242")
+            check("dexPageLabel", l.dexPageLabel(4242, 1717), "4242", "1717")
+            check("ownedCount", l.ownedCount(4242), "4242")
+            check("intervalLabel", l.intervalLabel(1860), "31")          // 1860s → 31 min
+            check("codexWindow-hours", l.codexWindow(420), "7")          // 420 min → 7 h
+            check("codexWindow-mins", l.codexWindow(37), "37")
+            check("importConfirmBody",
+                  l.importConfirmBody(incomingDex: 4242, incomingTokens: A,
+                                      exportedAt: "EXPAT", sourceDevice: "SRCDEV",
+                                      currentDex: 1717, currentTokens: B),
+                  "4242", A, "EXPAT", "SRCDEV", "1717", B)
+            check("eggDescription", l.eggDescription(.rare), l.rarityRare)
+            check("eggGuaranteeHint", l.eggGuaranteeHint(.uncommon), l.rarityUncommon)
+        }
+    }
+}

--- a/Tests/PokeTokenBarTests/PopoverNavigationTests.swift
+++ b/Tests/PokeTokenBarTests/PopoverNavigationTests.swift
@@ -47,6 +47,8 @@ final class RepresentativeLocalizationTests: XCTestCase {
             (.ja, "代表ポケモン", "現在のポケモンに合わせる", "図鑑で選ぶ…", "代表ポケモンに設定"),
             (.es, "Pokémon representativo", "Seguir al compañero actual", "Elegir en la Pokédex…",
              "Establecer como representante"),
+            (.fr, "Pokémon représentatif", "Suivre le compagnon actuel", "Choisir dans le Pokédex…",
+             "Définir comme représentatif"),
         ]
 
         XCTAssertEqual(expected.map(\.0), AppLanguage.allCases)


### PR DESCRIPTION
Add French as a fifth UI language, following the architecture guide in #149 and the Spanish PR (#159) as the template.

- AppLanguage gains a .fr case (apiCodes ["fr"], native label "Français"), and systemDefault maps the fr system locale to it.
- L.t(...) is extended to five languages; every UI string in Localization.swift is translated to French, using the informal "tu" register to match the app's playful companion tone.
- PokemonNature.name(_:) returns the 25 official French nature names, verified against PokéAPI's fr `names` data rather than invented.
- PokeAPIClient.langCodes now includes "fr" so French Pokémon species names are fetched (otherwise they fall back to English).
- Weekly limit labels use the compact "Hebdo" so French alert copy stays within the floating-pet speech bubble (PerformanceTests bubble-fit guard).
- Add LocalizationInterpolationTests: a parity guard asserting every language keeps the same \(...) interpolations, since the compiler only enforces the argument count, not that a translation kept its placeholders.

Refs #149
