### PR TITLE
feat: add Traditional Chinese (zh-Hant) localization

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,7 +13,7 @@
 [![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%99%A5-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/chattymin)
 
-[English](README.md) · [한국어](README.ko.md) · **日本語**
+[English](README.md) · [한국어](README.ko.md) · **日本語** · [繁體中文](README.zh-Hant.md)
 
 </div>
 
@@ -75,7 +75,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 <td width="45%" align="center"><img src="assets/settings-ja.png" width="300" alt="設定"></td>
 <td width="55%" valign="middle">
 <h3>設定はお好みで</h3>
-メニューバー表示項目、更新間隔（1–15分／手動）、ログイン時に起動、上限セクションだけを隠す Keychain オフ、警告／危険の閾値つき上限通知、パートナーのイベント通知。<b>韓国語／英語／日本語</b>の UI とポケモン名を完備。
+メニューバー表示項目、更新間隔（1–15分／手動）、ログイン時に起動、上限セクションだけを隠す Keychain オフ、警告／危険の閾値つき上限通知、パートナーのイベント通知。<b>韓国語／英語／日本語／スペイン語／繁体字中国語</b>の UI とポケモン名を完備。
 </td>
 </tr>
 <tr>

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 [![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%99%A5-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/chattymin)
 
-[English](README.md) · **한국어** · [日本語](README.ja.md)
+[English](README.md) · **한국어** · [日本語](README.ja.md) · [繁體中文](README.zh-Hant.md)
 
 </div>
 
@@ -75,7 +75,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 <td width="45%" align="center"><img src="assets/settings-ko.png" width="300" alt="설정"></td>
 <td width="55%" valign="middle">
 <h3>설정에서 취향대로</h3>
-메뉴바 표시 항목, 새로고침 간격(1–15분/수동), 로그인 시 자동 시작, 한도 섹션만 숨기는 Keychain 끄기, 경고/임박 임계값 한도 알림, companion 이벤트 알림. <b>한국어/영어/일본어</b> UI·포켓몬 이름 완비.
+메뉴바 표시 항목, 새로고침 간격(1–15분/수동), 로그인 시 자동 시작, 한도 섹션만 숨기는 Keychain 끄기, 경고/임박 임계값 한도 알림, companion 이벤트 알림. <b>한국어/영어/일본어/스페인어/번체 중국어</b> UI·포켓몬 이름 완비.
 </td>
 </tr>
 <tr>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%99%A5-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/chattymin)
 
-**English** · [한국어](README.ko.md) · [日本語](README.ja.md)
+**English** · [한국어](README.ko.md) · [日本語](README.ja.md) · [繁體中文](README.zh-Hant.md)
 
 </div>
 
@@ -75,7 +75,7 @@ The <b>Pokédex</b> folds every species you've owned into one cell — 24 per pa
 <td width="45%" align="center"><img src="assets/settings.png" width="300" alt="Settings"></td>
 <td width="55%" valign="middle">
 <h3>Tune it your way</h3>
-Menu-bar items, refresh interval (1–15 min or manual), launch at login, a Keychain opt-out that just hides the limits section, limit alerts with warning/critical thresholds, and companion event notifications. Full <b>KO / EN / JA</b> UI and Pokémon names.
+Menu-bar items, refresh interval (1–15 min or manual), launch at login, a Keychain opt-out that just hides the limits section, limit alerts with warning/critical thresholds, and companion event notifications. Full <b>KO / EN / JA / ES / ZH-Hant</b> UI and Pokémon names.
 </td>
 </tr>
 <tr>

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,0 +1,200 @@
+<div align="center">
+
+<img src="assets/icon.png" width="128" alt="PokeTokenBar 圖示">
+
+# PokeTokenBar
+
+**把你的 AI coding token 孵成寶可夢 — 就在選單列上。**
+
+[![Release](https://img.shields.io/github/v/release/chattymin/PokeTokenBar?color=444d56&label=release)](https://github.com/chattymin/PokeTokenBar/releases)
+[![macOS](https://img.shields.io/badge/macOS-14%2B-0969da)](https://www.apple.com/macos/)
+[![Swift](https://img.shields.io/badge/Swift-6-f05138)](https://swift.org)
+[![Homebrew](https://img.shields.io/badge/Homebrew-cask-8957e5)](#homebrew)
+[![License](https://img.shields.io/badge/license-MIT-3fb950)](LICENSE)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%99%A5-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/chattymin)
+
+[English](README.md) · [한국어](README.ko.md) · [日本語](README.ja.md) · **繁體中文**
+
+</div>
+
+PokeTokenBar 把你本來就在燒的 AI coding token — Claude Code、Codex、Gemini CLI、Antigravity、OpenCode、Hermes Agent、Cursor、Grok CLI、Copilot CLI 與 Kiro CLI — 變成 macOS 選單列上一隻會長大的**寶可夢夥伴**。花 token 孵蛋，沿著真實的進化鏈進化，畢業收進圖鑑，然後從新的蛋重新開始。夥伴底下其實是一個精準的用量追蹤器 — 今日用量、花費，以及官方 5 小時／每週上限，全部直接從你本機的日誌讀取。
+
+> Token 用量直接讀取本機的 Claude Code、Codex、Gemini CLI、Antigravity、OpenCode、Hermes Agent、Cursor、Grok CLI、Copilot CLI 與 Kiro CLI 資料（`totalTokens` = input + output + cache，本地日期）— 不需要任何外部 CLI。本專案為非官方、非商業的寶可夢同人專案 — 請見[授權與免責聲明](#授權與免責聲明)。
+
+## 為什麼要用
+
+- **一個你會想打開的用量追蹤器。** 你的用量在養一隻寶可夢：牠會孵化、進化、畢業，把圖鑑一格一格填滿 — 而每一隻異色都是再打開一次的理由。
+- 一眼看完今天的 token 用量與花費 — 不用開儀表板，也不用開瀏覽器分頁。
+- 追蹤官方 **5 小時／每週**上限，附重置倒數，以及照目前速度何時會撞上限的預估。
+
+<div align="center">
+<img src="assets/screenshot-home.gif" width="420" alt="彈出視窗首頁 — 夥伴、今日 token、官方上限">
+</div>
+
+## 運作方式
+
+1. 🥚 **照常寫程式。** 你在 Claude Code、Codex、Gemini CLI、Antigravity、OpenCode、Hermes Agent、Cursor、Grok CLI、Copilot CLI 或 Kiro CLI 燒掉的 token 會孵育一顆蛋 — 不用另外執行任何東西。
+2. 🐣 **孵化。** 蛋會孵出擁有真實進化鏈的寶可夢，資料來自 [PokéAPI](https://pokeapi.co/) — 第 1～5 世代任一條進化線（329 種可能的起點），依官方 capture rate 加權：一般種常出現，傳說則是 1/129 的大事。孵出後會立刻進入你的**圖鑑**，同時繼續培育。每次孵化都會抽到 25 種性格之一 — 而且偶爾會孵出 **✨ 異色**。
+3. ⚡ **進化。** 繼續寫程式，牠就會沿著實際的進化樹成長（1／2／3 階段，含分支），每次進化都有一小段閃光演出。
+4. 🎓 **畢業與收藏。** 到達最終進化並跨過門檻後會永久收進**圖鑑** — 越稀有越久（重度使用下，一般種約 3 天 → 傳說約 24 天）— 接著新的蛋就會送到。
+5. 🍬 **用滿上限，拿一顆糖。** 把 5 小時或每週用量上限用滿，就能得到**神奇糖果** — 從**背包**拿出來餵給目前的寶可夢。
+6. 🛒 **在商店消費。** 你已經用掉的每一個 token 都是可花用的貨幣 — 可以買**神奇糖果**、重抽性格的**薄荷**、永久提升異色機率的**閃耀護符**，或是買一顆蛋放走目前的夥伴重新開始。蛋分三種等級：普通的**寶可夢蛋**、保證孵出罕見以上的**罕見的蛋**，以及保證孵出稀有以上的**稀有的蛋**。
+
+## 功能導覽
+
+<table>
+<tr>
+<td width="45%" align="center"><img src="assets/floating-pet.gif" width="340" alt="桌面浮動寵物，含滑鼠懸停提示與右鍵選單"></td>
+<td width="55%" valign="middle">
+<h3>🐾 讓牠住在你的桌面上</h3>
+把夥伴從選單列移到桌面上，尺寸可從 48px 調到 192px。滑鼠移上去看今日用量，點一下開啟彈出視窗，右鍵叫出選單，想拖到哪就拖到哪 — 上限通知還能以對話泡泡的形式出現在牠頭上。
+</td>
+</tr>
+<tr>
+<td width="55%" valign="middle">
+<h3>在你的選單列裡</h3>
+一隻第五世代的動畫 sprite 就住在今日 token 總量旁邊（精簡格式，例如 <code>200.7M</code>）。可以加上今日花費（<code>$</code>）或官方上限 <code>%</code> — 也可以全部關掉，只留角色。
+</td>
+<td width="45%" align="center"><img src="assets/menubar.gif" width="240" alt="選單列"></td>
+</tr>
+<tr>
+<td width="45%" align="center"><img src="assets/shiny-banner.gif" width="340" alt="一般色與異色對比"></td>
+<td width="55%" valign="middle">
+<h3>✨ 偶爾一次 — 異色</h3>
+孵出的異色會在每一次進化後保留自己的配色 — 選單列、首頁卡片、進化鏈都一樣。圖鑑裡編號旁會有一個 ✨，點該格就會切換成異色配色。還有專屬通知，確保你不會錯過那一刻。
+</td>
+</tr>
+<tr>
+<td width="55%" valign="middle">
+<h3>值得填滿的圖鑑</h3>
+<b>圖鑑</b>把你養過的每個物種收斂成一格 — 每頁 24 格，依圖鑑編號排序，擁有異色的會標上 ✨。<b>捕捉紀錄</b>則保留每一隻個體：由新到舊，各自附上完整進化鏈、稀有度、性格與捕捉日期。
+</td>
+<td width="45%" align="center"><img src="assets/screenshot-collection-pokedex.png" width="300" alt="圖鑑 — 每個物種一格"><br><br><img src="assets/screenshot-collection-catchlog.png" width="300" alt="捕捉紀錄 — 每隻養過的寶可夢一列"></td>
+</tr>
+<tr>
+<td width="45%" align="center"><img src="assets/settings.png" width="300" alt="設定"></td>
+<td width="55%" valign="middle">
+<h3>調成你喜歡的樣子</h3>
+選單列顯示項目、更新間隔（1–15 分鐘或手動）、登入時自動啟動、只隱藏上限區塊的 Keychain 關閉選項、含警告／危急門檻的上限通知，以及夥伴事件通知。完整的 <b>KO／EN／JA／ES／ZH-Hant</b> 介面與寶可夢名稱。
+</td>
+</tr>
+<tr>
+<td width="55%" valign="middle">
+<h3>🍬 用滿上限，賺一顆神奇糖果</h3>
+把 5 小時或每週用量上限用滿，就會拿到一顆<b>神奇糖果</b> — 每個 5 小時區間一顆，每週上限五顆。從新的<b>背包</b>分頁拿出來餵給目前的寶可夢：被限流的那一刻，正好變成你升級的那一刻。
+</td>
+<td width="45%" align="center"><img src="assets/screenshot-bag.png" width="300" alt="背包裡的神奇糖果與薄荷"></td>
+</tr>
+<tr>
+<td width="45%" align="center"><img src="assets/screenshot-shop.png" width="300" alt="Token 商店 — 薄荷、神奇糖果、寶可夢蛋、罕見的蛋、閃耀護符、稀有的蛋"></td>
+<td width="55%" valign="middle">
+<h3>🛒 靠你的用量運轉的商店</h3>
+你已經用掉的 token 就是貨幣。在新的<b>商店</b>分頁裡，可以換<b>神奇糖果</b>培育目前的寶可夢、用<b>薄荷</b>重抽性格、買永久提升異色孵化機率的<b>閃耀護符</b>，或是買一顆蛋放走夥伴重新開始。蛋分三種等級 — 普通的<b>寶可夢蛋</b>、必定孵出罕見以上的<b>罕見的蛋</b>，以及必定孵出稀有以上的<b>稀有的蛋</b>。兩種高級蛋的抽選池都仍保留傳說，所以保底的蛋照樣可能給你驚喜。
+</td>
+</tr>
+</table>
+
+## 還有這些
+
+- **可互動的浮動寵物** — 滑鼠移上去看今日用量，點一下開主視窗，右鍵叫出選單；上限通知可以用對話泡泡彈出。
+- **各服務分頁** — 偵測到 Claude Code、Codex、Gemini CLI、Antigravity、OpenCode、Hermes Agent、Cursor、Grok CLI、Copilot CLI、Kiro CLI 其中兩個以上時，會出現精簡分頁切換；今日總計仍然是合併的。
+- **官方上限** — Claude 與 Codex 的 5 小時／每週使用率與重置倒數，就在今日數字下方。
+- **消耗速度預估** — 推算目前 5 小時區間何時會到 100%。
+- **App 內更新** — 一鍵檢查更新；目前版本顯示在設定裡。
+
+## 支援的工具
+
+| 工具 | 追蹤範圍 | 官方上限 |
+|---|---|---|
+| **Claude Code** | 今日 · 5 小時區間 · 週 · 月 | ✅ 5 小時／每週 |
+| **Codex** | 今日 · 週 · 月 | ✅ 5 小時／每週 |
+| **Gemini CLI** | 今日 · 週 · 月 | — |
+| **Antigravity** | 今日 · 5 小時區間 · 週 · 月 | — |
+| **OpenCode** | 今日 · 5 小時區間 · 週 · 月 | — |
+| **Hermes Agent** | 今日 · 5 小時區間 · 週 · 月 | — |
+| **Cursor** | 今日 · 5 小時區間 · 週 · 月 | — |
+| **Grok CLI** | 今日 · 5 小時區間 · 週 · 月 | — |
+| **Copilot CLI** | 今日 · 5 小時區間 · 週 · 月 | — |
+| **Kiro CLI** | 今日 · 5 小時區間 · 週 · 月 | —（推估） |
+
+全部都在本機讀取 — 不需要外部用量 CLI。要新增一個工具只需要一個 provider 檔案（見 [CONTRIBUTING.md](CONTRIBUTING.md)）。
+
+## 安裝
+
+### 系統需求
+
+macOS 14 以上（Apple Silicon 或 Intel）。就這樣 — token 用量直接從本機的 Claude Code、Codex、Gemini CLI、Antigravity、OpenCode、Hermes Agent、Cursor、Grok CLI、Copilot CLI 與 Kiro CLI 資料讀取，不需要任何外部用量 CLI。
+
+### Homebrew
+
+```bash
+brew install --cask chattymin/tap/poke-token-bar
+```
+
+採 ad-hoc／自簽章；cask 會在安裝時移除 quarantine 屬性。
+
+### 手動安裝（不使用 Homebrew）
+
+不想用 Homebrew？從[最新 release](https://github.com/chattymin/PokeTokenBar/releases/latest) 下載 `PokeTokenBar.zip`，解壓縮後把 `PokeTokenBar.app` 拖進 `/Applications`。
+
+因為這個 App 是 ad-hoc／自簽章（沒有用 Apple Developer 帳號公證），Gatekeeper 首次啟動時會顯示「無法辨識的開發者」警告。用以下任一方式處理一次即可：
+
+- **Finder：** 對 `PokeTokenBar.app` 按右鍵（或 Control-click）→ **打開** → 在對話框中再按一次 **打開**。
+- **終端機：** `xattr -dr com.apple.quarantine /Applications/PokeTokenBar.app`
+
+（Homebrew cask 會幫你移除 quarantine，所以不需要這一步。）
+
+### 從原始碼建置
+
+```bash
+swift build                  # debug
+swift test                   # 單元測試
+./scripts/build-app.sh       # release → PokeTokenBar.app → /Applications
+```
+
+## 資料來源
+
+| 來源 | 用途 | 說明 |
+|---|---|---|
+| `~/.claude/projects/**/*.jsonl` | Claude Code 每日／區間／每週／每月 | 直接讀取；以 message id 去重；增量快取 |
+| `~/.gemini/tmp/**/chats/*.json(l)` | Gemini CLI 每日／每月 | session 紀錄（每則訊息的 `tokens`）；每週 = 每日加總 |
+| `~/.gemini/antigravity-cli/conversations/*.db` | Antigravity 每日／區間／每週／每月 | SQLite 唯讀；從 Cascade protobuf blob 取得每次呼叫的用量；獨立 provider，不併入 Gemini；訂閱制，因此不估算費用 |
+| `~/.codex/sessions/**/*.jsonl` | Codex 每日／每月 | `token_count` 事件；每週 = 每日加總 |
+| `~/.local/share/opencode/opencode.db` | OpenCode 每日／區間／每週／每月 | SQLite 唯讀；也支援舊版 `storage/message` JSON |
+| `~/.hermes/state.db` | Hermes Agent 每日／區間／每週／每月 | SQLite 唯讀；session token 總計與已保存的費用 |
+| `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Cursor 每日／區間／每週／每月 | SQLite 唯讀；`cursorDiskKV` 中帶 `tokenCount` 的 bubble 項目 |
+| `~/.grok/sessions/**/updates.jsonl` | Grok CLI 每日／區間／每週／每月 | `turn_completed` 紀錄（每回合的 `usage`，伺服器回報的費用）；支援 `$GROK_HOME`；subagent session 會略過，因為其 token 已併入父回合 |
+| `~/.copilot/session-store.db` | Copilot CLI 每日／區間／每週／每月 | SQLite 唯讀；每次 API 呼叫一列 `assistant_usage_events`；支援 `$COPILOT_HOME`；`input_tokens` 已包含快取的 prompt，所以會扣掉 cache 讀寫；採 premium request 計費，因此不估算費用 |
+| `~/Library/Application Support/kiro-cli/data.sqlite3` | Kiro CLI 每日／區間／每週／每月 | SQLite 唯讀；對話歷史 JSON（`conversations`／`conversations_v2`）；Kiro 的本機資料庫從不記錄真實 token 數，也沒有伺服器端 session，所以 input 是把每回合重送的累積對話文字用 bytes÷4 做的**推估**（output 同樣取自實際串流回應大小）；被 `/clear` 或壓縮過的對話，其已計入的 token 會維持計入直到 App 重啟；不估算費用 |
+| Keychain／`~/.claude/.credentials.json` → `api.anthropic.com` | Claude 官方 5 小時／每週 % | 非官方端點；Keychain **只有在你按下更新時**才會讀取 — 自動輪詢永遠不讀 |
+| `codex app-server` | Codex 官方 5 小時／每週 % | 本機子行程；只取帳號快照，不會進行模型推論 |
+| [PokéAPI](https://pokeapi.co/) — `pokeapi.co`、`graphql.pokeapi.co` | 寶可夢物種與進化資料 | 執行期抓取；本機快取，絕不內建 |
+| `raw.githubusercontent.com/PokeAPI/sprites` | 寶可夢與道具 sprite | 執行期抓取；快取在 Application Support 下，絕不內建 |
+| `status.claude.com`、`status.openai.com` | 服務異常橫幅 | statuspage 摘要；僅供顯示 — 可在設定中關閉 |
+| `api.github.com` | 更新檢查 | 最新 release tag；啟動時與開啟彈出視窗時檢查 |
+
+## 隱私與權限
+
+- **在裝置上處理。** Token 用量直接從本機的 Claude Code、Codex、Gemini CLI、Antigravity、OpenCode、Hermes Agent、Cursor、Grok CLI、Copilot CLI 與 Kiro CLI 資料讀取。App 從不上傳用量，也不會執行模型推論。
+- **對外連線。** 這個 App 並非完全離線。它會連向七個主機：`pokeapi.co` 與 `graphql.pokeapi.co`（物種／進化）、`raw.githubusercontent.com`（sprite）、`api.anthropic.com`（Claude 官方上限）、`status.claude.com` 與 `status.openai.com`（異常橫幅 — 設定裡可關閉），以及 `api.github.com`（更新檢查）。**這些連線都不會帶上你的用量、token、prompt 或專案路徑** — 只有請求本身。
+- **Keychain（選用）。** Claude 的 OAuth 憑證**只有在你按下更新按鈕時**（設定裡，或彈出視窗的上限那一列）才會讀取。自動輪詢永遠不碰 Keychain，所以不會跳出密碼視窗；若 `~/.claude/.credentials.json` 可用，則改從該檔案取得。Token 只保存在記憶體中 — App 不會自己建立任何 Keychain 項目。Token 過期後，上限仍會顯示但停留在舊值，直到你手動更新。也可以在設定裡直接關閉 — 上限區塊就只是隱藏起來。
+- **寶可夢素材**是在執行期從 PokéAPI 抓取，且只快取在 `~/Library/Application Support/PokeTokenBar/` 底下。App 執行檔與其 release 產物都不含任何寶可夢素材。
+
+## 貢獻者
+
+歡迎任何規模的貢獻 — 建置、測試與發 pull request 的方式請見 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+[![Contributors](https://contrib.rocks/image?repo=chattymin/PokeTokenBar)](https://github.com/chattymin/PokeTokenBar/graphs/contributors)
+
+## 授權與免責聲明
+
+**MIT** — 見 [LICENSE](LICENSE)。MIT 授權只涵蓋本專案的原創原始碼；不授予任何第三方商標、美術素材，或透過本 App 取得之資料的任何權利。
+
+PokeTokenBar 是一個**非官方、非商業的同人專案**，**與任天堂、Game Freak、Creatures Inc. 或寶可夢公司均無隸屬關係，亦未獲其背書、贊助或核准。**「寶可夢／Pokémon」及所有相關名稱、角色與圖像均為其各自權利人之商標與著作權。本專案不主張擁有、也不主張對任何寶可夢智慧財產權的任何權利。
+
+- **App 執行檔與其 release 產物不內建任何寶可夢素材。** 寶可夢物種資料與 sprite 是在**執行期**從公開的 [PokéAPI](https://pokeapi.co) 抓取，並快取在使用者自己的裝置上；經由 PokéAPI 提供的 sprite 圖像，其權利仍屬各自權利人所有。
+- 本 repo 文件中出現的任何寶可夢圖像（螢幕截圖／GIF），純粹用於說明 App 的功能。
+- 本 App 免費提供，僅供**個人、非商業用途使用。**
+- 若您是權利人且對本專案有任何疑慮，請開 issue 或聯絡維護者，我們會盡快回覆。
+
+*本軟體以「現狀」提供，不附任何形式的擔保。本聲明不構成法律意見。*

--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -8,6 +8,8 @@ enum CompanionStateKind: String, Sendable {
 /// 앱 언어. 포켓몬 이름은 PokéAPI 다국어 names 에서 가져온다.
 enum AppLanguage: String, Codable, Sendable, CaseIterable {
     case ko, en, ja, es
+    /// 繁體中文 — rawValue 는 저장 포맷이자 `displayLocale` 식별자다(BCP-47 스크립트 태그).
+    case zhHant = "zh-Hant"
     /// PokéAPI language.name 후보(첫 매칭 사용)
     var apiCodes: [String] {
         switch self {
@@ -15,10 +17,15 @@ enum AppLanguage: String, Codable, Sendable, CaseIterable {
         case .en: return ["en"]
         case .ja: return ["ja-Hrkt", "ja"]
         case .es: return ["es"]
+        // PokéAPI 의 language.name 은 소문자다("zh-hant"). 대문자 표기는 응답과 매칭되지 않는다.
+        case .zhHant: return ["zh-hant", "zh-Hant"]
         }
     }
     var label: String {
-        switch self { case .ko: return "한국어"; case .en: return "English"; case .ja: return "日本語"; case .es: return "Español" }
+        switch self {
+        case .ko: return "한국어"; case .en: return "English"; case .ja: return "日本語"
+        case .es: return "Español"; case .zhHant: return "繁體中文"
+        }
     }
 
     var displayLocale: Locale { Locale(identifier: rawValue) }
@@ -30,14 +37,33 @@ enum AppLanguage: String, Codable, Sendable, CaseIterable {
     }
 
     /// 신규 설치 기본 언어 — 시스템 선호 언어에서 유추(글로벌 출시: 한국어 강제 금지).
-    /// ko/ja/es 만 매칭, 그 외 전부 영어(fallback-of-fallback). 기존 사용자는 저장된 언어를 그대로 쓴다.
-    static var systemDefault: AppLanguage {
-        switch Locale.preferredLanguages.first?.prefix(2).lowercased() {
+    /// ko/ja/es/zh-Hant 만 매칭, 그 외 전부 영어(fallback-of-fallback). 기존 사용자는 저장된 언어를 그대로 쓴다.
+    /// 중국어는 번체(zh-Hant/TW/HK/MO)만 매칭한다 — 간체(zh-Hans/CN/SG) 사용자에게 번체를 주면
+    /// 시스템 언어와 어긋난 화면이 되므로, 간체는 지원 전까지 영어 폴백을 유지한다.
+    static var systemDefault: AppLanguage { resolve(preferredLanguages: Locale.preferredLanguages) }
+
+    /// `systemDefault` 의 판정부 — 시스템 로케일을 주입받는 순수 함수로 분리했다.
+    /// `Locale.preferredLanguages` 를 직접 읽으면 테스트가 실행 기기의 언어에 따라 다른 분기만
+    /// 밟아, 새 언어의 매칭이 실제로 되는지 확인할 수 없다(커버리지는 통과하는 무테스트 상태).
+    static func resolve(preferredLanguages: [String]) -> AppLanguage {
+        guard let tag = preferredLanguages.first?.lowercased() else { return .en }
+        if isTraditionalChinese(tag) { return .zhHant }
+        switch tag.prefix(2) {
         case "ko": return .ko
         case "ja": return .ja
         case "es": return .es
         default:   return .en
         }
+    }
+
+    /// BCP-47 태그가 번체 중국어인지 — 스크립트 태그(Hant) 우선, 없으면 번체권 지역으로 판정.
+    /// 입력은 소문자로 정규화된 태그다(예: "zh-hant-tw", "zh-tw", "zh-hans-cn").
+    static func isTraditionalChinese(_ tag: String) -> Bool {
+        guard tag == "zh" || tag.hasPrefix("zh-") || tag.hasPrefix("zh_") else { return false }
+        let parts = tag.split(whereSeparator: { $0 == "-" || $0 == "_" }).map(String.init)
+        if parts.contains("hans") { return false }
+        if parts.contains("hant") { return true }
+        return parts.contains { ["tw", "hk", "mo"].contains($0) }
     }
 }
 
@@ -324,37 +350,40 @@ enum PokemonNature: String, Codable, Sendable, CaseIterable {
     case modest, mild, quiet, bashful, rash
     case calm, gentle, sassy, careful, quirky
 
-    /// 본가 공식 번역 명칭 (ko/en/ja/es).
+    /// 본가 공식 번역 명칭 (ko/en/ja/es/zh-Hant).
     func name(_ lang: AppLanguage) -> String {
-        let names: (String, String, String, String)
+        let names: (String, String, String, String, String)
         switch self {
-        case .hardy:   names = ("노력", "Hardy", "がんばりや", "Fuerte")
-        case .lonely:  names = ("외로움", "Lonely", "さみしがり", "Huraña")
-        case .brave:   names = ("용감", "Brave", "ゆうかん", "Audaz")
-        case .adamant: names = ("고집", "Adamant", "いじっぱり", "Firme")
-        case .naughty: names = ("개구쟁이", "Naughty", "やんちゃ", "Pícara")
-        case .bold:    names = ("대담", "Bold", "ずぶとい", "Osada")
-        case .docile:  names = ("온순", "Docile", "すなお", "Dócil")
-        case .relaxed: names = ("무사태평", "Relaxed", "のんき", "Plácida")
-        case .impish:  names = ("장난꾸러기", "Impish", "わんぱく", "Agitada")
-        case .lax:     names = ("촐랑", "Lax", "のうてんき", "Floja")
-        case .timid:   names = ("겁쟁이", "Timid", "おくびょう", "Miedosa")
-        case .hasty:   names = ("성급", "Hasty", "せっかち", "Activa")
-        case .serious: names = ("성실", "Serious", "まじめ", "Seria")
-        case .jolly:   names = ("명랑", "Jolly", "ようき", "Alegre")
-        case .naive:   names = ("천진난만", "Naive", "むじゃき", "Ingenua")
-        case .modest:  names = ("조심", "Modest", "ひかえめ", "Modesta")
-        case .mild:    names = ("의젓", "Mild", "おっとり", "Afable")
-        case .quiet:   names = ("냉정", "Quiet", "れいせい", "Mansa")
-        case .bashful: names = ("수줍음", "Bashful", "てれや", "Tímida")
-        case .rash:    names = ("덜렁", "Rash", "うっかりや", "Alocada")
-        case .calm:    names = ("차분", "Calm", "おだやか", "Serena")
-        case .gentle:  names = ("얌전", "Gentle", "おとなしい", "Amable")
-        case .sassy:   names = ("건방", "Sassy", "なまいき", "Grosera")
-        case .careful: names = ("신중", "Careful", "しんちょう", "Cauta")
-        case .quirky:  names = ("변덕", "Quirky", "きまぐれ", "Rara")
+        case .hardy:   names = ("노력", "Hardy", "がんばりや", "Fuerte", "勤奮")
+        case .lonely:  names = ("외로움", "Lonely", "さみしがり", "Huraña", "怕寂寞")
+        case .brave:   names = ("용감", "Brave", "ゆうかん", "Audaz", "勇敢")
+        case .adamant: names = ("고집", "Adamant", "いじっぱり", "Firme", "固執")
+        case .naughty: names = ("개구쟁이", "Naughty", "やんちゃ", "Pícara", "頑皮")
+        case .bold:    names = ("대담", "Bold", "ずぶとい", "Osada", "大膽")
+        case .docile:  names = ("온순", "Docile", "すなお", "Dócil", "坦率")
+        case .relaxed: names = ("무사태평", "Relaxed", "のんき", "Plácida", "悠閒")
+        case .impish:  names = ("장난꾸러기", "Impish", "わんぱく", "Agitada", "淘氣")
+        case .lax:     names = ("촐랑", "Lax", "のうてんき", "Floja", "樂天")
+        case .timid:   names = ("겁쟁이", "Timid", "おくびょう", "Miedosa", "膽小")
+        case .hasty:   names = ("성급", "Hasty", "せっかち", "Activa", "急躁")
+        case .serious: names = ("성실", "Serious", "まじめ", "Seria", "認真")
+        case .jolly:   names = ("명랑", "Jolly", "ようき", "Alegre", "開朗")
+        case .naive:   names = ("천진난만", "Naive", "むじゃき", "Ingenua", "天真")
+        case .modest:  names = ("조심", "Modest", "ひかえめ", "Modesta", "內斂")
+        case .mild:    names = ("의젓", "Mild", "おっとり", "Afable", "慢吞吞")
+        case .quiet:   names = ("냉정", "Quiet", "れいせい", "Mansa", "冷靜")
+        case .bashful: names = ("수줍음", "Bashful", "てれや", "Tímida", "害羞")
+        case .rash:    names = ("덜렁", "Rash", "うっかりや", "Alocada", "馬虎")
+        case .calm:    names = ("차분", "Calm", "おだやか", "Serena", "溫和")
+        case .gentle:  names = ("얌전", "Gentle", "おとなしい", "Amable", "溫順")
+        case .sassy:   names = ("건방", "Sassy", "なまいき", "Grosera", "自大")
+        case .careful: names = ("신중", "Careful", "しんちょう", "Cauta", "慎重")
+        case .quirky:  names = ("변덕", "Quirky", "きまぐれ", "Rara", "浮躁")
         }
-        switch lang { case .ko: return names.0; case .en: return names.1; case .ja: return names.2; case .es: return names.3 }
+        switch lang {
+        case .ko: return names.0; case .en: return names.1; case .ja: return names.2
+        case .es: return names.3; case .zhHant: return names.4
+        }
     }
 }
 

--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -18,7 +18,7 @@ enum AppLanguage: String, Codable, Sendable, CaseIterable {
         case .ja: return ["ja-Hrkt", "ja"]
         case .es: return ["es"]
         // PokéAPI 의 language.name 은 소문자다("zh-hant"). 대문자 표기는 응답과 매칭되지 않는다.
-        case .zhHant: return ["zh-hant", "zh-Hant"]
+        case .zhHant: return ["zh-hant"]
         }
     }
     var label: String {

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -7,57 +7,58 @@ struct L {
     let lang: AppLanguage
     init(_ lang: AppLanguage) { self.lang = lang }
 
-    private func t(_ ko: String, _ en: String, _ ja: String, _ es: String) -> String {
+    private func t(_ ko: String, _ en: String, _ ja: String, _ es: String, _ zhHant: String) -> String {
         switch lang {
         case .ko: return ko
         case .en: return en
         case .ja: return ja
         case .es: return es
+        case .zhHant: return zhHant
         }
     }
 
     // MARK: 탭
-    var home: String { t("홈", "Home", "ホーム", "Inicio") }
+    var home: String { t("홈", "Home", "ホーム", "Inicio", "首頁") }
     /// 상위 탭 이름 — 안에서 도감/포획 로그를 세그먼트로 전환하므로 둘을 아우르는 말이어야 한다.
     /// (ko 가 "도감"이면 탭과 세그먼트가 같은 이름이 돼 en/ja 의 Collection/コレクション 과도 어긋난다.)
-    var collection: String { t("컬렉션", "Collection", "コレクション", "Colección") }
+    var collection: String { t("컬렉션", "Collection", "コレクション", "Colección", "收藏") }
 
     // MARK: 헤더 (오늘/주/월)
-    var todayTokens: String { t("오늘 사용한 토큰", "Today's tokens", "本日のトークン", "Tokens de hoy") }
-    var thisWeek: String { t("이번 주", "This week", "今週", "Esta semana") }
-    var thisMonth: String { t("이번 달", "This month", "今月", "Este mes") }
+    var todayTokens: String { t("오늘 사용한 토큰", "Today's tokens", "本日のトークン", "Tokens de hoy", "今日 token 用量") }
+    var thisWeek: String { t("이번 주", "This week", "今週", "Esta semana", "本週") }
+    var thisMonth: String { t("이번 달", "This month", "今月", "Este mes", "本月") }
 
     // MARK: 한도 섹션
-    var limitsOfficial: String { t("한도 (공식)", "Limits (official)", "上限（公式）", "Límites (oficial)") }
-    var fiveHourSession: String { t("5시간 세션", "5-hour session", "5時間セッション", "Sesión de 5 horas") }
-    var weekly: String { t("주간", "Weekly", "週間", "Semanal") }
-    var weeklyOpus: String { t("주간 Opus", "Weekly Opus", "週間 Opus", "Opus semanal") }
-    var weeklySonnet: String { t("주간 Sonnet", "Weekly Sonnet", "週間 Sonnet", "Sonnet semanal") }
-    var claudeCurrentBlock: String { t("Claude 현재 5h 블록", "Claude current 5h block", "Claude 現在の5hブロック", "Bloque actual de 5h de Claude") }
-    var reset: String { t("리셋", "Reset", "リセット", "Reinicio") }
-    var limitReached: String { t("한도 도달", "Limit reached", "上限到達", "Límite alcanzado") }
-    var personalSpendLimit: String { t("개인 사용 한도", "Personal spend limit", "個人利用上限", "Límite de gasto personal") }
-    var staleLimits: String { t("갱신 지연", "Stale", "更新遅延", "Desactualizado") }
-    var refresh: String { t("갱신", "Refresh", "更新", "Actualizar") }
-    var limitsTapToLoad: String { t("공식 한도 불러오기", "Load official limits", "公式上限を読み込む", "Cargar límites oficiales") }
+    var limitsOfficial: String { t("한도 (공식)", "Limits (official)", "上限（公式）", "Límites (oficial)", "上限（官方）") }
+    var fiveHourSession: String { t("5시간 세션", "5-hour session", "5時間セッション", "Sesión de 5 horas", "5 小時區間") }
+    var weekly: String { t("주간", "Weekly", "週間", "Semanal", "每週") }
+    var weeklyOpus: String { t("주간 Opus", "Weekly Opus", "週間 Opus", "Opus semanal", "每週 Opus") }
+    var weeklySonnet: String { t("주간 Sonnet", "Weekly Sonnet", "週間 Sonnet", "Sonnet semanal", "每週 Sonnet") }
+    var claudeCurrentBlock: String { t("Claude 현재 5h 블록", "Claude current 5h block", "Claude 現在の5hブロック", "Bloque actual de 5h de Claude", "Claude 目前 5 小時區間") }
+    var reset: String { t("리셋", "Reset", "リセット", "Reinicio", "下次重置") }
+    var limitReached: String { t("한도 도달", "Limit reached", "上限到達", "Límite alcanzado", "已達上限") }
+    var personalSpendLimit: String { t("개인 사용 한도", "Personal spend limit", "個人利用上限", "Límite de gasto personal", "個人用量上限") }
+    var staleLimits: String { t("갱신 지연", "Stale", "更新遅延", "Desactualizado", "更新延遲") }
+    var refresh: String { t("갱신", "Refresh", "更新", "Actualizar", "更新") }
+    var limitsTapToLoad: String { t("공식 한도 불러오기", "Load official limits", "公式上限を読み込む", "Cargar límites oficiales", "載入官方上限") }
 
     /// 프로바이더 상태 페이지 인시던트 지표 → 현지화 라벨(표시 전용).
     func providerStatusLabel(_ indicator: ProviderStatusIndicator) -> String {
         switch indicator {
-        case .operational: return t("정상", "Operational", "正常", "Operativo")
-        case .minor:       return t("일부 장애", "Minor issues", "一部障害", "Problemas menores")
-        case .major:       return t("장애", "Major outage", "障害", "Interrupción grave")
-        case .critical:    return t("심각한 장애", "Critical outage", "重大障害", "Interrupción crítica")
-        case .maintenance: return t("점검 중", "Maintenance", "メンテナンス", "Mantenimiento")
-        case .unknown:     return t("상태 불명", "Status unknown", "状態不明", "Estado desconocido")
+        case .operational: return t("정상", "Operational", "正常", "Operativo", "正常")
+        case .minor:       return t("일부 장애", "Minor issues", "一部障害", "Problemas menores", "部分異常")
+        case .major:       return t("장애", "Major outage", "障害", "Interrupción grave", "服務中斷")
+        case .critical:    return t("심각한 장애", "Critical outage", "重大障害", "Interrupción crítica", "嚴重中斷")
+        case .maintenance: return t("점검 중", "Maintenance", "メンテナンス", "Mantenimiento", "維護中")
+        case .unknown:     return t("상태 불명", "Status unknown", "状態不明", "Estado desconocido", "狀態不明")
         }
     }
-    func plan(_ p: String) -> String { t("플랜 \(p)", "Plan \(p)", "プラン \(p)", "Plan \(p)") }
+    func plan(_ p: String) -> String { t("플랜 \(p)", "Plan \(p)", "プラン \(p)", "Plan \(p)", "方案 \(p)") }
     func forecastReach(_ time: String) -> String {
-        t("현재 속도면 \(time) 한도 도달", "At current rate, limit hit at \(time)", "現在のペースで \(time) に上限到達", "Al ritmo actual, límite alcanzado a las \(time)")
+        t("현재 속도면 \(time) 한도 도달", "At current rate, limit hit at \(time)", "現在のペースで \(time) に上限到達", "Al ritmo actual, límite alcanzado a las \(time)", "照目前速度，\(time) 會達到上限")
     }
     var forecastNoReach: String {
-        t("현재 속도로는 리셋 전 한도 도달 없음", "Won't hit limit before reset at current rate", "現在のペースではリセット前に上限到達なし", "Al ritmo actual, no alcanzarás el límite antes del reinicio")
+        t("현재 속도로는 리셋 전 한도 도달 없음", "Won't hit limit before reset at current rate", "現在のペースではリセット前に上限到達なし", "Al ritmo actual, no alcanzarás el límite antes del reinicio", "照目前速度，重置前不會達到上限")
     }
 
     /// Claude oauth/usage 신형 limits[] 엔트리 이름 — kind + 모델 스코프 기반.
@@ -67,8 +68,8 @@ struct L {
         case "weekly_all": return weekly
         case "weekly_scoped":
             // 모델명이 없으면 레거시 "주간" 행과 이름이 겹치므로 scoped 임을 구분 표기
-            guard let model else { return t("주간 (모델별)", "Weekly (scoped)", "週間（モデル別）", "Semanal (por modelo)") }
-            return t("주간 \(model)", "Weekly \(model)", "週間 \(model)", "Semanal \(model)")
+            guard let model else { return t("주간 (모델별)", "Weekly (scoped)", "週間（モデル別）", "Semanal (por modelo)", "每週（各模型）") }
+            return t("주간 \(model)", "Weekly \(model)", "週間 \(model)", "Semanal \(model)", "每週 \(model)")
         default:
             let base = kind ?? "limit"
             let name = model.map { " \($0)" } ?? ""
@@ -83,103 +84,107 @@ struct L {
         case 10_080: return weekly
         case let m? where m >= 60 && m % 60 == 0:
             let h = m / 60
-            return t("\(h)시간", "\(h)h", "\(h)時間", "\(h)h")
-        case let m?: return t("\(m)분", "\(m)m", "\(m)分", "\(m)m")
-        case nil: return t("한도", "Limit", "上限", "Límite")
+            return t("\(h)시간", "\(h)h", "\(h)時間", "\(h)h", "\(h) 小時")
+        case let m?: return t("\(m)분", "\(m)m", "\(m)分", "\(m)m", "\(m) 分鐘")
+        case nil: return t("한도", "Limit", "上限", "Límite", "上限")
         }
     }
 
     // MARK: 푸터
-    var refreshNow: String { t("지금 새로고침", "Refresh now", "今すぐ更新", "Actualizar ahora") }
-    var updated: String { t("갱신", "Updated", "更新", "Actualizado") }
-    var settings: String { t("설정", "Settings", "設定", "Ajustes") }
-    var back: String { t("뒤로", "Back", "戻る", "Atrás") }
-    var generalSectionTitle: String { t("일반", "General", "一般", "General") }
-    var menuBarSectionTitle: String { t("메뉴바에 표시", "Show in menu bar", "メニューバーに表示", "Mostrar en la barra de menús") }
-    var advancedSectionTitle: String { t("고급", "Advanced", "詳細", "Avanzado") }
-    var advancedDisclosureLabel: String { t("고급 설정 · 진단", "Advanced · diagnostics", "詳細設定・診断", "Avanzado · diagnóstico") }
-    var aboutSupportSectionTitle: String { t("정보 & 지원", "About & Support", "情報とサポート", "Acerca de y soporte") }
-    var quit: String { t("종료", "Quit", "終了", "Salir") }
+    var refreshNow: String { t("지금 새로고침", "Refresh now", "今すぐ更新", "Actualizar ahora", "立即重新整理") }
+    var updated: String { t("갱신", "Updated", "更新", "Actualizado", "上次更新") }
+    var settings: String { t("설정", "Settings", "設定", "Ajustes", "設定") }
+    var back: String { t("뒤로", "Back", "戻る", "Atrás", "返回") }
+    var generalSectionTitle: String { t("일반", "General", "一般", "General", "一般") }
+    var menuBarSectionTitle: String { t("메뉴바에 표시", "Show in menu bar", "メニューバーに表示", "Mostrar en la barra de menús", "在選單列顯示") }
+    var advancedSectionTitle: String { t("고급", "Advanced", "詳細", "Avanzado", "進階") }
+    var advancedDisclosureLabel: String { t("고급 설정 · 진단", "Advanced · diagnostics", "詳細設定・診断", "Avanzado · diagnóstico", "進階設定 · 診斷") }
+    var aboutSupportSectionTitle: String { t("정보 & 지원", "About & Support", "情報とサポート", "Acerca de y soporte", "關於與支援") }
+    var quit: String { t("종료", "Quit", "終了", "Salir", "結束") }
 
     // MARK: 설정
-    var refreshInterval: String { t("새로고침 간격", "Refresh interval", "更新間隔", "Intervalo de actualización") }
-    var language: String { t("언어", "Language", "言語", "Idioma") }
-    var menuBarItems: String { t("메뉴바 표시 항목 (복수 선택)", "Menu bar items (multi-select)", "メニューバー表示項目（複数選択）", "Elementos de la barra de menús (selección múltiple)") }
-    var todayTokensShort: String { t("오늘 토큰", "Today's tokens", "本日のトークン", "Tokens de hoy") }
-    var todayCost: String { t("오늘 비용 ($)", "Today's cost ($)", "本日のコスト ($)", "Coste de hoy ($)") }
-    var limitPercent: String { t("한도 %", "Limit %", "上限 %", "Límite %") }
-    var limitDisplayModeLabel: String { t("한도 표시 방식", "Limit display", "上限の表示", "Visualización del límite") }
-    var limitDisplayUsed: String { t("사용량", "Used", "使用量", "Usado") }
-    var limitDisplayRemaining: String { t("남은 양", "Remaining", "残量", "Restante") }
+    var refreshInterval: String { t("새로고침 간격", "Refresh interval", "更新間隔", "Intervalo de actualización", "更新間隔") }
+    var language: String { t("언어", "Language", "言語", "Idioma", "語言") }
+    var menuBarItems: String { t("메뉴바 표시 항목 (복수 선택)", "Menu bar items (multi-select)", "メニューバー表示項目（複数選択）", "Elementos de la barra de menús (selección múltiple)", "選單列顯示項目（可複選）") }
+    var todayTokensShort: String { t("오늘 토큰", "Today's tokens", "本日のトークン", "Tokens de hoy", "今日 token 用量") }
+    var todayCost: String { t("오늘 비용 ($)", "Today's cost ($)", "本日のコスト ($)", "Coste de hoy ($)", "今日花費 ($)") }
+    var limitPercent: String { t("한도 %", "Limit %", "上限 %", "Límite %", "上限 %") }
+    var limitDisplayModeLabel: String { t("한도 표시 방식", "Limit display", "上限の表示", "Visualización del límite", "上限顯示方式") }
+    var limitDisplayUsed: String { t("사용량", "Used", "使用量", "Usado", "已使用") }
+    var limitDisplayRemaining: String { t("남은 양", "Remaining", "残量", "Restante", "剩餘") }
     /// 팝오버 한도 행의 remaining 모드 표시 — %에 자기설명 접미사를 붙인다.
     func percentRemaining(_ percent: String) -> String {
-        t("\(percent) 남음", "\(percent) left", "残り\(percent)", "\(percent) restante")
+        t("\(percent) 남음", "\(percent) left", "残り\(percent)", "\(percent) restante", "剩餘 \(percent)")
     }
-    var allOffHint: String { t("전부 끄면 캐릭터만 표시됩니다", "All off shows only the character", "すべてオフにするとキャラクターのみ表示", "Si desactivas todo, solo se mostrará el personaje") }
+    var allOffHint: String { t("전부 끄면 캐릭터만 표시됩니다", "All off shows only the character", "すべてオフにするとキャラクターのみ表示", "Si desactivas todo, solo se mostrará el personaje", "全部關閉時只顯示角色") }
     // MARK: 플로팅 펫
-    var floatingPetSectionTitle: String { t("플로팅 펫", "Floating Pet", "フローティングペット", "Mascota flotante") }
-    var floatingPetEnableLabel: String { t("플로팅 펫 표시", "Show floating pet", "フローティングペットを表示", "Mostrar mascota flotante") }
+    var floatingPetSectionTitle: String { t("플로팅 펫", "Floating Pet", "フローティングペット", "Mascota flotante", "桌面寵物") }
+    var floatingPetEnableLabel: String { t("플로팅 펫 표시", "Show floating pet", "フローティングペットを表示", "Mostrar mascota flotante", "顯示桌面寵物") }
     var floatingPetHint: String {
         t("포켓몬이 화면 위에 떠 있어요 — 드래그로 위치를 옮길 수 있어요",
           "Your Pokémon floats over the screen — drag to reposition",
           "ポケモンが画面の上に浮かびます — ドラッグで移動できます",
-          "Tu Pokémon flota sobre la pantalla — arrástralo para moverlo")
+          "Tu Pokémon flota sobre la pantalla — arrástralo para moverlo",
+          "寶可夢會浮在畫面上 — 可以拖曳移動位置")
     }
-    var floatingPetSizeLabel: String { t("크기", "Size", "サイズ", "Tamaño") }
+    var floatingPetSizeLabel: String { t("크기", "Size", "サイズ", "Tamaño", "大小") }
     /// 지금은 한도 알림만 말풍선으로 뜨지만, 알림 종류가 늘어도 이 라벨은 그대로 쓴다.
     var floatingPetBubbleAlertsLabel: String {
-        t("말풍선으로 알림 받기", "Show notifications as bubbles", "通知を吹き出しで表示", "Mostrar notificaciones como globos")
+        t("말풍선으로 알림 받기", "Show notifications as bubbles", "通知を吹き出しで表示", "Mostrar notificaciones como globos", "用對話泡泡顯示通知")
     }
-    var floatingPetMenuOpen: String { t("토큰 바 열기", "Open Token Bar", "トークンバーを開く", "Abrir Token Bar") }
+    var floatingPetMenuOpen: String { t("토큰 바 열기", "Open Token Bar", "トークンバーを開く", "Abrir Token Bar", "開啟 Token Bar") }
     var floatingPetMenuHide: String {
-        t("플로팅 펫 끄기", "Turn off floating pet", "フローティングペットをオフ", "Desactivar mascota flotante")
+        t("플로팅 펫 끄기", "Turn off floating pet", "フローティングペットをオフ", "Desactivar mascota flotante", "關閉桌面寵物")
     }
     func floatingPetHoverTokensOnly(_ tokens: String) -> String {
-        t("오늘 \(tokens) 토큰", "Today: \(tokens) tokens", "今日: \(tokens) トークン", "Hoy: \(tokens) tokens")
+        t("오늘 \(tokens) 토큰", "Today: \(tokens) tokens", "今日: \(tokens) トークン", "Hoy: \(tokens) tokens", "今日 \(tokens) token")
     }
     func floatingPetHoverWithLimit(_ tokens: String, _ percent: String) -> String {
         t("오늘 \(tokens) 토큰 (한도 \(percent))",
           "Today: \(tokens) tokens (limit \(percent))",
           "今日: \(tokens) トークン（上限 \(percent)）",
-          "Hoy: \(tokens) tokens (límite \(percent))")
+          "Hoy: \(tokens) tokens (límite \(percent))",
+          "今日 \(tokens) token（上限 \(percent)）")
     }
 
-    var disableKeychain: String { t("Keychain 접근 끄기", "Disable Keychain access", "Keychainアクセスを無効化", "Desactivar acceso a Keychain") }
-    var disableKeychainHint: String { t("켜면 Keychain 접근 허용 팝업이 더 안 뜹니다 — 공식 한도(%)만 숨겨지고 토큰·비용은 그대로", "When on, no more Keychain permission pop-ups — only official limits (%) are hidden; tokens/cost stay", "オンにするとKeychain許可のポップアップが出なくなります — 公式上限(%)のみ非表示、トークン・費用はそのまま", "Al activarlo, ya no aparecerán los avisos de permiso de Keychain — solo se ocultan los límites oficiales (%), los tokens y el coste se mantienen") }
-    var refreshLimitToken: String { t("한도 토큰 캐시 갱신", "Refresh limit token cache", "上限トークンキャッシュを更新", "Actualizar caché del token de límite") }
-    var onlyOnPress: String { t("누를 때만 Keychain 을 읽어요 — 자동 폴링은 안 읽어 팝업이 안 떠요. 토큰 만료 후 이 버튼으로 한도 갱신", "Reads Keychain only when pressed — auto-polling never does, so no pop-ups. Refresh limits here after the token expires", "押した時のみKeychainを読みます — 自動更新では読まずポップアップも出ません。トークン期限切れ後はこのボタンで上限を更新", "Solo lee Keychain al pulsar — el sondeo automático nunca lo hace, así que no aparecen avisos. Usa este botón para actualizar los límites tras la expiración del token") }
-    var launchAtLogin: String { t("로그인 시 자동 시작", "Launch at login", "ログイン時に自動起動", "Iniciar al arrancar sesión") }
-    var bundledOnly: String { t(".app 번들로 설치된 경우에만 사용 가능 (scripts/build-app.sh)", "Available only when installed as an .app bundle (scripts/build-app.sh)", ".appバンドルでインストールした場合のみ利用可能 (scripts/build-app.sh)", "Disponible solo si se instaló como paquete .app (scripts/build-app.sh)") }
-    var notificationsSection: String { t("알림", "Notifications", "通知", "Notificaciones") }
-    var limitNotificationsLabel: String { t("한도 알림", "Limit alerts", "上限通知", "Alertas de límite") }
-    var companionNotificationsLabel: String { t("Companion 이벤트 (부화·진화·졸업)", "Companion events (hatch / evolve / graduate)", "コンパニオンイベント（孵化・進化・卒業）", "Eventos del compañero (eclosión / evolución / graduación)") }
-    var statusChecksLabel: String { t("프로바이더 상태 확인", "Provider status checks", "プロバイダー状態チェック", "Comprobación de estado de proveedores") }
-    var statusChecksHint: String { t("Claude·OpenAI 장애를 팝오버에 표시 (알림 아님)", "Show Claude / OpenAI incidents in the popover (not a notification)", "Claude・OpenAIの障害をポップオーバーに表示（通知ではない）", "Muestra incidentes de Claude/OpenAI en el popover (no es una notificación)") }
-    var warning: String { t("경고", "Warning", "警告", "Aviso") }
-    var critical: String { t("임박", "Critical", "切迫", "Crítico") }
-    var aggregationNote: String { t("토큰 집계 기준: totalTokens (input + output + cache, 로컬 날짜)", "Token basis: totalTokens (input + output + cache, local date)", "集計基準: totalTokens (input + output + cache, ローカル日付)", "Base de cálculo: totalTokens (input + output + cache, fecha local)") }
-    var close: String { t("닫기", "Close", "閉じる", "Cerrar") }
+    var disableKeychain: String { t("Keychain 접근 끄기", "Disable Keychain access", "Keychainアクセスを無効化", "Desactivar acceso a Keychain", "停用 Keychain 存取") }
+    var disableKeychainHint: String { t("켜면 Keychain 접근 허용 팝업이 더 안 뜹니다 — 공식 한도(%)만 숨겨지고 토큰·비용은 그대로", "When on, no more Keychain permission pop-ups — only official limits (%) are hidden; tokens/cost stay", "オンにするとKeychain許可のポップアップが出なくなります — 公式上限(%)のみ非表示、トークン・費用はそのまま", "Al activarlo, ya no aparecerán los avisos de permiso de Keychain — solo se ocultan los límites oficiales (%), los tokens y el coste se mantienen", "開啟後就不會再跳出 Keychain 權限視窗 — 只有官方上限 (%) 會被隱藏，token 與花費照常顯示") }
+    var refreshLimitToken: String { t("한도 토큰 캐시 갱신", "Refresh limit token cache", "上限トークンキャッシュを更新", "Actualizar caché del token de límite", "更新上限 token 快取") }
+    var onlyOnPress: String { t("누를 때만 Keychain 을 읽어요 — 자동 폴링은 안 읽어 팝업이 안 떠요. 토큰 만료 후 이 버튼으로 한도 갱신", "Reads Keychain only when pressed — auto-polling never does, so no pop-ups. Refresh limits here after the token expires", "押した時のみKeychainを読みます — 自動更新では読まずポップアップも出ません。トークン期限切れ後はこのボタンで上限を更新", "Solo lee Keychain al pulsar — el sondeo automático nunca lo hace, así que no aparecen avisos. Usa este botón para actualizar los límites tras la expiración del token", "只有按下時才會讀取 Keychain — 自動更新不會讀取，所以不會跳出視窗。token 過期後用這個按鈕更新上限") }
+    var launchAtLogin: String { t("로그인 시 자동 시작", "Launch at login", "ログイン時に自動起動", "Iniciar al arrancar sesión", "登入時自動啟動") }
+    var bundledOnly: String { t(".app 번들로 설치된 경우에만 사용 가능 (scripts/build-app.sh)", "Available only when installed as an .app bundle (scripts/build-app.sh)", ".appバンドルでインストールした場合のみ利用可能 (scripts/build-app.sh)", "Disponible solo si se instaló como paquete .app (scripts/build-app.sh)", "僅在以 .app 套件安裝時可用 (scripts/build-app.sh)") }
+    var notificationsSection: String { t("알림", "Notifications", "通知", "Notificaciones", "通知") }
+    var limitNotificationsLabel: String { t("한도 알림", "Limit alerts", "上限通知", "Alertas de límite", "上限通知") }
+    var companionNotificationsLabel: String { t("Companion 이벤트 (부화·진화·졸업)", "Companion events (hatch / evolve / graduate)", "コンパニオンイベント（孵化・進化・卒業）", "Eventos del compañero (eclosión / evolución / graduación)", "夥伴事件（孵化 · 進化 · 畢業）") }
+    var statusChecksLabel: String { t("프로바이더 상태 확인", "Provider status checks", "プロバイダー状態チェック", "Comprobación de estado de proveedores", "服務狀態檢查") }
+    var statusChecksHint: String { t("Claude·OpenAI 장애를 팝오버에 표시 (알림 아님)", "Show Claude / OpenAI incidents in the popover (not a notification)", "Claude・OpenAIの障害をポップオーバーに表示（通知ではない）", "Muestra incidentes de Claude/OpenAI en el popover (no es una notificación)", "在彈出視窗顯示 Claude · OpenAI 的服務異常（不是通知）") }
+    var warning: String { t("경고", "Warning", "警告", "Aviso", "警告") }
+    var critical: String { t("임박", "Critical", "切迫", "Crítico", "危急") }
+    var aggregationNote: String { t("토큰 집계 기준: totalTokens (input + output + cache, 로컬 날짜)", "Token basis: totalTokens (input + output + cache, local date)", "集計基準: totalTokens (input + output + cache, ローカル日付)", "Base de cálculo: totalTokens (input + output + cache, fecha local)", "token 計算基準：totalTokens (input + output + cache，本地日期)") }
+    var close: String { t("닫기", "Close", "閉じる", "Cerrar", "關閉") }
 
     // MARK: 세이브 이전 (설정 → 백업 & 이전)
-    var transferSectionTitle: String { t("백업 & 이전", "Backup & Transfer", "バックアップと移行", "Copia de seguridad y transferencia") }
-    var exportSaveLabel: String { t("세이브 내보내기", "Export save", "セーブを書き出す", "Exportar partida") }
+    var transferSectionTitle: String { t("백업 & 이전", "Backup & Transfer", "バックアップと移行", "Copia de seguridad y transferencia", "備份與轉移") }
+    var exportSaveLabel: String { t("세이브 내보내기", "Export save", "セーブを書き出す", "Exportar partida", "匯出存檔") }
     var exportSaveHint: String {
         t("도감·누적 토큰·가방·현재 포켓몬을 파일 하나로 저장해요",
           "Saves your Pokédex, lifetime tokens, Bag, and current Pokémon as one file",
           "図鑑・累計トークン・バッグ・現在のポケモンを1つのファイルに保存します",
-          "Guarda tu Pokédex, tokens acumulados, Bolsa y Pokémon actual en un solo archivo")
+          "Guarda tu Pokédex, tokens acumulados, Bolsa y Pokémon actual en un solo archivo",
+          "把圖鑑、累計 token、背包與目前的寶可夢存成一個檔案")
     }
-    var exportSaveButton: String { t("내보내기…", "Export…", "書き出す…", "Exportar…") }
-    var importSaveLabel: String { t("세이브 불러오기", "Import save", "セーブを読み込む", "Importar partida") }
+    var exportSaveButton: String { t("내보내기…", "Export…", "書き出す…", "Exportar…", "匯出…") }
+    var importSaveLabel: String { t("세이브 불러오기", "Import save", "セーブを読み込む", "Importar partida", "匯入存檔") }
     var importSaveHint: String {
         t("다른 Mac에서 내보낸 파일을 골라 이 Mac으로 이어서 키워요",
           "Pick a file exported from another Mac and continue here",
           "他のMacから書き出したファイルを選んでこのMacで続けます",
-          "Elige un archivo exportado desde otro Mac y continúa aquí")
+          "Elige un archivo exportado desde otro Mac y continúa aquí",
+          "選擇從其他 Mac 匯出的檔案，在這台繼續培育")
     }
-    var importSaveButton: String { t("불러오기…", "Import…", "読み込む…", "Importar…") }
+    var importSaveButton: String { t("불러오기…", "Import…", "読み込む…", "Importar…", "匯入…") }
     var importConfirmTitle: String {
-        t("이 Mac의 진행을 대체할까요?", "Replace this Mac's progress?", "このMacの進行を置き換えますか？", "¿Reemplazar el progreso de este Mac?")
+        t("이 Mac의 진행을 대체할까요?", "Replace this Mac's progress?", "このMacの進行を置き換えますか？", "¿Reemplazar el progreso de este Mac?", "要取代這台 Mac 的進度嗎？")
     }
     /// 무엇이 사라지는지 수치로 적는다 — 일반적인 "정말 진행할까요?" 보다 판단에 실제로 쓸모 있다.
     /// 내보낸 시각·출처 기기를 함께 보여주는 이유: 도감 수가 같으면 3주 전 세이브도 문구가 똑같아,
@@ -214,26 +219,36 @@ struct L {
           Este Mac ahora: Pokédex \(currentDex) · \(currentTokens) acumulados
 
           El progreso actual de este Mac será reemplazado. El estado anterior se guarda como copia de seguridad en la carpeta de estado (últimas 5).
+          """,
+          """
+          要匯入的存檔：圖鑑 \(incomingDex) 隻 · 累計 \(incomingTokens)
+          匯出時間：\(exportedAt) · \(sourceDevice)
+          目前這台 Mac：圖鑑 \(currentDex) 隻 · 累計 \(currentTokens)
+
+          這台 Mac 目前的進度會被取代。先前的狀態會以備份形式保留在狀態資料夾（最近 5 份）。
           """)
     }
-    var importConfirmReplace: String { t("대체", "Replace", "置き換える", "Reemplazar") }
+    var importConfirmReplace: String { t("대체", "Replace", "置き換える", "Reemplazar", "取代") }
     func importSaveDone(dex: Int, tokens: String) -> String {
         t("불러왔어요 — 도감 \(dex)마리 · 누적 \(tokens)",
           "Imported — \(dex) in Pokédex · \(tokens) lifetime",
           "読み込みました — 図鑑 \(dex)匹 · 累計 \(tokens)",
-          "Importado — Pokédex \(dex) · \(tokens) acumulados")
+          "Importado — Pokédex \(dex) · \(tokens) acumulados",
+          "已匯入 — 圖鑑 \(dex) 隻 · 累計 \(tokens)")
     }
     var importErrorNotSaveFile: String {
         t("PokeTokenBar 세이브 파일이 아니에요.",
           "That isn't a PokeTokenBar save file.",
           "PokeTokenBar のセーブファイルではありません。",
-          "Ese no es un archivo de partida de PokeTokenBar.")
+          "Ese no es un archivo de partida de PokeTokenBar.",
+          "這不是 PokeTokenBar 的存檔。")
     }
     var importErrorNewerSchema: String {
         t("더 새로운 버전에서 만든 세이브예요 — 앱을 업데이트한 뒤 다시 시도해 주세요.",
           "This save was made by a newer version — update the app and try again.",
           "より新しいバージョンで作成されたセーブです — アプリを更新してから再試行してください。",
-          "Esta partida se creó con una versión más reciente — actualiza la app e inténtalo de nuevo.")
+          "Esta partida se creó con una versión más reciente — actualiza la app e inténtalo de nuevo.",
+          "這個存檔是用更新的版本建立的 — 請先更新 App 再試一次。")
     }
     /// 불러오기 실패 사유 → 사용자 문구. 뷰가 아니라 여기 두는 이유는 이 매핑이 테스트 가능해야 하기
     /// 때문이다 — 매핑이 어긋나면 `SaveTransferError` 는 LocalizedError 가 아니라서 "The operation
@@ -251,36 +266,41 @@ struct L {
         t("세이브 파일이라기엔 너무 커요 — 다른 파일을 고른 것 같아요.",
           "That file is too large to be a save — it looks like the wrong file.",
           "セーブファイルにしては大きすぎます — 別のファイルを選んだようです。",
-          "Ese archivo es demasiado grande para ser una partida — parece que elegiste el archivo equivocado.")
+          "Ese archivo es demasiado grande para ser una partida — parece que elegiste el archivo equivocado.",
+          "這個檔案大得不像存檔 — 看起來是選錯檔案了。")
     }
     /// 백업을 못 남기면 불러오기를 중단한다 — 되돌릴 수단 없이 진행을 대체하지 않기 위해서다.
     var importErrorBackupFailed: String {
         t("현재 상태를 백업하지 못해 불러오기를 중단했어요 — 진행은 그대로예요. 디스크 여유 공간을 확인해 주세요.",
           "Import stopped because the current state couldn't be backed up — your progress is untouched. Check free disk space.",
           "現在の状態をバックアップできなかったため読み込みを中止しました — 進行はそのままです。ディスクの空き容量を確認してください。",
-          "Se detuvo la importación porque no se pudo hacer una copia de seguridad del estado actual — tu progreso no se ha tocado. Comprueba el espacio libre en disco.")
+          "Se detuvo la importación porque no se pudo hacer una copia de seguridad del estado actual — tu progreso no se ha tocado. Comprueba el espacio libre en disco.",
+          "因為無法備份目前的狀態，已中止匯入 — 你的進度沒有變動。請確認磁碟可用空間。")
     }
 
     // MARK: 문제점 알리기 (설정 → 메일 리포트)
-    var reportProblem: String { t("문제점 알리기", "Report a problem", "問題を報告", "Reportar un problema") }
-    var showLogFile: String { t("로그 파일 보기", "Show log file", "ログファイルを表示", "Mostrar archivo de registro") }
+    var reportProblem: String { t("문제점 알리기", "Report a problem", "問題を報告", "Reportar un problema", "回報問題") }
+    var showLogFile: String { t("로그 파일 보기", "Show log file", "ログファイルを表示", "Mostrar archivo de registro", "顯示日誌檔") }
     var reportAttachHint: String {
         t("메일에 로그 파일을 첨부해 주시면 원인 파악에 큰 도움이 돼요.",
           "Attaching the log file to the email helps a lot with diagnosis.",
           "メールにログファイルを添付していただくと原因の特定に役立ちます。",
-          "Adjuntar el archivo de registro al correo ayuda mucho a diagnosticar el problema.")
+          "Adjuntar el archivo de registro al correo ayuda mucho a diagnosticar el problema.",
+          "在信件中附上日誌檔，會很有助於找出原因。")
     }
     func reportMailFallback(_ address: String) -> String {
         t("메일 앱을 열 수 없어요. \(address) 로 직접 보내주세요.",
           "Couldn't open a mail app. Please email \(address) directly.",
           "メールアプリを開けません。\(address) 宛に直接お送りください。",
-          "No se pudo abrir una app de correo. Escribe directamente a \(address).")
+          "No se pudo abrir una app de correo. Escribe directamente a \(address).",
+          "無法開啟郵件 App。請直接寄信到 \(address)。")
     }
     func reportMailSubject(_ version: String) -> String {
         t("[PokeTokenBar] 문제 리포트 (v\(version))",
           "[PokeTokenBar] Problem report (v\(version))",
           "[PokeTokenBar] 問題レポート (v\(version))",
-          "[PokeTokenBar] Reporte de problema (v\(version))")
+          "[PokeTokenBar] Reporte de problema (v\(version))",
+          "[PokeTokenBar] 問題回報 (v\(version))")
     }
     func reportMailBody(version: String, os: String) -> String {
         t("""
@@ -322,53 +342,64 @@ struct L {
         Versión de la app: v\(version)
         macOS: \(os)
         Archivo de registro (se recomienda adjuntar): ~/Library/Logs/PokeTokenBar.log
+        """,
+        """
+        問題內容：
+        （請描述遇到的問題 — 什麼時候、在哪個畫面、發生了什麼事）
+
+
+        ---
+        App 版本: v\(version)
+        macOS: \(os)
+        日誌檔（建議附上）: ~/Library/Logs/PokeTokenBar.log
         """)
     }
 
     /// 새로고침 간격 라벨 (초 단위 값 → 표시). 0 = 수동.
     func intervalLabel(_ seconds: TimeInterval) -> String {
-        if seconds == 0 { return t("수동", "Manual", "手動", "Manual") }
+        if seconds == 0 { return t("수동", "Manual", "手動", "Manual", "手動") }
         let m = Int(seconds / 60)
-        return t("\(m)분", "\(m) min", "\(m)分", "\(m) min")
+        return t("\(m)분", "\(m) min", "\(m)分", "\(m) min", "\(m) 分鐘")
     }
 
     // MARK: 컴패니언
-    var finalForm: String { t("최종 진화체", "Final form", "最終進化", "Forma final") }
-    func stage(_ i: Int, _ k: Int) -> String { t("진화 단계 \(i) / \(k)", "Stage \(i) / \(k)", "進化段階 \(i) / \(k)", "Etapa \(i) / \(k)") }
-    var unknownNextEvolution: String { t("알 수 없는 다음 진화", "Unknown next evolution", "次の進化先は不明", "Próxima evolución desconocida") }
-    var eggIncubating: String { t("🥚 부화 준비 중", "🥚 Incubating", "🥚 孵化の準備中", "🥚 Incubando") }
-    func eggToHatch(_ amount: String) -> String { t("부화까지 \(amount)", "\(amount) to hatch", "孵化まで \(amount)", "\(amount) para eclosionar") }
-    func toNextEvolution(_ amount: String) -> String { t("다음 진화까지 \(amount)", "\(amount) to next evolution", "次の進化まで \(amount)", "\(amount) para la siguiente evolución") }
-    func toGraduation(_ amount: String) -> String { t("졸업까지 \(amount)", "\(amount) to graduation", "卒業まで \(amount)", "\(amount) para graduarse") }
+    var finalForm: String { t("최종 진화체", "Final form", "最終進化", "Forma final", "最終進化") }
+    func stage(_ i: Int, _ k: Int) -> String { t("진화 단계 \(i) / \(k)", "Stage \(i) / \(k)", "進化段階 \(i) / \(k)", "Etapa \(i) / \(k)", "進化階段 \(i) / \(k)") }
+    var unknownNextEvolution: String { t("알 수 없는 다음 진화", "Unknown next evolution", "次の進化先は不明", "Próxima evolución desconocida", "下一階段進化不明") }
+    var eggIncubating: String { t("🥚 부화 준비 중", "🥚 Incubating", "🥚 孵化の準備中", "🥚 Incubando", "🥚 孵化準備中") }
+    func eggToHatch(_ amount: String) -> String { t("부화까지 \(amount)", "\(amount) to hatch", "孵化まで \(amount)", "\(amount) para eclosionar", "距離孵化還要 \(amount)") }
+    func toNextEvolution(_ amount: String) -> String { t("다음 진화까지 \(amount)", "\(amount) to next evolution", "次の進化まで \(amount)", "\(amount) para la siguiente evolución", "距離下次進化還要 \(amount)") }
+    func toGraduation(_ amount: String) -> String { t("졸업까지 \(amount)", "\(amount) to graduation", "卒業まで \(amount)", "\(amount) para graduarse", "距離畢業還要 \(amount)") }
     func graduated(_ name: String) -> String {
         t("\(name) 졸업 → 도감에 보존. 새 Token Egg가 도착했어요!",
           "\(name) graduated → saved to the dex. A new Token Egg has arrived!",
           "\(name) 卒業 → 図鑑に保存。新しいToken Eggが届きました！",
-          "\(name) se graduó → guardado en la Pokédex. ¡Ha llegado un nuevo Token Egg!")
+          "\(name) se graduó → guardado en la Pokédex. ¡Ha llegado un nuevo Token Egg!",
+          "\(name) 畢業了 → 已保存到圖鑑。新的 Token Egg 送到了！")
     }
-    var dexEmptyTitle: String { t("아직 잡은 포켓몬이 없어요!", "No Pokémon caught yet!", "まだ捕まえたポケモンがいません！", "¡Todavía no has capturado ningún Pokémon!") }
-    var dexEmptyHint: String { t("토큰을 써서 첫 포켓몬을 부화시켜 보세요.", "Spend tokens to hatch your first Pokémon.", "トークンを使って最初のポケモンを孵化させましょう。", "Usa tokens para eclosionar tu primer Pokémon.") }
+    var dexEmptyTitle: String { t("아직 잡은 포켓몬이 없어요!", "No Pokémon caught yet!", "まだ捕まえたポケモンがいません！", "¡Todavía no has capturado ningún Pokémon!", "還沒有捕捉到任何寶可夢！") }
+    var dexEmptyHint: String { t("토큰을 써서 첫 포켓몬을 부화시켜 보세요.", "Spend tokens to hatch your first Pokémon.", "トークンを使って最初のポケモンを孵化させましょう。", "Usa tokens para eclosionar tu primer Pokémon.", "使用 token 來孵化第一隻寶可夢吧。") }
 
     // MARK: 도감 요약 헤더
-    var dexTitle: String { t("도감", "Pokédex", "図鑑", "Pokédex") }
-    func dexTotal(_ n: Int) -> String { t("총 \(n)마리", "\(n) total", "全\(n)匹", "\(n) en total") }
+    var dexTitle: String { t("도감", "Pokédex", "図鑑", "Pokédex", "圖鑑") }
+    func dexTotal(_ n: Int) -> String { t("총 \(n)마리", "\(n) total", "全\(n)匹", "\(n) en total", "共 \(n) 隻") }
     /// 포획 로그 = 개체 단위 기록(같은 라인 중복이 정상). 도감 = 종 단위 집계.
-    var catchLogTitle: String { t("포획 로그", "Catch log", "捕獲ログ", "Registro de capturas") }
+    var catchLogTitle: String { t("포획 로그", "Catch log", "捕獲ログ", "Registro de capturas", "捕捉紀錄") }
     /// 도감 총계는 개체가 아니라 종 수 — 로그의 dexTotal("총 N마리")과 단위가 다르다.
-    func dexSpeciesTotal(_ n: Int) -> String { t("\(n)종", "\(n) species", "\(n)種", "\(n) especies") }
+    func dexSpeciesTotal(_ n: Int) -> String { t("\(n)종", "\(n) species", "\(n)種", "\(n) especies", "\(n) 種") }
     func dexPageLabel(_ page: Int, _ total: Int) -> String {
-        t("\(total)페이지 중 \(page)페이지", "Page \(page) of \(total)", "\(total)ページ中 \(page)ページ", "Página \(page) de \(total)")
+        t("\(total)페이지 중 \(page)페이지", "Page \(page) of \(total)", "\(total)ページ中 \(page)ページ", "Página \(page) de \(total)", "第 \(page) 頁 / 共 \(total) 頁")
     }
-    var dexPagePrev: String { t("이전 페이지", "Previous page", "前のページ", "Página anterior") }
-    var dexPageNext: String { t("다음 페이지", "Next page", "次のページ", "Página siguiente") }
-    var dexRaising: String { t("키우는 중", "Raising", "育成中", "Criando") }
-    var rarityCommon: String { t("일반", "Common", "ノーマル", "Común") }
-    var rarityUncommon: String { t("고급", "Uncommon", "アンコモン", "Poco común") }
-    var rarityRare: String { t("희귀", "Rare", "レア", "Raro") }
-    var rarityLegendary: String { t("전설", "Legendary", "伝説", "Legendario") }
-    var dexFilterHint: String { t("탭하면 이 희귀도만 보기 · 다시 탭하면 전체", "Tap to show only this rarity · tap again to clear", "タップでこの希少度のみ表示・再タップで全体", "Toca para ver solo esta rareza · toca de nuevo para ver todo") }
+    var dexPagePrev: String { t("이전 페이지", "Previous page", "前のページ", "Página anterior", "上一頁") }
+    var dexPageNext: String { t("다음 페이지", "Next page", "次のページ", "Página siguiente", "下一頁") }
+    var dexRaising: String { t("키우는 중", "Raising", "育成中", "Criando", "培育中") }
+    var rarityCommon: String { t("일반", "Common", "ノーマル", "Común", "一般") }
+    var rarityUncommon: String { t("고급", "Uncommon", "アンコモン", "Poco común", "罕見") }
+    var rarityRare: String { t("희귀", "Rare", "レア", "Raro", "稀有") }
+    var rarityLegendary: String { t("전설", "Legendary", "伝説", "Legendario", "傳說") }
+    var dexFilterHint: String { t("탭하면 이 희귀도만 보기 · 다시 탭하면 전체", "Tap to show only this rarity · tap again to clear", "タップでこの希少度のみ表示・再タップで全体", "Toca para ver solo esta rareza · toca de nuevo para ver todo", "點一下只看這個稀有度 · 再點一下顯示全部") }
     /// 도감 칸의 ✨ 를 읽어주는 명사 — 이모지는 스크린리더가 일관되게 읽지 못한다.
-    var dexShinyLabel: String { t("이로치", "Shiny", "色違い", "Variocolor") }
+    var dexShinyLabel: String { t("이로치", "Shiny", "色違い", "Variocolor", "異色") }
     func rarityLabel(_ r: Rarity) -> String {
         switch r {
         case .common:    return rarityCommon
@@ -379,36 +410,37 @@ struct L {
     }
 
     // 상태 한 줄
-    var statusEgg: String { t("곧 깨어나요.", "Hatching soon.", "もうすぐ孵化します。", "Está a punto de eclosionar.") }
-    var statusIdle: String { t("오늘은 조용히 자리를 지켜요.", "Keeping quiet today.", "今日は静かにしています。", "Hoy se mantiene tranquilo.") }
-    var statusWorking: String { t("오늘의 작업 흔적이 쌓이고 있어요.", "Today's work is piling up.", "本日の作業が積み重なっています。", "El trabajo de hoy se va acumulando.") }
-    var statusFocus: String { t("지금은 집중 모드예요.", "In focus mode now.", "今は集中モードです。", "Ahora está en modo concentración.") }
-    var statusTired: String { t("한도에 가까워요. 잠깐 쉬어도 괜찮아요.", "Close to the limit. A short break is fine.", "上限が近いです。少し休んでも大丈夫。", "Está cerca del límite. Un pequeño descanso no vendría mal.") }
-    var statusSleep: String { t("지금은 자고 있어요.", "Sleeping now.", "今は眠っています。", "Ahora está durmiendo.") }
-    func statusEvolved(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！", "¡Evolucionó a \(name)!") }
-    var statusGrew: String { t("성장했어요!", "It grew!", "成長しました！", "¡Ha crecido!") }
+    var statusEgg: String { t("곧 깨어나요.", "Hatching soon.", "もうすぐ孵化します。", "Está a punto de eclosionar.", "快要孵化了。") }
+    var statusIdle: String { t("오늘은 조용히 자리를 지켜요.", "Keeping quiet today.", "今日は静かにしています。", "Hoy se mantiene tranquilo.", "今天安靜地待著。") }
+    var statusWorking: String { t("오늘의 작업 흔적이 쌓이고 있어요.", "Today's work is piling up.", "本日の作業が積み重なっています。", "El trabajo de hoy se va acumulando.", "今天的工作正在累積。") }
+    var statusFocus: String { t("지금은 집중 모드예요.", "In focus mode now.", "今は集中モードです。", "Ahora está en modo concentración.", "現在是專注模式。") }
+    var statusTired: String { t("한도에 가까워요. 잠깐 쉬어도 괜찮아요.", "Close to the limit. A short break is fine.", "上限が近いです。少し休んでも大丈夫。", "Está cerca del límite. Un pequeño descanso no vendría mal.", "快到上限了。休息一下也沒關係。") }
+    var statusSleep: String { t("지금은 자고 있어요.", "Sleeping now.", "今は眠っています。", "Ahora está durmiendo.", "現在正在睡覺。") }
+    func statusEvolved(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！", "¡Evolucionó a \(name)!", "進化成 \(name) 了！") }
+    var statusGrew: String { t("성장했어요!", "It grew!", "成長しました！", "¡Ha crecido!", "成長了！") }
 
     // MARK: companion 이벤트 시스템 알림
-    var notifHatchTitle: String { t("🥚 부화!", "🥚 Hatched!", "🥚 孵化！", "🥚 ¡Eclosionó!") }
-    func notifHatchBody(_ name: String) -> String { t("알에서 \(name)이(가) 나왔어요!", "\(name) hatched from the egg!", "タマゴから \(name) が生まれました！", "¡\(name) salió del huevo!") }
-    var notifShinyHatchTitle: String { t("✨ 이로치 포켓몬!", "✨ Shiny Pokémon!", "✨ 色違いポケモン！", "✨ ¡Pokémon variocolor!") }
-    func notifShinyHatchBody(_ name: String) -> String { t("이로치 \(name)이(가) 태어났어요! (1/64)", "A shiny \(name) hatched! (1 in 64)", "色違いの \(name) が生まれました！(1/64)", "¡Nació un \(name) variocolor! (1 entre 64)") }
-    var eggImminent: String { t("곧 부화해요!", "About to hatch!", "もうすぐ孵化！", "¡Está a punto de eclosionar!") }
+    var notifHatchTitle: String { t("🥚 부화!", "🥚 Hatched!", "🥚 孵化！", "🥚 ¡Eclosionó!", "🥚 孵化了！") }
+    func notifHatchBody(_ name: String) -> String { t("알에서 \(name)이(가) 나왔어요!", "\(name) hatched from the egg!", "タマゴから \(name) が生まれました！", "¡\(name) salió del huevo!", "蛋裡孵出了 \(name)！") }
+    var notifShinyHatchTitle: String { t("✨ 이로치 포켓몬!", "✨ Shiny Pokémon!", "✨ 色違いポケモン！", "✨ ¡Pokémon variocolor!", "✨ 異色寶可夢！") }
+    func notifShinyHatchBody(_ name: String) -> String { t("이로치 \(name)이(가) 태어났어요! (1/64)", "A shiny \(name) hatched! (1 in 64)", "色違いの \(name) が生まれました！(1/64)", "¡Nació un \(name) variocolor! (1 entre 64)", "異色的 \(name) 誕生了！(1/64)") }
+    var eggImminent: String { t("곧 부화해요!", "About to hatch!", "もうすぐ孵化！", "¡Está a punto de eclosionar!", "快孵化了！") }
     /// 첫 실행(아직 토큰 적립 0) 안내 — "왜 아무 일도 안 일어나지"를 방지.
     var eggFirstRunHint: String {
         t("로컬 AI 코딩 도구의 사용량으로 자라요. 약 5M 토큰을 쓰면 알이 부화해요.",
           "Grows from your local AI coding usage. Your egg hatches after ~5M tokens.",
           "ローカルの AI コーディング使用量で育ちます。約5Mトークンでタマゴが孵化します。",
-          "Crece con el uso de tus herramientas locales de programación con IA. Tu huevo eclosiona tras unos 5M de tokens.") }
-    var notifEvolveTitle: String { t("✨ 진화!", "✨ Evolved!", "✨ 進化！", "✨ ¡Evolucionó!") }
-    func notifEvolveBody(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！", "¡Evolucionó a \(name)!") }
+          "Crece con el uso de tus herramientas locales de programación con IA. Tu huevo eclosiona tras unos 5M de tokens.",
+          "會依照本機 AI coding 工具的用量成長。大約用掉 5M token 蛋就會孵化。") }
+    var notifEvolveTitle: String { t("✨ 진화!", "✨ Evolved!", "✨ 進化！", "✨ ¡Evolucionó!", "✨ 進化！") }
+    func notifEvolveBody(_ name: String) -> String { t("\(name)(으)로 진화했어요!", "Evolved into \(name)!", "\(name) に進化しました！", "¡Evolucionó a \(name)!", "進化成 \(name) 了！") }
     // 메타몽 위장 리빌 — 진화 못 하는 메타몽이 첫 진화 순간 정체를 드러낸다.
-    var notifDittoRevealTitle: String { t("🎭 어라? 메타몽!", "🎭 Huh? It's Ditto!", "🎭 あれ？メタモン！", "🎭 ¿Eh? ¡Es Ditto!") }
-    func notifDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 사실은 메타몽이었어요!", "You thought it was \(disguise) — it was Ditto all along!", "\(disguise) だと思ってた… 実はメタモンでした！", "Pensabas que era \(disguise) — ¡en realidad era Ditto!") }
-    var notifShinyDittoRevealTitle: String { t("🎭✨ 어라? 이로치 메타몽!", "🎭✨ Huh? A shiny Ditto!", "🎭✨ あれ？色違いメタモン！", "🎭✨ ¿Eh? ¡Un Ditto variocolor!") }
-    func notifShinyDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 이로치 메타몽이었어요! (1/64)", "You thought it was \(disguise) — it was a shiny Ditto! (1 in 64)", "\(disguise) だと思ってた… 色違いのメタモンでした！(1/64)", "Pensabas que era \(disguise) — ¡era un Ditto variocolor! (1 entre 64)") }
-    var notifGraduateTitle: String { t("🎓 졸업!", "🎓 Graduated!", "🎓 卒業！", "🎓 ¡Graduado!") }
-    func notifGraduateBody(_ name: String) -> String { t("\(name) — 도감에 보존! 새 알이 도착했어요.", "\(name) — saved to your Pokédex! A new egg has arrived.", "\(name) — 図鑑に保存！新しいタマゴが届きました。", "\(name) — ¡guardado en tu Pokédex! Ha llegado un nuevo huevo.") }
+    var notifDittoRevealTitle: String { t("🎭 어라? 메타몽!", "🎭 Huh? It's Ditto!", "🎭 あれ？メタモン！", "🎭 ¿Eh? ¡Es Ditto!", "🎭 咦？是百變怪！") }
+    func notifDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 사실은 메타몽이었어요!", "You thought it was \(disguise) — it was Ditto all along!", "\(disguise) だと思ってた… 実はメタモンでした！", "Pensabas que era \(disguise) — ¡en realidad era Ditto!", "還以為是 \(disguise) — 其實是百變怪！") }
+    var notifShinyDittoRevealTitle: String { t("🎭✨ 어라? 이로치 메타몽!", "🎭✨ Huh? A shiny Ditto!", "🎭✨ あれ？色違いメタモン！", "🎭✨ ¿Eh? ¡Un Ditto variocolor!", "🎭✨ 咦？異色百變怪！") }
+    func notifShinyDittoRevealBody(_ disguise: String) -> String { t("\(disguise)인 줄 알았는데 — 이로치 메타몽이었어요! (1/64)", "You thought it was \(disguise) — it was a shiny Ditto! (1 in 64)", "\(disguise) だと思ってた… 色違いのメタモンでした！(1/64)", "Pensabas que era \(disguise) — ¡era un Ditto variocolor! (1 entre 64)", "還以為是 \(disguise) — 竟然是異色的百變怪！(1/64)") }
+    var notifGraduateTitle: String { t("🎓 졸업!", "🎓 Graduated!", "🎓 卒業！", "🎓 ¡Graduado!", "🎓 畢業！") }
+    func notifGraduateBody(_ name: String) -> String { t("\(name) — 도감에 보존! 새 알이 도착했어요.", "\(name) — saved to your Pokédex! A new egg has arrived.", "\(name) — 図鑑に保存！新しいタマゴが届きました。", "\(name) — ¡guardado en tu Pokédex! Ha llegado un nuevo huevo.", "\(name) — 已保存到圖鑑！新的蛋送到了。") }
 
     // MARK: Claude 한도 토큰 갱신 오류 (친절 안내)
     func limitRefreshHTTPError(_ status: Int) -> String {
@@ -417,33 +449,38 @@ struct L {
                 "Claude 자격증명이 만료됐거나 권한이 없어요 (\(status)). Claude Code 로그인을 확인하세요. Codex만 쓴다면 무시해도 됩니다 — Codex 한도는 따로 표시돼요.",
                 "Claude credential is expired or unauthorized (\(status)). Check that you're signed in to Claude Code. If you only use Codex you can ignore this — Codex limits show separately.",
                 "Claude の認証情報が期限切れか権限がありません (\(status))。Claude Code にサインインしているか確認してください。Codex のみ使用する場合は無視できます — Codex の上限は別に表示されます。",
-                "La credencial de Claude expiró o no tiene permisos (\(status)). Comprueba que has iniciado sesión en Claude Code. Si solo usas Codex, puedes ignorar esto — los límites de Codex se muestran aparte.")
+                "La credencial de Claude expiró o no tiene permisos (\(status)). Comprueba que has iniciado sesión en Claude Code. Si solo usas Codex, puedes ignorar esto — los límites de Codex se muestran aparte.",
+                "Claude 憑證已過期或沒有權限 (\(status))。請確認已登入 Claude Code。如果只使用 Codex 可以忽略 — Codex 的上限會另外顯示。")
         }
-        return t("Claude 한도 조회 실패 (\(status)).", "Failed to fetch Claude limits (\(status)).", "Claude の上限取得に失敗しました (\(status))。", "No se pudieron obtener los límites de Claude (\(status)).")
+        return t("Claude 한도 조회 실패 (\(status)).", "Failed to fetch Claude limits (\(status)).", "Claude の上限取得に失敗しました (\(status))。", "No se pudieron obtener los límites de Claude (\(status)).", "無法取得 Claude 上限 (\(status))。")
     }
     var limitRefreshNoCredential: String {
         t("Claude 자격증명을 찾지 못했어요. Claude Code 에 로그인하면 한도가 표시됩니다. Codex만 쓴다면 무시해도 돼요.",
           "No Claude credential found. Sign in to Claude Code to see limits. If you only use Codex you can ignore this.",
           "Claude の認証情報が見つかりません。Claude Code にサインインすると上限が表示されます。Codex のみなら無視して構いません。",
-          "No se encontró ninguna credencial de Claude. Inicia sesión en Claude Code para ver los límites. Si solo usas Codex, puedes ignorar esto.")
+          "No se encontró ninguna credencial de Claude. Inicia sesión en Claude Code para ver los límites. Si solo usas Codex, puedes ignorar esto.",
+          "找不到 Claude 憑證。登入 Claude Code 後就會顯示上限。如果只使用 Codex 可以忽略。")
     }
     var limitRefreshReauthNeeded: String {
         t("Claude 자격증명에 계정 로그인 정보가 없어요. Claude Code 에서 `/login` 으로 다시 로그인하면 한도가 표시됩니다.",
           "Your Claude credential has no account sign-in. Run `/login` in Claude Code to sign in again and limits will appear.",
           "Claude の認証情報にアカウントのサインインが含まれていません。Claude Code で `/login` を実行して再度サインインすると上限が表示されます。",
-          "Tu credencial de Claude no tiene una sesión de cuenta asociada. Ejecuta `/login` en Claude Code para volver a iniciar sesión y ver los límites.")
+          "Tu credencial de Claude no tiene una sesión de cuenta asociada. Ejecuta `/login` en Claude Code para volver a iniciar sesión y ver los límites.",
+          "Claude 憑證裡沒有帳號登入資訊。在 Claude Code 執行 `/login` 重新登入後就會顯示上限。")
     }
     var limitRefreshGeneric: String {
         t("Claude 한도 조회에 실패했어요. 잠시 후 다시 시도하세요.",
           "Couldn't fetch Claude limits. Please try again shortly.",
           "Claude の上限取得に失敗しました。しばらくして再試行してください。",
-          "No se pudieron obtener los límites de Claude. Inténtalo de nuevo en unos momentos.")
+          "No se pudieron obtener los límites de Claude. Inténtalo de nuevo en unos momentos.",
+          "無法取得 Claude 上限。請稍後再試。")
     }
     var limitRefreshRateLimited: String {
         t("Claude 한도 조회가 일시 제한됐어요 (429). 잠시 쉬었다가 자동으로 재시도합니다.",
           "Claude limit checks are temporarily rate-limited (429). Backing off and retrying automatically.",
           "Claude の上限取得が一時的に制限されています (429)。少し待って自動的に再試行します。",
-          "Las comprobaciones de límites de Claude están temporalmente limitadas (429). Se reintentará automáticamente en breve.")
+          "Las comprobaciones de límites de Claude están temporalmente limitadas (429). Se reintentará automáticamente en breve.",
+          "Claude 上限查詢暫時被限流 (429)。稍後會自動重試。")
     }
 
     // MARK: Claude 세션 만료(401) 안내
@@ -451,61 +488,64 @@ struct L {
         t("Claude 세션 만료 — 한도가 갱신 안 돼요",
           "Claude session expired — limits can't refresh",
           "Claude セッション期限切れ — 上限を更新できません",
-          "Sesión de Claude expirada — los límites no se pueden actualizar")
+          "Sesión de Claude expirada — los límites no se pueden actualizar",
+          "Claude 登入階段已過期 — 無法更新上限")
     }
     var claudeAuthExpiredHint: String {
         t("표시된 값은 만료 전 기준이에요. 다시 시도하거나, Claude Code 를 한 번 실행하면 자동 갱신됩니다.",
           "Values shown are from before expiry. Retry, or run Claude Code once to refresh automatically.",
           "表示値は期限切れ前のものです。再試行するか、Claude Code を一度実行すると自動更新されます。",
-          "Los valores mostrados son de antes de la expiración. Reinténtalo, o ejecuta Claude Code una vez para actualizarlos automáticamente.")
+          "Los valores mostrados son de antes de la expiración. Reinténtalo, o ejecuta Claude Code una vez para actualizarlos automáticamente.",
+          "顯示的是過期前的數值。請重試，或執行一次 Claude Code 就會自動更新。")
     }
-    var retry: String { t("다시 시도", "Retry", "再試行", "Reintentar") }
+    var retry: String { t("다시 시도", "Retry", "再試行", "Reintentar", "重試") }
 
     // MARK: 업데이트 알림
     func updateAvailable(_ version: String, current: String) -> String {
         t("🆕 v\(version) 사용 가능 (현재 \(current))",
           "🆕 v\(version) available (you have \(current))",
           "🆕 v\(version) が利用可能（現在 \(current)）",
-          "🆕 v\(version) disponible (tienes \(current))")
+          "🆕 v\(version) disponible (tienes \(current))",
+          "🆕 v\(version) 可以更新了（目前 \(current)）")
     }
-    var updateButton: String { t("업데이트", "Update", "更新", "Actualizar") }
-    var updateLater: String { t("나중에", "Later", "後で", "Más tarde") }
-    var updating: String { t("업데이트 중…", "Updating…", "更新中…", "Actualizando…") }
-    var updateSectionTitle: String { t("업데이트", "Updates", "アップデート", "Actualizaciones") }
-    var updateNotificationsLabel: String { t("업데이트 알림", "Update notifications", "アップデート通知", "Notificaciones de actualización") }
-    var checkForUpdatesLabel: String { t("업데이트 확인", "Check for updates", "アップデートを確認", "Buscar actualizaciones") }
-    var checkNowButton: String { t("지금 확인", "Check now", "今すぐ確認", "Comprobar ahora") }
-    func updateFound(_ version: String) -> String { t("새 버전 v\(version) 있어요", "Version \(version) is available", "バージョン \(version) が利用可能です", "La versión \(version) está disponible") }
-    func upToDate(_ version: String) -> String { t("최신 버전이에요 (v\(version))", "You're on the latest (v\(version))", "最新です (v\(version))", "Tienes la última versión (v\(version))") }
+    var updateButton: String { t("업데이트", "Update", "更新", "Actualizar", "更新") }
+    var updateLater: String { t("나중에", "Later", "後で", "Más tarde", "稍後") }
+    var updating: String { t("업데이트 중…", "Updating…", "更新中…", "Actualizando…", "更新中…") }
+    var updateSectionTitle: String { t("업데이트", "Updates", "アップデート", "Actualizaciones", "更新") }
+    var updateNotificationsLabel: String { t("업데이트 알림", "Update notifications", "アップデート通知", "Notificaciones de actualización", "更新通知") }
+    var checkForUpdatesLabel: String { t("업데이트 확인", "Check for updates", "アップデートを確認", "Buscar actualizaciones", "檢查更新") }
+    var checkNowButton: String { t("지금 확인", "Check now", "今すぐ確認", "Comprobar ahora", "立即檢查") }
+    func updateFound(_ version: String) -> String { t("새 버전 v\(version) 있어요", "Version \(version) is available", "バージョン \(version) が利用可能です", "La versión \(version) está disponible", "有新版本 v\(version)") }
+    func upToDate(_ version: String) -> String { t("최신 버전이에요 (v\(version))", "You're on the latest (v\(version))", "最新です (v\(version))", "Tienes la última versión (v\(version))", "已是最新版本 (v\(version))") }
 
     // MARK: 알림
-    var notifCritical: String { t("한도 임박", "Limit imminent", "上限切迫", "Límite inminente") }
-    var notifWarning: String { t("한도 경고", "Limit warning", "上限警告", "Aviso de límite") }
+    var notifCritical: String { t("한도 임박", "Limit imminent", "上限切迫", "Límite inminente", "即將達到上限") }
+    var notifWarning: String { t("한도 경고", "Limit warning", "上限警告", "Aviso de límite", "上限警告") }
     func notifBody(_ name: String, _ percent: String) -> String {
-        t("\(name) 한도 \(percent) 사용", "\(name) at \(percent)", "\(name) 上限 \(percent) 使用", "\(name) al \(percent)")
+        t("\(name) 한도 \(percent) 사용", "\(name) at \(percent)", "\(name) 上限 \(percent) 使用", "\(name) al \(percent)", "\(name) 已使用 \(percent)")
     }
-    var claudeFiveHour: String { t("Claude 5시간 세션", "Claude 5-hour session", "Claude 5時間セッション", "Sesión de 5 horas de Claude") }
-    var claudeWeekly: String { t("Claude 주간", "Claude weekly", "Claude 週間", "Semanal de Claude") }
-    var codexPersonalLimit: String { t("Codex 개인 한도", "Codex personal limit", "Codex 個人上限", "Límite personal de Codex") }
+    var claudeFiveHour: String { t("Claude 5시간 세션", "Claude 5-hour session", "Claude 5時間セッション", "Sesión de 5 horas de Claude", "Claude 5 小時區間") }
+    var claudeWeekly: String { t("Claude 주간", "Claude weekly", "Claude 週間", "Semanal de Claude", "Claude 每週") }
+    var codexPersonalLimit: String { t("Codex 개인 한도", "Codex personal limit", "Codex 個人上限", "Límite personal de Codex", "Codex 個人上限") }
 
     // MARK: 가방 / 아이템
-    var bag: String { t("가방", "Bag", "バッグ", "Bolsa") }
-    var bagEmptyTitle: String { t("아직 가방이 비어있어요!", "Your bag is empty!", "バッグはまだ空っぽです！", "¡Tu bolsa todavía está vacía!") }
-    var useItem: String { t("사용하기", "Use", "つかう", "Usar") }
-    var use: String { t("사용", "Use", "つかう", "Usar") }
-    var cancel: String { t("취소", "Cancel", "キャンセル", "Cancelar") }
+    var bag: String { t("가방", "Bag", "バッグ", "Bolsa", "背包") }
+    var bagEmptyTitle: String { t("아직 가방이 비어있어요!", "Your bag is empty!", "バッグはまだ空っぽです！", "¡Tu bolsa todavía está vacía!", "背包還是空的！") }
+    var useItem: String { t("사용하기", "Use", "つかう", "Usar", "使用") }
+    var use: String { t("사용", "Use", "つかう", "Usar", "使用") }
+    var cancel: String { t("취소", "Cancel", "キャンセル", "Cancelar", "取消") }
     func useOnCurrent(_ name: String) -> String {
-        t("\(name)에게 사용할까요?", "Use on \(name)?", "\(name) に使いますか？", "¿Usar en \(name)?")
+        t("\(name)에게 사용할까요?", "Use on \(name)?", "\(name) に使いますか？", "¿Usar en \(name)?", "要對 \(name) 使用嗎？")
     }
-    var useAfterHatch: String { t("부화 후 사용할 수 있어요", "Usable after hatching", "孵化後に使えます", "Se puede usar después de eclosionar") }
-    var useNeedsPokemon: String { t("사용할 포켓몬이 없어요", "No Pokémon to use it on", "使えるポケモンがいません", "No hay ningún Pokémon en quien usarlo") }
+    var useAfterHatch: String { t("부화 후 사용할 수 있어요", "Usable after hatching", "孵化後に使えます", "Se puede usar después de eclosionar", "孵化後才能使用") }
+    var useNeedsPokemon: String { t("사용할 포켓몬이 없어요", "No Pokémon to use it on", "使えるポケモンがいません", "No hay ningún Pokémon en quien usarlo", "沒有可以使用的寶可夢") }
 
     /// 아이템 표시명 — species 처럼 공식 현지명.
     func itemName(_ kind: ItemKind) -> String {
         switch kind {
-        case .rareCandy: return t("이상한 사탕", "Rare Candy", "ふしぎなアメ", "Caramelo Raro")
-        case .mint:      return t("민트", "Mint", "ミント", "Menta")
-        case .shinyCharm: return t("이로치 부적", "Shiny Charm", "ひかるおまもり", "Amuleto Iris")
+        case .rareCandy: return t("이상한 사탕", "Rare Candy", "ふしぎなアメ", "Caramelo Raro", "神奇糖果")
+        case .mint:      return t("민트", "Mint", "ミント", "Menta", "薄荷")
+        case .shinyCharm: return t("이로치 부적", "Shiny Charm", "ひかるおまもり", "Amuleto Iris", "閃耀護符")
         }
     }
     func itemDescription(_ kind: ItemKind) -> String {
@@ -515,42 +555,45 @@ struct L {
             return t("현재 포켓몬의 경험치를 \(xp) 올려줘요.",
                      "Raises your Pokémon's EXP by \(xp).",
                      "ポケモンの経験値を\(xp)上げます。",
-                     "Aumenta la experiencia de tu Pokémon en \(xp).")
+                     "Aumenta la experiencia de tu Pokémon en \(xp).",
+                     "讓目前的寶可夢獲得 \(xp) 經驗值。")
         case .mint:
             return t("현재 포켓몬의 성격을 랜덤으로 바꿔줘요.",
                      "Randomly changes your Pokémon's nature.",
                      "ポケモンのせいかくをランダムに変えます。",
-                     "Cambia aleatoriamente la naturaleza de tu Pokémon.")
+                     "Cambia aleatoriamente la naturaleza de tu Pokémon.",
+                     "隨機改變目前寶可夢的性格。")
         case .shinyCharm:
             return t("보유하면 이로치 포켓몬이 태어날 확률이 올라가요.",
                      "While owned, raises the chance of hatching a shiny.",
                      "持っていると色違いが生まれる確率が上がります。",
-                     "Mientras lo tengas, aumenta la probabilidad de que nazca un Pokémon variocolor.")
+                     "Mientras lo tengas, aumenta la probabilidad de que nazca un Pokémon variocolor.",
+                     "持有時會提高孵出異色寶可夢的機率。")
         }
     }
     /// 가방 사용 컨트롤의 효과 힌트 — 민트("성격 랜덤 변경", 사탕의 "+XP" 자리).
-    var mintEffectHint: String { t("성격 랜덤 변경", "Random nature", "せいかくランダム変更", "Naturaleza aleatoria") }
+    var mintEffectHint: String { t("성격 랜덤 변경", "Random nature", "せいかくランダム変更", "Naturaleza aleatoria", "隨機改變性格") }
 
     // MARK: 상점 (재화 = 사용한 토큰)
-    var shop: String { t("상점", "Shop", "ショップ", "Tienda") }
-    var spendableTokens: String { t("쓸 수 있는 토큰", "Spendable tokens", "使えるトークン", "Tokens disponibles") }
-    var shopHint: String { t("사용한 토큰으로 아이템을 살 수 있어요.", "Spend the tokens you've used on items.", "使ったトークンでアイテムを購入できます。", "Usa los tokens que has consumido para comprar objetos.") }
-    var buy: String { t("구매", "Buy", "購入", "Comprar") }
-    func buyConfirm(_ name: String) -> String { t("\(name) 구매할까요?", "Buy \(name)?", "\(name) を購入しますか？", "¿Comprar \(name)?") }
-    var notEnoughTokens: String { t("토큰이 부족해요", "Not enough tokens", "トークンが足りません", "No tienes suficientes tokens") }
-    func ownedCount(_ n: Int) -> String { t("보유 ×\(n)", "Owned ×\(n)", "所持 ×\(n)", "En posesión ×\(n)") }
-    var shopPriceLabel: String { t("가격", "Price", "価格", "Precio") }
-    var ownedAlready: String { t("보유 중", "Owned", "所持済み", "En posesión") }
-    var shinyCharmEffectHint: String { t("이로치 확률 ↑ · 적용 중", "Shiny rate ↑ · active", "色違い率↑ · 適用中", "Prob. variocolor ↑ · activo") }
+    var shop: String { t("상점", "Shop", "ショップ", "Tienda", "商店") }
+    var spendableTokens: String { t("쓸 수 있는 토큰", "Spendable tokens", "使えるトークン", "Tokens disponibles", "可用 token") }
+    var shopHint: String { t("사용한 토큰으로 아이템을 살 수 있어요.", "Spend the tokens you've used on items.", "使ったトークンでアイテムを購入できます。", "Usa los tokens que has consumido para comprar objetos.", "用已經花掉的 token 購買道具。") }
+    var buy: String { t("구매", "Buy", "購入", "Comprar", "購買") }
+    func buyConfirm(_ name: String) -> String { t("\(name) 구매할까요?", "Buy \(name)?", "\(name) を購入しますか？", "¿Comprar \(name)?", "要購買 \(name) 嗎？") }
+    var notEnoughTokens: String { t("토큰이 부족해요", "Not enough tokens", "トークンが足りません", "No tienes suficientes tokens", "token 不足") }
+    func ownedCount(_ n: Int) -> String { t("보유 ×\(n)", "Owned ×\(n)", "所持 ×\(n)", "En posesión ×\(n)", "持有 ×\(n)") }
+    var shopPriceLabel: String { t("가격", "Price", "価格", "Precio", "價格") }
+    var ownedAlready: String { t("보유 중", "Owned", "所持済み", "En posesión", "已持有") }
+    var shinyCharmEffectHint: String { t("이로치 확률 ↑ · 적용 중", "Shiny rate ↑ · active", "色違い率↑ · 適用中", "Prob. variocolor ↑ · activo", "異色機率 ↑ · 生效中") }
     // 알 (리롤) — tier = 보증 등급 하한(nil = 보증 없는 기본 알).
     // 이름은 `rarityLabel(r) + " 알"` 식 조합으로 만들지 않는다: 한국어·영어는 맞아떨어져도 일본어에서
     // 조사가 어긋난다(レアのタマゴ vs 자연스러운 レアなタマゴ). 세 언어를 명시 트리플로 적는다.
     func eggName(_ tier: Rarity?) -> String {
         switch tier {
-        case nil, .common?: return t("포켓몬 알", "Pokémon Egg", "ポケモンのタマゴ", "Huevo Pokémon")
-        case .uncommon?:  return t("고급 알", "Uncommon Egg", "アンコモンのタマゴ", "Huevo poco común")
-        case .rare?:      return t("희귀 알", "Rare Egg", "レアのタマゴ", "Huevo raro")
-        case .legendary?: return t("전설 알", "Legendary Egg", "でんせつのタマゴ", "Huevo legendario")   // 미판매(FreshEgg.shopTiers)
+        case nil, .common?: return t("포켓몬 알", "Pokémon Egg", "ポケモンのタマゴ", "Huevo Pokémon", "寶可夢蛋")
+        case .uncommon?:  return t("고급 알", "Uncommon Egg", "アンコモンのタマゴ", "Huevo poco común", "罕見的蛋")
+        case .rare?:      return t("희귀 알", "Rare Egg", "レアのタマゴ", "Huevo raro", "稀有的蛋")
+        case .legendary?: return t("전설 알", "Legendary Egg", "でんせつのタマゴ", "Huevo legendario", "傳說的蛋")   // 미판매(FreshEgg.shopTiers)
         }
     }
     func eggDescription(_ tier: Rarity?) -> String {
@@ -558,39 +601,44 @@ struct L {
             return t("지금 포켓몬을 놓아주고 새 알로 다시 시작해요.",
                      "Send off your current Pokémon and start fresh with a new egg.",
                      "いまのポケモンを手放して新しいタマゴからやり直します。",
-                     "Suelta a tu Pokémon actual y empieza de nuevo con un huevo nuevo.")
+                     "Suelta a tu Pokémon actual y empieza de nuevo con un huevo nuevo.",
+                     "放走目前的寶可夢，換一顆新的蛋重新開始。")
         }
         let r = rarityLabel(tier)
         return t("지금 포켓몬을 놓아주고 \(r) 이상이 확정으로 나오는 알을 받아요.",
                  "Send off your current Pokémon for an egg guaranteed to hatch \(r) or better.",
                  "いまのポケモンを手放して \(r) 以上が確定で孵るタマゴをもらいます。",
-                 "Suelta a tu Pokémon actual y consigue un huevo garantizado de \(r) o superior.")
+                 "Suelta a tu Pokémon actual y consigue un huevo garantizado de \(r) o superior.",
+                 "放走目前的寶可夢，換一顆保證孵出 \(r) 以上的蛋。")
     }
     /// 인큐베이션 중 표시하는 보증 배지 — 어떤 알을 품고 있는지 한 줄로.
     func eggGuaranteeHint(_ tier: Rarity) -> String {
         let r = rarityLabel(tier)
-        return t("\(r) 이상 확정", "\(r) or better", "\(r) 以上確定", "\(r) o superior garantizado")
+        return t("\(r) 이상 확정", "\(r) or better", "\(r) 以上確定", "\(r) o superior garantizado", "保證 \(r) 以上")
     }
     func eggConfirm(_ monName: String, _ eggName: String) -> String {
         t("\(monName)을(를) 놓아주고 \(eggName)(으)로 바꿀까요?",
           "Send off \(monName) for the \(eggName)?",
           "\(monName) を手放して \(eggName) にしますか？",
-          "¿Soltar a \(monName) y cambiarlo por \(eggName)?")
+          "¿Soltar a \(monName) y cambiarlo por \(eggName)?",
+          "要放走 \(monName)，換成 \(eggName) 嗎？")
     }
-    var freshEggShinyWarning: String { t("⚠️ 이로치 포켓몬이에요! 정말 놓아줄까요?", "⚠️ This one is shiny! Really send it off?", "⚠️ 色違いです！本当に手放しますか？", "⚠️ ¡Este es variocolor! ¿Seguro que quieres soltarlo?") }
-    var freshEggDiscardShiny: String { t("이로치 놓아주기", "Send shiny off", "手放す", "Soltar variocolor") }
+    var freshEggShinyWarning: String { t("⚠️ 이로치 포켓몬이에요! 정말 놓아줄까요?", "⚠️ This one is shiny! Really send it off?", "⚠️ 色違いです！本当に手放しますか？", "⚠️ ¡Este es variocolor! ¿Seguro que quieres soltarlo?", "⚠️ 這是異色寶可夢！真的要放走嗎？") }
+    var freshEggDiscardShiny: String { t("이로치 놓아주기", "Send shiny off", "手放す", "Soltar variocolor", "放走異色") }
 
     // MARK: 사탕 획득 알림 ("왜 받는지" = 토큰 한도를 다 채운 수고에 대한 보상)
     func notifCandyTitle(item: String, count: Int) -> String {
         t("🍬 \(item) \(count)개를 받았어요!",
           "🍬 You got \(count)× \(item)!",
           "🍬 \(item)を\(count)個もらいました！",
-          "🍬 ¡Has recibido \(count)× \(item)!")
+          "🍬 ¡Has recibido \(count)× \(item)!",
+          "🍬 獲得了 \(count) 個 \(item)！")
     }
     func notifCandyBody(window: String) -> String {
         t("\(window) 토큰 한도를 다 채웠어요. 열심히 쓴 만큼 사탕을 드려요 — 포켓몬에게 써서 진화시켜 보세요!",
           "You maxed out your \(window) token limit. A treat for the effort — use it to evolve your Pokémon!",
           "\(window)のトークン上限を使い切りました。がんばったごほうびです — ポケモンに使って進化させよう！",
-          "Has agotado tu límite de tokens \(window). Un premio por el esfuerzo — ¡úsalo para evolucionar a tu Pokémon!")
+          "Has agotado tu límite de tokens \(window). Un premio por el esfuerzo — ¡úsalo para evolucionar a tu Pokémon!",
+          "你把 \(window) 的 token 上限用完了。這是努力的獎勵 — 用在寶可夢身上讓牠進化吧！")
     }
 }

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -21,7 +21,9 @@ protocol PokeProviding: Sendable {
 actor PokeAPIClient: PokeProviding {
     static let shared = PokeAPIClient()
     private let base = URL(string: "https://pokeapi.co/api/v2")!
-    private let langCodes = ["ko", "en", "ja-Hrkt", "ja", "es"]
+    /// 종 이름을 보관할 언어 코드 — `AppLanguage.apiCodes` 에서 파생한다(단일 소스).
+    /// 리터럴 목록으로 두면 언어를 추가할 때 이 줄을 잊고, 새 언어만 조용히 영어 이름이 된다.
+    static let langCodes = Set(AppLanguage.allCases.flatMap(\.apiCodes))
     private var speciesCache: [Int: SpeciesDTO] = [:]
     private var lineCache: [Int: EvoLine] = [:]   // 프리패칭 → 부화 순간 네트워크 0
 
@@ -42,7 +44,7 @@ actor PokeAPIClient: PokeProviding {
         for id in allIDs(tree) {
             let sp = try await species(id)
             var byLang: [String: String] = [:]
-            for n in sp.names where langCodes.contains(n.language.name) { byLang[n.language.name] = n.name }
+            for n in sp.names where Self.langCodes.contains(n.language.name) { byLang[n.language.name] = n.name }
             names[id] = byLang
         }
         let line = EvoLine(baseID: baseSpeciesID, tree: tree, rarity: rarity, names: names)

--- a/Tests/PokeTokenBarTests/TraditionalChineseTests.swift
+++ b/Tests/PokeTokenBarTests/TraditionalChineseTests.swift
@@ -1,0 +1,269 @@
+import XCTest
+@testable import PokeTokenBar
+
+// MARK: 번체 중국어(zh-Hant)
+
+/// 언어를 추가할 때 컴파일러가 못 잡는 지점만 고정한다.
+/// `t()` 의 인자 개수는 컴파일이 강제하므로 "빠진 문자열"은 여기서 볼 필요가 없다. 대신 조용히
+/// 깨지는 네 가지 — (1) 저장 포맷·표시 로케일, (2) 시스템 언어 유추(간체를 번체로 오인),
+/// (3) PokéAPI 이름 코드 누락(전부 영어 이름으로 폴백), (4) 다른 언어 문자열 혼입 — 을 검증한다.
+final class TraditionalChineseLocalizationTests: XCTestCase {
+
+    // MARK: 저장 포맷 · 로케일
+
+    func testRawValueIsBCP47AndRoundTrips() {
+        XCTAssertEqual(AppLanguage.zhHant.rawValue, "zh-Hant")
+        XCTAssertTrue(AppLanguage.allCases.contains(.zhHant))
+        // rawValue 는 세이브에 그대로 들어간다 — 바뀌면 기존 사용자의 언어 설정이 초기화된다.
+        XCTAssertEqual(AppLanguage(rawValue: "zh-Hant"), .zhHant)
+        XCTAssertEqual(AppLanguage.zhHant.label, "繁體中文")
+    }
+
+    /// 로케일이 어긋나면 팝오버의 자동 생성 문장만 다른 언어로 섞인다("上次更新" 옆에 "3 hours ago").
+    func testDisplayLocaleProducesTraditionalRelativeTime() {
+        XCTAssertEqual(AppLanguage.zhHant.displayLocale.identifier, "zh-Hant")
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let f = RelativeDateTimeFormatter()
+        f.locale = AppLanguage.zhHant.displayLocale
+        let relative = f.localizedString(for: now.addingTimeInterval(-3 * 3600), relativeTo: now)
+
+        XCTAssertTrue(relative.contains("小時"), "번체 상대 시각이 아님: \(relative)")
+        XCTAssertFalse(relative.contains("小时"), "간체가 새어 들어옴: \(relative)")
+    }
+
+    // MARK: 시스템 언어 유추
+
+    /// 간체(zh-Hans/CN/SG) 사용자에게 번체를 주면 시스템 언어와 어긋난 화면이 된다 — 번체권만 매칭.
+    func testSystemDefaultMatchesOnlyTraditionalVariants() {
+        for tag in ["zh-hant", "zh-hant-tw", "zh-hant-hk", "zh-tw", "zh-hk", "zh-mo", "zh_tw"] {
+            XCTAssertTrue(AppLanguage.isTraditionalChinese(tag), "번체로 판정해야 함: \(tag)")
+        }
+        // 스크립트 태그 없는 "zh" 는 번체라고 단정할 수 없다 → 영어 폴백(기존 동작 유지).
+        for tag in ["zh", "zh-hans", "zh-hans-cn", "zh-cn", "zh-sg", "ko-kr", "ja-jp", "en-us", ""] {
+            XCTAssertFalse(AppLanguage.isTraditionalChinese(tag), "번체가 아님: \(tag)")
+        }
+        // 스크립트 태그가 지역보다 우선한다 — zh-Hant-CN 은 번체, zh-Hans-TW 는 간체.
+        XCTAssertTrue(AppLanguage.isTraditionalChinese("zh-hant-cn"))
+        XCTAssertFalse(AppLanguage.isTraditionalChinese("zh-hans-tw"))
+    }
+
+    /// 언어 추가로 기존 사용자의 기본값이 흔들리면 안 된다 — ko/ja/es/en 유추는 그대로.
+    /// 실행 기기의 언어에 좌우되지 않게 선호 언어 목록을 주입해 전 분기를 밟는다.
+    func testResolveCoversEveryLanguageBranch() {
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: ["zh-Hant-TW", "en-US"]), .zhHant)
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: ["zh-TW"]), .zhHant)
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: ["ko-KR"]), .ko)
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: ["ja-JP"]), .ja)
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: ["es-ES"]), .es)
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: ["en-US"]), .en)
+        // 간체·미지원 언어·빈 목록은 영어 폴백(기존 동작).
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: ["zh-Hans-CN"]), .en)
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: ["fr-FR"]), .en)
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: []), .en)
+        // 첫 항목만 본다 — 2순위 언어가 결과를 바꾸면 안 된다.
+        XCTAssertEqual(AppLanguage.resolve(preferredLanguages: ["en-US", "zh-Hant-TW"]), .en)
+
+        XCTAssertTrue(AppLanguage.allCases.contains(AppLanguage.systemDefault))
+    }
+
+    /// 언어 선택 메뉴에 쓰이는 표시명 — 비면 고를 수 없는 항목이 되고, 겹치면 구분할 수 없다.
+    func testEveryLanguageHasDistinctLabel() {
+        let labels = AppLanguage.allCases.map(\.label)
+        XCTAssertEqual(Set(labels).count, AppLanguage.allCases.count)
+        XCTAssertFalse(labels.contains(where: \.isEmpty))
+    }
+
+    // MARK: PokéAPI 이름
+
+    /// PokéAPI 응답의 `language.name` 은 소문자다("zh-hant"). 대문자만 넣으면 매칭이 실패해
+    /// 조용히 영어 이름(Pikachu)이 표시된다 — 그 경로를 실제 매칭으로 고정한다.
+    func testSpeciesNameResolvesFromLowercaseAPICode() {
+        let byLang = ["en": "Pikachu", "ja": "ピカチュウ", "ko": "피카츄", "zh-hant": "皮卡丘"]
+        XCTAssertEqual(AppLanguage.zhHant.resolveName(byLang), "皮卡丘")
+        // 번체 이름이 없는 종은 영어로 폴백 — 빈 칸이 되지 않는다.
+        XCTAssertEqual(AppLanguage.zhHant.resolveName(["en": "Pikachu"]), "Pikachu")
+    }
+
+    /// 클라이언트가 저장하는 언어 코드가 `apiCodes` 를 덮지 못하면 위 폴백이 항상 영어가 된다.
+    /// 리터럴 목록으로 되돌리는 회귀를 막기 위해 전 언어를 순회한다.
+    func testClientKeepsEveryLanguageAPICode() {
+        for lang in AppLanguage.allCases {
+            for code in lang.apiCodes {
+                XCTAssertTrue(PokeAPIClient.langCodes.contains(code), "\(lang.rawValue) 의 \(code) 가 누락됨")
+            }
+        }
+    }
+
+    // MARK: UI 문자열 혼입
+
+    /// 다른 언어 칸을 복사해 넣는 실수(한글·가나 잔류, 간체 혼입)를 걸러낸다.
+    /// 이 앱의 UI 문자열은 전부 한자를 포함하므로 "한자 있음 + 한글/가나 없음"이 성립한다.
+    func testStringsAreTraditionalChineseWithNoOtherScript() {
+        let l = L(.zhHant)
+        for (key, value) in Self.samples(l) {
+            XCTAssertFalse(value.isEmpty, "\(key) 비어 있음")
+            XCTAssertTrue(value.unicodeScalars.contains(where: Self.isHan), "\(key) 에 한자가 없음: \(value)")
+            XCTAssertFalse(value.unicodeScalars.contains(where: Self.isHangul), "\(key) 에 한글 잔류: \(value)")
+            XCTAssertFalse(value.unicodeScalars.contains(where: Self.isKana), "\(key) 에 가나 잔류: \(value)")
+        }
+    }
+
+    /// 보간값이 번역 과정에서 사라지면 숫자·이름 없는 문장이 된다(컴파일은 통과한다).
+    func testInterpolationsSurviveTranslation() {
+        let l = L(.zhHant)
+        XCTAssertTrue(l.stage(2, 3).contains("2") && l.stage(2, 3).contains("3"))
+        XCTAssertTrue(l.eggToHatch("1.2M").contains("1.2M"))
+        XCTAssertTrue(l.notifBody("Claude 每週", "85%").contains("Claude 每週"))
+        XCTAssertTrue(l.notifBody("Claude 每週", "85%").contains("85%"))
+        XCTAssertTrue(l.notifCandyTitle(item: l.itemName(.rareCandy), count: 3).contains("3"))
+        XCTAssertTrue(l.updateAvailable("2.6.0", current: "2.5.1").contains("2.6.0"))
+        XCTAssertTrue(l.upToDate("2.5.1").contains("2.5.1"))
+        XCTAssertTrue(l.limitRefreshHTTPError(500).contains("500"))
+        XCTAssertTrue(l.reportMailFallback("a@b.c").contains("a@b.c"))
+        XCTAssertTrue(l.dexPageLabel(2, 7).contains("2") && l.dexPageLabel(2, 7).contains("7"))
+
+        let mail = l.reportMailBody(version: "2.5.1", os: "26.3.1")
+        XCTAssertTrue(mail.contains("2.5.1") && mail.contains("26.3.1"))
+        XCTAssertTrue(mail.contains("~/Library/Logs/PokeTokenBar.log"), "로그 경로가 번역돼 사라지면 안 된다")
+
+        let confirm = l.importConfirmBody(incomingDex: 12, incomingTokens: "5.0M",
+                                          exportedAt: "2026-08-19", sourceDevice: "MacBook",
+                                          currentDex: 3, currentTokens: "1.0M")
+        for token in ["12", "5.0M", "2026-08-19", "MacBook", "3", "1.0M"] {
+            XCTAssertTrue(confirm.contains(token), "\(token) 누락: \(confirm)")
+        }
+    }
+
+    /// 성격 25종의 번체 명칭 — 본가 공식 표기이고 서로 겹치지 않아야 한다(도감 표시 식별자).
+    func testNatureNamesAreDistinctTraditionalChinese() {
+        let names = PokemonNature.allCases.map { $0.name(.zhHant) }
+        XCTAssertEqual(Set(names).count, 25)
+        XCTAssertEqual(PokemonNature.hardy.name(.zhHant), "勤奮")
+        XCTAssertEqual(PokemonNature.quirky.name(.zhHant), "浮躁")
+        for name in names {
+            XCTAssertTrue(name.unicodeScalars.allSatisfy(Self.isHan), "한자 외 문자 포함: \(name)")
+        }
+    }
+
+    // MARK: 헬퍼
+
+    private static func isHan(_ s: Unicode.Scalar) -> Bool { (0x4E00...0x9FFF).contains(Int(s.value)) }
+    private static func isHangul(_ s: Unicode.Scalar) -> Bool {
+        let v = Int(s.value)
+        return (0xAC00...0xD7A3).contains(v) || (0x1100...0x11FF).contains(v) || (0x3130...0x318F).contains(v)
+    }
+    private static func isKana(_ s: Unicode.Scalar) -> Bool {
+        let v = Int(s.value)
+        return (0x3040...0x309F).contains(v) || (0x30A0...0x30FF).contains(v)
+    }
+
+    /// 섹션별 대표 문자열 — L 의 프로퍼티는 계산 프로퍼티라 Mirror 로 순회할 수 없어 직접 나열한다.
+    private static func samples(_ l: L) -> [(String, String)] {
+        [
+            ("home", l.home), ("collection", l.collection),
+            ("todayTokens", l.todayTokens), ("thisWeek", l.thisWeek), ("thisMonth", l.thisMonth),
+            ("limitsOfficial", l.limitsOfficial), ("fiveHourSession", l.fiveHourSession),
+            ("weekly", l.weekly), ("reset", l.reset), ("limitReached", l.limitReached),
+            ("personalSpendLimit", l.personalSpendLimit), ("staleLimits", l.staleLimits),
+            ("refresh", l.refresh), ("limitsTapToLoad", l.limitsTapToLoad),
+            ("providerStatus.operational", l.providerStatusLabel(.operational)),
+            ("providerStatus.major", l.providerStatusLabel(.major)),
+            ("providerStatus.unknown", l.providerStatusLabel(.unknown)),
+            ("plan", l.plan("Max")), ("forecastReach", l.forecastReach("14:00")),
+            ("forecastNoReach", l.forecastNoReach),
+            ("claudeLimitEntry.session", l.claudeLimitEntry(kind: "session", model: nil)),
+            ("claudeLimitEntry.scoped", l.claudeLimitEntry(kind: "weekly_scoped", model: nil)),
+            ("codexWindow.300", l.codexWindow(300)), ("codexWindow.90", l.codexWindow(90)),
+            ("codexWindow.nil", l.codexWindow(nil)),
+            ("refreshNow", l.refreshNow), ("updated", l.updated), ("settings", l.settings),
+            ("back", l.back), ("quit", l.quit), ("close", l.close),
+            ("generalSectionTitle", l.generalSectionTitle), ("menuBarSectionTitle", l.menuBarSectionTitle),
+            ("advancedSectionTitle", l.advancedSectionTitle), ("advancedDisclosureLabel", l.advancedDisclosureLabel),
+            ("aboutSupportSectionTitle", l.aboutSupportSectionTitle),
+            ("refreshInterval", l.refreshInterval), ("language", l.language),
+            ("menuBarItems", l.menuBarItems), ("todayCost", l.todayCost),
+            ("limitDisplayModeLabel", l.limitDisplayModeLabel), ("limitDisplayUsed", l.limitDisplayUsed),
+            ("limitDisplayRemaining", l.limitDisplayRemaining), ("percentRemaining", l.percentRemaining("20%")),
+            ("allOffHint", l.allOffHint),
+            ("floatingPetSectionTitle", l.floatingPetSectionTitle), ("floatingPetEnableLabel", l.floatingPetEnableLabel),
+            ("floatingPetHint", l.floatingPetHint), ("floatingPetSizeLabel", l.floatingPetSizeLabel),
+            ("floatingPetBubbleAlertsLabel", l.floatingPetBubbleAlertsLabel),
+            ("floatingPetMenuOpen", l.floatingPetMenuOpen), ("floatingPetMenuHide", l.floatingPetMenuHide),
+            ("floatingPetHoverTokensOnly", l.floatingPetHoverTokensOnly("1.2M")),
+            ("floatingPetHoverWithLimit", l.floatingPetHoverWithLimit("1.2M", "80%")),
+            ("disableKeychain", l.disableKeychain), ("disableKeychainHint", l.disableKeychainHint),
+            ("refreshLimitToken", l.refreshLimitToken), ("onlyOnPress", l.onlyOnPress),
+            ("launchAtLogin", l.launchAtLogin), ("bundledOnly", l.bundledOnly),
+            ("notificationsSection", l.notificationsSection), ("limitNotificationsLabel", l.limitNotificationsLabel),
+            ("companionNotificationsLabel", l.companionNotificationsLabel),
+            ("statusChecksLabel", l.statusChecksLabel), ("statusChecksHint", l.statusChecksHint),
+            ("warning", l.warning), ("critical", l.critical), ("aggregationNote", l.aggregationNote),
+            ("transferSectionTitle", l.transferSectionTitle), ("exportSaveLabel", l.exportSaveLabel),
+            ("exportSaveHint", l.exportSaveHint), ("exportSaveButton", l.exportSaveButton),
+            ("importSaveLabel", l.importSaveLabel), ("importSaveHint", l.importSaveHint),
+            ("importSaveButton", l.importSaveButton), ("importConfirmTitle", l.importConfirmTitle),
+            ("importConfirmReplace", l.importConfirmReplace),
+            ("importSaveDone", l.importSaveDone(dex: 1, tokens: "1M")),
+            ("importErrorNotSaveFile", l.importErrorNotSaveFile), ("importErrorNewerSchema", l.importErrorNewerSchema),
+            ("importErrorTooLarge", l.importErrorTooLarge), ("importErrorBackupFailed", l.importErrorBackupFailed),
+            ("reportProblem", l.reportProblem), ("showLogFile", l.showLogFile),
+            ("reportAttachHint", l.reportAttachHint), ("reportMailSubject", l.reportMailSubject("2.5.1")),
+            ("intervalLabel.0", l.intervalLabel(0)), ("intervalLabel.300", l.intervalLabel(300)),
+            ("finalForm", l.finalForm), ("stage", l.stage(1, 2)),
+            ("unknownNextEvolution", l.unknownNextEvolution), ("eggIncubating", l.eggIncubating),
+            ("eggToHatch", l.eggToHatch("1M")), ("toNextEvolution", l.toNextEvolution("1M")),
+            ("toGraduation", l.toGraduation("1M")), ("graduated", l.graduated("皮卡丘")),
+            ("dexEmptyTitle", l.dexEmptyTitle), ("dexEmptyHint", l.dexEmptyHint),
+            ("dexTitle", l.dexTitle), ("dexTotal", l.dexTotal(3)), ("catchLogTitle", l.catchLogTitle),
+            ("dexSpeciesTotal", l.dexSpeciesTotal(3)), ("dexPageLabel", l.dexPageLabel(1, 2)),
+            ("dexPagePrev", l.dexPagePrev), ("dexPageNext", l.dexPageNext), ("dexRaising", l.dexRaising),
+            ("rarity.common", l.rarityLabel(.common)), ("rarity.uncommon", l.rarityLabel(.uncommon)),
+            ("rarity.rare", l.rarityLabel(.rare)), ("rarity.legendary", l.rarityLabel(.legendary)),
+            ("dexFilterHint", l.dexFilterHint), ("dexShinyLabel", l.dexShinyLabel),
+            ("statusEgg", l.statusEgg), ("statusIdle", l.statusIdle), ("statusWorking", l.statusWorking),
+            ("statusFocus", l.statusFocus), ("statusTired", l.statusTired), ("statusSleep", l.statusSleep),
+            ("statusEvolved", l.statusEvolved("皮卡丘")), ("statusGrew", l.statusGrew),
+            ("notifHatchTitle", l.notifHatchTitle), ("notifHatchBody", l.notifHatchBody("皮卡丘")),
+            ("notifShinyHatchTitle", l.notifShinyHatchTitle), ("notifShinyHatchBody", l.notifShinyHatchBody("皮卡丘")),
+            ("eggImminent", l.eggImminent), ("eggFirstRunHint", l.eggFirstRunHint),
+            ("notifEvolveTitle", l.notifEvolveTitle), ("notifEvolveBody", l.notifEvolveBody("雷丘")),
+            ("notifDittoRevealTitle", l.notifDittoRevealTitle), ("notifDittoRevealBody", l.notifDittoRevealBody("皮卡丘")),
+            ("notifShinyDittoRevealTitle", l.notifShinyDittoRevealTitle),
+            ("notifShinyDittoRevealBody", l.notifShinyDittoRevealBody("皮卡丘")),
+            ("notifGraduateTitle", l.notifGraduateTitle), ("notifGraduateBody", l.notifGraduateBody("雷丘")),
+            ("limitRefreshHTTPError.401", l.limitRefreshHTTPError(401)),
+            ("limitRefreshHTTPError.500", l.limitRefreshHTTPError(500)),
+            ("limitRefreshNoCredential", l.limitRefreshNoCredential),
+            ("limitRefreshReauthNeeded", l.limitRefreshReauthNeeded),
+            ("limitRefreshGeneric", l.limitRefreshGeneric), ("limitRefreshRateLimited", l.limitRefreshRateLimited),
+            ("claudeAuthExpiredTitle", l.claudeAuthExpiredTitle), ("claudeAuthExpiredHint", l.claudeAuthExpiredHint),
+            ("retry", l.retry), ("updateAvailable", l.updateAvailable("2.6.0", current: "2.5.1")),
+            ("updateButton", l.updateButton), ("updateLater", l.updateLater), ("updating", l.updating),
+            ("updateSectionTitle", l.updateSectionTitle), ("updateNotificationsLabel", l.updateNotificationsLabel),
+            ("checkForUpdatesLabel", l.checkForUpdatesLabel), ("checkNowButton", l.checkNowButton),
+            ("updateFound", l.updateFound("2.6.0")), ("upToDate", l.upToDate("2.5.1")),
+            ("notifCritical", l.notifCritical), ("notifWarning", l.notifWarning),
+            ("claudeFiveHour", l.claudeFiveHour), ("claudeWeekly", l.claudeWeekly),
+            ("codexPersonalLimit", l.codexPersonalLimit),
+            ("bag", l.bag), ("bagEmptyTitle", l.bagEmptyTitle), ("useItem", l.useItem), ("use", l.use),
+            ("cancel", l.cancel), ("useOnCurrent", l.useOnCurrent("皮卡丘")),
+            ("useAfterHatch", l.useAfterHatch), ("useNeedsPokemon", l.useNeedsPokemon),
+            ("item.rareCandy", l.itemName(.rareCandy)), ("item.mint", l.itemName(.mint)),
+            ("item.shinyCharm", l.itemName(.shinyCharm)),
+            ("itemDesc.rareCandy", l.itemDescription(.rareCandy)), ("itemDesc.mint", l.itemDescription(.mint)),
+            ("itemDesc.shinyCharm", l.itemDescription(.shinyCharm)), ("mintEffectHint", l.mintEffectHint),
+            ("shop", l.shop), ("spendableTokens", l.spendableTokens), ("shopHint", l.shopHint),
+            ("buy", l.buy), ("buyConfirm", l.buyConfirm("薄荷")), ("notEnoughTokens", l.notEnoughTokens),
+            ("ownedCount", l.ownedCount(2)), ("shopPriceLabel", l.shopPriceLabel), ("ownedAlready", l.ownedAlready),
+            ("shinyCharmEffectHint", l.shinyCharmEffectHint),
+            ("eggName.nil", l.eggName(nil)), ("eggName.uncommon", l.eggName(.uncommon)),
+            ("eggName.rare", l.eggName(.rare)), ("eggName.legendary", l.eggName(.legendary)),
+            ("eggDescription.nil", l.eggDescription(nil)), ("eggDescription.rare", l.eggDescription(.rare)),
+            ("eggGuaranteeHint", l.eggGuaranteeHint(.rare)), ("eggConfirm", l.eggConfirm("皮卡丘", "稀有的蛋")),
+            ("freshEggShinyWarning", l.freshEggShinyWarning), ("freshEggDiscardShiny", l.freshEggDiscardShiny),
+            ("notifCandyTitle", l.notifCandyTitle(item: "神奇糖果", count: 2)),
+            ("notifCandyBody", l.notifCandyBody(window: "Claude 每週")),
+        ]
+    }
+}

--- a/Tests/PokeTokenBarTests/TraditionalChineseTests.swift
+++ b/Tests/PokeTokenBarTests/TraditionalChineseTests.swift
@@ -79,6 +79,10 @@ final class TraditionalChineseLocalizationTests: XCTestCase {
     /// PokéAPI 응답의 `language.name` 은 소문자다("zh-hant"). 대문자만 넣으면 매칭이 실패해
     /// 조용히 영어 이름(Pikachu)이 표시된다 — 그 경로를 실제 매칭으로 고정한다.
     func testSpeciesNameResolvesFromLowercaseAPICode() {
+        // 소문자 하나만 둔다 — 대문자 변형은 응답에 존재하지 않아 매칭되지 않는 죽은 항목이고,
+        // `PokeAPIClient.langCodes` 에도 그대로 실린다.
+        XCTAssertEqual(AppLanguage.zhHant.apiCodes, ["zh-hant"])
+
         let byLang = ["en": "Pikachu", "ja": "ピカチュウ", "ko": "피카츄", "zh-hant": "皮卡丘"]
         XCTAssertEqual(AppLanguage.zhHant.resolveName(byLang), "皮卡丘")
         // 번체 이름이 없는 종은 영어로 폴백 — 빈 칸이 되지 않는다.


### PR DESCRIPTION
## Summary

Adds Traditional Chinese (`zh-Hant`) as the fifth UI language, alongside ko / en / ja / es.

- `AppLanguage` gains `case zhHant = "zh-Hant"`. The raw value doubles as the persisted save format and as the `displayLocale` identifier, so the popover's relative dates follow the app language.
- All 207 `t(...)` call sites and the 25 nature names get their zh-Hant column. The existing ko/en/ja/es columns are untouched — I verified this mechanically by re-parsing both revisions and diffing the first four arguments of every call (0 differences).
- Nature names use the official Traditional Chinese names from the main series (勤奮 / 怕寂寞 / 固執 …).
- Pokémon names come from PokéAPI's `zh-hant` data at runtime, so no name table is bundled.
- The system-language guess matches Traditional variants only (`zh-Hant`, `zh-TW`, `zh-HK`, `zh-MO`). Simplified users (`zh-Hans`, `zh-CN`, `zh-SG`) keep the English fallback rather than being shown a script they did not ask for, and a bare `zh` is not assumed to be Traditional.
- Adds `README.zh-Hant.md`, linked from the language row of the other three.

**Why `zh-Hant` rather than `zh-TW`:** the script subtag is region-neutral, so one entry serves TW/HK/MO; it matches PokéAPI's own `zh-hant` code, keeping one concept end to end; and it stays consistent with the region-neutral `ko`/`en`/`ja`/`es` entries. A future `zh-HK` for Hong Kong vocabulary can be added later without renaming anything. The wording itself leans Taiwan Mandarin.

### One change worth a second look

`PokeAPIClient.langCodes` was a literal array that has to be edited by hand for every new language, and forgetting it is silent — the new language resolves no species name and quietly falls back to English, which reads like a data gap rather than a missing line of code. I changed it to derive from `AppLanguage.apiCodes`, which also meant widening it from `private let` to `static let` so a test can assert the invariant. The resulting set is a superset of the old list, so lookups are unchanged for the existing languages. It is an isolated commit (`0904bc8`) — happy to drop or split it if you would rather keep that line explicit.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## UI changes

No layout changes. The Settings language picker is `.menu` style and driven by `AppLanguage.allCases`, so it gains one entry with no change to the view code. Every other screen keeps its layout with Traditional Chinese text.

| Before | After |
| ------ | ----- |
| Language picker: 한국어 / English / 日本語 / Español | Language picker: 한국어 / English / 日本語 / Español / 繁體中文 |

`PerformanceTests.testLocalizedAlertBubbleFitsDefaultPanel` already iterates `AppLanguage.allCases`, so the new alert strings are verified to fit the floating pet's speech bubble without truncating.

## Checklist

- [x] `swift build` and `swift test` pass locally — 686 tests, and `./scripts/test-gate.sh` reports 89.93% line coverage on the logic core
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change

### On the tests

The argument count of `t(...)` is compiler-enforced, so a missing string cannot ship. `TraditionalChineseTests` covers what the compiler cannot see: the Traditional/Simplified matching table (including script tags winning over region — `zh-Hant-CN` is Traditional, `zh-Hans-TW` is not), every branch of `resolve(preferredLanguages:)` with the locale injected rather than read from the host machine, that the relative-time formatter produces 小時 and not 小时, that the client keeps an API code for every language, that interpolations survived translation, and script leakage (every sampled string carries Han characters and no Hangul or kana — which is what a copy-pasted column looks like). Both guards were checked by injecting the defect they are meant to catch.
