### PR TITLE
feat: add Docker Agent (docker/docker-agent) usage tracking

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI）を、macOS メニューバーの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
+PokeTokenBar は、あなたがすでに使っている AI コーディングトークン（Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI・Docker Agent）を、macOS メニューバーの中で育っていく **ポケモンのパートナー** に変えます。トークンを使うとタマゴが孵化し、実際の進化ラインに沿って進化し、最終進化後に図鑑へ卒業して、また新しいタマゴが始まります。パートナーの下には正確な使用量トラッカーがあります — 今日の使用量・コスト、公式の5時間／週間上限をローカルログから直接読み取ります。
 
-> トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI データから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
+> トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI・Docker Agent データから直接読み取ります（`totalTokens` = input + output + cache、ローカル日付）— 外部 CLI 不要。非公式・非商用のポケモンファンプロジェクトです — [ライセンス & 免責](#ライセンス--免責) を参照。
 
 ## なぜ
 
@@ -33,7 +33,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 
 ## しくみ
 
-1. 🥚 **いつも通りコーディング。** Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI で使うトークンがタマゴを温めます — 追加の操作は不要です。
+1. 🥚 **いつも通りコーディング。** Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI・Docker Agent で使うトークンがタマゴを温めます — 追加の操作は不要です。
 2. 🐣 **孵化。** [PokéAPI](https://pokeapi.co/) の**第1〜5世代すべての進化系統（起点329種）**から、公式の捕獲率で重み付けされて生まれます — よくいるポケモンは頻繁に、伝説は129回に1回。孵化したポケモンは育成中もすぐに **図鑑** に表示されます。孵化ごとに25種類のせいかくがひとつ決まり — **ごくまれな偶然で ✨ 色違いが生まれます**。
 3. ⚡ **進化。** コーディングを続けると実際の進化ツリー（1/2/3段階、分岐）に沿って育ち、各段階で小さな演出が流れます。
 4. 🎓 **卒業 & 収集。** 最終進化 + 閾値で **図鑑** に永久保存されます — レアなほど時間がかかり（ヘビーユーザーで common ≈3日 → legendary ≈24日）— 新しいタマゴが届きます。
@@ -97,7 +97,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 ## そのほかにも
 
 - **インタラクティブなフローティングペット** — ホバーで今日の使用量、クリックでメイン画面、右クリックでメニュー。上限アラートは吹き出しでも表示。
-- **サービス別タブ** — Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI のうち2つ以上が検出されると、小さなタブでサービス別の詳細を切替（今日の合計は合算のまま）。
+- **サービス別タブ** — Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI・Docker Agent のうち2つ以上が検出されると、小さなタブでサービス別の詳細を切替（今日の合計は合算のまま）。
 - **公式の上限** — Claude・Codex の5時間／週間使用率とリセットのカウントダウンを、今日の数字のすぐ下に。
 - **消費予測** — 現在の5時間ウィンドウが100%に達する時刻を予測。
 - **アプリ内アップデート** — ワンクリックの更新確認、設定に現在のバージョンを表示。
@@ -116,6 +116,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 | **Grok CLI** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Copilot CLI** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Kiro CLI** | 今日 · 5時間ブロック · 週 · 月 | — (推定値) |
+| **Docker Agent** | 今日 · 5時間ブロック · 週 · 月 | — |
 
 すべてローカルから読み取り — 外部の使用量CLIは不要。ツール追加はプロバイダーファイル1つで完結します（[CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) 参照）。
 
@@ -123,7 +124,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 
 ### 必要条件
 
-macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI データから直接読み取り、外部の使用量 CLI は不要です。
+macOS 14+（Apple Silicon または Intel）。それだけ — トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI・Docker Agent データから直接読み取り、外部の使用量 CLI は不要です。
 
 ### Homebrew
 
@@ -166,6 +167,7 @@ swift test                   # ユニットテスト
 | `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` レコード（ターン単位の `usage`、サーバー報告のコスト）；`$GROK_HOME` を設定していればそのパス；サブエージェントのセッションは親ターンに合算済みのため除外 |
 | `~/.copilot/session-store.db` | Copilot CLI daily/blocks/weekly/monthly | SQLite 読み取り専用；`assistant_usage_events` の1行が API 呼び出し1回；`$COPILOT_HOME` を設定していればそのパス；`input_tokens` にキャッシュ分が含まれるため cache read/write を差し引いて集計；premium request 課金のためコストは推定しない |
 | `~/Library/Application Support/kiro-cli/data.sqlite3` | Kiro CLI daily/blocks/weekly/monthly | SQLite 読み取り専用；会話履歴 JSON（`conversations`/`conversations_v2`）；Kiro のローカル DB は実際のトークン数を記録せず、サーバー側セッションも無いため、input は毎ターン再送される累積会話テキストをバイト÷4 で**推定**（output は実際のストリーミング応答バイトから算出）；`/clear`・圧縮で消えた会話の集計済みトークンはアプリ再起動まで数え続ける；コストは推定しない |
+| `~/.cagent/session.db` | Docker Agent daily/blocks/weekly/monthly | SQLite 読み取り専用；チャットメッセージごとに `session_items` 1 行（メッセージ別トークン使用量と docker-agent 自身が計算したドルコスト）；`$DOCKER_AGENT_DATA_DIR` / `$CAGENT_DATA_DIR` に対応；上流プロバイダーがキャッシュトークンを `input_tokens` に含める場合は差し引き |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 公式 5h/週間 % | 非公式 endpoint；Keychain は**更新ボタンを押した時のみ**読み取り — 自動更新では読みません |
 | `codex app-server` | Codex 公式 5h/週間 % | ローカル子プロセス；アカウント snapshot のみ、モデル turn なし |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | ポケモンの種・進化 | ランタイム取得；ローカルキャッシュ、バンドルしない |
@@ -175,7 +177,7 @@ swift test                   # ユニットテスト
 
 ## プライバシー & 権限
 
-- **オンデバイス。** トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI データから直接読み取ります。使用量のアップロードも、モデルの推論実行も行いません。
+- **オンデバイス。** トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI・Docker Agent データから直接読み取ります。使用量のアップロードも、モデルの推論実行も行いません。
 - **外部リクエスト。** 本アプリは完全オフラインではありません。7つのホストに接続します — `pokeapi.co`・`graphql.pokeapi.co`（種・進化）、`raw.githubusercontent.com`（スプライト）、`api.anthropic.com`（Claude 公式の上限）、`status.claude.com`・`status.openai.com`（障害バナー — 設定でオフ可）、`api.github.com`（アップデート確認）。**いずれのリクエストにも使用量・トークン・プロンプト・プロジェクトのパスは含まれません** — 送られるのはリクエストそのものだけです。
 - **Keychain（任意）。** Claude OAuth 資格情報は**更新ボタンを押した時のみ**読み取ります（設定、またはポップオーバーの上限行）。自動更新では Keychain に触れないためパスワードのプロンプトは表示されず、`~/.claude/.credentials.json` があればそちらから取得します。トークンはメモリ上にのみ保持し、**アプリ自身の Keychain 項目は作成しません。** トークンが期限切れになると、上限は更新するまで以前の値（stale）として表示されます。設定でオフにすると上限セクションが非表示になります。
 - **ポケモンのアセット** はランタイムに PokéAPI から取得し、`~/Library/Application Support/PokeTokenBar/` にのみキャッシュされます。アプリのバイナリおよびリリース成果物にポケモンのアセットは含まれません。

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · Antigravity · OpenCode · Hermes Agent · Cursor · Grok CLI · Copilot CLI · Kiro CLI)을 macOS 메뉴바 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
+PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code · Codex · Gemini CLI · Antigravity · OpenCode · Hermes Agent · Cursor · Grok CLI · Copilot CLI · Kiro CLI · Docker Agent)을 macOS 메뉴바 속 자라나는 **포켓몬 companion**으로 바꿔줍니다. 토큰을 쓰면 알이 부화하고, 실제 진화 라인을 따라 진화하며, 최종 진화 후 도감에 졸업하고, 다시 새 알이 시작됩니다. companion 아래에는 정확한 사용량 트래커가 있습니다 — 오늘의 사용량·비용, 공식 5시간/주간 한도를 로컬 로그에서 직접 읽습니다.
 
-> 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 데이터에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
+> 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI·Docker Agent 데이터에서 직접 읽습니다(`totalTokens` = input + output + cache, 로컬 날짜) — 외부 CLI 불필요. 비공식·비상업 포켓몬 팬 프로젝트 — [라이선스 & 면책](#라이선스--면책) 참고.
 
 ## 왜
 
@@ -33,7 +33,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 
 ## 어떻게 자라나요
 
-1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
+1. 🥚 **평소처럼 코딩하세요.** Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI·Docker Agent에서 태우는 토큰이 알을 품습니다 — 따로 돌릴 건 없어요.
 2. 🐣 **부화.** [PokéAPI](https://pokeapi.co/)의 **1~5세대 모든 진화 계보(시작점 329종)**에서 공식 capture rate 가중으로 태어납니다 — 흔한 포켓몬은 자주, 전설은 부화 129번에 1번. 부화한 포켓몬은 키우는 동안에도 **도감**에 바로 나타납니다. 부화마다 25종 성격 중 하나가 정해지고 — **아주 특별한 우연으론 ✨ 이로치가 태어납니다**.
 3. ⚡ **진화.** 계속 코딩하면 실제 진화 트리(1/2/3단, 분기)를 따라 자라고, 단계마다 작은 연출이 반겨줍니다.
 4. 🎓 **졸업 & 수집.** 최종 진화 + 임계 도달 시 **도감**에 영구 보존됩니다 — 희귀할수록 오래 걸리고(헤비 유저 기준 common ≈3일 → legendary ≈24일) — 새 알이 도착합니다.
@@ -97,7 +97,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 ## 이 밖에도
 
 - **인터랙티브 플로팅 펫** — 호버로 오늘 사용량, 클릭으로 메인 창, 우클릭 메뉴; 한도 알림은 말풍선으로도 표시.
-- **서비스별 탭** — Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 중 2개 이상 감지되면 작은 탭으로 상세를 서비스별 전환(오늘 합계는 통합 유지).
+- **서비스별 탭** — Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI·Docker Agent 중 2개 이상 감지되면 작은 탭으로 상세를 서비스별 전환(오늘 합계는 통합 유지).
 - **공식 한도** — Claude·Codex 5시간/주간 사용률 + 리셋 카운트다운을 오늘 숫자 바로 아래에.
 - **소진 예측** — 현재 5시간 창이 100%에 도달할 시각 예측.
 - **인앱 업데이트** — 원클릭 업데이트 확인, 설정에 현재 버전 표시.
@@ -116,6 +116,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 | **Grok CLI** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Copilot CLI** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Kiro CLI** | 오늘 · 5시간 블록 · 주 · 월 | — (추정치) |
+| **Docker Agent** | 오늘 · 5시간 블록 · 주 · 월 | — |
 
 모두 로컬에서 읽습니다 — 외부 사용량 CLI 불필요. 도구 추가는 프로바이더 파일 하나면 됩니다([CONTRIBUTING.ko.md](CONTRIBUTING.ko.md) 참고).
 
@@ -123,7 +124,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 
 ### 요구사항
 
-macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 데이터에서 직접 읽으며 외부 사용량 CLI가 필요 없습니다.
+macOS 14+ (Apple Silicon 또는 Intel). 끝입니다 — 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI·Docker Agent 데이터에서 직접 읽으며 외부 사용량 CLI가 필요 없습니다.
 
 ### Homebrew
 
@@ -166,6 +167,7 @@ swift test                   # 단위 테스트
 | `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` 레코드(턴 단위 `usage`, 서버 보고 비용); `$GROK_HOME` 설정 시 그 경로; 서브에이전트 세션은 토큰이 부모 턴에 이미 포함돼 제외 |
 | `~/.copilot/session-store.db` | Copilot CLI daily/blocks/weekly/monthly | SQLite 읽기 전용; `assistant_usage_events` 1행 = API 호출 1건; `$COPILOT_HOME` 설정 시 그 경로; `input_tokens` 에 캐시 프롬프트가 이미 포함돼 캐시 read/write 를 빼고 집계; premium request 과금이라 비용은 추정하지 않음 |
 | `~/Library/Application Support/kiro-cli/data.sqlite3` | Kiro CLI daily/blocks/weekly/monthly | SQLite 읽기 전용; 대화 히스토리 JSON(`conversations`/`conversations_v2`); Kiro 로컬 DB 는 실제 토큰 수를 저장하지 않고 서버 측 세션도 없어, input 은 매 턴 재전송되는 누적 대화 텍스트를 바이트÷4 로 **추정**(output 은 실제 스트리밍 응답 바이트 기준); `/clear`·압축으로 지워진 대화의 이미 집계된 토큰은 앱을 재시작하기 전까지는 계속 집계됨; 비용은 추정하지 않음 |
+| `~/.cagent/session.db` | Docker Agent daily/blocks/weekly/monthly | SQLite 읽기 전용; 채팅 메시지당 `session_items` 한 행(메시지별 토큰 사용량 + docker-agent 가 직접 계산한 달러 비용); `$DOCKER_AGENT_DATA_DIR` / `$CAGENT_DATA_DIR` 지원; 상류 프로바이더가 캐시 토큰을 `input_tokens` 에 포함하는 경우 차감 |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude 공식 5h/주간 % | 비공식 endpoint; Keychain 은 **갱신 버튼을 누를 때만** 읽음 — 자동 폴링은 읽지 않음 |
 | `codex app-server` | Codex 공식 5h/주간 % | 로컬 자식 프로세스; 계정 snapshot만, 모델 turn 없음 |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | 포켓몬 종·진화 | 런타임 fetch; 로컬 캐시, 번들 안 함 |
@@ -175,7 +177,7 @@ swift test                   # 단위 테스트
 
 ## 프라이버시 & 권한
 
-- **온디바이스.** 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 데이터에서 직접 읽습니다. 사용량을 업로드하거나 모델 turn을 실행하지 않습니다.
+- **온디바이스.** 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI·Docker Agent 데이터에서 직접 읽습니다. 사용량을 업로드하거나 모델 turn을 실행하지 않습니다.
 - **외부 요청.** 앱은 완전 오프라인이 아닙니다. 7개 호스트에 접속합니다 — `pokeapi.co`·`graphql.pokeapi.co`(종·진화), `raw.githubusercontent.com`(스프라이트), `api.anthropic.com`(Claude 공식 한도), `status.claude.com`·`status.openai.com`(장애 배너 — 설정에서 끌 수 있음), `api.github.com`(업데이트 확인). **어느 요청에도 사용량·토큰·프롬프트·프로젝트 경로는 담기지 않습니다** — 요청 자체만 나갑니다.
 - **Keychain(선택).** Claude OAuth 자격증명은 **갱신 버튼을 누를 때만** 읽습니다(설정, 또는 팝오버의 한도 행). 자동 폴링은 Keychain 을 건드리지 않으므로 비밀번호 프롬프트가 뜨지 않고, `~/.claude/.credentials.json` 이 있으면 그쪽에서 가져옵니다. 토큰은 메모리에만 두며 **앱 자체 Keychain 항목은 만들지 않습니다.** 토큰이 만료되면 한도는 갱신 전까지 이전 값(stale)으로 표시됩니다. 설정에서 끄면 한도 섹션만 숨겨집니다.
 - **포켓몬 에셋**은 런타임에 PokéAPI에서 받아오며 `~/Library/Application Support/PokeTokenBar/`에만 캐시됩니다. 앱 바이너리와 릴리스 아티팩트에는 포켓몬 에셋이 포함되지 않습니다.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 </div>
 
-PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI & Kiro CLI — into a growing **Pokémon companion** in your macOS menu bar. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
+PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, Kiro CLI & Docker Agent — into a growing **Pokémon companion** in your macOS menu bar. Spend tokens, hatch an egg, evolve it through its real evolution line, graduate it into your Pokédex, and start again. Underneath the companion it's a precise usage tracker — today's spend, cost, and official 5-hour / weekly limits, read straight from your local logs.
 
-> Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
+> Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, Kiro CLI, and Docker Agent data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
 
 ## Why
 
@@ -33,7 +33,7 @@ PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, 
 
 ## How it works
 
-1. 🥚 **Code as usual.** The tokens you burn in Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, or Kiro CLI incubate an egg — nothing extra to run.
+1. 🥚 **Code as usual.** The tokens you burn in Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, Kiro CLI, or Docker Agent incubate an egg — nothing extra to run.
 2. 🐣 **Hatch.** Eggs hatch into Pokémon with real evolution lines from [PokéAPI](https://pokeapi.co/) — any Gen 1–5 line (329 possible starts), weighted by the official capture rate: commons hatch often, a legendary is a 1-in-129 event. It appears in your **Pokédex** immediately while you raise it. Every hatch rolls one of 25 natures — and once in a rare while, the egg hatches **✨ Shiny**.
 3. ⚡ **Evolve.** Keep coding and it grows through its actual evolution tree (1/2/3 stages, branching), with a little flash celebration at each step.
 4. 🎓 **Graduate & collect.** Final form + threshold permanently archives it in your **Pokédex** — rarer takes longer (≈3 days common → ≈24 days legendary at heavy use) — and a fresh egg arrives.
@@ -97,7 +97,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 ## Also in the box
 
 - **Interactive floating pet** — hover for today's usage, click to open the main window, right-click for a menu; limit alerts can pop up as speech bubbles.
-- **Per-service tabs** — when two or more of Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI are detected, compact tabs switch between them; today's total stays combined.
+- **Per-service tabs** — when two or more of Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, Kiro CLI, and Docker Agent are detected, compact tabs switch between them; today's total stays combined.
 - **Official limits** — Claude & Codex 5-hour / weekly utilization with reset countdowns, right under today's numbers.
 - **Burn-rate forecast** — projects when the current 5h window hits 100%.
 - **In-app updates** — one-click update check; current version shown in Settings.
@@ -116,6 +116,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 | **Grok CLI** | today · 5h block · week · month | — |
 | **Copilot CLI** | today · 5h block · week · month | — |
 | **Kiro CLI** | today · 5h block · week · month | — (estimated) |
+| **Docker Agent** | today · 5h block · week · month | — |
 
 All read locally — no external usage CLI required. Adding a tool is one provider file (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 
@@ -123,7 +124,7 @@ All read locally — no external usage CLI required. Adding a tool is one provid
 
 ### Requirements
 
-macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data, with no external usage CLI required.
+macOS 14+ (Apple Silicon or Intel). That's it — token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, Kiro CLI, and Docker Agent data, with no external usage CLI required.
 
 ### Homebrew
 
@@ -166,6 +167,7 @@ swift test                   # unit tests
 | `~/.grok/sessions/**/updates.jsonl` | Grok CLI daily/blocks/weekly/monthly | `turn_completed` records (per-turn `usage`, server-reported cost); honours `$GROK_HOME`; subagent sessions are skipped because their tokens are already folded into the parent turn |
 | `~/.copilot/session-store.db` | Copilot CLI daily/blocks/weekly/monthly | SQLite read-only; one `assistant_usage_events` row per API call; honours `$COPILOT_HOME`; `input_tokens` already contains the cached prompt, so cache reads/writes are subtracted; premium-request billing, so no cost is estimated |
 | `~/Library/Application Support/kiro-cli/data.sqlite3` | Kiro CLI daily/blocks/weekly/monthly | SQLite read-only; conversation history JSON (`conversations`/`conversations_v2`); Kiro's local database never records real token counts, and there is no server-side session, so input is a bytes÷4 **estimate** of the accumulated conversation text resent on every turn (output likewise from the real streamed response size); a `/clear`d or compacted conversation's already-counted tokens stay counted until the app restarts; no cost is estimated |
+| `~/.cagent/session.db` | Docker Agent daily/blocks/weekly/monthly | SQLite read-only; one `session_items` row per chat message with per-message token usage and the dollar cost docker-agent itself computed; honours `$DOCKER_AGENT_DATA_DIR` / `$CAGENT_DATA_DIR`; cached prompt tokens are subtracted from `input_tokens` where the upstream provider folds them in |
 | Keychain / `~/.claude/.credentials.json` → `api.anthropic.com` | Claude official 5h/weekly % | unofficial endpoint; the Keychain is read **only when you press refresh** — auto-polling never reads it |
 | `codex app-server` | Codex official 5h/weekly % | local child process; account snapshot only, no model turn |
 | [PokéAPI](https://pokeapi.co/) — `pokeapi.co`, `graphql.pokeapi.co` | Pokémon species &amp; evolution | runtime fetch; cached locally, never bundled |
@@ -175,7 +177,7 @@ swift test                   # unit tests
 
 ## Privacy & permissions
 
-- **On-device.** Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data. The app never uploads usage or runs model turns.
+- **On-device.** Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, Kiro CLI, and Docker Agent data. The app never uploads usage or runs model turns.
 - **Outbound requests.** The app is not fully offline. It talks to seven hosts: `pokeapi.co` and `graphql.pokeapi.co` (species/evolution), `raw.githubusercontent.com` (sprites), `api.anthropic.com` (Claude official limits), `status.claude.com` and `status.openai.com` (incident banner — off switch in Settings), and `api.github.com` (update check). **None of them carry your usage, tokens, prompts, or project paths** — only the request itself.
 - **Keychain (optional).** The Claude OAuth credential is read **only when you press a refresh button** (Settings, or the limits row in the popover). Automatic polling never touches the Keychain, so it never raises a password prompt; when available, the credential is taken from `~/.claude/.credentials.json` instead. The token is held in memory only — the app creates no Keychain item of its own. Once the token expires, limits stay visible but stale until you refresh. Turn it off in Settings — the limits section simply hides.
 - **Pokémon assets** are fetched at runtime from PokéAPI and cached only under `~/Library/Application Support/PokeTokenBar/`. The app binary and its release artifacts contain no Pokémon assets.

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -7,6 +7,7 @@ private enum LocalAdditionalSource: String, Sendable {
     case cursor
     case copilot
     case kiro
+    case docker
 }
 
 /// OpenCode usage from its local SQLite database and legacy message files.
@@ -105,6 +106,28 @@ struct LocalKiroProvider: UsageProvider {
     }
 }
 
+/// Docker Agent (docker/docker-agent, previously "cagent") usage from its local
+/// session store (`~/.cagent/session.db`).
+///
+/// Every `session_items` row is one chat message; assistant rows persist per-message
+/// token usage plus the dollar cost docker-agent itself computed against the models.dev
+/// catalog. That figure flows through `Entry.explicitCost`, so `reportsCost` stays the
+/// protocol default (true) — no estimate is being dressed up as money here.
+struct LocalDockerProvider: UsageProvider {
+    let id = "docker"
+    let displayName = "Docker Agent"
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .docker)
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey())
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .docker)
+        return enrichment(entries: entries)
+    }
+}
+
 private func enrichment(entries: [LocalUsageReader.Entry]) -> ProviderEnrichment {
     let now = Date()
     let monthStart = LocalUsageReader.startOfMonth(now)
@@ -186,6 +209,11 @@ private actor LocalAdditionalUsageCache {
             // silently drop out of today's total.
             since = periodStart
             afterRowIDByPath = [:]
+        case .docker:
+            // `session_items` appends one row per message in steady state; `/undo` and
+            // session deletes can shrink MAX(rowid), which surfaces as `didReset` below.
+            since = periodStart
+            afterRowIDByPath = previous?.highWaterByPath ?? [:]
         }
         let existing = previous?.entries ?? []
         let task = Task.detached(priority: .utility) {
@@ -215,6 +243,17 @@ private actor LocalAdditionalUsageCache {
                     modifiedSince: since, afterRowIDByPath: afterRowIDByPath)
                 // A pruned / recreated session store restarts ids — the cached rows would
                 // then collide with different events, so keep only the rescan.
+                if loaded.didReset {
+                    return (loaded.entries, loaded.highWaterByPath)
+                }
+                return (
+                    LocalUsageReader.dedupKeepMax(existing + loaded.entries),
+                    loaded.highWaterByPath)
+            case .docker:
+                let loaded = LocalAdditionalUsageReader.dockerEntries(
+                    modifiedSince: since, afterRowIDByPath: afterRowIDByPath)
+                // An undone tail / recreated DB / VACUUM restarts rowids — cached entry ids
+                // would then name different items, so keep only the rescan.
                 if loaded.didReset {
                     return (loaded.entries, loaded.highWaterByPath)
                 }
@@ -912,6 +951,98 @@ enum LocalAdditionalUsageReader {
         if let array = value as? [Any] { return array.reduce(0) { $0 + kiroJSONValueByteLength($1) } }
         if let dict = value as? Object { return dict.values.reduce(0) { $0 + kiroJSONValueByteLength($1) } }
         return 0
+    }
+
+    // MARK: Docker Agent (cagent) database
+
+    static var defaultDockerRoots: [URL] {
+        environmentPaths("DOCKER_AGENT_DATA_DIR")
+            ?? environmentPaths("CAGENT_DATA_DIR")
+            ?? [FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cagent")]
+    }
+
+    /// Read Docker Agent usage rows newer than `modifiedSince`.
+    ///
+    /// docker-agent persists one `session_items` row per chat message. Rows are appended
+    /// in steady state, so the scan watermarks on `rowid` like Cursor; `/undo`, session
+    /// deletion and VACUUM can shrink `MAX(rowid)`, which the shared scanner turns into a
+    /// cold rescan (`didReset`). There is no time column to prefilter on — the timestamp
+    /// lives inside `message_json` — so windowing is left to the scanner's date filter.
+    static func dockerEntries(
+        modifiedSince: Date,
+        afterRowID: Int64 = 0,
+        afterRowIDByPath: [String: Int64]? = nil,
+        roots: [URL]? = nil
+    ) -> IncrementalStoreLoadResult {
+        scanIncrementalStores(
+            roots: roots ?? defaultDockerRoots,
+            modifiedSince: modifiedSince,
+            afterRowID: afterRowID,
+            afterRowIDByPath: afterRowIDByPath,
+            databaseURL: dockerDatabaseURL(from:),
+            maxRowIDSQL: "SELECT MAX(rowid) FROM session_items",
+            rowSQL: { effectiveAfter, _ in
+                IncrementalRowQuery(
+                    sql: """
+                    SELECT rowid, message_json, usage_json, model, cost
+                    FROM session_items WHERE rowid > ?1
+                    """,
+                    bindInt64: effectiveAfter,
+                    bindText: nil)
+            },
+            parse: { statement, database in
+                parseDockerSessionItemRow(statement, database: database)
+            })
+    }
+
+    private static func dockerDatabaseURL(from root: URL) -> URL {
+        root.pathExtension == "db" ? root : root.appendingPathComponent("session.db")
+    }
+
+    private static func parseDockerSessionItemRow(
+        _ statement: OpaquePointer,
+        database: URL
+    ) -> LocalUsageReader.Entry? {
+        let rowID = sqlite3_column_int64(statement, 0)
+        guard let payload = columnText(statement, 1),
+              let message = jsonObject(data: Data(payload.utf8)) else { return nil }
+        // The `usage_json`/`model`/`cost` columns were denormalized out of `message_json`
+        // by a later migration and stay NULL on rows written before it — each value falls
+        // back to the copy embedded in the message independently.
+        guard let usage = columnText(statement, 2).flatMap({ jsonObject(data: Data($0.utf8)) })
+            ?? message["usage"] as? Object else { return nil } // user/tool rows carry no usage
+        guard let createdAt = stringValue(message["created_at"]),
+              // No timestamp → no stable local day to attribute to. Skip rather than fall
+              // back to the session's start, which would misdate a long session's later usage.
+              let date = parseISO8601(createdAt) else { return nil }
+        let model = stringValue(columnText(statement, 3))
+            ?? stringValue(message["model"]) ?? "unknown"
+        let columnCost = sqlite3_column_type(statement, 4) == SQLITE_NULL
+            ? nil : sqlite3_column_double(statement, 4)
+        // docker-agent's own models.dev dollar figure; 0 means "unknown/free", and passing
+        // it through would suppress the pricing-table fallback in `Bucket.add`.
+        let cost = [columnCost, doubleValue(message["cost"])]
+            .compactMap { $0 }.first { $0 > 0 }
+        let cacheRead = intValue(usage["cached_input_tokens"])
+        let cacheWrite = intValue(usage["cached_write_tokens"])
+        // docker-agent normalizes several upstream providers into one usage shape, and the
+        // OpenAI-shaped rows count cached tokens inside `input_tokens` — subtract them so
+        // the same prompt tokens aren't counted twice; the clamp covers providers that
+        // already exclude them (a bounded undercount of the uncached suffix).
+        let input = max(0, intValue(usage["input_tokens"]) - cacheRead - cacheWrite)
+        // `reasoning_tokens` is a breakdown of `output_tokens`, not an extra charge.
+        return makeEntry(
+            // rowid is only unique within one store, and the env override may name several
+            // roots — without the database in the key, same-numbered rows would collapse
+            // during dedup (same hazard as Copilot's multi-store ids).
+            id: "docker|\(database.path)|\(rowID)",
+            date: date,
+            model: model,
+            input: input,
+            output: intValue(usage["output_tokens"]),
+            cacheWrite: cacheWrite,
+            cacheRead: cacheRead,
+            cost: cost)
     }
 
     // MARK: Shared utilities

--- a/Sources/PokeTokenBar/Core/UsageEnvironment.swift
+++ b/Sources/PokeTokenBar/Core/UsageEnvironment.swift
@@ -21,6 +21,10 @@ enum UsageEnvironment {
         "HERMES_HOME",         // Hermes 홈
         "COPILOT_HOME",        // Copilot CLI 홈
         "GROK_HOME",           // Grok CLI 홈
+        "CURSOR_DATA_DIR",     // Cursor globalStorage 루트(콤마로 다중)
+        "KIRO_CLI_HOME",       // Kiro CLI 홈
+        "DOCKER_AGENT_DATA_DIR", // Docker Agent(cagent) 데이터 디렉터리
+        "CAGENT_DATA_DIR",     // 위의 구명(cagent) fallback — 업스트림 DOCKER_AGENT_*/CAGENT_* 관례
     ]
 
     /// `name` 의 값. 프로세스 환경이 우선이고, 없으면 로그인 셸에서 읽은 값을 쓴다.

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -398,6 +398,7 @@ final class UsageStore {
         LocalClaudeProvider(), LocalCodexProvider(), LocalGeminiProvider(),
         LocalAntigravityProvider(), LocalOpenCodeProvider(), LocalHermesProvider(),
         LocalCursorProvider(), LocalGrokProvider(), LocalCopilotProvider(), LocalKiroProvider(),
+        LocalDockerProvider(),
     ],
          claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),

--- a/Tests/PokeTokenBarTests/DockerUsageTests.swift
+++ b/Tests/PokeTokenBarTests/DockerUsageTests.swift
@@ -1,0 +1,453 @@
+import SQLite3
+import XCTest
+@testable import PokeTokenBar
+
+/// Docker Agent (docker/docker-agent, previously "cagent") parser + incremental-scan
+/// wiring. The store lives at `<data dir>/session.db`; every `session_items` row is one
+/// chat message whose assistant rows persist per-message usage and a docker-computed cost.
+/// The scanner-generic invariants (watermark preservation, didReset recovery) are pinned
+/// by IncrementalStoreScanTests — here we exercise the docker-specific plumbing of them.
+final class DockerUsageTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PokeTokenBar-DockerUsageTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+        temporaryDirectory = nil
+    }
+
+    // MARK: - Row parsing
+
+    /// The denormalized `usage_json`/`model`/`cost` columns are authoritative when present —
+    /// the copies embedded in `message_json` are deliberately different here to prove it.
+    func testReadsAssistantUsageFromDenormalizedColumns() throws {
+        try createSessionItems()
+        try insertItem(
+            message: try json([
+                "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+                "model": "embedded-model", "cost": 9.99,
+                "usage": ["input_tokens": 1, "output_tokens": 1],
+            ]),
+            usage: try json(["input_tokens": 1000, "output_tokens": 300,
+                             "cached_input_tokens": 400, "cached_write_tokens": 100]),
+            model: "claude-sonnet-4-5", cost: 0.42)
+
+        let loaded = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+
+        let entry = try XCTUnwrap(loaded.entries.first)
+        XCTAssertEqual(loaded.entries.count, 1)
+        XCTAssertEqual(entry.model, "claude-sonnet-4-5")
+        XCTAssertEqual(entry.explicitCost, 0.42)
+        XCTAssertEqual(entry.cacheRead, 400)
+        XCTAssertEqual(entry.cacheWrite, 100)
+        XCTAssertEqual(entry.input, 500, "input_tokens minus the cached subset")
+        XCTAssertEqual(entry.output, 300)
+        XCTAssertEqual(entry.date, try date("2026-01-02T12:00:00Z"))
+        XCTAssertEqual(entry.id, "docker|\(databaseURL.path)|1")
+        XCTAssertFalse(loaded.didReset)
+    }
+
+    /// Rows written before the denormalizing migration carry the values only inside
+    /// `message_json` — each field must fall back independently.
+    func testFallsBackToMessageJSONWhenColumnsAreNull() throws {
+        try createSessionItems()
+        try insertItem(
+            message: try json([
+                "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+                "model": "gpt-5", "cost": 0.07,
+                "usage": ["input_tokens": 120, "output_tokens": 30,
+                          "cached_input_tokens": 20, "cached_write_tokens": 0],
+            ]))
+
+        let entry = try XCTUnwrap(LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory]).entries.first)
+        XCTAssertEqual(entry.model, "gpt-5")
+        XCTAssertEqual(entry.explicitCost, 0.07)
+        XCTAssertEqual(entry.input, 100)
+        XCTAssertEqual(entry.output, 30)
+        XCTAssertEqual(entry.cacheRead, 20)
+    }
+
+    /// docker-agent writes cost 0 for local Docker Model Runner models — a zero must not
+    /// become `explicitCost`, or it would suppress the pricing-table fallback in Bucket.add.
+    func testZeroCostIsNotTreatedAsExplicit() throws {
+        try createSessionItems()
+        try insertItem(
+            message: try json([
+                "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+                "model": "qwen3", "cost": 0,
+                "usage": ["input_tokens": 100, "output_tokens": 10],
+            ]),
+            cost: 0)
+
+        let entry = try XCTUnwrap(LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory]).entries.first)
+        XCTAssertNil(entry.explicitCost)
+    }
+
+    /// User and tool messages carry no usage object — they are not billed calls.
+    /// An assistant row whose usage is all zeros likewise produces no entry.
+    func testItemsWithoutUsageOrAllZeroUsageAreSkipped() throws {
+        try createSessionItems()
+        try insertItem(message: try json([
+            "role": "user", "created_at": "2026-01-02T12:00:00Z", "content": "hello",
+        ]))
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:01Z",
+            "usage": ["input_tokens": 0, "output_tokens": 0],
+        ]))
+
+        XCTAssertTrue(LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory]).entries.isEmpty)
+    }
+
+    /// `session_items` has no time column of its own — a message without a parseable
+    /// `created_at` has no local day to attribute to, so it is skipped rather than dated
+    /// off the session start (which would misdate a long session's later usage).
+    func testItemsMissingCreatedAtAreSkipped() throws {
+        try createSessionItems()
+        try insertItem(message: try json([
+            "role": "assistant",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ]))
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "not-a-date",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ]))
+
+        XCTAssertTrue(LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory]).entries.isEmpty)
+    }
+
+    func testMalformedMessageJSONRowsAreSkipped() throws {
+        try createSessionItems()
+        try insertItem(message: "{not json")
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ]))
+
+        let loaded = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertEqual(loaded.entries.count, 1)
+        XCTAssertEqual(loaded.highWaterRowID, 2, "a skipped row still advances the watermark")
+    }
+
+    /// cagent normalizes several upstream providers into one usage shape. Anthropic-shaped
+    /// rows report `input_tokens` *excluding* the cached tokens — the subtraction must clamp
+    /// at zero instead of going negative (the `max(0, …)` branch on its own, A=false B=true).
+    func testCacheSubtractionClampsForAnthropicShapedRows() throws {
+        try createSessionItems()
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+            "usage": ["input_tokens": 50, "output_tokens": 10,
+                      "cached_input_tokens": 400, "cached_write_tokens": 100],
+        ]))
+
+        let entry = try XCTUnwrap(LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory]).entries.first)
+        XCTAssertEqual(entry.input, 0, "50 - 400 - 100 clamps to 0, never negative")
+        XCTAssertEqual(entry.cacheRead, 400)
+        XCTAssertEqual(entry.cacheWrite, 100)
+        XCTAssertEqual(entry.total, 510)
+    }
+
+    /// `reasoning_tokens` is a breakdown of `output_tokens`, not an extra charge.
+    func testReasoningTokensAreNotAddedToOutput() throws {
+        try createSessionItems()
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+            "usage": ["input_tokens": 100, "output_tokens": 80, "reasoning_tokens": 60],
+        ]))
+
+        let entry = try XCTUnwrap(LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory]).entries.first)
+        XCTAssertEqual(entry.output, 80)
+        XCTAssertEqual(entry.total, 180)
+    }
+
+    func testItemsBeforeTheWindowAreExcluded() throws {
+        try createSessionItems()
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2025-12-15T12:00:00Z",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ]))
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ]))
+
+        let loaded = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory])
+        XCTAssertEqual(loaded.entries.map(\.id), ["docker|\(databaseURL.path)|2"])
+    }
+
+    // MARK: - Incremental scanning
+
+    func testRescanningTheSameDatabaseProducesStableEntryIDs() throws {
+        try createSessionItems()
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ]))
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:01:00Z",
+            "usage": ["input_tokens": 200, "output_tokens": 20],
+        ]))
+
+        let since = try date("2026-01-01T00:00:00Z")
+        let first = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: since, roots: [temporaryDirectory]).entries
+        let second = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: since, roots: [temporaryDirectory]).entries
+        XCTAssertEqual(LocalUsageReader.dedupKeepMax(first + second).count, first.count)
+        XCTAssertEqual(Set(first.map(\.id)), Set(second.map(\.id)))
+    }
+
+    func testIncrementalScanReturnsOnlyRowsAfterTheWatermark() throws {
+        try createSessionItems()
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ]))
+        let since = try date("2026-01-01T00:00:00Z")
+        let cold = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertEqual(cold.highWaterRowID, 1)
+
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:01:00Z",
+            "usage": ["input_tokens": 200, "output_tokens": 20],
+        ]))
+        let incremental = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: since, afterRowIDByPath: cold.highWaterByPath,
+            roots: [temporaryDirectory])
+
+        XCTAssertEqual(incremental.entries.map(\.id), ["docker|\(databaseURL.path)|2"])
+        XCTAssertEqual(incremental.highWaterRowID, 2)
+        XCTAssertFalse(incremental.didReset)
+    }
+
+    /// `/undo` (or a recreated DB) can remove the newest rows — MAX(rowid) drops below the
+    /// watermark, and the scan must fall back to a cold rescan and say so via `didReset`,
+    /// because the cached entry ids would otherwise name different items after rowid reuse.
+    func testDeletingTheNewestRowsTriggersColdRescan() throws {
+        try createSessionItems()
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ]))
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:01:00Z",
+            "usage": ["input_tokens": 200, "output_tokens": 20],
+        ]))
+        let since = try date("2026-01-01T00:00:00Z")
+        let cold = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: since, roots: [temporaryDirectory])
+        XCTAssertEqual(cold.highWaterRowID, 2)
+
+        try execute(databaseURL, sql: "DELETE FROM session_items WHERE rowid = 2")
+        let rescanned = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: since, afterRowIDByPath: cold.highWaterByPath,
+            roots: [temporaryDirectory])
+
+        XCTAssertTrue(rescanned.didReset)
+        XCTAssertEqual(rescanned.entries.map(\.id), ["docker|\(databaseURL.path)|1"])
+        XCTAssertEqual(rescanned.highWaterRowID, 1)
+    }
+
+    /// rowid is only unique within one store, and the env override may name several roots —
+    /// same-numbered rows must not collapse into one event during dedup.
+    func testEntriesFromTwoStoresDoNotCollapse() throws {
+        let otherRoot = temporaryDirectory.appendingPathComponent("second")
+        try FileManager.default.createDirectory(at: otherRoot, withIntermediateDirectories: true)
+        let message = try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ])
+        for database in [databaseURL, otherRoot.appendingPathComponent("session.db")] {
+            try createSessionItems(at: database)
+            try insertItem(message: message, into: database)
+        }
+
+        let loaded = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"),
+            roots: [temporaryDirectory, otherRoot])
+        XCTAssertEqual(loaded.entries.count, 2)
+        XCTAssertEqual(Set(loaded.entries.map(\.id)).count, 2)
+    }
+
+    // MARK: - Roots
+
+    func testAcceptsADirectDatabasePathAsRoot() throws {
+        try createSessionItems()
+        try insertItem(message: try json([
+            "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+            "usage": ["input_tokens": 100, "output_tokens": 10],
+        ]))
+
+        let loaded = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [databaseURL])
+        XCTAssertEqual(loaded.entries.count, 1)
+    }
+
+    func testNonexistentRootReturnsNothing() {
+        let loaded = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: .distantPast, roots: [URL(fileURLWithPath: "/nonexistent/cagent")])
+        XCTAssertTrue(loaded.entries.isEmpty)
+        XCTAssertFalse(loaded.didReset)
+    }
+
+    func testDefaultRootIsTheCagentHome() {
+        let expected = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cagent")
+        let roots = LocalAdditionalUsageReader.defaultDockerRoots
+        let environment = ProcessInfo.processInfo.environment
+        if environment["DOCKER_AGENT_DATA_DIR"] == nil, environment["CAGENT_DATA_DIR"] == nil {
+            XCTAssertEqual(roots, [expected])
+        }
+        XCTAssertFalse(roots.isEmpty)
+    }
+
+    // MARK: - Aggregation
+
+    /// docker's own dollar figure must flow into the daily aggregate via `explicitCost`.
+    func testDailyAggregatesTokensAndExplicitCost() throws {
+        try createSessionItems()
+        try insertItem(
+            message: try json([
+                "role": "assistant", "created_at": "2026-01-02T12:00:00Z",
+                "usage": ["input_tokens": 100, "output_tokens": 10],
+            ]),
+            cost: 0.30)
+        try insertItem(
+            message: try json([
+                "role": "assistant", "created_at": "2026-01-02T12:01:00Z",
+                "usage": ["input_tokens": 200, "output_tokens": 20],
+            ]),
+            cost: 0.20)
+
+        let entries = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: try date("2026-01-01T00:00:00Z"), roots: [temporaryDirectory]).entries
+        let day = try XCTUnwrap(entries.first?.localDay)
+        let daily = try XCTUnwrap(LocalUsageReader.daily(entries: entries, localDay: day))
+        XCTAssertEqual(daily.totalTokens, 330)
+        XCTAssertEqual(daily.totalCost, 0.5, accuracy: 0.000_001)
+    }
+
+    // MARK: - Provider identity
+
+    func testLocalDockerProviderIdentity() {
+        let provider = LocalDockerProvider()
+        XCTAssertEqual(provider.id, "docker")
+        XCTAssertEqual(provider.displayName, "Docker Agent")
+        XCTAssertTrue(provider.reportsCost, "docker-agent persists its own models.dev dollar cost")
+    }
+
+    // MARK: - Real-data smoke test
+
+    func testPrintRealDockerAggregate() throws {
+        guard ProcessInfo.processInfo.environment["PTB_PARITY"] == "1" else {
+            throw XCTSkip("set PTB_PARITY=1 for the local Docker Agent smoke test")
+        }
+        let roots = LocalAdditionalUsageReader.defaultDockerRoots
+        guard roots.contains(where: { FileManager.default.fileExists(atPath: $0.path) }) else {
+            throw XCTSkip("no local Docker Agent data directory")
+        }
+        let entries = LocalAdditionalUsageReader.dockerEntries(
+            modifiedSince: LocalUsageReader.startOfMonth(Date())).entries
+        XCTAssertFalse(entries.isEmpty)
+        let today = LocalUsageReader.todayKey()
+        let todayTotal = entries.filter { $0.localDay == today }.reduce(0) { $0 + $1.total }
+        print("DOCKER_NATIVE_PARITY entries=\(entries.count) today=\(todayTotal) month=\(entries.reduce(0) { $0 + $1.total })")
+    }
+
+    // MARK: - Fixture construction
+
+    private var databaseURL: URL {
+        temporaryDirectory.appendingPathComponent("session.db")
+    }
+
+    private func createSessionItems(at database: URL? = nil) throws {
+        try execute(database ?? databaseURL, sql: """
+        CREATE TABLE IF NOT EXISTS session_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            position INTEGER,
+            item_type TEXT,
+            agent_name TEXT,
+            message_json TEXT,
+            cost REAL,
+            model TEXT,
+            usage_json TEXT
+        );
+        """)
+    }
+
+    /// Inserts one message row. `usage`/`model`/`cost` stay NULL unless given, matching
+    /// rows written before cagent's denormalizing migration.
+    private func insertItem(
+        message: String,
+        usage: String? = nil,
+        model: String? = nil,
+        cost: Double? = nil,
+        into database: URL? = nil
+    ) throws {
+        let target = database ?? databaseURL
+        var handle: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(target.path, &handle), SQLITE_OK)
+        guard let handle else { throw NSError(domain: "SQLite", code: 1) }
+        defer { sqlite3_close(handle) }
+        var statement: OpaquePointer?
+        let sql = """
+        INSERT INTO session_items (session_id, position, item_type, message_json, usage_json, model, cost)
+        VALUES ('session-1', 0, 'message', ?1, ?2, ?3, ?4)
+        """
+        XCTAssertEqual(sqlite3_prepare_v2(handle, sql, -1, &statement, nil), SQLITE_OK)
+        guard let statement else { throw NSError(domain: "SQLite", code: 2) }
+        defer { sqlite3_finalize(statement) }
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(statement, 1, message, -1, transient)
+        if let usage { sqlite3_bind_text(statement, 2, usage, -1, transient) }
+        else { sqlite3_bind_null(statement, 2) }
+        if let model { sqlite3_bind_text(statement, 3, model, -1, transient) }
+        else { sqlite3_bind_null(statement, 3) }
+        if let cost { sqlite3_bind_double(statement, 4, cost) }
+        else { sqlite3_bind_null(statement, 4) }
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+    }
+
+    private func execute(_ database: URL, sql: String) throws {
+        var handle: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(database.path, &handle), SQLITE_OK)
+        guard let handle else { throw NSError(domain: "SQLite", code: 1) }
+        defer { sqlite3_close(handle) }
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(handle, sql, nil, nil, &errorMessage)
+        let message = errorMessage.map { String(cString: $0) }
+        sqlite3_free(errorMessage)
+        XCTAssertEqual(result, SQLITE_OK, message ?? "SQLite statement failed")
+        if result != SQLITE_OK { throw NSError(domain: "SQLite", code: Int(result)) }
+    }
+
+    private func json(_ object: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object)
+        return String(data: data, encoding: .utf8)!
+    }
+
+    private func date(_ value: String) throws -> Date {
+        try XCTUnwrap(ISO8601DateFormatter().date(from: value))
+    }
+}

--- a/Tests/PokeTokenBarTests/DockerUsageTests.swift
+++ b/Tests/PokeTokenBarTests/DockerUsageTests.swift
@@ -69,7 +69,8 @@ final class DockerUsageTests: XCTestCase {
             modifiedSince: try date("2026-01-01T00:00:00Z"),
             roots: [temporaryDirectory]).entries.first)
         XCTAssertEqual(entry.model, "gpt-5")
-        XCTAssertEqual(entry.explicitCost, 0.07)
+        // NSNumber-decoded JSON doubles round-trip inexactly (0.07 → 0.07000000000000003).
+        XCTAssertEqual(try XCTUnwrap(entry.explicitCost), 0.07, accuracy: 0.000_001)
         XCTAssertEqual(entry.input, 100)
         XCTAssertEqual(entry.output, 30)
         XCTAssertEqual(entry.cacheRead, 20)

--- a/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
+++ b/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
@@ -134,7 +134,7 @@ final class LocalAdditionalUsageTests: XCTestCase {
         XCTAssertEqual(
             Set(store.registeredProviderIDs),
             Set(["claude_code", "codex", "gemini", "antigravity",
-                 "opencode", "hermes", "cursor", "grok", "copilot", "kiro"]))
+                 "opencode", "hermes", "cursor", "grok", "copilot", "kiro", "docker"]))
     }
 
     func testPrintRealOpenCodeAggregate() throws {

--- a/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
@@ -21,7 +21,8 @@ final class ProviderTabLayoutTests: XCTestCase {
     private var allProviders: [ProviderSnapshot] {
         [("claude_code", "Claude Code"), ("codex", "Codex"), ("gemini", "Gemini"),
          ("antigravity", "Antigravity"), ("opencode", "OpenCode"), ("hermes", "Hermes Agent"),
-         ("cursor", "Cursor"), ("grok", "Grok"), ("copilot", "Copilot"), ("kiro", "Kiro")]
+         ("cursor", "Cursor"), ("grok", "Grok"), ("copilot", "Copilot"), ("kiro", "Kiro"),
+         ("docker", "Docker Agent")]
             .map { snapshot($0.0, $0.1) }
     }
 

--- a/Tests/PokeTokenBarTests/UsageEnvironmentTests.swift
+++ b/Tests/PokeTokenBarTests/UsageEnvironmentTests.swift
@@ -157,10 +157,34 @@ final class UsageEnvironmentTests: XCTestCase {
     }
 
     /// 실제로 조회되는 이름 집합이 프로바이더 override 와 어긋나지 않게 고정한다.
-    func testRegisteredNamesCoverEveryProviderOverride() {
-        for name in ["CLAUDE_CONFIG_DIR", "OPENCODE_DATA_DIR", "HERMES_HOME", "COPILOT_HOME", "GROK_HOME"] {
-            XCTAssertTrue(UsageEnvironment.names.contains(name), "\(name) 이 조회 대상에서 빠졌다")
+    ///
+    /// 원래는 하드코딩 목록 5개와 비교했는데, 그 형태는 `CURSOR_DATA_DIR`/`KIRO_CLI_HOME` 이
+    /// `names` 에 빠진 채(= override 가 조용히 죽은 채) 통과했다 — 목록 두 벌이 함께 표류한 것.
+    /// 그래서 소스에서 실제 조회 지점(`environmentPaths("…")`/`UsageEnvironment.value("…")`)을
+    /// 긁어와 대조한다. 새 프로바이더가 이름 등록을 빼먹으면 여기서 기계로 걸린다.
+    func testRegisteredNamesCoverEveryProviderOverride() throws {
+        let sources = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()    // PokeTokenBarTests
+            .deletingLastPathComponent()    // Tests
+            .deletingLastPathComponent()    // repo root
+            .appendingPathComponent("Sources/PokeTokenBar")
+        let lookup = try NSRegularExpression(
+            pattern: #"(?:environmentPaths|UsageEnvironment\.value)\("([A-Z0-9_]+)"\)"#)
+
+        var used: Set<String> = []
+        let enumerator = try XCTUnwrap(FileManager.default.enumerator(
+            at: sources, includingPropertiesForKeys: nil))
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let text = try String(contentsOf: url, encoding: .utf8)
+            for match in lookup.matches(in: text, range: NSRange(text.startIndex..., in: text)) {
+                guard let range = Range(match.range(at: 1), in: text) else { continue }
+                used.insert(String(text[range]))
+            }
         }
+
+        XCTAssertFalse(used.isEmpty, "조회 지점을 하나도 못 찾았다 — 정규식/경로가 소스와 표류")
+        let missing = used.subtracting(UsageEnvironment.names)
+        XCTAssertTrue(missing.isEmpty, "소스가 조회하는 override 가 names 에 없다(죽은 override): \(missing.sorted())")
         XCTAssertEqual(Set(UsageEnvironment.names).count, UsageEnvironment.names.count, "이름 중복")
         for name in UsageEnvironment.names {
             XCTAssertTrue(BinaryLocator.isShellSafeEnvironmentName(name), "\(name) 은 셸 조회가 거부한다")

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -600,6 +600,32 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(preferring: "kiro")?.providerID, "kiro", "탭에 노출됨")
     }
 
+    /// 신규 provider(docker) 의 snapshot 이 today/week/month/burn 에 흘러가는지 확인.
+    /// kiro 와 달리 `reportsCost = true` 라 비용 집계 경로까지 함께 본다.
+    /// (파서/스키마 회귀는 DockerUsageTests.swift 담당 — 여기는 store 집계 경로만 본다.)
+    func testDockerSnapshotFlowsThroughTodayWeekMonthBurnAndCost() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(100_000_000))
+        let docker = FakeUsageProvider(id: "docker", displayName: "Docker Agent",
+                                       daily: todayDaily(50_000_000, cost: 1.25))
+        docker.enrichment = ProviderEnrichment(
+            activeBlock: block(tokensPerMinute: 200_000), blocksOK: true,
+            weekTotal: PeriodUsage(period: "w", totalTokens: 90_000_000, totalCost: 2.5),
+            monthTotal: PeriodUsage(period: "m", totalTokens: 300_000_000, totalCost: 7.5),
+            periodsOK: true)
+        let store = makeStore(providers: [claude, docker])
+        await store.refresh(scheduleEmptyRetry: false)
+
+        XCTAssertEqual(store.todayTotalTokens, 150_000_000)
+        XCTAssertEqual(store.todayTokensByProvider["docker"], 50_000_000)
+        XCTAssertEqual(store.weekTotalTokens, 90_000_000)
+        XCTAssertEqual(store.monthTotalTokens, 300_000_000)
+        XCTAssertEqual(store.todayCostTotal, 1.25, "docker 는 reportsCost=true → 비용 합계에 포함")
+        XCTAssertEqual(store.weekCostTotal, 2.5)
+        XCTAssertEqual(store.monthCostTotal, 7.5)
+        XCTAssertEqual(store.burnTier, .fast, "burn 이 docker 의 활성 블록을 반영")
+        XCTAssertEqual(store.snapshot(preferring: "docker")?.providerID, "docker", "탭에 노출됨")
+    }
+
     func testCodexOnlyWhenClaudeHasNoData() async {
         let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: nil) // 데이터 없음
         let codex = FakeUsageProvider(id: "codex", displayName: "Codex", daily: todayDaily(50_000_000))

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -80,6 +80,14 @@ read_when:
   (`shellEnvironmentValues`) — 이름마다 띄우면 프로바이더가 늘수록 기동이 그만큼 느려진다.
   프로세스 환경에 전부 있으면 셸을 아예 안 띄우는 분기도 함께 가드한다(`…SkipsShellLookup`).
   `export FOO=` 처럼 **빈 값은 미설정으로** 취급한다 — 값으로 받으면 없는 경로를 스캔하고 조용히 0 이 된다.
+- **레지스트리 가드를 하드코딩 목록으로 쓰면 목록 두 벌이 함께 표류한다 — 가드는 소스에서 유도하라.**
+  위 `UsageEnvironment` 체계가 생긴 *뒤에* 추가된 `CURSOR_DATA_DIR`·`KIRO_CLI_HOME` 은
+  `environmentPaths()` 로 조회는 하는데 `names` 등록이 빠졌고(`value()` 는 `names` 만 resolve → override 가
+  조용히 죽음), 가드 테스트가 하드코딩 5개 이름만 비교해서 그대로 통과했다(docker 추가 중 발견, 함께 수정).
+  등록 강제 가드는 기대 목록을 손으로 두 번 쓰는 형태가 아니라 **소스를 스캔해 실제 사용처에서 유도**한다 —
+  `testRegisteredNamesCoverEveryProviderOverride` 가 `environmentPaths("…")`/`UsageEnvironment.value("…")`
+  호출을 긁어 `names` 와 대조한다. 같은 부류: 기대 집합을 하드코딩하는 가드는 새 항목이 *양쪽 다* 빠졌을 때
+  침묵한다 — 진실의 원천(소스·레지스트리)에서 한쪽을 유도할 수 있으면 반드시 그렇게 한다.
 - **디렉터리 탐색은 깊이만 막으면 폭이 안 막히지만, 이름 기반 가지치기는 더 위험하다.** 깊이 가지치기는
   `> maxDepth` 가 아니라 `>= maxDepth` 에서 걸어야 한 단계 더 내려가지 않는다(전자는 상한+1 까지 방문).
   깊이 상한은 **실제 레이아웃 깊이를 테스트로 고정**하고 여유를 둔다 — 경계에 붙여 두면 상위 소스가 한 단계

--- a/docs/reference/provider-extension.md
+++ b/docs/reference/provider-extension.md
@@ -27,5 +27,8 @@ read_when:
   루트가 겹쳐도 합계는 전역 dedup 이 바로잡지만, 중복 루트는 스캔 비용을 배로 늘리므로
   `normalizedRoots` 로 접는다.
 - **append-only SQLite 사용량 스토어** (Cursor `cursorDiskKV`, Copilot `assistant_usage_events`,
-  앞으로 같은 형태의 세 번째 소스) = `LocalAdditionalUsageReader.scanIncrementalStores`. URL 매핑·
-  `MAX` SQL·row query·parse 만 넘긴다. watermark 루프를 프로바이더마다 복사하지 마라 (#157).
+  Docker Agent `session_items`, 앞으로 같은 형태의 소스) = `LocalAdditionalUsageReader.scanIncrementalStores`.
+  URL 매핑·`MAX` SQL·row query·parse 만 넘긴다. watermark 루프를 프로바이더마다 복사하지 마라 (#157).
+- **위치 override 환경변수를 새로 쓰면 `UsageEnvironment.names` 에도 등록한다** — 조회(`value`)는
+  `names` 만 resolve 하므로 등록이 빠지면 override 가 조용히 죽는다. 등록 누락은
+  `testRegisteredNamesCoverEveryProviderOverride` 가 소스 스캔으로 잡는다(defect-log 참조).


### PR DESCRIPTION
## Summary

Adds **Docker Agent** (docker/docker-agent, formerly *cagent* — the `docker agent` CLI plugin / `docker-agent` Homebrew binary) as an eleventh usage provider.

- **Data source**: `<data dir>/session.db` (default `~/.cagent`), read-only. Every `session_items` row is one chat message; assistant rows persist per-message token usage (`usage_json`, with a `message_json` fallback for rows written before cagent's denormalizing migration) and the dollar cost docker-agent itself computed against the models.dev catalog — so `reportsCost` stays true and the cost flows through `Entry.explicitCost`.
- **Scanning**: reuses `LocalAdditionalUsageReader.scanIncrementalStores` with a `rowid` watermark (the Cursor/Copilot shape anticipated by `docs/reference/provider-extension.md`). `/undo`, session deletion, and VACUUM shrink `MAX(rowid)` and fall back to a cold rescan via `didReset`.
- **Token mapping**: cached read/write tokens are subtracted from `input_tokens` (clamped at zero) to avoid double counting across the provider shapes cagent normalizes; `reasoning_tokens` is a breakdown of output and is not added.
- **Roots**: `$DOCKER_AGENT_DATA_DIR` / `$CAGENT_DATA_DIR` override → `~/.cagent`, resolved through `UsageEnvironment` like every other provider.

## Defect fix included (per the defect protocol)

`CURSOR_DATA_DIR` and `KIRO_CLI_HOME` were looked up by their readers but never registered in `UsageEnvironment.names`, so `value()` always returned nil and those overrides were silently dead. The guard test compared against a second hardcoded 5-name list, so both lists drifted together. This PR registers the missing names and rewrites `testRegisteredNamesCoverEveryProviderOverride` to derive the expected set by scanning the sources for `environmentPaths("…")` / `UsageEnvironment.value("…")` call sites, killing the class. Captured in `docs/reference/defect-log.md`.

## Tests

- New `DockerUsageTests.swift`: column vs JSON-fallback parsing, zero-cost handling, user/tool/malformed/undated row skipping, cache-subtraction clamp branch, reasoning-token exclusion, window filtering, id stability across rescans, incremental watermark behavior, `didReset` on deleted tail, multi-store id non-collision, root seams, provider identity, and a `PTB_PARITY=1`-gated real-data smoke test.
- `UsageStoreTests`: docker snapshot flows through today/week/month/burn and — unlike kiro — the cost aggregates.
- Registry guards updated: `LocalAdditionalUsageTests`, `ProviderTabLayoutTests`.

## Docs

READMEs (en/ko/ja) updated in all provider-list spots plus the Works-with and Data-sources tables; `provider-extension.md` now names `session_items` among the incremental-store users and documents the env-name registration rule.

> Note: authored in a Linux sandbox without a Swift toolchain — relying on CI (macos-15 `swift build` + `test-gate.sh`) for the test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)