### PR TITLE
docs: correct the Antigravity step-timestamp entry in the defect log

### DIFF
--- a/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AntigravityUsageTests.swift
@@ -193,6 +193,25 @@ final class AntigravityUsageTests: XCTestCase {
     /// One execution answers several times. Pairing them in order follows the execution as it
     /// runs; collapsing them onto its last step would file a turn under the wrong day whenever
     /// an execution straddles midnight.
+    /// The step lookup does not filter on `step_type`, so every row that carries the execution id
+    /// joins the ordinal list — including rows that are not generations. Characterises the current
+    /// join so that narrowing it later (which needs the real `step_type` values first) shows up here
+    /// rather than in someone's daily total.
+    func testAnyStepSharingTheExecutionJoinsTheOrdinal() throws {
+        let early = try date("2026-03-04T10:00:00Z")
+        let late = try date("2026-03-04T20:00:00Z")
+        try writeConversation("c1", records: [
+            undatedRecord(responseID: "r0", model: "gemini-3.7-flash", execution: "e1",
+                          input: 100, output: 20, cacheRead: 300),
+        ], steps: [
+            makeStep(execution: "e1", queued: early, finished: early),
+            makeStep(execution: "e1", responseID: "a-different-response", queued: late, finished: late),
+        ])
+
+        let entry = try XCTUnwrap(readAll().first)
+        XCTAssertEqual(entry.date.timeIntervalSince1970, early.timeIntervalSince1970, accuracy: 1)
+    }
+
     func testStepTimesAreHandedOutInOrderWithinAnExecution() throws {
         let times = try [
             date("2026-03-04T23:50:00Z"), date("2026-03-04T23:55:00Z"), date("2026-03-05T00:05:00Z"),

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -65,10 +65,22 @@ read_when:
   **같은 스펠링이 표면마다 의미가 다를 수 있다**(Grok `inputTokens`=캐시 포함 durable wire vs `input_tokens`=캐시
   제외 헤드리스 투영) — 별칭으로 합치면 캐시분을 두 번 빼거나 두 번 더한다.
 - **Antigravity의 생성 시각은 `gen_metadata` 한 곳에 고정돼 있지 않다.** 구 포맷은
-  `chat_start_metadata.created_at`에 시각을 넣지만, 현재 포맷은 같은 `response_id`를 가진
-  `steps(step_type=15).metadata`에 타임스탬프를 둔다. 토큰 필드는 유지되므로 `gen_metadata`만 읽으면
-  오늘 사용량이 통째로 `nil`이 된다. 두 레코드의 행 순서가 같다는 가정 대신 `response_id`로 직접 연결하고,
-  구 포맷의 직접 시각은 계속 우선한다. 회귀 가드는 `testCurrentGenerationFormatUsesStepMetadataTimestamp`다.
+  `chat_start_metadata.created_at`에 시각을 넣지만, 현재 포맷은 그 필드를 비우고 `steps.metadata`에
+  타임스탬프를 둔다(`8 finished_at`, 없으면 `1 created_at`). 토큰 필드는 유지되므로 `gen_metadata`만
+  읽으면 오늘 사용량이 통째로 `nil`이 된다. 연결은 네 단계다: 구 포맷의 직접 시각 → `response_id`
+  1:1(`steps.metadata` 의 `9.11`) → 같은 `execution_id`(`12`) 안에서의 등장 순서 → 스토어 mtime.
+  **행 순서(`idx`)로 잇지 마라** — `gen_metadata.idx` 는 자기만의 조밀한 수열이라 같은 대화 안에서도
+  `steps.idx` 와 분 단위로 어긋난다. mtime 이 최후수단인 이유는 스토어 하나에 값이 하나뿐이라
+  대화의 앞선 날들을 마지막 기록일로 끌어오기 때문이다(실측: 신포맷 스토어 10개에서 11,523,909 토큰이
+  하루 뒤로 이동하고 원래 날짜는 0이 됐다).
+  **`steps` 는 종류를 가리지 않고 전부 읽는다** — 쿼리에 `step_type` 조건이 없다. `execution_id` 를 가진
+  행은 generation 이 아니어도 순서 대응 후보 목록에 들어가므로, 3단계는 그 실행의 다른 step 시각을
+  집어갈 수 있다(합성 스토어로 확인). 실제 스토어에서 이 혼입이 얼마나 되는지는 **아직 측정되지 않았다** —
+  근거는 `created_at` 이 남아 있는 스토어와 대조해 ~2분 이내라는 것뿐이다. 좁히려면 `step_type` 값을
+  실데이터로 먼저 확정하라: 테스트 픽스처의 `steps` 에는 그 컬럼 자체가 없어, 실측 없이 조건만 넣으면
+  스토어를 통째로 못 읽는 쪽으로 무너진다. 회귀 가드는
+  `testCurrentGenerationFormatUsesStepMetadataTimestamp`·`testTheJoinIsTheExecutionIdAndNotTheRowIndex`·
+  `testStepTimesAreHandedOutInOrderWithinAnExecution`·`testStoreMtimeRemainsTheLastResort`.
 - **사용량 소스의 "복사·재기록" 경로를 먼저 찾아라 (이중집계·재날짜화).** 세션 fork·재생·서브에이전트는 같은
   지출을 여러 파일에 남기거나 시각을 다시 찍는다. 규칙: ① dedup 키는 *턴 자체* 의 전역 유일 id(파일·세션 경로를
   섞지 마라 — 복사본이 별건이 된다) ② 시각은 *기록* 시각이 아니라 *턴* 시각(fork 는 봉투 timestamp 를 새로


### PR DESCRIPTION
## Summary

The Antigravity entry in `docs/reference/defect-log.md` describes the timestamp lookup as
filtering `steps` on `step_type = 15`. The reader applies no such filter — it reads every
`steps` row that carries metadata and indexes it by both response id and execution id.

The defect log is what the next person reads before touching this parser, so the mismatch
is worth correcting on its own. The entry now spells out the four tiers the reader actually
walks (writer `created_at` → `response_id` 1:1 → position within an `execution_id` → store
mtime), records why the store mtime is the last resort, and notes that any row carrying the
execution id joins the ordinal list whether or not it is a generation.

Narrowing that join needs the real `step_type` values measured against live stores first.
The test fixture's `steps` table has no such column, so adding the condition without
measuring would make the reader fail to read whole stores rather than read them more
precisely. That is recorded in the entry instead of guessed at here.

`testAnyStepSharingTheExecutionJoinsTheOrdinal` characterises the join so a later change to
it surfaces in the suite rather than in someone's daily total. Verified it can fail:
restricting the execution index to rows that carry a response id makes it fail on the
assertion, and reverting restores it.

No behaviour change. `swift test` — 722 tests, 9 skipped, 0 failures.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Other: characterization test

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change
