### PR TITLE
fix: wait for specific PID instead of process name in update loop (#175)

### DIFF
--- a/Sources/PokeTokenBar/Core/UpdateChecker.swift
+++ b/Sources/PokeTokenBar/Core/UpdateChecker.swift
@@ -110,31 +110,36 @@ final class UpdateChecker {
         return process.terminationStatus == 0
     }
 
-    /// 앱이 완전히 종료된 뒤 tap 갱신 + cask 업그레이드 + 재오픈을 수행하는 분리(detached) 스크립트.
+    /// 앱이 완전히 종료된 뒤 tap 갱신 + cask 업그레이드 + 재오픈을 수행하는 분리(detached) 스크립트 본문.
     /// - `brew update` 선행: auto-update 빈도 제한(기본 24h)으로 stale 한 로컬 tap 때문에 `brew upgrade`
     ///   가 no-op(exit 0) 되어 "업데이트 안 됨 + 앱만 종료"가 나던 문제를 막는다.
-    /// - 앱 종료를 기다림(pgrep): 실행 중 번들 교체 레이스 + 재오픈 LaunchServices(-600) 레이스 회피.
+    /// - 앱 종료를 기다림(`kill -0 $3`): 실행 중 번들 교체 레이스 + 재오픈 LaunchServices(-600) 레이스 회피.
+    ///   `pgrep -x` 대신 특정 PID를 감시하여 중복 인스턴스가 실행 중일 때도 20s 타임아웃 없이 즉시 진행 (#175).
     /// - brew 를 백그라운드+워치독(≤300s)으로 감싸 hang 시에도 reopen 이 반드시 실행되게 함
     ///   (앱이 종료된 채 영영 안 돌아오는 것 방지). 종료 직후 재오픈 실패 대비 `open` 재시도.
-    /// 인자는 positional($1=brew, $2=bundlePath)로 전달 — 셸 인젝션 차단.
-    private static func launchDetachedUpgrade(brew: String) {
-        let bundlePath = Bundle.main.bundlePath
-        let script = """
-        for i in $(seq 1 40); do pgrep -x PokeTokenBar >/dev/null 2>&1 || break; sleep 0.5; done
-        export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
-        ( "$1" update; "$1" upgrade --cask poke-token-bar ) &
-        brew_pid=$!
-        for i in $(seq 1 300); do kill -0 "$brew_pid" 2>/dev/null || break; sleep 1; done
-        kill "$brew_pid" 2>/dev/null
-        for i in $(seq 1 15); do
-          launchctl kickstart -k "gui/$(id -u)/io.github.chattymin.poketokenbar.login" 2>/dev/null && break
-          open "$2" 2>/dev/null && break
-          sleep 1
-        done
-        """
+    /// 인자는 positional($1=brew, $2=bundlePath, $3=pid)로 전달 — 셸 인젝션 차단.
+    nonisolated static let detachedUpgradeScript = """
+    for i in $(seq 1 40); do kill -0 "$3" 2>/dev/null || break; sleep 0.5; done
+    export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+    ( "$1" update; "$1" upgrade --cask poke-token-bar ) &
+    brew_pid=$!
+    for i in $(seq 1 300); do kill -0 "$brew_pid" 2>/dev/null || break; sleep 1; done
+    kill "$brew_pid" 2>/dev/null
+    for i in $(seq 1 15); do
+      launchctl kickstart -k "gui/$(id -u)/io.github.chattymin.poketokenbar.login" 2>/dev/null && break
+      open "$2" 2>/dev/null && break
+      sleep 1
+    done
+    """
+
+    nonisolated static func launchDetachedUpgrade(
+        brew: String,
+        pid: pid_t = ProcessInfo.processInfo.processIdentifier,
+        bundlePath: String = Bundle.main.bundlePath
+    ) {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/bin/sh")
-        task.arguments = ["-c", script, "sh", brew, bundlePath]
+        task.arguments = ["-c", detachedUpgradeScript, "sh", brew, bundlePath, String(pid)]
         try? task.run()
     }
 }

--- a/Tests/PokeTokenBarTests/UpdateCheckerTests.swift
+++ b/Tests/PokeTokenBarTests/UpdateCheckerTests.swift
@@ -24,4 +24,25 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertTrue(UpdateChecker.isNewer("2.0.1", than: "2.0"))   // 2.0.1 > 2.0.0
         XCTAssertFalse(UpdateChecker.isNewer("2.0", than: "2.0.0"))  // 동일
     }
+
+    // MARK: - Detached upgrade script wait loop (#175)
+
+    func testDetachedUpgradeScriptWaitsOnPidNotProcessName() {
+        let script = UpdateChecker.detachedUpgradeScript
+        XCTAssertFalse(
+            script.contains("pgrep -x"),
+            "pgrep -x matches any instance by name and always times out when a duplicate runs"
+        )
+        XCTAssertTrue(
+            script.contains("kill -0 \"$3\""),
+            "the wait loop must wait on the specific terminating PID via $3"
+        )
+    }
+
+    func testDetachedUpgradeScriptUsesPositionalParameters() {
+        let script = UpdateChecker.detachedUpgradeScript
+        XCTAssertTrue(script.contains("\"$1\" update"), "must execute brew via $1 positional arg")
+        XCTAssertTrue(script.contains("\"$1\" upgrade"), "must execute brew upgrade via $1 positional arg")
+        XCTAssertTrue(script.contains("open \"$2\""), "must open bundlePath via $2 positional arg")
+    }
 }

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -342,3 +342,12 @@ read_when:
   넣어 보고, 로컬 장부만 새 기기 기준으로 다시 잡는다(`SaveTransfer.rebasedForThisDevice`). 회귀 가드:
   `testTransferDayTokensStillCountAfterRebase` — 재정렬 없는 대조군을 같이 돌려 결함 조건이 살아 있는지도
   함께 확인한다(테스트가 트리거 브랜치를 실제로 밟는지 보증).
+
+## 프로세스 제어·업데이트
+
+- **`pgrep -x <name>` 은 실행 파일의 정체성 검사이지, 기다리는 특정 프로세스에 대한 검사가 아니다.**
+  중복 인스턴스가 떠 있는 동안 실행될 수 있는 모든 wait-for-exit 루프는 PID를 받아야 한다. `UpdateChecker`가
+  자동 업데이트 시 앱 종료를 기다릴 때 `pgrep -x PokeTokenBar`를 쓰면, 중복 인스턴스가 살아있는 동안 루프를
+  결코 빠져나오지 못하고 20초 타임아웃을 온전히 소모한다(#175). `ProcessInfo.processInfo.processIdentifier`로
+  종료 대상 프로세스 PID를 전달하고 `kill -0 "$3"`로 특정 프로세스의 종료를 대기한다.
+


### PR DESCRIPTION
## Summary

Fixes #175

`UpdateChecker.applyUpdate()` triggers `NSApp.terminate(nil)` after launching the detached background update script. The detached script previously waited for the app to terminate by running `pgrep -x PokeTokenBar`. Because `pgrep -x` matches on executable process name, running a duplicate instance caused the wait loop to never break, burning the full 20s timeout and falling through.

This PR updates the detached script to wait on the specific terminating process:

- Passes the terminating process's PID (`ProcessInfo.processInfo.processIdentifier`) as positional argument `$3` to the detached script (`sh brew bundlePath pid`).
- Replaces `pgrep -x PokeTokenBar` with `kill -0 "$3" 2>/dev/null || break` in the wait loop.
- Exposes `detachedUpgradeScript` as `nonisolated static let` for deterministic test verification.
- Adds defect class record to `docs/reference/defect-log.md`: *`pgrep -x <name>` is an identity check on the executable, not on the process you are waiting for.*

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation

## UI changes

No visual UI change. The update script now exits the wait loop immediately upon the terminating instance's exit without unnecessary 20s timeout hangs when duplicate instances exist.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change

## Tests

`UpdateCheckerTests`:

- `testDetachedUpgradeScriptWaitsOnPidNotProcessName` — asserts `pgrep -x` is not used and `kill -0 "$3"` is present in the wait loop.
- `testDetachedUpgradeScriptUsesPositionalParameters` — asserts all positional parameters (`$1` brew, `$2` bundlePath, `$3` pid) are correctly wired.

`swift test --filter UpdateCheckerTests`: 8 tests, 0 failures.

Full test suite: 278 tests, 0 failures.

## How to verify

```bash
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --filter UpdateCheckerTests
```

---
🤖 *Generated with Antigravity 2.0 (AGY 2.0)*
