### PR TITLE
Label official limits with the account they belong to

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -53,6 +53,7 @@ struct L {
         }
     }
     func plan(_ p: String) -> String { t("플랜 \(p)", "Plan \(p)", "プラン \(p)", "Plan \(p)") }
+    func limitsAccount(_ a: String) -> String { t("계정 \(a)", "Account \(a)", "アカウント \(a)", "Cuenta \(a)") }
     func forecastReach(_ time: String) -> String {
         t("현재 속도면 \(time) 한도 도달", "At current rate, limit hit at \(time)", "現在のペースで \(time) に上限到達", "Al ritmo actual, límite alcanzado a las \(time)")
     }

--- a/Sources/PokeTokenBar/Core/Models.swift
+++ b/Sources/PokeTokenBar/Core/Models.swift
@@ -201,6 +201,10 @@ struct LimitStatus: Decodable, Sendable {
     /// CodingKeys 에 없어 디코드 시 무시되고, OAuthLimitsProvider.fetch 가 채운다.
     var subscriptionType: String?
     var rateLimitTier: String?
+    /// 토큰의 실제 주인 — usage 응답이 아니라 profile endpoint(OAuthProfileCache)에서 주입한다.
+    /// 같은 기기에서 두 계정이 하나의 Keychain 항목을 덮어쓸 때 어느 계정의 한도인지 구분하는 라벨.
+    var accountEmail: String?
+    var accountOrganizationName: String?
 
     private enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
@@ -221,6 +225,17 @@ struct LimitStatus: Decodable, Sendable {
             return "\(base) \(multiplier)"
         }
         return base
+    }
+
+    /// 계정 라벨 — "email · 조직명". 개인 플랜의 자동 생성 조직명("<email>'s Organization")은
+    /// 이메일과 중복 정보라 생략한다(조직명에 이메일이 포함되는지로 판정). 이메일 없으면 nil —
+    /// 조직명만으로는 어느 로그인인지 특정되지 않아 부분 라벨을 만들지 않는다.
+    var accountDisplay: String? {
+        guard let accountEmail, !accountEmail.isEmpty else { return nil }
+        guard let org = accountOrganizationName, !org.isEmpty, !org.contains(accountEmail) else {
+            return accountEmail
+        }
+        return "\(accountEmail) · \(org)"
     }
 
     /// rateLimitTier 끝의 배수 토큰("20x"/"5x") 추출 — "_" 로 나눠 숫자+x 형태를 찾는다.

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -27,6 +27,7 @@ struct OAuthLimitsProvider: ClaudeLimitsProviding, Sendable {
 
     func fetch(allowKeychainPrompt: Bool = false) async throws -> LimitStatus {
         let token = try await accessTokenCache.accessToken(allowKeychainPrompt: allowKeychainPrompt)
+        var activeToken = token
         var status: LimitStatus
         do {
             status = try await fetchStatus(accessToken: token)
@@ -39,11 +40,19 @@ struct OAuthLimitsProvider: ClaudeLimitsProviding, Sendable {
                 allowKeychainPrompt: allowKeychainPrompt, bypassCache: true)
             guard refreshed != token else { throw error }
             status = try await fetchStatus(accessToken: refreshed)
+            activeToken = refreshed
         }
         // 플랜은 usage 응답이 아니라 방금 읽은 자격증명(캐시)에 담겨 있다 — 추가 Keychain 접근 없음.
         let plan = await accessTokenCache.planInfo()
         status.subscriptionType = plan.subscriptionType
         status.rateLimitTier = plan.rateLimitTier
+        // 계정 식별(이메일·조직) — 같은 기기에서 두 계정이 하나의 Keychain 항목을 번갈아 덮어쓰면
+        // 한도 바가 어느 계정 것인지 소리 없이 뒤바뀐다. 토큰의 실제 주인을 profile endpoint 로
+        // 조회해 라벨링한다. best-effort: 실패해도 한도 표시는 그대로 (라벨만 생략).
+        if let identity = await OAuthProfileCache.shared.identity(accessToken: activeToken) {
+            status.accountEmail = identity.email
+            status.accountOrganizationName = identity.organizationName
+        }
         return status
     }
 
@@ -69,6 +78,58 @@ struct OAuthLimitsProvider: ClaudeLimitsProviding, Sendable {
               let seconds = TimeInterval(raw.trimmingCharacters(in: .whitespaces)),
               seconds > 0 else { return nil }
         return min(seconds, 3600)
+    }
+}
+
+/// OAuth 토큰의 실제 주인(계정 이메일·조직명). usage 응답에는 계정 정보가 없어 profile endpoint 로 조회한다.
+struct AccountIdentity: Equatable, Sendable {
+    let email: String
+    let organizationName: String?
+}
+
+/// profile 조회 캐시 — 토큰이 바뀌지 않는 한 계정 주인도 바뀌지 않으므로 토큰당 1회만 네트워크를 탄다
+/// (한도 폴링마다 HTTP 요청이 2배가 되는 것을 방지). 실패는 캐시하지 않는다 — 토큰이 바뀐 직후 조회가
+/// 실패했을 때 이전 계정 라벨을 계속 보여주면 라벨링이 없느니만 못하다(잘못된 계정 표시).
+actor OAuthProfileCache {
+    static let shared = OAuthProfileCache()
+    private var cachedToken: String?
+    private var cachedIdentity: AccountIdentity?
+
+    func identity(accessToken: String) async -> AccountIdentity? {
+        if cachedToken == accessToken { return cachedIdentity }
+        guard let identity = await Self.fetchIdentity(accessToken: accessToken) else { return nil }
+        cachedToken = accessToken
+        cachedIdentity = identity
+        return identity
+    }
+
+    private static let profileURL = URL(string: "https://api.anthropic.com/api/oauth/profile")!
+
+    private static func fetchIdentity(accessToken: String) async -> AccountIdentity? {
+        var request = URLRequest(url: profileURL, timeoutInterval: 15)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+        return OAuthProfileData.identity(from: data)
+    }
+}
+
+/// profile 응답 파싱 — 순수 함수로 분리해 픽스처로 테스트한다.
+enum OAuthProfileData {
+    /// `{"account":{"email":...},"organization":{"name":...}}` → AccountIdentity.
+    /// email 이 없거나 비면 응답 전체를 버린다(부분 라벨은 오인 소지) — organization 은 선택.
+    static func identity(from data: Data) -> AccountIdentity? {
+        guard
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let account = json["account"] as? [String: Any],
+            let email = account["email"] as? String, !email.isEmpty
+        else {
+            return nil
+        }
+        let organization = json["organization"] as? [String: Any]
+        let orgName = (organization?["name"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        return AccountIdentity(email: email, organizationName: orgName)
     }
 }
 

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -308,6 +308,13 @@ struct PopoverView: View {
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
+                // 계정 라벨 — 두 계정이 한 Keychain 항목을 번갈아 쓰는 기기에서 이 한도가
+                // 어느 계정 것인지 알려준다 (없으면 라벨 없이 종전과 동일).
+                if let account = limits.accountDisplay {
+                    Text(l.limitsAccount(account))
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
                 // 세션 만료 시 표시값은 만료 전 기준 → 흐리게 처리해 "현재 값 아님"을 시각적으로 전달
                 VStack(alignment: .leading, spacing: 8) {
                     limitRow(name: l.fiveHourSession, window: limits.fiveHour)

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -214,6 +214,50 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(status.scopedLimitEntries.count, 2)
     }
 
+    /// /api/oauth/profile 응답 → AccountIdentity 파싱. email 필수, organization 선택.
+    func testOAuthProfileIdentityParsing() {
+        let full = """
+        {"account":{"uuid":"a-1","email":"dev@example.com","display_name":"Dev"},
+        "organization":{"uuid":"o-1","name":"Acme Corp","organization_type":"claude_team"}}
+        """.data(using: .utf8)!
+        XCTAssertEqual(OAuthProfileData.identity(from: full),
+                       AccountIdentity(email: "dev@example.com", organizationName: "Acme Corp"))
+
+        // organization 이 null(개인 플랜에서 관측 가능) → 이메일만
+        let noOrg = """
+        {"account":{"email":"dev@example.com"},"organization":null}
+        """.data(using: .utf8)!
+        XCTAssertEqual(OAuthProfileData.identity(from: noOrg),
+                       AccountIdentity(email: "dev@example.com", organizationName: nil))
+
+        // email 누락/빈 문자열 → 부분 라벨 대신 전체 무시
+        let noEmail = """
+        {"account":{"uuid":"a-1"},"organization":{"name":"Acme Corp"}}
+        """.data(using: .utf8)!
+        XCTAssertNil(OAuthProfileData.identity(from: noEmail))
+        let emptyEmail = """
+        {"account":{"email":""},"organization":{"name":"Acme Corp"}}
+        """.data(using: .utf8)!
+        XCTAssertNil(OAuthProfileData.identity(from: emptyEmail))
+    }
+
+    /// 계정 라벨 — 팀/기업 조직명은 붙이고, 개인 플랜의 자동 생성 조직명("<email>'s Organization")은
+    /// 이메일과 중복이라 생략한다.
+    func testLimitStatusAccountDisplay() throws {
+        var status = try JSONDecoder().decode(LimitStatus.self, from: Data("{}".utf8))
+        XCTAssertNil(status.accountDisplay)
+
+        status.accountEmail = "dev@example.com"
+        status.accountOrganizationName = "Acme Corp"
+        XCTAssertEqual(status.accountDisplay, "dev@example.com · Acme Corp")
+
+        status.accountOrganizationName = "dev@example.com's Organization"
+        XCTAssertEqual(status.accountDisplay, "dev@example.com")
+
+        status.accountOrganizationName = nil
+        XCTAssertEqual(status.accountDisplay, "dev@example.com")
+    }
+
     /// 플랜 표시 문자열 — subscriptionType + rateLimitTier 조립. Max 는 배수까지 세분화.
     /// 조합표 전수: {max×20x, max×5x, pro×배수없음, free×nil, 구독없음}.
     func testPlanDisplay() throws {


### PR DESCRIPTION
## Summary

Two Claude Code accounts on one Mac (e.g. a personal Max plan and an employer Team plan, switched via `CLAUDE_CONFIG_DIR`) overwrite the single `Claude Code-credentials` Keychain item whenever either CLI refreshes its token. The official-limits section then silently flips between accounts: the five-hour/weekly bars belong to whichever account refreshed last, and nothing in the UI says which one that is. (Observed on my own machine — the limits alternated between my Max 5x and my Team plan depending on which CLI ran last, which is what sent me digging.)

This PR labels the limits with the account they actually belong to:

- Fetch the token owner's identity from `https://api.anthropic.com/api/oauth/profile` — same host, auth header, and beta header as the existing `oauth/usage` call. Best-effort: any failure and the limits render exactly as before, with no label.
- Cache the identity per access token (`OAuthProfileCache` actor), so limit polling does not double its request count — one profile request per new token. Failures are not cached, so a stale label from a previous account can never stick after a token switch.
- Parsing is a pure function (`OAuthProfileData.identity(from:)`) tested with fixtures. Email is required; a response without one is discarded entirely rather than producing a partial label.
- `LimitStatus.accountDisplay` renders `email · org name`, suppressing the auto-generated personal org ("<email>'s Organization") since it duplicates the email.
- No new Keychain access and no new secret handling — the profile call reuses the access token already held in memory for the usage call.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

| Before | After |
| ------ | ----- |
| Limits section shows `Plan Max 5x` above the five-hour/weekly bars, with no indication which account they belong to | One extra tertiary caption under the plan row: `Account dev@example.com · Acme Corp` (or just `Account dev@example.com` on personal plans). When the profile lookup fails or hasn't run, the section is pixel-identical to before |

New string `limitsAccount` localized for all four languages (ko/en/ja/es).

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see CONTRIBUTING)
- [x] Tests were added or updated for this change

Test notes: added `testOAuthProfileIdentityParsing` (full/`organization:null`/missing-email/empty-email fixtures) and `testLimitStatusAccountDisplay` (org shown, personal org suppressed, email-only, nil). Local machine has Command Line Tools only (no XCTest), so the suite ran on a fork CI run of this branch; `swift build` verified locally.

Related: this is deliberately labeling-only. Reading multiple credentials / per-account limit selection is a bigger design I'm proposing separately as an issue (multi-account attribution), and per-provider scan folders are already in flight in #162/#187 — this PR doesn't touch scanning at all.
