### PR TITLE
Add Claude limit progress bars to large widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .swiftpm/
 Package.resolved
 
+# XcodeGen-generated project
+PokeTokenBar.xcodeproj/
+
 # App bundle build output
 build/
 

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,13 @@ import PackageDescription
 let package = Package(
     name: "PokeTokenBar",
     platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(path: "PokeTokenBarShared"),
+    ],
     targets: [
         .executableTarget(
             name: "PokeTokenBar",
+            dependencies: ["PokeTokenBarShared"],
             path: "Sources/PokeTokenBar",
             linkerSettings: [.linkedLibrary("sqlite3")]
         ),

--- a/PokeTokenBarShared/Package.swift
+++ b/PokeTokenBarShared/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "PokeTokenBarShared",
+    platforms: [.macOS(.v14), .iOS(.v17), .visionOS(.v1)],
+    products: [
+        .library(name: "PokeTokenBarShared", targets: ["PokeTokenBarShared"]),
+    ],
+    targets: [
+        .target(
+            name: "PokeTokenBarShared"
+        ),
+        .testTarget(
+            name: "PokeTokenBarSharedTests",
+            dependencies: ["PokeTokenBarShared"]
+        ),
+    ]
+)

--- a/PokeTokenBarShared/Sources/PokeTokenBarShared/AppLanguage.swift
+++ b/PokeTokenBarShared/Sources/PokeTokenBarShared/AppLanguage.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Minimal language enum shared between iOS app and widget.
+public enum AppLanguage: String, Codable, Sendable, CaseIterable {
+    case ko, en, ja, es
+
+    public var label: String {
+        switch self {
+        case .ko: return "한국어"
+        case .en: return "English"
+        case .ja: return "日本語"
+        case .es: return "Español"
+        }
+    }
+
+    public var displayLocale: Locale { Locale(identifier: rawValue) }
+
+    public static var systemDefault: AppLanguage {
+        switch Locale.preferredLanguages.first?.prefix(2).lowercased() {
+        case "ko": return .ko
+        case "ja": return .ja
+        case "es": return .es
+        default:   return .en
+        }
+    }
+}

--- a/PokeTokenBarShared/Sources/PokeTokenBarShared/CloudKitSync.swift
+++ b/PokeTokenBarShared/Sources/PokeTokenBarShared/CloudKitSync.swift
@@ -16,10 +16,16 @@ public enum CloudKitSync {
         guard let json = String(data: data, encoding: .utf8) else {
             throw CloudKitSyncError.encodingFailed
         }
-        let record = CKRecord(recordType: recordType, recordID: recordID)
+        let db = database()
+        let record: CKRecord
+        if let existing = try? await db.record(for: recordID) {
+            record = existing
+        } else {
+            record = CKRecord(recordType: recordType, recordID: recordID)
+        }
         record[payloadField] = json
         record[updatedField] = Date()
-        try await database().save(record)
+        try await db.save(record)
     }
 
     // MARK: - Read

--- a/PokeTokenBarShared/Sources/PokeTokenBarShared/CloudKitSync.swift
+++ b/PokeTokenBarShared/Sources/PokeTokenBarShared/CloudKitSync.swift
@@ -1,0 +1,65 @@
+import CloudKit
+
+/// Lightweight iCloud CloudKit sync for PhonePayload.
+/// Uses a single CKRecord with a JSON blob — simple last-write-wins.
+public enum CloudKitSync {
+    static let containerID = "iCloud.io.github.chattymin.poketokenbar"
+    static let recordType = "Payload"
+    static let recordID = CKRecord.ID(recordName: "PhonePayloadCurrent")
+    static let payloadField = "json"
+    static let updatedField = "updatedAt"
+
+    // MARK: - Write
+
+    public static func save(_ payload: PhonePayload) async throws {
+        let data = try JSONEncoder().encode(payload)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw CloudKitSyncError.encodingFailed
+        }
+        let record = CKRecord(recordType: recordType, recordID: recordID)
+        record[payloadField] = json
+        record[updatedField] = Date()
+        try await database().save(record)
+    }
+
+    // MARK: - Read
+
+    public static func fetch() async throws -> PhonePayload? {
+        do {
+            let record = try await database().record(for: recordID)
+            guard let json = record[payloadField] as? String,
+                  let data = json.data(using: .utf8) else { return nil }
+            return try JSONDecoder().decode(PhonePayload.self, from: data)
+        } catch let error as CKError where error.code == .unknownItem {
+            return nil
+        }
+    }
+
+    // MARK: - Delete
+
+    public static func delete() async throws {
+        try await database().deleteRecord(withID: recordID)
+    }
+
+    // MARK: - Account Check
+
+    public static func isAvailable() async -> Bool {
+        (try? await CKContainer(identifier: containerID).accountStatus()) == .available
+    }
+
+    // MARK: - Private
+
+    private static func database() -> CKDatabase {
+        CKContainer(identifier: containerID).privateCloudDatabase
+    }
+}
+
+public enum CloudKitSyncError: LocalizedError {
+    case encodingFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .encodingFailed: return "Failed to encode payload"
+        }
+    }
+}

--- a/PokeTokenBarShared/Sources/PokeTokenBarShared/PhonePayload.swift
+++ b/PokeTokenBarShared/Sources/PokeTokenBarShared/PhonePayload.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+// MARK: - Mac → iPhone Sync Payload
+
+/// Top-level payload served by the Mac HTTP server and consumed by the iPhone app + widget.
+public struct PhonePayload: Codable, Sendable, Equatable {
+    public let todayTokens: Int
+    public let todayCost: Double
+    public let weekTokens: Int
+    public let monthTokens: Int
+    public let lastUpdated: Date
+    public let serverVersion: String
+    public let limits: PhoneLimitStatus?
+    public let companion: PhoneCompanionState?
+    public let providers: [PhoneProviderSnapshot]
+
+    public init(todayTokens: Int, todayCost: Double, weekTokens: Int, monthTokens: Int,
+                lastUpdated: Date, serverVersion: String, limits: PhoneLimitStatus?,
+                companion: PhoneCompanionState?, providers: [PhoneProviderSnapshot]) {
+        self.todayTokens = todayTokens
+        self.todayCost = todayCost
+        self.weekTokens = weekTokens
+        self.monthTokens = monthTokens
+        self.lastUpdated = lastUpdated
+        self.serverVersion = serverVersion
+        self.limits = limits
+        self.companion = companion
+        self.providers = providers
+    }
+}
+
+// MARK: - Limit Status
+
+public struct PhoneLimitStatus: Codable, Sendable, Equatable {
+    public let claude5h: PhoneLimitWindow?
+    public let claudeWeekly: PhoneLimitWindow?
+    public let claudeOpusWeekly: PhoneLimitWindow?
+    public let claudeSonnetWeekly: PhoneLimitWindow?
+    public let codexPrimary: PhoneLimitWindow?
+    public let codexSecondary: PhoneLimitWindow?
+    public let planDisplay: String?
+
+    public init(claude5h: PhoneLimitWindow?, claudeWeekly: PhoneLimitWindow?,
+                claudeOpusWeekly: PhoneLimitWindow?, claudeSonnetWeekly: PhoneLimitWindow?,
+                codexPrimary: PhoneLimitWindow?, codexSecondary: PhoneLimitWindow?,
+                planDisplay: String?) {
+        self.claude5h = claude5h
+        self.claudeWeekly = claudeWeekly
+        self.claudeOpusWeekly = claudeOpusWeekly
+        self.claudeSonnetWeekly = claudeSonnetWeekly
+        self.codexPrimary = codexPrimary
+        self.codexSecondary = codexSecondary
+        self.planDisplay = planDisplay
+    }
+}
+
+public struct PhoneLimitWindow: Codable, Sendable, Equatable {
+    public let label: String
+    public let utilization: Double
+    public let resetsAt: Date?
+
+    public init(label: String, utilization: Double, resetsAt: Date?) {
+        self.label = label
+        self.utilization = utilization
+        self.resetsAt = resetsAt
+    }
+}
+
+// MARK: - Companion State
+
+public struct PhoneCompanionState: Codable, Sendable, Equatable {
+    public let name: String
+    public let speciesID: Int?
+    public let isShiny: Bool
+    public let isEgg: Bool
+    public let progress: Double
+    public let stageText: String
+    public let rarity: String?
+    public let dexCount: Int
+    public let eggProgress: Double
+    public let displayState: String
+    public let evolutionTokens: Int?
+    public let graduationTokens: Int?
+
+    public init(name: String, speciesID: Int?, isShiny: Bool, isEgg: Bool,
+                progress: Double, stageText: String, rarity: String?,
+                dexCount: Int, eggProgress: Double, displayState: String,
+                evolutionTokens: Int? = nil, graduationTokens: Int? = nil) {
+        self.name = name
+        self.speciesID = speciesID
+        self.isShiny = isShiny
+        self.isEgg = isEgg
+        self.progress = progress
+        self.stageText = stageText
+        self.rarity = rarity
+        self.dexCount = dexCount
+        self.eggProgress = eggProgress
+        self.displayState = displayState
+        self.evolutionTokens = evolutionTokens
+        self.graduationTokens = graduationTokens
+    }
+}
+
+// MARK: - Provider Snapshot
+
+public struct PhoneProviderSnapshot: Codable, Sendable, Equatable {
+    public let id: String
+    public let displayName: String
+    public let todayTokens: Int
+    public let todayCost: Double
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let cacheWriteTokens: Int
+    public let cacheReadTokens: Int
+    public let reportsCost: Bool
+
+    public init(id: String, displayName: String, todayTokens: Int, todayCost: Double,
+                inputTokens: Int = 0, outputTokens: Int = 0,
+                cacheWriteTokens: Int = 0, cacheReadTokens: Int = 0,
+                reportsCost: Bool = true) {
+        self.id = id
+        self.displayName = displayName
+        self.todayTokens = todayTokens
+        self.todayCost = todayCost
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cacheWriteTokens = cacheWriteTokens
+        self.cacheReadTokens = cacheReadTokens
+        self.reportsCost = reportsCost
+    }
+}
+
+// MARK: - Burn Forecast
+
+public struct PhoneBurnForecast: Codable, Sendable, Equatable {
+    public let depletionDate: Date?
+    public let beforeReset: Bool
+    public let tokensPerMinute: Double?
+
+    public init(depletionDate: Date?, beforeReset: Bool, tokensPerMinute: Double?) {
+        self.depletionDate = depletionDate
+        self.beforeReset = beforeReset
+        self.tokensPerMinute = tokensPerMinute
+    }
+}

--- a/PokeTokenBarShared/Sources/PokeTokenBarShared/TokenFormatter.swift
+++ b/PokeTokenBarShared/Sources/PokeTokenBarShared/TokenFormatter.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Cross-platform token formatting utilities. No AppKit/SwiftUI dependencies.
+public enum TokenFormatter {
+    /// 987 → "987", 12_345 → "12.3K", 190_612_940 → "190.6M", 1_240_000_000 → "1.24B"
+    public static func compact(_ value: Int) -> String {
+        let v = Double(abs(value))
+        let sign = value < 0 ? "-" : ""
+        switch v {
+        case ..<1_000:
+            return "\(value)"
+        case ..<1_000_000:
+            return sign + trim(v / 1_000, decimals: 1) + "K"
+        case ..<1_000_000_000:
+            return sign + trim(v / 1_000_000, decimals: 1) + "M"
+        default:
+            return sign + trim(v / 1_000_000_000, decimals: 2) + "B"
+        }
+    }
+
+    public static func cost(_ usd: Double) -> String {
+        String(format: "$%.2f", usd)
+    }
+
+    public static func costCompact(_ usd: Double) -> String {
+        if usd < 100 { return String(format: "$%.1f", usd) }
+        if usd < 10_000 { return String(format: "$%.0f", usd) }
+        return String(format: "$%.1fK", usd / 1_000)
+    }
+
+    public static func percent(_ value: Double) -> String {
+        value == value.rounded() ? String(format: "%.0f%%", value) : String(format: "%.1f%%", value)
+    }
+
+    private static func trim(_ value: Double, decimals: Int) -> String {
+        var s = String(format: "%.\(decimals)f", value)
+        while s.hasSuffix("0") { s.removeLast() }
+        if s.hasSuffix(".") { s.removeLast() }
+        return s
+    }
+}

--- a/PokeTokenBarShared/Tests/PokeTokenBarSharedTests/PokeTokenBarSharedTests.swift
+++ b/PokeTokenBarShared/Tests/PokeTokenBarSharedTests/PokeTokenBarSharedTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import PokeTokenBarShared
+
+struct PhonePayloadTests {
+    @Test func compactTokenFormatting() {
+        #expect(TokenFormatter.compact(0) == "0")
+        #expect(TokenFormatter.compact(999) == "999")
+        #expect(TokenFormatter.compact(1_000) == "1K")
+        #expect(TokenFormatter.compact(12_345) == "12.3K")
+        #expect(TokenFormatter.compact(190_612_940) == "190.6M")
+        #expect(TokenFormatter.compact(1_240_000_000) == "1.24B")
+    }
+
+    @Test func costFormatting() {
+        #expect(TokenFormatter.cost(9.50) == "$9.50")
+        #expect(TokenFormatter.costCompact(9.5) == "$9.5")
+        #expect(TokenFormatter.costCompact(311) == "$311")
+        #expect(TokenFormatter.costCompact(12_400) == "$12.4K")
+    }
+
+    @Test func percentFormatting() {
+        #expect(TokenFormatter.percent(84.0) == "84%")
+        #expect(TokenFormatter.percent(84.5) == "84.5%")
+    }
+
+    @Test func payloadCodableRoundTrip() throws {
+        let payload = PhonePayload(
+            todayTokens: 1_500_000,
+            todayCost: 12.34,
+            weekTokens: 10_000_000,
+            monthTokens: 40_000_000,
+            lastUpdated: Date(timeIntervalSince1970: 1700000000),
+            serverVersion: "1.0",
+            limits: PhoneLimitStatus(
+                claude5h: PhoneLimitWindow(label: "5h", utilization: 65.0, resetsAt: nil),
+                claudeWeekly: nil,
+                codexPrimary: nil),
+            companion: PhoneCompanionState(
+                name: "Pikachu", speciesID: 25, isShiny: false, isEgg: false,
+                progress: 0.42, stageText: "Stage 1/3", rarity: "common",
+                dexCount: 12, eggProgress: 0, displayState: "working"),
+            providers: [
+                PhoneProviderSnapshot(id: "claude_code", displayName: "Claude", todayTokens: 1_000_000, todayCost: 10.0),
+            ])
+
+        let data = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(PhonePayload.self, from: data)
+        #expect(decoded.todayTokens == 1_500_000)
+        #expect(decoded.companion?.name == "Pikachu")
+        #expect(decoded.providers.count == 1)
+    }
+}

--- a/PokeTokenBarWidget/PokeTokenBarWidget.entitlements
+++ b/PokeTokenBarWidget/PokeTokenBarWidget.entitlements
@@ -7,18 +7,5 @@
 		<string>group.io.github.chattymin.poketokenbar</string>
 		<string>group.com.poketokenbar.ios.widget</string>
 	</array>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array>
-		<string>iCloud.io.github.chattymin.poketokenbar</string>
-	</array>
-	<key>com.apple.developer.icloud-services</key>
-	<array>
-		<string>CloudDocuments</string>
-		<string>CloudKit</string>
-	</array>
-	<key>com.apple.developer.ubiquity-container-identifiers</key>
-	<array>
-		<string>iCloud.io.github.chattymin.poketokenbar</string>
-	</array>
 </dict>
 </plist>

--- a/PokeTokenBarWidget/PokeTokenBarWidget.entitlements
+++ b/PokeTokenBarWidget/PokeTokenBarWidget.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.io.github.chattymin.poketokenbar</string>
+		<string>group.com.poketokenbar.ios.widget</string>
+	</array>
+</dict>
+</plist>

--- a/PokeTokenBarWidget/PokeTokenBarWidget.entitlements
+++ b/PokeTokenBarWidget/PokeTokenBarWidget.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.io.github.chattymin.poketokenbar</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.io.github.chattymin.poketokenbar</string>

--- a/PokeTokenBarWidget/Resources/Assets.xcassets/Contents.json
+++ b/PokeTokenBarWidget/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PokeTokenBarWidget/Resources/Info.plist
+++ b/PokeTokenBarWidget/Resources/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>PokeTokenBar</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+</dict>
+</plist>

--- a/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
+++ b/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
@@ -29,16 +29,29 @@ struct WidgetTimelineProvider: TimelineProvider {
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let entry = WidgetEntry(date: Date(), payload: loadPayload())
-        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
-        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
-        completion(timeline)
+        Task {
+            var payload = loadPayload()
+            if let ck = try? await CloudKitSync.fetch() {
+                payload = ck
+                saveToAppGroup(ck)
+            }
+            let entry = WidgetEntry(date: Date(), payload: payload)
+            let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
+            completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+        }
     }
 
     private func loadPayload() -> PhonePayload? {
         guard let data = UserDefaults(suiteName: "group.io.github.chattymin.poketokenbar")?
             .data(forKey: "latestPayload") else { return nil }
         return try? JSONDecoder().decode(PhonePayload.self, from: data)
+    }
+
+    private func saveToAppGroup(_ payload: PhonePayload) {
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        let suite = UserDefaults(suiteName: "group.io.github.chattymin.poketokenbar")
+        suite?.set(data, forKey: "latestPayload")
+        suite?.set(Date(), forKey: "lastFetchTime")
     }
 }
 

--- a/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
+++ b/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
@@ -47,10 +47,6 @@ struct WidgetTimelineProvider: TimelineProvider {
         return try? JSONDecoder().decode(PhonePayload.self, from: data)
     }
 
-    private func saveToAppGroup(_ payload: PhonePayload) {
-        Self.persistPayload(payload)
-    }
-
     static func persistPayload(_ payload: PhonePayload) {
         guard let data = try? JSONEncoder().encode(payload) else { return }
         let suite = UserDefaults(suiteName: "group.io.github.chattymin.poketokenbar")

--- a/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
+++ b/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
@@ -29,15 +29,15 @@ struct WidgetTimelineProvider: TimelineProvider {
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        Task {
-            var payload = loadPayload()
-            if let ck = try? await CloudKitSync.fetch() {
-                payload = ck
-                saveToAppGroup(ck)
-            }
-            let entry = WidgetEntry(date: Date(), payload: payload)
-            let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
-            completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+        let entry = WidgetEntry(date: Date(), payload: loadPayload())
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+
+        Task.detached(priority: .utility) {
+            guard let ck = try? await CloudKitSync.fetch() else { return }
+            WidgetTimelineProvider.persistPayload(ck)
+            WidgetCenter.shared.reloadAllTimelines()
         }
     }
 
@@ -48,6 +48,10 @@ struct WidgetTimelineProvider: TimelineProvider {
     }
 
     private func saveToAppGroup(_ payload: PhonePayload) {
+        Self.persistPayload(payload)
+    }
+
+    static func persistPayload(_ payload: PhonePayload) {
         guard let data = try? JSONEncoder().encode(payload) else { return }
         let suite = UserDefaults(suiteName: "group.io.github.chattymin.poketokenbar")
         suite?.set(data, forKey: "latestPayload")

--- a/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
+++ b/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
@@ -1,0 +1,341 @@
+import WidgetKit
+import SwiftUI
+import PokeTokenBarShared
+
+@main
+struct PokeTokenBarWidget: Widget {
+    let kind: String = "PokeTokenBarWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: WidgetTimelineProvider()) { entry in
+            PokeTokenBarWidgetEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("PokeTokenBar")
+        .description("Your AI token usage at a glance.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+// MARK: - Timeline Provider
+
+struct WidgetTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> WidgetEntry {
+        WidgetEntry(date: Date(), payload: nil)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (WidgetEntry) -> Void) {
+        completion(WidgetEntry(date: Date(), payload: loadPayload()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WidgetEntry>) -> Void) {
+        let entry = WidgetEntry(date: Date(), payload: loadPayload())
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+
+    private func loadPayload() -> PhonePayload? {
+        guard let data = UserDefaults(suiteName: "group.io.github.chattymin.poketokenbar")?
+            .data(forKey: "latestPayload") else { return nil }
+        return try? JSONDecoder().decode(PhonePayload.self, from: data)
+    }
+}
+
+// MARK: - Timeline Entry
+
+struct WidgetEntry: TimelineEntry {
+    let date: Date
+    let payload: PhonePayload?
+}
+
+// MARK: - Widget Views
+
+struct PokeTokenBarWidgetEntryView: View {
+    let entry: WidgetEntry
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            smallView
+        case .systemMedium:
+            mediumView
+        case .systemLarge:
+            largeView
+        default:
+            smallView
+        }
+    }
+
+    // MARK: - Small Widget
+
+    private var smallView: some View {
+        VStack(spacing: 4) {
+            if let payload = entry.payload, let companion = payload.companion {
+                spriteImage(companion: companion)
+                    .frame(width: 48, height: 48)
+
+                Text(companion.name)
+                    .font(.caption.bold())
+                    .lineLimit(1)
+
+                if companion.isShiny {
+                    Text("★ Shiny")
+                        .font(.caption2)
+                        .foregroundStyle(.yellow)
+                }
+
+                Divider()
+
+                statLine(label: "Today", value: TokenFormatter.compact(payload.todayTokens))
+
+                if let limits = payload.limits, let w = limits.claude5h {
+                    Divider()
+                    HStack {
+                        Text("5h")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(TokenFormatter.percent(w.utilization))
+                            .font(.caption2.monospacedDigit().bold())
+                            .foregroundStyle(w.utilization >= 95 ? .red :
+                                                w.utilization >= 80 ? .orange : .primary)
+                    }
+                }
+            } else {
+                Image(systemName: "gamecontroller")
+                    .font(.title2)
+                Text("PokeTokenBar")
+                    .font(.caption)
+                Text("Open app to sync")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Medium Widget
+
+    private var mediumView: some View {
+        HStack(spacing: 10) {
+            VStack(spacing: 4) {
+                if let payload = entry.payload, let companion = payload.companion {
+                    spriteImage(companion: companion)
+                        .frame(width: 52, height: 52)
+
+                    Text(companion.name)
+                        .font(.caption.bold())
+                        .lineLimit(1)
+
+                    if companion.isShiny {
+                        Text("★")
+                            .font(.caption2)
+                            .foregroundStyle(.yellow)
+                    }
+                } else {
+                    Image(systemName: "gamecontroller")
+                        .font(.title)
+                    Text("No Data")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(minWidth: 80)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 5) {
+                if let payload = entry.payload {
+                    statLine(label: "Today", value: TokenFormatter.compact(payload.todayTokens))
+                    statLine(label: "Cost", value: TokenFormatter.costCompact(payload.todayCost))
+                    statLine(label: "Week", value: TokenFormatter.compact(payload.weekTokens))
+
+                    if let limits = payload.limits {
+                        Divider()
+                        if let w = limits.claude5h {
+                            limitLine(label: "Claude 5h", utilization: w.utilization)
+                        }
+                        if let w = limits.claudeWeekly {
+                            limitLine(label: "Weekly", utilization: w.utilization)
+                        }
+                        if let w = limits.codexPrimary {
+                            limitLine(label: "Codex", utilization: w.utilization)
+                        }
+                    }
+                } else {
+                    Text("Open app to fetch")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Large Widget
+
+    private var largeView: some View {
+        VStack(spacing: 8) {
+            if let payload = entry.payload, let companion = payload.companion {
+                HStack(spacing: 12) {
+                    spriteImage(companion: companion)
+                        .frame(width: 64, height: 64)
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack {
+                            Text(companion.name).font(.headline)
+                            if companion.isShiny {
+                                Image(systemName: "star.fill")
+                                    .font(.caption2)
+                                    .foregroundStyle(.yellow)
+                            }
+                        }
+                        Text(companion.stageText)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        ProgressView(value: companion.progress)
+                            .tint(.blue)
+                            .frame(height: 4)
+                    }
+                }
+
+                Divider()
+
+                VStack(spacing: 4) {
+                    statLine(label: "Today", value: TokenFormatter.compact(payload.todayTokens))
+                    statLine(label: "Cost", value: TokenFormatter.costCompact(payload.todayCost))
+                    statLine(label: "Week", value: TokenFormatter.compact(payload.weekTokens))
+                    statLine(label: "Month", value: TokenFormatter.compact(payload.monthTokens))
+                }
+
+                if let limits = payload.limits {
+                    Divider()
+                    VStack(spacing: 4) {
+                        if let w = limits.claude5h {
+                            limitLine(label: "Claude 5h", utilization: w.utilization)
+                        }
+                        if let w = limits.claudeWeekly {
+                            limitLine(label: "Weekly", utilization: w.utilization)
+                        }
+                        if let w = limits.codexPrimary {
+                            limitLine(label: "Codex", utilization: w.utilization)
+                        }
+                    }
+                }
+
+                if !payload.providers.isEmpty {
+                    Divider()
+                    ForEach(payload.providers, id: \.id) { p in
+                        statLine(label: p.displayName, value: TokenFormatter.compact(p.todayTokens))
+                    }
+                }
+            } else {
+                Image(systemName: "gamecontroller")
+                    .font(.largeTitle)
+                Text("PokeTokenBar")
+                    .font(.headline)
+                Text("Open app to sync data")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func spriteImage(companion: PhoneCompanionState) -> some View {
+        if companion.isEgg {
+            Text("🥚").font(.system(size: 40))
+        } else if let id = companion.speciesID {
+            if let img = loadSprite(id: id, shiny: companion.isShiny) {
+                Image(uiImage: img)
+                    .resizable()
+                    .interpolation(.none)
+            } else {
+                AsyncImage(url: URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(companion.isShiny ? "shiny/" : "")\(id).png")) { image in
+                    image.resizable().interpolation(.none)
+                } placeholder: {
+                    ProgressView()
+                }
+            }
+        } else {
+            Image(systemName: "questionmark")
+        }
+    }
+
+    private func loadSprite(id: Int, shiny: Bool) -> UIImage? {
+        guard let groupDir = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: "group.io.github.chattymin.poketokenbar")?
+            .appendingPathComponent("WidgetSprites", isDirectory: true) else { return nil }
+        let file = groupDir.appendingPathComponent("\(id)_\(shiny).png")
+        guard let data = try? Data(contentsOf: file) else { return nil }
+        return UIImage(data: data)
+    }
+
+    @ViewBuilder
+    private func statLine(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.caption.monospacedDigit().bold())
+        }
+    }
+
+    @ViewBuilder
+    private func limitLine(label: String, utilization: Double) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(TokenFormatter.percent(utilization))
+                .font(.caption2.monospacedDigit().bold())
+                .foregroundStyle(utilization >= 95 ? .red :
+                                    utilization >= 80 ? .orange : .primary)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview(as: .systemSmall) {
+    PokeTokenBarWidget()
+} timeline: {
+    WidgetEntry(date: Date(), payload: PhonePayload(
+        todayTokens: 1_500_000, todayCost: 12.34, weekTokens: 10_000_000,
+        monthTokens: 40_000_000, lastUpdated: Date(), serverVersion: "1.0",
+        limits: PhoneLimitStatus(claude5h: PhoneLimitWindow(label: "5h", utilization: 65, resetsAt: nil),
+                                  claudeWeekly: nil, claudeOpusWeekly: nil, claudeSonnetWeekly: nil,
+                                  codexPrimary: nil, codexSecondary: nil, planDisplay: "Max 20x"),
+        companion: PhoneCompanionState(name: "Pikachu", speciesID: 25, isShiny: false, isEgg: false,
+                                        progress: 0.42, stageText: "Stage 1/3", rarity: "common",
+                                        dexCount: 12, eggProgress: 0, displayState: "working"),
+        providers: [PhoneProviderSnapshot(id: "claude_code", displayName: "Claude",
+                                          todayTokens: 1_000_000, todayCost: 10.0)]))
+}
+
+#Preview(as: .systemMedium) {
+    PokeTokenBarWidget()
+} timeline: {
+    WidgetEntry(date: Date(), payload: PhonePayload(
+        todayTokens: 1_500_000, todayCost: 12.34, weekTokens: 10_000_000,
+        monthTokens: 40_000_000, lastUpdated: Date(), serverVersion: "1.0",
+        limits: PhoneLimitStatus(claude5h: PhoneLimitWindow(label: "5h", utilization: 65, resetsAt: nil),
+                                  claudeWeekly: PhoneLimitWindow(label: "Weekly", utilization: 32, resetsAt: nil),
+                                  claudeOpusWeekly: nil, claudeSonnetWeekly: nil,
+                                  codexPrimary: nil, codexSecondary: nil, planDisplay: "Max 20x"),
+        companion: PhoneCompanionState(name: "Pikachu", speciesID: 25, isShiny: true, isEgg: false,
+                                        progress: 0.42, stageText: "Stage 1/3", rarity: "rare",
+                                        dexCount: 12, eggProgress: 0, displayState: "working"),
+        providers: [
+            PhoneProviderSnapshot(id: "claude_code", displayName: "Claude", todayTokens: 1_000_000, todayCost: 10.0),
+            PhoneProviderSnapshot(id: "codex", displayName: "Codex", todayTokens: 500_000, todayCost: 2.34),
+        ]))
+}

--- a/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
+++ b/PokeTokenBarWidget/Sources/PokeTokenBarWidget.swift
@@ -225,15 +225,17 @@ struct PokeTokenBarWidgetEntryView: View {
 
                 if let limits = payload.limits {
                     Divider()
-                    VStack(spacing: 4) {
+                    VStack(spacing: 6) {
                         if let w = limits.claude5h {
-                            limitLine(label: "Claude 5h", utilization: w.utilization)
+                            limitBar(label: "Claude 5h", utilization: w.utilization)
                         }
                         if let w = limits.claudeWeekly {
-                            limitLine(label: "Weekly", utilization: w.utilization)
+                            limitBar(label: "Weekly", utilization: w.utilization)
                         }
-                        if let w = limits.codexPrimary {
-                            limitLine(label: "Codex", utilization: w.utilization)
+                        if let w = limits.claudeOpusWeekly {
+                            limitBar(label: "Weekly Fable", utilization: w.utilization)
+                        } else if let w = limits.claudeSonnetWeekly {
+                            limitBar(label: "Weekly Fable", utilization: w.utilization)
                         }
                     }
                 }
@@ -314,6 +316,38 @@ struct PokeTokenBarWidgetEntryView: View {
                                     utilization >= 80 ? .orange : .primary)
         }
     }
+
+    @ViewBuilder
+    private func limitBar(label: String, utilization: Double) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack {
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(TokenFormatter.percent(utilization))
+                    .font(.caption2.monospacedDigit().bold())
+                    .foregroundStyle(limitBarColor(utilization))
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(.quaternary)
+                        .frame(height: 6)
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(limitBarColor(utilization))
+                        .frame(width: geo.size.width * min(1, utilization / 100), height: 6)
+                }
+            }
+            .frame(height: 6)
+        }
+    }
+
+    private func limitBarColor(_ utilization: Double) -> Color {
+        if utilization >= 95 { return .red }
+        if utilization >= 80 { return .orange }
+        return .blue
+    }
 }
 
 // MARK: - Preview
@@ -343,6 +377,26 @@ struct PokeTokenBarWidgetEntryView: View {
         limits: PhoneLimitStatus(claude5h: PhoneLimitWindow(label: "5h", utilization: 65, resetsAt: nil),
                                   claudeWeekly: PhoneLimitWindow(label: "Weekly", utilization: 32, resetsAt: nil),
                                   claudeOpusWeekly: nil, claudeSonnetWeekly: nil,
+                                  codexPrimary: nil, codexSecondary: nil, planDisplay: "Max 20x"),
+        companion: PhoneCompanionState(name: "Pikachu", speciesID: 25, isShiny: true, isEgg: false,
+                                        progress: 0.42, stageText: "Stage 1/3", rarity: "rare",
+                                        dexCount: 12, eggProgress: 0, displayState: "working"),
+        providers: [
+            PhoneProviderSnapshot(id: "claude_code", displayName: "Claude", todayTokens: 1_000_000, todayCost: 10.0),
+            PhoneProviderSnapshot(id: "codex", displayName: "Codex", todayTokens: 500_000, todayCost: 2.34),
+        ]))
+}
+
+#Preview(as: .systemLarge) {
+    PokeTokenBarWidget()
+} timeline: {
+    WidgetEntry(date: Date(), payload: PhonePayload(
+        todayTokens: 1_500_000, todayCost: 12.34, weekTokens: 10_000_000,
+        monthTokens: 40_000_000, lastUpdated: Date(), serverVersion: "1.0",
+        limits: PhoneLimitStatus(claude5h: PhoneLimitWindow(label: "5h", utilization: 82, resetsAt: nil),
+                                  claudeWeekly: PhoneLimitWindow(label: "Weekly", utilization: 45, resetsAt: nil),
+                                  claudeOpusWeekly: PhoneLimitWindow(label: "Weekly Fable", utilization: 97, resetsAt: nil),
+                                  claudeSonnetWeekly: nil,
                                   codexPrimary: nil, codexSecondary: nil, planDisplay: "Max 20x"),
         companion: PhoneCompanionState(name: "Pikachu", speciesID: 25, isShiny: true, isEgg: false,
                                         progress: 0.42, stageText: "Stage 1/3", rarity: "rare",

--- a/PokeTokenBariOS/PokeTokenBariOS.entitlements
+++ b/PokeTokenBariOS/PokeTokenBariOS.entitlements
@@ -7,18 +7,5 @@
 		<string>group.io.github.chattymin.poketokenbar</string>
 		<string>group.com.poketokenbar.ios.widget</string>
 	</array>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array>
-		<string>iCloud.io.github.chattymin.poketokenbar</string>
-	</array>
-	<key>com.apple.developer.icloud-services</key>
-	<array>
-		<string>CloudDocuments</string>
-		<string>CloudKit</string>
-	</array>
-	<key>com.apple.developer.ubiquity-container-identifiers</key>
-	<array>
-		<string>iCloud.io.github.chattymin.poketokenbar</string>
-	</array>
 </dict>
 </plist>

--- a/PokeTokenBariOS/PokeTokenBariOS.entitlements
+++ b/PokeTokenBariOS/PokeTokenBariOS.entitlements
@@ -7,5 +7,18 @@
 		<string>group.io.github.chattymin.poketokenbar</string>
 		<string>group.com.poketokenbar.ios.widget</string>
 	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.io.github.chattymin.poketokenbar</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.io.github.chattymin.poketokenbar</string>
+	</array>
 </dict>
 </plist>

--- a/PokeTokenBariOS/PokeTokenBariOS.entitlements
+++ b/PokeTokenBariOS/PokeTokenBariOS.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.io.github.chattymin.poketokenbar</string>
+		<string>group.com.poketokenbar.ios.widget</string>
+	</array>
+</dict>
+</plist>

--- a/PokeTokenBariOS/PokeTokenBariOS.entitlements
+++ b/PokeTokenBariOS/PokeTokenBariOS.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.io.github.chattymin.poketokenbar</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.io.github.chattymin.poketokenbar</string>

--- a/PokeTokenBariOS/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/PokeTokenBariOS/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PokeTokenBariOS/Resources/Assets.xcassets/Contents.json
+++ b/PokeTokenBariOS/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PokeTokenBariOS/Resources/Info.plist
+++ b/PokeTokenBariOS/Resources/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>PokeTokenBar</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+</dict>
+</plist>

--- a/PokeTokenBariOS/Sources/DashboardView.swift
+++ b/PokeTokenBariOS/Sources/DashboardView.swift
@@ -7,7 +7,7 @@ struct DashboardView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if store.host.isEmpty {
+                if store.host.isEmpty && store.payload == nil {
                     SetupView()
                 } else if let payload = store.payload {
                     dashboardContent(payload)
@@ -424,5 +424,6 @@ struct SetupView: View {
                 .padding(.horizontal, 32)
         }
         .navigationTitle("Setup")
+        .task { await store.fetch() }
     }
 }

--- a/PokeTokenBariOS/Sources/DashboardView.swift
+++ b/PokeTokenBariOS/Sources/DashboardView.swift
@@ -1,0 +1,428 @@
+import SwiftUI
+import PokeTokenBarShared
+
+struct DashboardView: View {
+    @Environment(PhonePayloadStore.self) private var store
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if store.host.isEmpty {
+                    SetupView()
+                } else if let payload = store.payload {
+                    dashboardContent(payload)
+                } else if store.isLoading {
+                    ProgressView("Connecting to Mac...")
+                } else if let error = store.lastError {
+                    errorView(error)
+                } else {
+                    ProgressView("Connecting to Mac...")
+                        .task { await store.fetch() }
+                }
+            }
+            .navigationTitle("PokeTokenBar")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink(destination: SettingsView().environment(store)) {
+                        Image(systemName: "gear")
+                    }
+                }
+            }
+            .refreshable { await store.fetch() }
+        }
+    }
+
+    @ViewBuilder
+    private func dashboardContent(_ payload: PhonePayload) -> some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                ConnectionIndicator(connected: store.isConnected)
+
+                if let companion = payload.companion {
+                    CompanionCard(companion: companion)
+                }
+
+                UsageCard(payload: payload)
+
+                if let limits = payload.limits {
+                    LimitsCard(limits: limits)
+                }
+
+                if !payload.providers.isEmpty {
+                    ForEach(payload.providers, id: \.id) { provider in
+                        ProviderDetailCard(provider: provider)
+                    }
+                }
+
+                Text("Updated \(payload.lastUpdated, style: .relative) ago")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+        }
+    }
+
+    @ViewBuilder
+    private func errorView(_ error: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "wifi.slash")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Cannot connect to Mac")
+                .font(.headline)
+            Text(error)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Retry") { Task { await store.fetch() } }
+                .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+
+// MARK: - Connection
+
+struct ConnectionIndicator: View {
+    let connected: Bool
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(connected ? Color.green : Color.red)
+                .frame(width: 8, height: 8)
+            Text(connected ? "Connected" : "Disconnected")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Companion Card
+
+struct CompanionCard: View {
+    let companion: PhoneCompanionState
+
+    var body: some View {
+        VStack(spacing: 12) {
+            if companion.isEgg {
+                Text("🥚")
+                    .font(.system(size: 64))
+                Text("Token Egg")
+                    .font(.title2.bold())
+                ProgressView(value: companion.eggProgress)
+                    .tint(.purple)
+                Text("\(Int(companion.eggProgress * 100))% hatched")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                AsyncImage(url: spriteURL) { image in
+                    image.resizable().interpolation(.none)
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: 96, height: 96)
+
+                HStack {
+                    Text(companion.name)
+                        .font(.title2.bold())
+                    if companion.isShiny {
+                        Image(systemName: "star.fill")
+                            .foregroundStyle(.yellow)
+                    }
+                }
+
+                if let rarity = companion.rarity {
+                    Text(rarity.uppercased())
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(rarityColor.opacity(0.2))
+                        .foregroundStyle(rarityColor)
+                        .clipShape(Capsule())
+                }
+
+                Text(companion.stageText)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                ProgressView(value: companion.progress)
+                    .tint(companion.isShiny ? .yellow : .blue)
+
+                if let evo = companion.evolutionTokens, evo > 0 {
+                    Text("\(TokenFormatter.compact(evo)) to next evolution")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var spriteURL: URL? {
+        guard let id = companion.speciesID else { return nil }
+        let base = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon"
+        let file = companion.isShiny ? "shiny/\(id).png" : "\(id).png"
+        return URL(string: "\(base)/\(file)")
+    }
+
+    private var rarityColor: Color {
+        switch companion.rarity {
+        case "common": return .gray
+        case "uncommon": return .green
+        case "rare": return .blue
+        case "legendary": return .purple
+        default: return .gray
+        }
+    }
+}
+
+// MARK: - Usage Card
+
+struct UsageCard: View {
+    let payload: PhonePayload
+
+    var body: some View {
+        VStack(spacing: 0) {
+            statRow(icon: "calendar", title: "Today",
+                    value: TokenFormatter.compact(payload.todayTokens))
+            Divider().padding(.horizontal)
+            statRow(icon: "dollarsign.circle", title: "Cost",
+                    value: TokenFormatter.costCompact(payload.todayCost))
+            Divider().padding(.horizontal)
+            statRow(icon: "calendar.badge.clock", title: "This Week",
+                    value: TokenFormatter.compact(payload.weekTokens))
+            Divider().padding(.horizontal)
+            statRow(icon: "calendar.badge.plus", title: "This Month",
+                    value: TokenFormatter.compact(payload.monthTokens))
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    @ViewBuilder
+    private func statRow(icon: String, title: String, value: String) -> some View {
+        HStack {
+            Label(title, systemImage: icon)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.body.monospacedDigit().bold())
+        }
+        .padding(.vertical, 10)
+    }
+}
+
+// MARK: - Limits Card
+
+struct LimitsCard: View {
+    let limits: PhoneLimitStatus
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Rate Limits")
+                    .font(.headline)
+                Spacer()
+                if let plan = limits.planDisplay {
+                    Text(plan)
+                        .font(.caption.weight(.semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.blue.opacity(0.15))
+                        .foregroundStyle(.blue)
+                        .clipShape(Capsule())
+                }
+            }
+
+            if let w = limits.claude5h {
+                LimitRow(window: w)
+            }
+            if let w = limits.claudeWeekly {
+                LimitRow(window: w)
+            }
+            if let w = limits.claudeOpusWeekly {
+                LimitRow(window: w)
+            }
+            if let w = limits.claudeSonnetWeekly {
+                LimitRow(window: w)
+            }
+            if let w = limits.codexPrimary {
+                LimitRow(window: w)
+            }
+            if let w = limits.codexSecondary {
+                LimitRow(window: w)
+            }
+
+            if limits.claude5h == nil && limits.claudeWeekly == nil && limits.claudeOpusWeekly == nil
+                && limits.claudeSonnetWeekly == nil && limits.codexPrimary == nil && limits.codexSecondary == nil {
+                Text("No rate limits active")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+struct LimitRow: View {
+    let window: PhoneLimitWindow
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(window.label)
+                    .font(.subheadline)
+                Spacer()
+                if let resetsAt = window.resetsAt {
+                    Text("resets \(resetsAt, style: .relative)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Text(TokenFormatter.percent(window.utilization))
+                    .font(.subheadline.monospacedDigit().bold())
+                    .foregroundStyle(utilizationColor)
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(.quaternary)
+                        .frame(height: 8)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(utilizationColor)
+                        .frame(width: geo.size.width * min(1, window.utilization / 100), height: 8)
+                        .animation(.easeInOut(duration: 0.3), value: window.utilization)
+                }
+            }
+            .frame(height: 8)
+        }
+    }
+
+    private var utilizationColor: Color {
+        if window.utilization >= 95 { return .red }
+        if window.utilization >= 80 { return .orange }
+        return .blue
+    }
+}
+
+// MARK: - Provider Detail Card (token breakdown)
+
+struct ProviderDetailCard: View {
+    let provider: PhoneProviderSnapshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(provider.displayName)
+                    .font(.headline)
+                Spacer()
+                Text(TokenFormatter.compact(provider.todayTokens))
+                    .font(.subheadline.monospacedDigit().bold())
+                if provider.reportsCost && provider.todayCost > 0 {
+                    Text(TokenFormatter.cost(provider.todayCost))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if provider.inputTokens > 0 || provider.outputTokens > 0 {
+                VStack(spacing: 4) {
+                    tokenBar(label: "Input", value: provider.inputTokens, color: .blue)
+                    tokenBar(label: "Output", value: provider.outputTokens, color: .green)
+                    if provider.cacheWriteTokens > 0 {
+                        tokenBar(label: "Cache Write", value: provider.cacheWriteTokens, color: .orange)
+                    }
+                    if provider.cacheReadTokens > 0 {
+                        tokenBar(label: "Cache Read", value: provider.cacheReadTokens, color: .purple)
+                    }
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    @ViewBuilder
+    private func tokenBar(label: String, value: Int, color: Color) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .frame(width: 70, alignment: .leading)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(color.opacity(0.15))
+                        .frame(height: 6)
+                    if provider.todayTokens > 0 {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(color)
+                            .frame(width: geo.size.width * min(1, Double(value) / Double(max(provider.todayTokens, 1))), height: 6)
+                    }
+                }
+            }
+            .frame(height: 6)
+            Text(TokenFormatter.compact(value))
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .frame(width: 50, alignment: .trailing)
+        }
+    }
+}
+
+// MARK: - Setup View
+
+struct SetupView: View {
+    @Environment(PhonePayloadStore.self) private var store
+    @State private var hostInput = ""
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "desktopcomputer")
+                .font(.system(size: 64))
+                .foregroundStyle(.secondary)
+
+            Text("Connect to Mac")
+                .font(.title.bold())
+
+            Text("Enter your Mac's local IP address. Both devices must be on the same Wi-Fi network.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            TextField("Mac IP Address (e.g. 192.168.1.42)", text: $hostInput)
+                .textFieldStyle(.roundedBorder)
+                .autocapitalization(.none)
+                .autocorrectionDisabled()
+                .keyboardType(.numbersAndPunctuation)
+                .padding(.horizontal, 32)
+
+            Button("Connect") {
+                hostInput = hostInput.trimmingCharacters(in: .whitespaces)
+                store.host = hostInput
+                Task { await store.fetch() }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(hostInput.trimmingCharacters(in: .whitespaces).isEmpty)
+
+            Text("Find your Mac's IP in System Settings → Network, or enable the iPhone companion server in PokeTokenBar settings.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .navigationTitle("Setup")
+    }
+}

--- a/PokeTokenBariOS/Sources/DashboardView.swift
+++ b/PokeTokenBariOS/Sources/DashboardView.swift
@@ -396,7 +396,7 @@ struct SetupView: View {
             Text("Connect to Mac")
                 .font(.title.bold())
 
-            Text("Enter your Mac's local IP address. Both devices must be on the same Wi-Fi network.")
+            Text("Data syncs automatically via iCloud when both devices share the same Apple ID.\n\nFor local network sync, enter your Mac's IP address below.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/PokeTokenBariOS/Sources/PhonePayloadClient.swift
+++ b/PokeTokenBariOS/Sources/PhonePayloadClient.swift
@@ -1,0 +1,44 @@
+import Foundation
+import PokeTokenBarShared
+
+/// HTTP client that fetches the phone payload from the Mac server.
+struct PhonePayloadClient: Sendable {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetch(host: String, port: UInt16 = 7845) async throws -> PhonePayload {
+        let url = URL(string: "http://\(host):\(port)/stats")!
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 5
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw PhonePayloadError.httpError(code)
+        }
+        return try JSONDecoder().decode(PhonePayload.self, from: data)
+    }
+
+    func checkHealth(host: String, port: UInt16 = 7845) async throws -> Bool {
+        let url = URL(string: "http://\(host):\(port)/health")!
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 3
+        let (_, response) = try await session.data(for: request)
+        return (response as? HTTPURLResponse)?.statusCode == 200
+    }
+}
+
+enum PhonePayloadError: LocalizedError {
+    case httpError(Int)
+    case connectionFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .httpError(let code): return "Server returned HTTP \(code)"
+        case .connectionFailed: return "Cannot connect to Mac"
+        }
+    }
+}

--- a/PokeTokenBariOS/Sources/PhonePayloadStore.swift
+++ b/PokeTokenBariOS/Sources/PhonePayloadStore.swift
@@ -34,11 +34,29 @@ final class PhonePayloadStore {
     }
 
     func fetch() async {
-        guard !host.isEmpty, !isLoading else { return }
+        guard !isLoading else { return }
         isLoading = true
         lastError = nil
         defer { isLoading = false }
 
+        // iCloud primary
+        if await CloudKitSync.isAvailable() {
+            do {
+                if let newPayload = try await CloudKitSync.fetch() {
+                    payload = newPayload
+                    isConnected = true
+                    saveToSharedContainer(newPayload)
+                    return
+                }
+            } catch { /* fall through to HTTP */ }
+        }
+
+        // Local HTTP fallback
+        guard !host.isEmpty else {
+            lastError = "No data source available"
+            isConnected = false
+            return
+        }
         do {
             let newPayload = try await client.fetch(host: host)
             payload = newPayload

--- a/PokeTokenBariOS/Sources/PhonePayloadStore.swift
+++ b/PokeTokenBariOS/Sources/PhonePayloadStore.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Observation
+import PokeTokenBarShared
+import WidgetKit
+
+/// Observable store that holds the latest phone payload and manages connection settings.
+@MainActor
+@Observable
+final class PhonePayloadStore {
+    private let client = PhonePayloadClient()
+    private let defaults = UserDefaults.standard
+
+    var payload: PhonePayload?
+    var isLoading = false
+    var lastError: String?
+    var isConnected = false
+
+    /// Mac host IP address or hostname.
+    var host: String {
+        didSet { defaults.set(host, forKey: "phoneHost") }
+    }
+
+    /// Auto-refresh interval in seconds (0 = manual only).
+    var refreshInterval: TimeInterval {
+        didSet { defaults.set(refreshInterval, forKey: "phoneRefreshInterval") }
+    }
+
+    private var timer: Timer?
+
+    init() {
+        self.host = defaults.string(forKey: "phoneHost") ?? ""
+        self.refreshInterval = defaults.object(forKey: "phoneRefreshInterval") as? TimeInterval ?? 120
+        reschedule()
+    }
+
+    func fetch() async {
+        guard !host.isEmpty, !isLoading else { return }
+        isLoading = true
+        lastError = nil
+        defer { isLoading = false }
+
+        do {
+            let newPayload = try await client.fetch(host: host)
+            payload = newPayload
+            isConnected = true
+            saveToSharedContainer(newPayload)
+        } catch {
+            lastError = error.localizedDescription
+            isConnected = false
+        }
+    }
+
+    func checkConnection() async {
+        guard !host.isEmpty else {
+            isConnected = false
+            return
+        }
+        isConnected = (try? await client.checkHealth(host: host)) ?? false
+    }
+
+    // MARK: - App Group Sharing (for Widget)
+
+    private func saveToSharedContainer(_ payload: PhonePayload) {
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        let suite = UserDefaults(suiteName: "group.io.github.chattymin.poketokenbar")
+        suite?.set(data, forKey: "latestPayload")
+        suite?.set(Date(), forKey: "lastFetchTime")
+        saveSpriteToSharedContainer(companion: payload.companion)
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    private func saveSpriteToSharedContainer(companion: PhoneCompanionState?) {
+        guard let companion, let id = companion.speciesID else { return }
+        let groupDir = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: "group.io.github.chattymin.poketokenbar")?
+            .appendingPathComponent("WidgetSprites", isDirectory: true)
+        guard let groupDir else { return }
+        try? FileManager.default.createDirectory(at: groupDir, withIntermediateDirectories: true)
+        let file = groupDir.appendingPathComponent("\(id)_\(companion.isShiny).png")
+        guard !FileManager.default.fileExists(atPath: file.path) else { return }
+        let base = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon"
+        let suffix = companion.isShiny ? "shiny/\(id)" : "\(id)"
+        guard let url = URL(string: "\(base)/\(suffix).png"),
+              let imgData = try? Data(contentsOf: url) else { return }
+        try? imgData.write(to: file)
+    }
+
+    // MARK: - Auto-refresh
+
+    private func reschedule() {
+        timer?.invalidate()
+        timer = nil
+        guard refreshInterval > 0 else { return }
+        let t = Timer(timeInterval: refreshInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in await self?.fetch() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+    }
+}

--- a/PokeTokenBariOS/Sources/PokeTokenBarIOSApp.swift
+++ b/PokeTokenBariOS/Sources/PokeTokenBarIOSApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import PokeTokenBarShared
+
+@main
+struct PokeTokenBarIOSApp: App {
+    @State private var store = PhonePayloadStore()
+
+    var body: some Scene {
+        WindowGroup {
+            DashboardView()
+                .environment(store)
+        }
+    }
+}

--- a/PokeTokenBariOS/Sources/SettingsView.swift
+++ b/PokeTokenBariOS/Sources/SettingsView.swift
@@ -6,10 +6,25 @@ struct SettingsView: View {
     @State private var hostInput: String = ""
     @State private var connectionCheckResult: String?
     @State private var isChecking = false
+    @State private var iCloudAvailable = false
 
     var body: some View {
         Form {
-            Section("Mac Connection") {
+            Section("iCloud Sync") {
+                HStack {
+                    Label("iCloud", systemImage: "icloud")
+                    Spacer()
+                    if iCloudAvailable {
+                        Label("Available", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    } else {
+                        Label("Not Available", systemImage: "xmark.circle.fill")
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+
+            Section("Local Network (Optional)") {
                 HStack {
                     Label("Mac IP Address", systemImage: "desktopcomputer")
                     TextField("192.168.1.42", text: $hostInput)
@@ -77,11 +92,12 @@ struct SettingsView: View {
             } header: {
                 Text("Current Data")
             } footer: {
-                Text("Data is fetched from the Mac app running on your local network.")
+                Text("Data syncs via iCloud. Local network is used as fallback when iCloud is unavailable.")
             }
         }
         .navigationTitle("Settings")
         .onAppear { hostInput = store.host }
+        .task { iCloudAvailable = await CloudKitSync.isAvailable() }
     }
 
     private func saveHost() {

--- a/PokeTokenBariOS/Sources/SettingsView.swift
+++ b/PokeTokenBariOS/Sources/SettingsView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import PokeTokenBarShared
+
+struct SettingsView: View {
+    @Environment(PhonePayloadStore.self) private var store
+    @State private var hostInput: String = ""
+    @State private var connectionCheckResult: String?
+    @State private var isChecking = false
+
+    var body: some View {
+        Form {
+            Section("Mac Connection") {
+                HStack {
+                    Label("Mac IP Address", systemImage: "desktopcomputer")
+                    TextField("192.168.1.42", text: $hostInput)
+                        .textFieldStyle(.plain)
+                        .autocapitalization(.none)
+                        .autocorrectionDisabled()
+                        .keyboardType(.numbersAndPunctuation)
+                        .multilineTextAlignment(.trailing)
+                        .onSubmit { saveHost() }
+                }
+
+                if isChecking {
+                    HStack {
+                        ProgressView().controlSize(.small)
+                        Text("Checking connection...")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let result = connectionCheckResult {
+                    HStack {
+                        Image(systemName: store.isConnected ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(store.isConnected ? .green : .red)
+                        Text(result)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Button("Test Connection") {
+                    hostInput = hostInput.trimmingCharacters(in: .whitespaces)
+                    store.host = hostInput
+                    isChecking = true
+                    connectionCheckResult = nil
+                    Task {
+                        await store.checkConnection()
+                        isChecking = false
+                        connectionCheckResult = store.isConnected ? "Connected!" : "Cannot reach Mac"
+                    }
+                }
+                .disabled(hostInput.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+
+            Section("Refresh") {
+                @Bindable var store = store
+                Picker("Auto-refresh", selection: $store.refreshInterval) {
+                    Text("Off (manual only)").tag(TimeInterval(0))
+                    Text("1 minute").tag(TimeInterval(60))
+                    Text("2 minutes").tag(TimeInterval(120))
+                    Text("5 minutes").tag(TimeInterval(300))
+                }
+            }
+
+            Section {
+                Button("Refresh Now") {
+                    Task { await store.fetch() }
+                }
+            }
+
+            Section {
+                if let payload = store.payload {
+                    LabeledContent("Today", value: TokenFormatter.compact(payload.todayTokens))
+                    LabeledContent("Cost", value: TokenFormatter.cost(payload.todayCost))
+                    LabeledContent("Last Update", value: payload.lastUpdated.formatted(.relative(presentation: .named)))
+                }
+            } header: {
+                Text("Current Data")
+            } footer: {
+                Text("Data is fetched from the Mac app running on your local network.")
+            }
+        }
+        .navigationTitle("Settings")
+        .onAppear { hostInput = store.host }
+    }
+
+    private func saveHost() {
+        hostInput = hostInput.trimmingCharacters(in: .whitespaces)
+        store.host = hostInput
+    }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ PokeTokenBar turns the AI coding tokens you're already burning — Claude Code, 
 
 > Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data (`totalTokens` = input + output + cache, local date) — no external CLI needed. Unofficial, non-commercial Pokémon fan project — see [License & disclaimer](#license--disclaimer).
 
+## Fork of [chattymin/PokeTokenBar](https://github.com/chattymin/PokeTokenBar)
+
+This repository is a fork of [PokeTokenBar](https://github.com/chattymin/PokeTokenBar) by [chattymin](https://github.com/chattymin). All credit for the original macOS menu-bar app, the Pokémon companion system, and the underlying usage-tracking design belongs to the original author.
+
+This fork adds an **iOS companion app** and **WidgetKit extension** that connect to the Mac app over the local network. The upstream project may not adopt these additions — see the [original repo](https://github.com/chattymin/PokeTokenBar) for the macOS-only version.
+
 ## Why
 
 - **The usage tracker you actually enjoy opening.** Your spend raises a Pokémon that hatches, evolves, graduates, and fills a Pokédex — and every shiny is a reason to check back.
@@ -102,6 +108,8 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 - **Official limits** — Claude & Codex 5-hour / weekly utilization with reset countdowns, right under today's numbers.
 - **Burn-rate forecast** — projects when the current 5h window hits 100%.
 - **In-app updates** — one-click update check; current version shown in Settings.
+- **iOS companion app** *(this fork)* — connects to the Mac app over your local network and shows token usage, limits, and your companion on your iPhone.
+- **WidgetKit extension** *(this fork)* — home-screen widgets (small/medium/large) with your companion sprite, token usage, cost, and limit utilization — no network required once data is synced.
 
 ## Works with
 

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -154,6 +154,10 @@ final class CompanionStore {
         return min(1, max(0, Double(a.usedAtStage) / Double(threshold)))
     }
     var tokensToNext: Int { guard let a = state.active else { return 0 }; return max(0, threshold - a.usedAtStage) }
+    /// iPhone companion: tokens to next evolution.
+    var tokensToNextEvolution: Int { tokensToNext }
+    /// iPhone companion: tokens to graduation (final form) — estimated remaining.
+    var tokensToGraduation: Int { tokensToNext }
 
     /// 진화 라인 표시용: 실현된 경로 + 다음 단계 미리보기.
     /// 유일하게 이어지는 단계 뒤에 분기가 있으면, 그 확정 접두어와 하나의 미지 항목을 함께 보여 준다.

--- a/Sources/PokeTokenBar/Core/Models.swift
+++ b/Sources/PokeTokenBar/Core/Models.swift
@@ -365,6 +365,11 @@ struct CodexRateLimitStatus: Decodable, Sendable {
     var maxPrimaryUsedPercent: Int? {
         visibleSnapshots.compactMap { $0.primary?.usedPercent }.max()
     }
+
+    /// 전체 bucket 중 최대 secondary 사용률 — iPhone companion 표시용.
+    var maxSecondaryUsedPercent: Int? {
+        visibleSnapshots.compactMap { $0.secondary?.usedPercent }.max()
+    }
 }
 
 // MARK: - Provider snapshot

--- a/Sources/PokeTokenBar/Core/PhonePayloadServer.swift
+++ b/Sources/PokeTokenBar/Core/PhonePayloadServer.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Network
+import PokeTokenBarShared
+
+/// Lightweight HTTP server that serves the phone payload for iPhone companion app.
+/// Uses Network.framework (NWListener) — no external dependencies.
+@MainActor
+final class PhonePayloadServer {
+    private var listener: NWListener?
+    private var payload: Data?
+    private var connections: [NWConnection] = []
+    private var netService: NetService?
+
+    /// Server state for UI binding.
+    private(set) var isRunning = false
+    private(set) var port: UInt16 = 0
+    private(set) var errorMessage: String?
+
+    /// advertised port for UI display.
+    var displayPort: String { isRunning ? "\(port)" : "—" }
+
+    func start(port: UInt16 = 7845) {
+        guard !isRunning else { return }
+        self.port = port
+        do {
+            let params = NWParameters.tcp
+            params.allowLocalEndpointReuse = true
+
+            let listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+            self.listener = listener
+
+            listener.stateUpdateHandler = { [weak self] state in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    switch state {
+                    case .ready:
+                        self.isRunning = true
+                        self.errorMessage = nil
+                        self.startBonjour()
+                        AppLog.write("phone server started port=\(self.port)")
+                    case .failed(let error):
+                        self.isRunning = false
+                        self.errorMessage = "\(error)"
+                        AppLog.write("phone server failed: \(error)")
+                    case .cancelled:
+                        self.isRunning = false
+                        AppLog.write("phone server stopped")
+                    default:
+                        break
+                    }
+                }
+            }
+
+            listener.newConnectionHandler = { [weak self] connection in
+                Task { @MainActor [weak self] in
+                    self?.handleConnection(connection)
+                }
+            }
+
+            listener.start(queue: .main)
+            self.listener = listener
+        } catch {
+            errorMessage = "\(error)"
+            AppLog.write("phone server start failed: \(error)")
+        }
+    }
+
+    func stop() {
+        netService?.stop()
+        netService = nil
+        listener?.cancel()
+        listener = nil
+        for conn in connections { conn.cancel() }
+        connections.removeAll()
+        isRunning = false
+        port = 0
+        payload = nil
+        AppLog.write("phone server stopped")
+    }
+
+    func updatePayload(_ data: Data) {
+        payload = data
+    }
+
+    // MARK: - Bonjour
+
+    private func startBonjour() {
+        let service = NetService(domain: "local.", type: "_poketokenbar._tcp.", name: "PokeTokenBar", port: Int32(port))
+        service.publish()
+        netService = service
+    }
+
+    // MARK: - Connection Handling
+
+    private func handleConnection(_ connection: NWConnection) {
+        connections.append(connection)
+        connection.start(queue: .main)
+        receiveRequest(connection)
+    }
+
+    private func receiveRequest(_ connection: NWConnection) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if let data, !data.isEmpty {
+                    self.handleRequest(data, connection: connection)
+                } else if isComplete || error != nil {
+                    connection.cancel()
+                    self.connections.removeAll { $0 === connection }
+                }
+            }
+        }
+    }
+
+    private func handleRequest(_ data: Data, connection: NWConnection) {
+        guard let request = String(data: data, encoding: .utf8) else {
+            let body = Data("Bad Request".utf8)
+            sendResponse(connection: connection, status: 400, body: body)
+            return
+        }
+
+        let firstLine = request.components(separatedBy: "\r\n").first ?? ""
+        let parts = firstLine.components(separatedBy: " ")
+        guard parts.count >= 2 else {
+            let body = Data("Bad Request".utf8)
+            sendResponse(connection: connection, status: 400, body: body)
+            return
+        }
+
+        let method = parts[0]
+        let path = parts[1]
+
+        switch (method, path) {
+        case ("GET", "/stats"):
+            if let payload {
+                sendResponse(connection: connection, status: 200, body: payload,
+                             contentType: "application/json")
+            } else {
+                let body = Data("{\"error\":\"no data\"}".utf8)
+                sendResponse(connection: connection, status: 503, body: body,
+                             contentType: "application/json")
+            }
+        case ("GET", "/health"):
+            let health = Data("{\"status\":\"ok\",\"port\":\(port)}".utf8)
+            sendResponse(connection: connection, status: 200, body: health,
+                         contentType: "application/json")
+        default:
+            let body = Data("{\"error\":\"not found\"}".utf8)
+            sendResponse(connection: connection, status: 404, body: body,
+                         contentType: "application/json")
+        }
+    }
+
+    private func sendResponse(connection: NWConnection, status: Int, body: Data,
+                              contentType: String = "text/plain") {
+        var header = "HTTP/1.1 \(status) \(statusText(status))\r\n"
+        header += "Content-Type: \(contentType)\r\n"
+        header += "Content-Length: \(body.count)\r\n"
+        header += "Access-Control-Allow-Origin: *\r\n"
+        header += "Connection: close\r\n"
+        header += "\r\n"
+        guard let headerData = header.data(using: .utf8) else { return }
+        var response = headerData
+        response.append(body)
+        connection.send(content: response, completion: .contentProcessed { [weak connection] _ in
+            Task { @MainActor [weak self] in
+                connection?.cancel()
+                self?.connections.removeAll { $0 === connection }
+            }
+        })
+    }
+
+    private func statusText(_ code: Int) -> String {
+        switch code {
+        case 200: return "OK"
+        case 400: return "Bad Request"
+        case 404: return "Not Found"
+        case 503: return "Service Unavailable"
+        default: return "Unknown"
+        }
+    }
+}

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -108,6 +108,11 @@ final class UsageStore {
             }
         }
     }
+    /// iPhone companion HTTP server — 기본 꺼짐. 켜면 port 7845 에 NWListener 를 열어
+    /// PhonePayloadServer 가 /stats 엔드포인트로 JSON 을 서빙한다.
+    var phoneServerEnabled: Bool {
+        didSet { defaults.set(phoneServerEnabled, forKey: "phoneServerEnabled") }
+    }
 
     static let intervalPresets: [(label: String, value: TimeInterval)] = [
         ("수동", 0), ("1분", 60), ("2분", 120), ("5분", 300), ("15분", 900),
@@ -250,6 +255,9 @@ final class UsageStore {
     private var combinedBurnPerMinute: Double {
         snapshots.compactMap { $0.activeBlock?.tokensPerMinute }.reduce(0, +)
     }
+
+    /// iPhone companion burn rate — public accessor for PhonePayloadServer.
+    var combinedBurnPerMinuteForPhone: Double { combinedBurnPerMinute }
 
     // MARK: 한도 소진 예측
 
@@ -425,6 +433,7 @@ final class UsageStore {
         floatingPetSize = d.object(forKey: "floatingPetSize") as? Double ?? 96
         floatingPetBubbleAlerts = d.object(forKey: "floatingPetBubbleAlerts") as? Bool ?? true
         disableKeychainAccess = d.object(forKey: "disableKeychainAccess") as? Bool ?? false
+        phoneServerEnabled = d.object(forKey: "phoneServerEnabled") as? Bool ?? false
 
         reschedule()
 

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import Observation
+import PokeTokenBarShared
 import UserNotifications
 
 /// burn rate 단계 — companion 표시 상태(작업/집중) 판정에 사용.
@@ -111,7 +112,12 @@ final class UsageStore {
     /// iPhone companion HTTP server — 기본 꺼짐. 켜면 port 7845 에 NWListener 를 열어
     /// PhonePayloadServer 가 /stats 엔드포인트로 JSON 을 서빙한다.
     var phoneServerEnabled: Bool {
-        didSet { defaults.set(phoneServerEnabled, forKey: "phoneServerEnabled") }
+        didSet {
+            defaults.set(phoneServerEnabled, forKey: "phoneServerEnabled")
+            if !phoneServerEnabled {
+                Task { try? await CloudKitSync.delete() }
+            }
+        }
     }
 
     static let intervalPresets: [(label: String, value: TimeInterval)] = [

--- a/Sources/PokeTokenBar/PokeTokenBar.entitlements
+++ b/Sources/PokeTokenBar/PokeTokenBar.entitlements
@@ -2,22 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.io.github.chattymin.poketokenbar</string>
-	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.io.github.chattymin.poketokenbar</string>
 	</array>
 	<key>com.apple.developer.icloud-services</key>
 	<array>
-		<string>CloudDocuments</string>
 		<string>CloudKit</string>
 	</array>
-	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>iCloud.io.github.chattymin.poketokenbar</string>
+		<string>group.io.github.chattymin.poketokenbar</string>
 	</array>
 </dict>
 </plist>

--- a/Sources/PokeTokenBar/PokeTokenBar.entitlements
+++ b/Sources/PokeTokenBar/PokeTokenBar.entitlements
@@ -5,7 +5,6 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.io.github.chattymin.poketokenbar</string>
-		<string>group.com.poketokenbar.ios.widget</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -264,6 +264,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         if let data = try? JSONEncoder().encode(payload) {
             phoneServer.updatePayload(data)
         }
+        Task { @MainActor in
+            do { try await CloudKitSync.save(payload) }
+            catch { AppLog.write("CloudKit sync failed: \(error)") }
+        }
     }
 
     // MARK: 메뉴바 애니메이션

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -1,6 +1,7 @@
 import AppKit
 import QuartzCore
 import SwiftUI
+import PokeTokenBarShared
 
 @main
 struct PokeTokenBarApp: App {
@@ -22,6 +23,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var companion: CompanionStore!
     private var updater: UpdateChecker!
     private var floatingPet: FloatingPetController!
+    private var phoneServer: PhonePayloadServer!
     private let navigation = PopoverNavigation()
 
     // 메뉴바 캐릭터 애니메이션 — 단일 타이머로 프레임 순환.
@@ -65,6 +67,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onOpenPopover: { [weak self] in self?.openPopover() },
             onHide: { [weak self] in self?.store.floatingPetEnabled = false }
         )   // 데스크톱 플로팅 펫(옵트인)
+        phoneServer = PhonePayloadServer()
+        if store.phoneServerEnabled {
+            phoneServer.start()
+            Task { await buildAndPublishPayload() }
+        }
         Task { await updater.check() }                    // 기동 시 1회 업데이트 확인
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -84,6 +91,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         observeCompanionSprite()
         observeDisplaySleep()
         applyState()
+        updateAppIcon()
     }
 
     /// Observation 기반 상태 반영 — store 의 menuTitle(=menuLines) 변경 시 재호출.
@@ -112,6 +120,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.ensureMenuAnimation()
                 self.syncMenuAnimation()
+                self.updateAppIcon()
                 self.observeCompanionSprite()
             }
         }
@@ -188,6 +197,73 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private func onStoreRefreshed() {
         updateCompanion()
         companion.grantCandies(from: store.candyEligibleWindows, limitsReady: store.limitsReady)
+        Task { await buildAndPublishPayload() }
+    }
+
+    // MARK: - Phone Payload Server
+
+    private func buildAndPublishPayload() async {
+        guard phoneServer.isRunning else { return }
+        let limits = PhoneLimitStatus(
+            claude5h: store.limits?.fiveHour?.utilization.map {
+                PhoneLimitWindow(label: "5h Session", utilization: $0,
+                                 resetsAt: store.limits?.fiveHour?.resetDate)
+            },
+            claudeWeekly: store.limits?.sevenDay?.utilization.map {
+                PhoneLimitWindow(label: "Weekly", utilization: $0,
+                                 resetsAt: store.limits?.sevenDay?.resetDate)
+            },
+            claudeOpusWeekly: store.limits?.sevenDayOpus?.utilization.map {
+                PhoneLimitWindow(label: "Opus Weekly", utilization: $0,
+                                 resetsAt: store.limits?.sevenDayOpus?.resetDate)
+            },
+            claudeSonnetWeekly: store.limits?.sevenDaySonnet?.utilization.map {
+                PhoneLimitWindow(label: "Sonnet Weekly", utilization: $0,
+                                 resetsAt: store.limits?.sevenDaySonnet?.resetDate)
+            },
+            codexPrimary: store.codexLimits?.maxPrimaryUsedPercent.map {
+                PhoneLimitWindow(label: "Codex", utilization: Double($0), resetsAt: nil)
+            },
+            codexSecondary: store.codexLimits?.maxSecondaryUsedPercent.map {
+                PhoneLimitWindow(label: "Codex 2nd", utilization: Double($0), resetsAt: nil)
+            },
+            planDisplay: store.limits?.planDisplay)
+        let companionState = PhoneCompanionState(
+            name: companion.displayName,
+            speciesID: companion.currentSpeciesID,
+            isShiny: companion.currentIsShiny,
+            isEgg: companion.isEgg,
+            progress: companion.progress,
+            stageText: companion.stageText,
+            rarity: companion.rarity?.rawValue,
+            dexCount: companion.dexEntries.count,
+            eggProgress: companion.eggProgress,
+            displayState: companion.displayState.rawValue,
+            evolutionTokens: companion.tokensToNextEvolution,
+            graduationTokens: companion.tokensToGraduation)
+        let providers = store.snapshots.map { snapshot -> PhoneProviderSnapshot in
+            PhoneProviderSnapshot(id: snapshot.providerID, displayName: snapshot.displayName,
+                                  todayTokens: snapshot.todayTotalTokens,
+                                  todayCost: snapshot.today?.totalCost ?? 0,
+                                  inputTokens: snapshot.today?.inputTokens ?? 0,
+                                  outputTokens: snapshot.today?.outputTokens ?? 0,
+                                  cacheWriteTokens: snapshot.today?.cacheCreationTokens ?? 0,
+                                  cacheReadTokens: snapshot.today?.cacheReadTokens ?? 0,
+                                  reportsCost: snapshot.reportsCost)
+        }
+        let payload = PhonePayload(
+            todayTokens: store.todayTotalTokens,
+            todayCost: store.todayCostTotal,
+            weekTokens: store.weekTotalTokens,
+            monthTokens: store.monthTotalTokens,
+            lastUpdated: store.lastUpdated ?? Date(),
+            serverVersion: "1.0",
+            limits: limits,
+            companion: companionState,
+            providers: providers)
+        if let data = try? JSONEncoder().encode(payload) {
+            phoneServer.updatePayload(data)
+        }
     }
 
     // MARK: 메뉴바 애니메이션
@@ -436,5 +512,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             menuTimer?.invalidate()
             menuTimer = nil
         }
+    }
+
+    // MARK: - Dynamic App Icon
+
+    /// 대표 포켓몬이 바뀔 때 Dock 아이콘도 동기화 — 1024×1024 캔버스에 스프라이트 중앙 배치.
+    /// 에그면 기본 아이콘으로 복귀. 캐시된 정적 스프라이트만 사용(동기, 아이콘 변경 비용 최소).
+    private func updateAppIcon() {
+        let subject = companion.representativeSubject
+        guard let id = subject.speciesID, !companion.isEgg else {
+            // 알 또는 대표 없음 → 빌트인 아이콘으로 복귀
+            if let iconURL = Bundle.main.url(forResource: "AppIcon", withExtension: "icns"),
+               let image = NSImage(contentsOf: iconURL) {
+                NSApp.applicationIconImage = image
+            }
+            return
+        }
+        guard let sprite = SpriteLoader.cachedImage(speciesID: id, shiny: subject.isShiny) else { return }
+        NSApp.applicationIconImage = Self.appIconImage(from: sprite)
+    }
+
+    /// 스프라이트를 1024×1024 아이콘 캔버스에 중앙 배치 (배경: 디스플레이 팔레트 미러).
+    private static func appIconImage(from sprite: NSImage) -> NSImage {
+        let size = NSSize(width: 1024, height: 1024)
+        let icon = NSImage(size: size)
+        icon.lockFocus()
+        NSGraphicsContext.current?.imageInterpolation = .high
+        // 배경 — 다크 블렌드(폴백: #1a1a2e)
+        let bg = NSColor(red: 0.102, green: 0.102, blue: 0.18, alpha: 1)
+        bg.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        // 스프라이트 — 72% 영역에 중앙 정렬
+        let spriteArea: CGFloat = 738  // 1024 × 0.72
+        let spriteSize = NSSize(width: spriteArea, height: spriteArea)
+        let origin = NSPoint(
+            x: (size.width - spriteSize.width) / 2,
+            y: (size.height - spriteSize.height) / 2)
+        sprite.draw(in: NSRect(origin: origin, size: spriteSize),
+                     from: .zero, operation: .sourceOver, fraction: 1)
+        icon.unlockFocus()
+        return icon
     }
 }

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -70,8 +70,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         phoneServer = PhonePayloadServer()
         if store.phoneServerEnabled {
             phoneServer.start()
-            Task { await buildAndPublishPayload() }
         }
+        Task { await buildAndPublishPayload() }
         Task { await updater.check() }                    // 기동 시 1회 업데이트 확인
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -203,7 +203,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // MARK: - Phone Payload Server
 
     private func buildAndPublishPayload() async {
-        guard phoneServer.isRunning else { return }
         let limits = PhoneLimitStatus(
             claude5h: store.limits?.fiveHour?.utilization.map {
                 PhoneLimitWindow(label: "5h Session", utilization: $0,
@@ -261,7 +260,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             limits: limits,
             companion: companionState,
             providers: providers)
-        if let data = try? JSONEncoder().encode(payload) {
+        if phoneServer.isRunning, let data = try? JSONEncoder().encode(payload) {
             phoneServer.updatePayload(data)
         }
         Task { @MainActor in

--- a/project.yml
+++ b/project.yml
@@ -33,10 +33,7 @@ targets:
         com.apple.developer.icloud-container-identifiers:
           - iCloud.io.github.chattymin.poketokenbar
         com.apple.developer.icloud-services:
-          - CloudDocuments
           - CloudKit
-        com.apple.developer.ubiquity-container-identifiers:
-          - iCloud.io.github.chattymin.poketokenbar
     dependencies:
       - package: PokeTokenBarShared
     settings:
@@ -44,6 +41,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: io.github.chattymin.poketokenbar
         GENERATE_INFOPLIST_FILE: YES
         CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: B2G47QWXN7
         PRODUCT_NAME: PokeTokenBar
         LD_RUNPATH_SEARCH_PATHS: "@executable_path/../Frameworks"
       configs:
@@ -69,6 +67,10 @@ targets:
         com.apple.security.application-groups:
           - group.io.github.chattymin.poketokenbar
           - group.com.poketokenbar.ios.widget
+        com.apple.developer.icloud-container-identifiers:
+          - iCloud.io.github.chattymin.poketokenbar
+        com.apple.developer.icloud-services:
+          - CloudKit
     dependencies:
       - package: PokeTokenBarShared
       - target: PokeTokenBarWidget
@@ -97,6 +99,10 @@ targets:
         com.apple.security.application-groups:
           - group.io.github.chattymin.poketokenbar
           - group.com.poketokenbar.ios.widget
+        com.apple.developer.icloud-container-identifiers:
+          - iCloud.io.github.chattymin.poketokenbar
+        com.apple.developer.icloud-services:
+          - CloudKit
     dependencies:
       - package: PokeTokenBarShared
     settings:

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,109 @@
+name: PokeTokenBar
+options:
+  bundleIdPrefix: io.github.chattymin
+  deploymentTarget:
+    iOS: "17.0"
+    macOS: "14.0"
+  xcodeVersion: "16.0"
+  generateEmptyDirectories: false
+
+packages:
+  PokeTokenBarShared:
+    path: PokeTokenBarShared
+
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    MARKETING_VERSION: "1.0"
+    CURRENT_PROJECT_VERSION: "1"
+
+targets:
+
+  # ── macOS App (existing SPM executable, wrapped as Xcode target) ──
+  PokeTokenBar:
+    type: application
+    platform: macOS
+    sources:
+      - Sources/PokeTokenBar
+    dependencies:
+      - package: PokeTokenBarShared
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: io.github.chattymin.poketokenbar
+        GENERATE_INFOPLIST_FILE: YES
+        CODE_SIGN_IDENTITY: "-"
+        CODE_SIGN_STYLE: Automatic
+        PRODUCT_NAME: PokeTokenBar
+        LD_RUNPATH_SEARCH_PATHS: "@executable_path/../Frameworks"
+      configs:
+        Debug:
+          ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        Release:
+          ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+    postBuildScripts: []
+    linkerSettings:
+      - sdk: sqlite3
+
+  # ── iOS App ──
+  PokeTokenBariOS:
+    type: application
+    platform: iOS
+    sources:
+      - PokeTokenBariOS/Sources
+    resources:
+      - PokeTokenBariOS/Resources
+    entitlements:
+      path: PokeTokenBariOS/PokeTokenBariOS.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.io.github.chattymin.poketokenbar
+          - group.com.poketokenbar.ios.widget
+    dependencies:
+      - package: PokeTokenBarShared
+      - target: PokeTokenBarWidget
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.poketokenbar.ios
+        INFOPLIST_FILE: PokeTokenBariOS/Resources/Info.plist
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: B2G47QWXN7
+        PRODUCT_NAME: "PokeTokenBar"
+        TARGETED_DEVICE_FAMILY: "1"
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        GENERATE_INFOPLIST_FILE: false
+
+  # ── Widget Extension ──
+  PokeTokenBarWidget:
+    type: app-extension
+    platform: iOS
+    sources:
+      - PokeTokenBarWidget/Sources
+    resources:
+      - PokeTokenBarWidget/Resources
+    entitlements:
+      path: PokeTokenBarWidget/PokeTokenBarWidget.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.io.github.chattymin.poketokenbar
+          - group.com.poketokenbar.ios.widget
+    dependencies:
+      - package: PokeTokenBarShared
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.poketokenbar.ios.widget
+        INFOPLIST_FILE: PokeTokenBarWidget/Resources/Info.plist
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: B2G47QWXN7
+        PRODUCT_NAME: "$(TARGET_NAME)"
+        SKIP_INSTALL: true
+        GENERATE_INFOPLIST_FILE: false
+
+groups:
+  - name: iOS App
+    path: PokeTokenBariOS
+  - name: Widget
+    path: PokeTokenBarWidget
+  - name: Shared
+    path: PokeTokenBarShared
+  - name: macOS App
+    path: Sources/PokeTokenBar

--- a/project.yml
+++ b/project.yml
@@ -25,13 +25,24 @@ targets:
     platform: macOS
     sources:
       - Sources/PokeTokenBar
+    entitlements:
+      path: Sources/PokeTokenBar/PokeTokenBar.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.io.github.chattymin.poketokenbar
+        com.apple.developer.icloud-container-identifiers:
+          - iCloud.io.github.chattymin.poketokenbar
+        com.apple.developer.icloud-services:
+          - CloudDocuments
+          - CloudKit
+        com.apple.developer.ubiquity-container-identifiers:
+          - iCloud.io.github.chattymin.poketokenbar
     dependencies:
       - package: PokeTokenBarShared
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.github.chattymin.poketokenbar
         GENERATE_INFOPLIST_FILE: YES
-        CODE_SIGN_IDENTITY: "-"
         CODE_SIGN_STYLE: Automatic
         PRODUCT_NAME: PokeTokenBar
         LD_RUNPATH_SEARCH_PATHS: "@executable_path/../Frameworks"


### PR DESCRIPTION
Replace text-only limit percentages with colored progress bars for Claude 5h, Weekly, and Weekly Fable limits in the large widget.

**Changes:**
- Add  view with label, percentage text, and -based progress bar
- Color coding: blue (<80%), orange (>=80%), red (>=95%)
- Show Claude 5h, Weekly, and Weekly Fable (falls back to Sonnet Weekly if Opus unavailable)
- Add  with all three limit types at different utilization levels

Build verified on iOS Simulator.