### PR TITLE
fix: prevent invisible text in floating pet hover tooltip

### DIFF
--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -46,6 +46,34 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
         var wouldTruncate: Bool
     }
 
+    /// AppKit 호버 콜아웃에 사용할 appearance 해석 완료 색상.
+    ///
+    /// 이 콜아웃은 SwiftUI가 아니라 `NSTextField`와 레이어 기반 `NSView`로 조립된다.
+    /// 텍스트 필드에 semantic `NSColor`를 그대로 지정하면 뷰의 effective appearance로
+    /// 해석되지만, `windowBackgroundColor.cgColor`는 현재 그리기 appearance에서 즉시
+    /// 색상이 굳어진다. 세 색상을 하나의 appearance에서 함께 해석해야 글자와 외곽선이
+    /// 같은 라이트/다크 모드를 유지한다.
+    struct HoverCalloutColors {
+        var text: NSColor
+        var background: NSColor
+        var border: NSColor
+    }
+
+    static func hoverCalloutColors(for appearance: NSAppearance) -> HoverCalloutColors {
+        HoverCalloutColors(
+            text: snapshot(NSColor.labelColor, for: appearance),
+            background: snapshot(NSColor.windowBackgroundColor, for: appearance),
+            border: snapshot(NSColor.separatorColor, for: appearance))
+    }
+
+    private static func snapshot(_ color: NSColor, for appearance: NSAppearance) -> NSColor {
+        var resolved = color
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = NSColor(cgColor: color.cgColor) ?? color
+        }
+        return resolved
+    }
+
     private var onOpenPopover: (() -> Void)?
     private var onHide: (() -> Void)?
 
@@ -223,9 +251,11 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
         // Don't cover an active limit bubble — the speech bubble is the priority surface.
         if store.currentBubbleAlert != nil { hideHoverCallout(); return }
         let text = currentHoverText()
+        let appearance = NSApp.effectiveAppearance
+        let colors = Self.hoverCalloutColors(for: appearance)
         let label = NSTextField(labelWithString: text)
         label.font = .systemFont(ofSize: 11)
-        label.textColor = .labelColor
+        label.textColor = colors.text
         label.backgroundColor = .clear
         label.drawsBackground = false
         label.sizeToFit()
@@ -234,16 +264,18 @@ final class FloatingPetController: NSObject, NSWindowDelegate {
         let size = NSSize(width: label.bounds.width + pad * 2,
                           height: label.bounds.height + pad * 2)
         let container = NSView(frame: NSRect(origin: .zero, size: size))
+        container.appearance = appearance
         container.wantsLayer = true
-        container.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        container.layer?.backgroundColor = colors.background.cgColor
         container.layer?.cornerRadius = 8
         container.layer?.borderWidth = 0.5
-        container.layer?.borderColor = NSColor.separatorColor.cgColor
+        container.layer?.borderColor = colors.border.cgColor
         label.frame.origin = NSPoint(x: pad, y: pad)
         container.addSubview(label)
 
         let hp = hoverPanel ?? makeHoverPanel()
         hoverPanel = hp
+        hp.appearance = appearance
         hp.contentView = container
         hp.setContentSize(size)
         let petFrame = pet.frame

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -197,6 +197,32 @@ final class FloatingPetEnergyTests: XCTestCase {
                                         l.percentRemaining(TokenFormatter.percent(58))))
     }
 
+    /// [회귀] 호버 콜아웃의 글자와 외곽선은 같은 appearance에서 해석되어야 한다.
+    /// 기존 경로는 텍스트 필드에 동적 `.labelColor`를 지정하면서 뷰를 만드는 동안
+    /// `windowBackgroundColor.cgColor`를 굳혔다. 그 결과 다크 모드에서 밝은 말풍선에
+    /// 흰 글자가 놓일 수 있었다.
+    func testHoverCalloutColorsFollowLightAndDarkAppearance() throws {
+        let light = try XCTUnwrap(NSAppearance(named: .aqua))
+        let dark = try XCTUnwrap(NSAppearance(named: .darkAqua))
+        let lightColors = FloatingPetController.hoverCalloutColors(for: light)
+        let darkColors = FloatingPetController.hoverCalloutColors(for: dark)
+
+        XCTAssertTrue(lightColors.text.isEqual(Self.snapshot(NSColor.labelColor, for: light)))
+        XCTAssertTrue(lightColors.background.isEqual(Self.snapshot(NSColor.windowBackgroundColor, for: light)))
+        XCTAssertTrue(lightColors.border.isEqual(Self.snapshot(NSColor.separatorColor, for: light)))
+        XCTAssertTrue(darkColors.text.isEqual(Self.snapshot(NSColor.labelColor, for: dark)))
+        XCTAssertTrue(darkColors.background.isEqual(Self.snapshot(NSColor.windowBackgroundColor, for: dark)))
+        XCTAssertTrue(darkColors.border.isEqual(Self.snapshot(NSColor.separatorColor, for: dark)))
+
+        XCTAssertFalse(lightColors.text.isEqual(darkColors.text), "text color must change with appearance")
+        XCTAssertFalse(lightColors.background.isEqual(darkColors.background),
+                      "bubble background must change with appearance")
+        XCTAssertFalse(lightColors.text.isEqual(lightColors.background),
+                       "라이트 모드 콜아웃 글자는 배경과 달라야 함")
+        XCTAssertFalse(darkColors.text.isEqual(darkColors.background),
+                       "다크 모드 콜아웃 글자는 배경과 달라야 함")
+    }
+
     /// Alert copy in *every* language must fit the default bubble panel — width-capped wrap,
     /// not intrinsic `.fixedSize` that clipped ja by ~9pt (owner review on #124).
     /// Iterate `allCases`, never a literal list: a hardcoded `[.ko, .en, .ja]` silently stopped
@@ -308,6 +334,14 @@ final class FloatingPetEnergyTests: XCTestCase {
             "Codex \(l.codexWindow(10_080))",
             "Claude \(l.claudeLimitEntry(kind: "weekly_scoped", model: "Opus"))",
         ]
+    }
+
+    private static func snapshot(_ color: NSColor, for appearance: NSAppearance) -> NSColor {
+        var resolved = color
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = NSColor(cgColor: color.cgColor) ?? color
+        }
+        return resolved
     }
 
     /// Grow a wrapping body until unconstrained `measureSpeechBubble` height has jumped


### PR DESCRIPTION
## Summary

Fixes invisible text in the floating pet hover tooltip when macOS is using dark mode.

## Root cause

The tooltip text used the dynamic `labelColor`, while the bubble background converted `windowBackgroundColor` to `CGColor` before the view's effective appearance was applied. In dark mode, the text and background could therefore resolve from different appearances.

## UI evidence

### Dark mode reproduction

<!-- The dark-mode screenshot will be uploaded to this PR after creation. -->
![Dark mode: tooltip text is invisible](https://github.com/user-attachments/assets/d798aea9-ad6f-4e2a-a68a-225c2eb99c42)


### Light mode reference

<!-- The light-mode screenshot will be uploaded to this PR after creation. -->
![Light mode: tooltip text is visible](https://github.com/user-attachments/assets/472ba217-da15-4fa7-a2c9-6addedd43c06)


## Changes

- Resolve tooltip text, background, and border colors from the same effective appearance.
- Apply the appearance to the hover panel and its container view.
- Add regression coverage for both Aqua and Dark Aqua appearances.

## Tests

- `swift test --filter FloatingPetEnergyTests.testHoverCalloutColorsFollowLightAndDarkAppearance`
- `./scripts/test-gate.sh`
- 702 tests passed, 8 skipped
- Logic-core line coverage: 89.99%

## Scope

This change only affects the floating pet hover tooltip's appearance.
