### PR TITLE
feat: add companion tuning controls and desktop pet visibility toggle

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -109,6 +109,60 @@ enum PokemonBalance {
         let denom = Double(kk * (kk + 1)) / 2.0
         return Int((total * Double(i) / denom).rounded())
     }
+
+    // MARK: 난이도 배율 (설정 슬라이더)
+
+    /// 사용자 조절 배율의 허용 범위. 1 미만이면 기본보다 빠르고·싸며, 1 초과면 느리고·비싸다.
+    static let difficultyRange: ClosedRange<Double> = 0.0001...20.0
+    /// 기본값 — 이 값에서 모든 밸런스가 위 상수표 그대로다(기존 동작과 동일).
+    static let defaultDifficulty: Double = 1.0
+
+    /// 저장값을 허용 범위로 조인다. UserDefaults 는 `defaults write` 로 외부에서 쓸 수 있어
+    /// 0·음수·NaN 이 실제로 들어올 수 있고, 배율 0 은 임계 0(진행률 0 나눗셈·퇴화한 진화 루프)이 된다.
+    static func clampDifficulty(_ value: Double) -> Double {
+        guard value.isFinite else { return defaultDifficulty }
+        return min(max(value, difficultyRange.lowerBound), difficultyRange.upperBound)
+    }
+
+    /// 기본값 × 난이도 — 임계·가격 공통. **상수표 자체는 스케일하지 않는다**: 등급 알 가격이
+    /// `graduationTotal` 의 *비율*로 파생되므로(FreshEgg.price), 표를 건드리면 성장 배율이 상점
+    /// 가격까지 끌고 간다. 소비 지점에서만 곱해 두 배율을 서로 독립으로 유지한다.
+    static func scaled(_ base: Int, by difficulty: Double) -> Int {
+        Int((Double(base) * clampDifficulty(difficulty)).rounded())
+    }
+
+    // MARK: 슬라이더 위치 ↔ 배율 (로그 매핑)
+    //
+    // 범위가 다섯 자릿수를 넘어 선형 슬라이더로는 못 쓴다 — 1.0(기본)이 트랙의 5% 지점에 몰려
+    // 실사용 구간을 손으로 집을 수 없고, 0.1 미만은 전부 한 틱에 뭉갠다. 위치를 로그로 매핑해
+    // "배율 10배당 이동거리"를 일정하게 만든다.
+
+    /// 기본값(100%)이 트랙에서 차지하는 폭. 로그축이라 1.0 근처 1px 이 배율 7% 에 해당해서,
+    /// 값 기준으로 스냅하면 창이 1px 보다 좁아져 드래그가 100% 를 그냥 지나친다 —
+    /// 되돌릴 수단이 없어지므로 창을 **위치 기준**으로 잡는다(트랙의 ±1%).
+    private static let defaultSnapWidth = 0.01
+
+    /// 슬라이더 위치(0…1) → 배율.
+    static func difficulty(atPosition position: Double) -> Double {
+        let lo = difficultyRange.lowerBound, hi = difficultyRange.upperBound
+        let p = min(max(position, 0), 1)
+        if abs(p - difficultyPosition(defaultDifficulty)) < defaultSnapWidth { return defaultDifficulty }
+        return snapDifficulty(lo * pow(hi / lo, p))
+    }
+
+    /// 배율 → 슬라이더 위치(0…1).
+    static func difficultyPosition(_ value: Double) -> Double {
+        let lo = difficultyRange.lowerBound, hi = difficultyRange.upperBound
+        return log(clampDifficulty(value) / lo) / log(hi / lo)
+    }
+
+    /// 로그 슬라이더에서 나온 값을 유효숫자 2자리로 정리한다 — 없으면 1.0473 같은 값이 그대로 표시된다.
+    /// 기본값 되돌리기는 여기가 아니라 `difficulty(atPosition:)` 의 위치 스냅이 담당한다.
+    static func snapDifficulty(_ value: Double) -> Double {
+        guard value > 0 else { return difficultyRange.lowerBound }
+        let magnitude = pow(10, (log10(value)).rounded(.down) - 1)
+        return ((value / magnitude).rounded() * magnitude)
+    }
 }
 
 /// 인벤토리 아이템 종류 — 확장 대비 enum(현재 이상한 사탕 1종). rawValue 로 CompanionState.inventory 에 저장.

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -42,19 +42,38 @@ final class CompanionStore {
     private let fileURL: URL
     private var rng: any RandomNumberGenerator
     private let dittoDisguiseRollingEnabled: Bool
+    private let defaults: UserDefaults
     /// 세션 내 활성 개체 교체 감지용. await 뒤 이전 개체의 결과가 새 개체를 덮지 않게 한다.
     private var activeGeneration = 0
+
+    // MARK: 난이도 배율 (설정 — UserDefaults)
+    //
+    // 세이브(CompanionState)가 아니라 UserDefaults 에 둔다. 이건 진행 상황이 아니라 취향 설정이고
+    // (설정창의 다른 슬라이더와 같은 자리), 세이브에 넣으면 남의 세이브를 불러올 때 내 난이도가 조용히
+    // 바뀌며 SaveTransfer 의 관대 디코딩·검증까지 새 수치 필드를 떠안는다.
+
+    /// 성장 배율 — 알 부화 임계 + 진화/졸업 임계에 곱한다. 낮을수록 빨리 자란다.
+    /// 사탕 XP(RareCandy.xp)는 스케일하지 않는다 — 함께 곱하면 서로 상쇄돼 사탕만 난이도를 안 탄다.
+    private(set) var growthDifficulty: Double
+    /// 상점 배율 — 아이템·알 가격에 곱한다. 낮을수록 싸다.
+    private(set) var shopDifficulty: Double
 
     init(provider: any PokeProviding = PokeAPIClient.shared,
          clock: @escaping () -> Date = Date.init,
          fileURL: URL? = nil,
          rng: any RandomNumberGenerator = SystemRandomNumberGenerator(),
-         dittoDisguiseRollingEnabled: Bool = AppEnv.isBundledApp) {
+         dittoDisguiseRollingEnabled: Bool = AppEnv.isBundledApp,
+         defaults: UserDefaults = .standard) {
         self.provider = provider
         self.clock = clock
         self.fileURL = fileURL ?? Self.defaultURL()
         self.rng = rng
         self.dittoDisguiseRollingEnabled = dittoDisguiseRollingEnabled
+        self.defaults = defaults
+        growthDifficulty = PokemonBalance.clampDifficulty(
+            defaults.object(forKey: "growthDifficulty") as? Double ?? PokemonBalance.defaultDifficulty)
+        shopDifficulty = PokemonBalance.clampDifficulty(
+            defaults.object(forKey: "shopDifficulty") as? Double ?? PokemonBalance.defaultDifficulty)
         load()
         refreshRepresentativeSubject()
         if state.active != nil { displayState = .idle }
@@ -82,6 +101,54 @@ final class CompanionStore {
 
     var language: AppLanguage { state.language }
     func setLanguage(_ lang: AppLanguage) { state.language = lang; save() }
+
+    // MARK: 난이도 — 설정에서 조절, 즉시 반영(재시작 불필요)
+
+    /// 성장 배율 변경. 배율을 내리면 이미 쌓인 진행도가 그 자리에서 임계를 넘을 수 있으므로,
+    /// 다음 사용량 폴링(기본 120s)까지 기다리지 않고 여기서 진화·부화 판정을 다시 돌린다.
+    /// `applyUsage(0)` 은 메타몽 리빌·라인 로드 뒤 재평가에 쓰는 기존 킥과 같은 형태이며,
+    /// 내부에서 save() 까지 수행한다(활성 개체가 없으면 no-op).
+    func setGrowthDifficulty(_ value: Double) {
+        let clamped = PokemonBalance.clampDifficulty(value)
+        guard clamped != growthDifficulty else { return }
+        growthDifficulty = clamped
+        defaults.set(clamped, forKey: "growthDifficulty")
+        applyUsage(0)
+        if state.active == nil, state.eggUsage >= eggHatchThreshold, !isHatching {
+            Task { await hatchIfNeeded() }
+        }
+    }
+
+    /// 상점 배율 변경 — 가격은 순수 읽기(파생값)라 재평가할 상태가 없다.
+    func setShopDifficulty(_ value: Double) {
+        let clamped = PokemonBalance.clampDifficulty(value)
+        guard clamped != shopDifficulty else { return }
+        shopDifficulty = clamped
+        defaults.set(clamped, forKey: "shopDifficulty")
+    }
+
+    /// 난이도를 반영한 알 부화 임계.
+    private var eggHatchThreshold: Int {
+        PokemonBalance.scaled(PokemonBalance.eggHatchThreshold, by: growthDifficulty)
+    }
+
+    /// 난이도를 반영한 단계 임계. **`PokemonBalance.phaseThreshold` 를 직접 부르지 않는다** —
+    /// 배율을 빠뜨린 호출부가 생기면 그 경로만 조용히 기본 난이도로 돌아간다.
+    private func stageThreshold(rarity: Rarity, totalForms: Int, stageIndex: Int) -> Int {
+        PokemonBalance.scaled(
+            PokemonBalance.phaseThreshold(rarity: rarity, totalForms: totalForms, stageIndex: stageIndex),
+            by: growthDifficulty)
+    }
+
+    /// 상점 표시·결제에 쓰는 실제 가격 — 기본가 × 상점 난이도. 미판매면 nil.
+    func price(of kind: ItemKind) -> Int? {
+        kind.shopPrice.map { PokemonBalance.scaled($0, by: shopDifficulty) }
+    }
+
+    /// 알을 포함한 상점 한 줄의 실제 가격.
+    func price(of entry: ShopEntry) -> Int {
+        PokemonBalance.scaled(entry.price, by: shopDifficulty)
+    }
     /// 앱 전체 UI 문자열 — language 변경 시 자동 재렌더.
     var l: L { L(language) }
 
@@ -129,8 +196,8 @@ final class CompanionStore {
     // 알 인큐베이션 (active 없을 때)
     var isEgg: Bool { state.active == nil }
     var eggStarted: Bool { state.eggUsage > 0 }
-    var eggProgress: Double { min(1, max(0, Double(state.eggUsage) / Double(PokemonBalance.eggHatchThreshold))) }
-    var eggTokensToHatch: Int { max(0, PokemonBalance.eggHatchThreshold - state.eggUsage) }
+    var eggProgress: Double { min(1, max(0, Double(state.eggUsage) / Double(eggHatchThreshold))) }
+    var eggTokensToHatch: Int { max(0, eggHatchThreshold - state.eggUsage) }
 
     var displayName: String {
         guard let a = state.active, let line = currentLine else { return "Token Egg" }
@@ -147,7 +214,7 @@ final class CompanionStore {
     }
     var threshold: Int {
         guard let a = state.active else { return 1 }
-        return PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: a.stageIndex)
+        return stageThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: a.stageIndex)
     }
     var progress: Double {
         guard let a = state.active, threshold > 0 else { return 0 }
@@ -443,7 +510,7 @@ final class CompanionStore {
             Task { await ensureEggPrefetch() }
         }
         // 알이 부화 임계에 도달하면 부화
-        if state.active == nil, state.eggUsage >= PokemonBalance.eggHatchThreshold, !isHatching {
+        if state.active == nil, state.eggUsage >= eggHatchThreshold, !isHatching {
             Task { await hatchIfNeeded() }
         }
         // active 인데 라인 미로딩(앱 재시작) → 로드
@@ -453,7 +520,7 @@ final class CompanionStore {
         // 위장 메타몽이 첫 진화 임계 도달 → 리빌(재시작 등 applyUsage 킥을 못 탄 경우 백업 트리거)
         if let a = state.active, a.dittoDisguise != nil, !a.dittoRevealed, currentLine != nil,
            !isHatching, !isRevealingDitto,
-           a.usedAtStage >= PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0) {
+           a.usedAtStage >= stageThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0) {
             Task { await revealDitto() }
         }
         displayState = computeState(burnTier: burnTier, limitWarning: limitWarning,
@@ -472,7 +539,7 @@ final class CompanionStore {
         while state.active != nil, guardCount < 50 {
             guardCount += 1
             let a = state.active!
-            let thr = PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: a.stageIndex)
+            let thr = stageThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: a.stageIndex)
             guard a.usedAtStage >= thr else { break }
             guard let node = line.tree.node(withID: a.currentID) else { break }
             // 위장체는 부화 때는 다형태지만, 에셋 정규화/마이그레이션 뒤 leaf가 될 수 있다.
@@ -695,7 +762,7 @@ final class CompanionStore {
             let aDone = isPurchasedPassive(a)
             let bDone = isPurchasedPassive(b)
             if aDone != bDone { return !aDone }
-            return a.price < b.price
+            return price(of: a) < price(of: b)
         }
     }
 
@@ -707,7 +774,7 @@ final class CompanionStore {
 
     /// 구매 가능 — 잔액이 그 아이템 가격 이상(상점 미판매면 false). 활성/알 무관(재고는 미리 쌓아둘 수 있음).
     func canBuy(_ kind: ItemKind) -> Bool {
-        guard let price = kind.shopPrice else { return false }
+        guard let price = price(of: kind) else { return false }
         if kind.isPassive && itemCount(kind) > 0 { return false }   // 보유형은 1회만(재구매 불가)
         return availableTokens >= price
     }
@@ -716,7 +783,7 @@ final class CompanionStore {
     /// 무영향(지출 원장만 증가). 잔액 부족/미판매면 no-op(false).
     @discardableResult
     func buy(_ kind: ItemKind) -> Bool {
-        guard let price = kind.shopPrice, availableTokens >= price else { return false }
+        guard let price = price(of: kind), availableTokens >= price else { return false }
         if kind.isPassive && itemCount(kind) > 0 { return false }   // 보유형 중복 구매 방지(방어)
         state.spentTokens += price
         state.inventory[kind.rawValue, default: 0] += 1
@@ -743,7 +810,7 @@ final class CompanionStore {
         // 새 알 구매는 `hasActive` 에 막혀 되돌릴 수단이 없다. 가격만 계산되면 값이 빠져나가므로
         // 판매 목록을 여기서 강제한다(호출부 하나가 실수하면 토큰이 통째로 사라진다).
         guard FreshEgg.shopTiers.contains(tier) else { return false }
-        return hasActive && availableTokens >= FreshEgg.price(guaranteeing: tier)
+        return hasActive && availableTokens >= price(of: .egg(tier))
     }
 
     /// 알 구매 — 현재 포켓몬을 폐기하고 처음부터 인큐베이션하는 새 알로. 지갑에서 가격 차감.
@@ -755,20 +822,63 @@ final class CompanionStore {
     @discardableResult
     func buyEgg(_ tier: Rarity?) -> Bool {
         guard canBuyEgg(tier) else { return false }
-        state.spentTokens += FreshEgg.price(guaranteeing: tier)
+        state.spentTokens += price(of: .egg(tier))
+        resetToFreshEgg(tier: tier, pinnedBase: nil)
+        AppLog.write("egg purchased: discarded active, tier=\(tier?.rawValue ?? "none")")
+        return true
+    }
+
+    /// 현재 개체를 폐기하고 처음부터 인큐베이션하는 새 알로 되돌리는 공통 전이 —
+    /// 구매(`buyEgg`)와 스폰(`spawnEgg`)이 공유한다. 둘이 각자 상태를 만지면 한쪽만 고쳐져
+    /// 조용히 어긋난다(대표 종 복구·세대 증가를 빠뜨리는 식).
+    ///
+    /// `graduate()` 의 알-리셋만 미러링하고 dex/collectedFinals(도감·확률 가중)는 손대지 않는다
+    /// → "뽑은 적 없던 것처럼". 성장(usedAtStage)은 소멸한다.
+    /// `pinnedBase` 가 있으면 그 종으로 부화하도록 pre-roll 을 고정한다(nil = 평소대로 롤).
+    private func resetToFreshEgg(tier: Rarity?, pinnedBase: Int?) {
         state.active = nil            // 폐기 (졸업 아님 — dex/collectedFinals 미변경)
         state.reconcileRepresentativeSelection()   // 미졸업 개체에만 있던 대표 종은 자동 추적으로 복귀
         activeGeneration += 1
         currentLine = nil
         state.eggUsage = 0            // 새 알은 처음부터 인큐베이션(재부화에 5M 필요)
         state.eggTier = tier          // 등급 보증(nil = 보증 없음)
-        state.pendingHatchID = nil    // 새 보증으로 처음부터 롤(활성 포켓몬이 있는 동안엔 원래 비어 있다)
+        state.pendingHatchID = pinnedBase   // nil 이면 프리패치가 평소대로 롤한다
         prefetchedLineID = nil
         justGraduated = nil; justEvolvedTo = nil; eventUntil = nil
-        AppLog.write("egg purchased: discarded active, tier=\(tier?.rawValue ?? "none")")
+        displayState = .egg           // 다음 폴링 틱까지 이전 개체의 상태 문구가 남지 않게
         Task { await self.ensureEggPrefetch() }   // 다음 부화 예열
         save()
-        return true
+    }
+
+    // MARK: 알 스폰 (설정 — 종 지정)
+
+    /// 스폰 목록에 쓸 base 종(도감 번호순). 인덱스를 못 받아오면 비어 있다(오프라인·엔드포인트 장애).
+    private(set) var spawnableBases: [BaseSpecies] = []
+
+    /// 설정 화면이 열릴 때 한 번 채운다. 부화 후보와 **같은 인덱스**를 쓴다 — 목록과 실제 부화
+    /// 가능 종이 어긋나지 않게(메타몽 제외·5세대 상한 같은 규칙이 자동으로 따라온다).
+    func loadSpawnableBases() async {
+        guard spawnableBases.isEmpty else { return }
+        guard let index = try? await provider.baseSpeciesIndex() else { return }
+        spawnableBases = index.sorted { $0.id < $1.id }
+    }
+
+    /// 스폰 목록 한 줄의 표시 문자열 — "#25 피카츄". 이름이 없으면(REST 폴백·구버전 캐시) 번호만.
+    /// 번호와 이름을 **여기서 함께** 만든다 — 호출부가 번호를 덧붙이면 이름 없는 항목이 "#25 #25" 가 된다.
+    func spawnableLabel(_ species: BaseSpecies) -> String {
+        guard let name = state.language.resolveName(species.names ?? [:]) else { return "#\(species.id)" }
+        return "#\(species.id) \(name)"
+    }
+
+    /// 현재 개체를 폐기하고, 지정한 종으로 부화할 알로 교체한다(설정 전용).
+    /// 부화 자체는 평소 규칙 그대로다 — 인큐베이션 임계를 채워야 깨지고, 이로치·성격은 그때 롤된다.
+    /// 종만 고정할 뿐 결과를 통째로 만들어 주지 않는다.
+    ///
+    /// 알 상태에서도 호출할 수 있다(`buyEgg` 와 달리 활성 개체를 요구하지 않는다) — 방금 스폰한
+    /// 알의 종을 바꾸는 게 이 도구의 주 용도이고, 폐기할 개체가 없으면 그냥 pre-roll 만 바뀐다.
+    func spawnEgg(baseID: Int) {
+        resetToFreshEgg(tier: nil, pinnedBase: baseID)
+        AppLog.write("egg spawned: discarded active, pinned base=\(baseID)")
     }
 
     // 보증 없는 기본 알 래퍼 — 기존 호출부/테스트 호환.
@@ -840,7 +950,7 @@ final class CompanionStore {
     // MARK: 부화
 
     func hatchIfNeeded() async {
-        guard state.active == nil, !isHatching, state.eggUsage >= PokemonBalance.eggHatchThreshold else { return }
+        guard state.active == nil, !isHatching, state.eggUsage >= eggHatchThreshold else { return }
         // 프리패치가 "종 롤 중"(pending 미확정)일 때만 대기 — 이중 rng 소비 방지.
         // pending 확정 후의 예열(라인/스프라이트)과는 동시 진행해도 안전하다.
         guard state.pendingHatchID != nil || !prefetchInFlight else { return }
@@ -960,7 +1070,7 @@ final class CompanionStore {
         }
         currentLine = line
         // 부화 임계 초과분은 부화체 성장에 이월(낭비 없음).
-        let overflow = max(0, state.eggUsage - PokemonBalance.eggHatchThreshold)
+        let overflow = max(0, state.eggUsage - eggHatchThreshold)
         state.eggUsage = 0
         state.eggTier = nil   // 보증은 이 부화로 소비된다(다음 알은 다시 무보증)
         // 개체 롤 — shiny(1/64)·성격(25종)은 부화 순간 확정, 진화해도 유지.
@@ -999,7 +1109,7 @@ final class CompanionStore {
     private func revealDitto() async {
         guard let a = state.active, a.dittoDisguise != nil, !a.dittoRevealed, !isRevealingDitto else { return }
         let generation = activeGeneration
-        let firstEvoThr = PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0)
+        let firstEvoThr = stageThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0)
         guard a.usedAtStage >= firstEvoThr else { return }   // 임계 미달 방어
         isRevealingDitto = true
         defer { isRevealingDitto = false }
@@ -1008,7 +1118,7 @@ final class CompanionStore {
         }
         guard activeGeneration == generation,
               var m = state.active, m.dittoDisguise != nil, !m.dittoRevealed else { return }
-        let latestFirstEvoThr = PokemonBalance.phaseThreshold(rarity: m.rarity, totalForms: m.totalForms, stageIndex: 0)
+        let latestFirstEvoThr = stageThreshold(rarity: m.rarity, totalForms: m.totalForms, stageIndex: 0)
         guard m.usedAtStage >= latestFirstEvoThr else { return }
         let disguiseName = currentLine?.localizedName(m.baseID, state.language) ?? "#\(m.baseID)"
         let carryOver = max(0, m.usedAtStage - latestFirstEvoThr)   // 위장체 첫 진화 초과분 → 메타몽 성장 이월

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -130,6 +130,44 @@ struct L {
         t("대표로 설정", "Set as representative", "代表ポケモンに設定", "Establecer como representante")
     }
     var representativeBadge: String { t("대표", "Representative", "代表", "Representante") }
+    // MARK: 난이도
+    var difficultySectionTitle: String { t("난이도", "Difficulty", "難易度", "Dificultad") }
+    var difficultyGrowthLabel: String { t("성장", "Growth", "成長", "Crecimiento") }
+    var difficultyShopLabel: String { t("상점 가격", "Shop prices", "ショップ価格", "Precios de la tienda") }
+    var difficultyHint: String {
+        t("기본값 100% 기준이에요 — 낮추면 빨리 자라고 싸지고, 높이면 그 반대예요",
+          "Percentages of the default balance — lower grows faster and costs less, higher does the opposite",
+          "標準バランスに対する割合です — 下げると早く育ち安くなり、上げるとその逆になります",
+          "Porcentajes del balance predeterminado: si los bajas, crece más rápido y cuesta menos; si los subes, al revés")
+    }
+    /// 슬라이더 옆 현재 배율 — 퍼센트 표기(1.0 = 100%). 범위가 0.01%~2000% 라 작은 쪽은 자릿수를
+    /// 더 보여준다(고정 소수점이면 0.01% 와 0.05% 가 똑같이 "0%" 로 뭉갠다).
+    func difficultyValue(_ value: Double) -> String {
+        let percent = value * 100
+        if percent >= 10 { return String(format: "%.0f%%", percent) }
+        if percent >= 1 { return String(format: "%.1f%%", percent) }
+        return String(format: "%.2f%%", percent)
+    }
+    // MARK: 알 스폰 (설정)
+    var spawnEggSectionTitle: String { t("알 스폰", "Spawn Egg", "タマゴを出す", "Generar huevo") }
+    var spawnEggSpeciesLabel: String { t("종", "Species", "ポケモン", "Especie") }
+    var spawnEggChoosePlaceholder: String { t("선택…", "Choose…", "選択…", "Elegir…") }
+    var spawnEggButton: String { t("스폰", "Spawn", "出す", "Generar") }
+    var spawnEggHint: String {
+        t("지금 포켓몬을 놓아주고 고른 종으로 부화할 알을 놓아요 — 도감엔 남지 않아요",
+          "Releases your current Pokémon and leaves an egg that hatches into the chosen species — no Pokédex credit",
+          "今のポケモンを手放し、選んだ種でかえるタマゴを置きます — 図鑑には残りません",
+          "Libera a tu Pokémon actual y deja un huevo que eclosionará en la especie elegida (no cuenta para la Pokédex)")
+    }
+    var spawnEggUnavailable: String {
+        t("종 목록을 불러오지 못했어요 — 연결을 확인해 주세요",
+          "Couldn't load the species list — check your connection",
+          "種の一覧を読み込めませんでした — 接続を確認してください",
+          "No se pudo cargar la lista de especies: revisa tu conexión")
+    }
+    func generationLabel(_ number: Int) -> String {
+        t("\(number)세대", "Gen \(number)", "第\(number)世代", "Gen \(number)")
+    }
     // MARK: 플로팅 펫
     var floatingPetSectionTitle: String { t("플로팅 펫", "Floating Pet", "フローティングペット", "Mascota flotante") }
     var floatingPetEnableLabel: String { t("플로팅 펫 표시", "Show floating pet", "フローティングペットを表示", "Mostrar mascota flotante") }
@@ -140,6 +178,19 @@ struct L {
           "Tu Pokémon flota sobre la pantalla — arrástralo para moverlo")
     }
     var floatingPetSizeLabel: String { t("크기", "Size", "サイズ", "Tamaño") }
+    /// 푸터 눈 아이콘의 툴팁(켜져 있을 때) — 켜는 쪽 문구는 floatingPetEnableLabel 을 그대로 쓴다.
+    var floatingPetHideLabel: String {
+        t("플로팅 펫 숨기기", "Hide floating pet", "フローティングペットを隠す", "Ocultar mascota flotante")
+    }
+    var floatingPetSmoothLabel: String {
+        t("부드러운 애니메이션", "Smooth animation", "なめらかなアニメーション", "Animación fluida")
+    }
+    var floatingPetSmoothHint: String {
+        t("팝오버와 같은 fps 로 움직여요 — 끄면 배터리를 아끼는 대신 뚝뚝 끊겨 보여요",
+          "Runs at the same fps as the popover — off saves battery but looks choppy",
+          "ポップオーバーと同じfpsで動きます — オフにすると省電力ですがカクつきます",
+          "Se mueve a los mismos fps que el popover; al desactivarlo ahorras batería pero se ve entrecortado")
+    }
     /// 지금은 한도 알림만 말풍선으로 뜨지만, 알림 종류가 늘어도 이 라벨은 그대로 쓴다.
     var floatingPetBubbleAlertsLabel: String {
         t("말풍선으로 알림 받기", "Show notifications as bubbles", "通知を吹き出しで表示", "Mostrar notificaciones como globos")

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -4,6 +4,9 @@ import Foundation
 struct BaseSpecies: Sendable, Codable {
     let id: Int
     let captureRate: Int    // 3(뮤츠급)~255(캐터피급), 공식 희귀도 신호
+    /// 언어코드→이름(설정의 알 스폰 목록 표시용). base 인덱스 1쿼리에 실려 오므로 추가 요청이 없다.
+    /// **비어 있을 수 있다** — REST 폴백 경로와 이 필드 이전에 저장된 디스크 캐시. 표시는 #id 로 폴백한다.
+    var names: [String: String]? = nil
 }
 
 /// 포켓몬 라인 데이터 제공(주입 가능 — 테스트는 스텁 사용).
@@ -62,9 +65,28 @@ actor PokeAPIClient: PokeProviding {
         return dir.appendingPathComponent("base-index.json")
     }()
     private struct BaseIndexSnapshot: Codable { let fetchedAt: Date; let entries: [BaseSpecies] }
+
+    /// 이름 필드가 생기기 전에 저장된 캐시인가. 관대 디코딩(`names` 옵셔널) 덕에 옛 스냅샷도 그대로
+    /// 읽히지만, 그러면 30일 TTL 이 끝날 때까지 스폰 목록이 전부 "#id" 로 남는다 — **스키마가 바뀐
+    /// 캐시는 만료로 취급**해 다시 받아야 한다. 디코딩 호환성은 캐시 무효화를 대신해 주지 않는다.
+    ///
+    /// 재요청이 실패하면 호출부의 catch 가 이 스냅샷으로 폴백한다 — 이름이 없어도 부화 후보로는
+    /// 멀쩡하므로 오프라인 동작은 그대로다(이름은 있으면 좋은 것이지 부화의 전제가 아니다).
+    static func indexPredatesNames(_ entries: [BaseSpecies]) -> Bool {
+        !entries.contains { !($0.names?.isEmpty ?? true) }
+    }
     private struct GraphQLBaseResponse: Decodable {
         struct DataBox: Decodable { let pokemonspecies: [Row] }
-        struct Row: Decodable { let id: Int; let capture_rate: Int }
+        struct NameRow: Decodable {
+            struct Language: Decodable { let name: String }
+            let name: String
+            let language: Language
+        }
+        struct Row: Decodable {
+            let id: Int
+            let capture_rate: Int
+            let pokemonspeciesnames: [NameRow]
+        }
         let data: DataBox
     }
 
@@ -75,7 +97,8 @@ actor PokeAPIClient: PokeProviding {
         if let c = baseIndexCache { return c }
         let disk = (try? Data(contentsOf: Self.baseIndexFile))
             .flatMap { try? JSONDecoder().decode(BaseIndexSnapshot.self, from: $0) }
-        if let disk, Date().timeIntervalSince(disk.fetchedAt) < 30 * 86400, !disk.entries.isEmpty {
+        if let disk, !Self.indexPredatesNames(disk.entries),
+           Date().timeIntervalSince(disk.fetchedAt) < 30 * 86400, !disk.entries.isEmpty {
             baseIndexCache = disk.entries
             return disk.entries
         }
@@ -148,12 +171,19 @@ actor PokeAPIClient: PokeProviding {
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         // 메타몽(#132)은 위장 리빌 전용 → 일반 부화 풀에서 제외(_neq).
         let maxID = PokemonAssets.animatedSpeciesIDs.upperBound
-        let query = "{ pokemonspecies(where: {evolves_from_species_id: {_is_null: true}, id: {_lte: \(maxID), _neq: \(PokemonOdds.dittoSpeciesID)}}, order_by: {id: asc}) { id capture_rate } }"
+        // 이름을 같은 쿼리에 실어 온다(중첩 조인) — 설정의 스폰 목록이 329종 이름을 위해
+        // 별도 요청을 돌리지 않게. 언어는 line() 과 같은 langCodes 단일 소스를 쓴다.
+        let langFilter = langCodes.map { "\"\($0)\"" }.joined(separator: ", ")
+        let query = "{ pokemonspecies(where: {evolves_from_species_id: {_is_null: true}, id: {_lte: \(maxID), _neq: \(PokemonOdds.dittoSpeciesID)}}, order_by: {id: asc}) { id capture_rate pokemonspeciesnames(where: {language: {name: {_in: [\(langFilter)]}}}) { name language { name } } } }"
         req.httpBody = try JSONSerialization.data(withJSONObject: ["query": query])
         let (data, resp) = try await URLSession.shared.data(for: req)
         guard (resp as? HTTPURLResponse)?.statusCode == 200 else { throw URLError(.badServerResponse) }
         let decoded = try JSONDecoder().decode(GraphQLBaseResponse.self, from: data)
-        let entries = decoded.data.pokemonspecies.map { BaseSpecies(id: $0.id, captureRate: $0.capture_rate) }
+        let entries = decoded.data.pokemonspecies.map { row in
+            BaseSpecies(id: row.id, captureRate: row.capture_rate,
+                        names: Dictionary(row.pokemonspeciesnames.map { ($0.language.name, $0.name) },
+                                          uniquingKeysWith: { first, _ in first }))
+        }
         guard !entries.isEmpty else { throw URLError(.cannotParseResponse) }
         return entries
     }

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -96,6 +96,13 @@ final class UsageStore {
     var floatingPetBubbleAlerts: Bool {
         didSet { defaults.set(floatingPetBubbleAlerts, forKey: "floatingPetBubbleAlerts") }
     }
+    /// 펫을 팝오버와 같은 네이티브 fps(10~16)로 돌릴지. 끄면 `FloatingPetView.frameFloor`(0.4s≈2.5fps)
+    /// 배터리 캡이 걸린다 — 상시 표시 표면의 idle wakeup 을 억제하는 원래 규율(defect-log §에너지).
+    /// 켜면 팝오버와 같은 부드러움을 얻는 대신 wakeup 이 늘어난다. 저전력 모드의 정적화는 이 설정과
+    /// 무관하게 항상 우선한다(`FloatingPetController.shouldAnimate`).
+    var floatingPetSmoothAnimation: Bool {
+        didSet { defaults.set(floatingPetSmoothAnimation, forKey: "floatingPetSmoothAnimation") }
+    }
     var disableKeychainAccess: Bool {
         didSet {
             defaults.set(disableKeychainAccess, forKey: "disableKeychainAccess")   // 저장 누락이던 기존 버그 — 재시작 후 풀렸음
@@ -424,6 +431,7 @@ final class UsageStore {
         floatingPetEnabled = d.object(forKey: "floatingPetEnabled") as? Bool ?? false
         floatingPetSize = d.object(forKey: "floatingPetSize") as? Double ?? 96
         floatingPetBubbleAlerts = d.object(forKey: "floatingPetBubbleAlerts") as? Bool ?? true
+        floatingPetSmoothAnimation = d.object(forKey: "floatingPetSmoothAnimation") as? Bool ?? true
         disableKeychainAccess = d.object(forKey: "disableKeychainAccess") as? Bool ?? false
 
         reschedule()

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -174,7 +174,9 @@ struct SpriteView: View {
         }
         // GIF 재생 중엔 bob 정지(프레임 자체가 움직임) — 폴백/정적일 때만 상하 움직임
         .offset(y: bob && frames.isEmpty && up ? -3 : 0)
-        .task(id: "\(speciesID.map(String.init) ?? "nil")-\(shiny)") {
+        // minFrameDelay 를 id 에 포함한다 — 프레임 루프는 시작 시점의 하한을 들고 돌기 때문에,
+        // 빠지면 설정을 바꿔도 다음 스프라이트 교체 전까지 옛 fps 로 계속 돈다(설정이 안 먹는 것처럼 보인다).
+        .task(id: "\(speciesID.map(String.init) ?? "nil")-\(shiny)-\(minFrameDelay)") {
             // animated 프레임은 id/shiny 변경 시 항상 초기화(이전 개체 프레임 잔상 방지)
             frames = []
             frameIndex = 0

--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -412,6 +412,13 @@ final class PetHostingView: NSHostingView<AnyView> {
 
 struct FloatingPetView: View {
     static let frameFloor: TimeInterval = 0.4
+
+    /// 푸터 토글의 SF Symbol — 지금 상태를 그린다(보이는 중 = 뜬 눈). 순수 판정이라 뒤집힘을 테스트로 잠근다.
+    static func visibilitySymbol(visible: Bool) -> String { visible ? "eye" : "eye.slash" }
+
+    /// 실제로 적용할 프레임 하한 — 부드러움 설정이 켜지면 네이티브(0, 팝오버와 동일),
+    /// 꺼지면 배터리 캡(`frameFloor`). 순수 판정이라 두 분기를 테스트로 잠근다.
+    static func effectiveFrameFloor(smooth: Bool) -> TimeInterval { smooth ? 0 : frameFloor }
     var animated: Bool = true
     @Environment(UsageStore.self) private var store
     @Environment(CompanionStore.self) private var companion
@@ -427,7 +434,8 @@ struct FloatingPetView: View {
             }
 
             SpriteView(speciesID: subject.speciesID, size: size, animated: animated,
-                       shiny: subject.isShiny, minFrameDelay: Self.frameFloor)
+                       shiny: subject.isShiny,
+                       minFrameDelay: Self.effectiveFrameFloor(smooth: store.floatingPetSmoothAnimation))
                 .frame(width: size, height: size)
                 .zIndex(0)
         }

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -600,6 +600,15 @@ struct PopoverView: View {
                 }
             }
             Spacer()
+            // 데스크톱 펫 표시 토글 — 설정창의 스위치와 **같은 값**(store.floatingPetEnabled)을 읽고 쓴다.
+            // @Observable 이라 어느 쪽에서 바꾸든 다른 쪽이 즉시 따라온다(별도 동기화 없음).
+            Button {
+                store.floatingPetEnabled.toggle()
+            } label: {
+                Image(systemName: FloatingPetView.visibilitySymbol(visible: store.floatingPetEnabled))
+            }
+            .buttonStyle(.borderless)
+            .help(store.floatingPetEnabled ? l.floatingPetHideLabel : l.floatingPetEnableLabel)
             Button {
                 nav.showSettings = true
             } label: {

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -13,6 +13,7 @@ struct SettingsView: View {
     @State private var launchAtLoginError: String?
     @State private var reportError: String?
     @State private var advancedExpanded = false
+    @State private var spawnBaseID: Int?
     @State private var isCheckingUpdate = false
     @State private var didCheckUpdate = false
     private var l: L { companion.l }
@@ -47,6 +48,8 @@ struct SettingsView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     generalGroup(store)
+                    difficultyGroup
+                    spawnEggGroup
                     menuBarGroup(store)
                     floatingPetGroup(store)
                     notificationsGroup(store)
@@ -189,6 +192,95 @@ struct SettingsView: View {
         }
     }
 
+    /// 난이도 — 성장(부화·진화·졸업 임계)과 상점 가격에 각각 곱하는 배율. 즉시 반영된다.
+    private var difficultyGroup: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            settingsSection(l.difficultySectionTitle) {
+                difficultyRow(l.difficultyGrowthLabel, value: companion.growthDifficulty,
+                              position: Binding(
+                                get: { PokemonBalance.difficultyPosition(companion.growthDifficulty) },
+                                set: { companion.setGrowthDifficulty(PokemonBalance.difficulty(atPosition: $0)) }))
+                Divider()
+                difficultyRow(l.difficultyShopLabel, value: companion.shopDifficulty,
+                              position: Binding(
+                                get: { PokemonBalance.difficultyPosition(companion.shopDifficulty) },
+                                set: { companion.setShopDifficulty(PokemonBalance.difficulty(atPosition: $0)) }))
+            }
+            Text(l.difficultyHint).font(.caption2).foregroundStyle(.tertiary).padding(.leading, 4)
+        }
+    }
+
+    /// 배율 슬라이더 한 줄 — 플로팅 펫 크기 행과 같은 형태(라벨 / 슬라이더 / 우측 고정폭 수치).
+    /// 슬라이더가 움직이는 건 배율이 아니라 **로그 위치(0…1)** 다(PokemonBalance 주석 참조).
+    /// step 을 두지 않는다 — 눈금 간격이 배율 단위로 일정하지 않고, 스냅은 값 쪽에서 한다.
+    private func difficultyRow(_ label: String, value: Double,
+                               position: Binding<Double>) -> some View {
+        groupRow {
+            Text(label).font(.callout).frame(width: 76, alignment: .leading)
+            Slider(value: position, in: 0...1)
+            Text(l.difficultyValue(value))
+                .font(.caption).monospacedDigit().frame(width: 52, alignment: .trailing)
+        }
+    }
+
+    /// 세대 구간 — 329종을 한 메뉴에 평면으로 쏟으면 고르기가 어려워 세대별 서브메뉴로 나눈다.
+    /// 표시 전용 묶음이라 이 뷰 안에 둔다(부화 후보 규칙은 여전히 base 인덱스가 단일 소스).
+    private static let generations: [(number: Int, range: ClosedRange<Int>)] = [
+        (1, 1...151), (2, 152...251), (3, 252...386), (4, 387...493), (5, 494...649),
+    ]
+
+    private var spawnSelectionText: String {
+        guard let id = spawnBaseID,
+              let species = companion.spawnableBases.first(where: { $0.id == id }) else {
+            return l.spawnEggChoosePlaceholder
+        }
+        return companion.spawnableLabel(species)
+    }
+
+    /// 알 스폰 — 종을 지정해 새 알로 갈아끼운다. 부화 자체는 평소 규칙(인큐베이션·이로치 롤) 그대로다.
+    private var spawnEggGroup: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            settingsSection(l.spawnEggSectionTitle) {
+                groupRow {
+                    Text(l.spawnEggSpeciesLabel)
+                        .lineLimit(1).frame(maxWidth: .infinity, alignment: .leading)
+                    Menu {
+                        ForEach(Self.generations, id: \.number) { generation in
+                            let members = companion.spawnableBases.filter { generation.range.contains($0.id) }
+                            if !members.isEmpty {
+                                Menu(l.generationLabel(generation.number)) {
+                                    ForEach(members, id: \.id) { species in
+                                        Button(companion.spawnableLabel(species)) {
+                                            spawnBaseID = species.id
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } label: {
+                        Text(spawnSelectionText).lineLimit(1).truncationMode(.tail)
+                    }
+                    .controlSize(.small)
+                    .frame(width: 132, alignment: .trailing)
+                    .layoutPriority(1)
+                    .disabled(companion.spawnableBases.isEmpty)
+
+                    Button(l.spawnEggButton) {
+                        guard let id = spawnBaseID else { return }
+                        companion.spawnEgg(baseID: id)
+                        onClose()   // 방금 놓인 알을 홈에서 바로 보여 준다
+                    }
+                    .controlSize(.small)
+                    .disabled(spawnBaseID == nil)
+                }
+            }
+            Text(companion.spawnableBases.isEmpty ? l.spawnEggUnavailable : l.spawnEggHint)
+                .font(.caption2).foregroundStyle(.tertiary).padding(.leading, 4)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .task { await companion.loadSpawnableBases() }
+    }
+
     @ViewBuilder
     private func menuBarGroup(_ store: UsageStore) -> some View {
         @Bindable var store = store
@@ -224,6 +316,17 @@ struct SettingsView: View {
                     Slider(value: $store.floatingPetSize, in: 48...192, step: 8)
                     Text("\(Int(store.floatingPetSize))px")
                         .font(.caption).monospacedDigit().frame(width: 44, alignment: .trailing)
+                }
+                Divider()
+                groupRow {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(l.floatingPetSmoothLabel)
+                        Text(l.floatingPetSmoothHint).font(.caption2).foregroundStyle(.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $store.floatingPetSmoothAnimation)
+                        .labelsHidden().toggleStyle(.switch).controlSize(.small)
                 }
                 Divider()
                 toggleRow(l.floatingPetBubbleAlertsLabel, $store.floatingPetBubbleAlerts)

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -51,7 +51,7 @@ private struct ShopItemCard: View {
     let kind: ItemKind
     @State private var confirming = false
 
-    private var price: Int { kind.shopPrice ?? 0 }
+    private var price: Int { store.price(of: kind) ?? 0 }
 
     var body: some View {
         let l = store.l
@@ -133,7 +133,7 @@ private struct EggCard: View {
     @State private var stage: Stage = .idle
     private enum Stage { case idle, confirm, shinyConfirm }
 
-    private var price: Int { FreshEgg.price(guaranteeing: tier) }
+    private var price: Int { store.price(of: .egg(tier)) }
 
     var body: some View {
         let l = store.l

--- a/Tests/PokeTokenBarTests/DifficultyTests.swift
+++ b/Tests/PokeTokenBarTests/DifficultyTests.swift
@@ -1,0 +1,442 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// 난이도 배율 — 검증 배율이 표시가 아니라 **실제 동작**을 바꾸는지 확인한다.
+/// 핵심 형태: 같은 토큰 입력에 배율만 다르게 줘서 결과(진화/부화/구매 성사)가 갈리는지 본다.
+@MainActor
+final class DifficultyTests: XCTestCase {
+
+    private func line() -> EvoLine {
+        var names: [Int: [String: String]] = [:]
+        for id in [1, 2, 3] { names[id] = ["en": "P\(id)"] }
+        return EvoLine(baseID: 1,
+                       tree: EvoNode(speciesID: 1, children: [EvoNode(speciesID: 2, children: [EvoNode(speciesID: 3, children: [])])]),
+                       rarity: .common, names: names)
+    }
+
+    /// `used` 를 주면 지갑 잔액이 시드된 상태 파일로 시작한다(ShopTests 와 같은 JSON 시드 패턴).
+    private func store(growth: Double = 1.0, shop: Double = 1.0, used: Int = 0) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("ptb-diff-\(UUID().uuidString).json")
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":\(used),\"spentTokens\":0,"
+            + "\"lastDate\":\"d\",\"dex\":[],\"collectedFinals\":[]}"
+        try? json.data(using: .utf8)!.write(to: url)
+        let suite = UserDefaults(suiteName: "ptb-diff-\(UUID().uuidString)")!
+        suite.set(growth, forKey: "growthDifficulty")
+        suite.set(shop, forKey: "shopDifficulty")
+        return CompanionStore(provider: StubDiffProvider(value: line()),
+                              clock: { Date(timeIntervalSince1970: 1_700_000_000) },
+                              fileURL: url, rng: SeededDiffRNG(seed: 7),
+                              dittoDisguiseRollingEnabled: false,
+                              defaults: suite)
+    }
+
+    private func hatched(growth: Double = 1.0, shop: Double = 1.0, used: Int = 0) async -> CompanionStore {
+        let s = store(growth: growth, shop: shop, used: used)
+        await s.hatch(baseID: 1)
+        return s
+    }
+
+    // MARK: 1. 진화 — 같은 토큰, 다른 결과 (표시가 아니라 상태 전이)
+
+    func testSameTokensEvolveOnlyWhenDifficultyLowered() async {
+        let baseThreshold = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0)
+        let half = baseThreshold / 2
+
+        let normal = await hatched(growth: 1.0)
+        normal.applyUsage(half)
+        XCTAssertEqual(normal.state.active?.stageIndex, 0, "1.0x: 절반으론 진화하면 안 된다")
+        XCTAssertEqual(normal.state.active?.currentID, 1)
+
+        let easy = await hatched(growth: 0.5)
+        easy.applyUsage(half)
+        XCTAssertEqual(easy.state.active?.stageIndex, 1, "0.5x: 같은 절반으로 진화해야 한다")
+        XCTAssertEqual(easy.state.active?.currentID, 2, "실제 종이 바뀌었는가(표시가 아니라 상태)")
+    }
+
+    func testHarderDifficultyBlocksEvolutionThatWouldOtherwiseHappen() async {
+        let baseThreshold = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0)
+
+        let normal = await hatched(growth: 1.0)
+        normal.applyUsage(baseThreshold)
+        XCTAssertEqual(normal.state.active?.stageIndex, 1, "1.0x: 정확히 임계면 진화")
+
+        let hard = await hatched(growth: 2.0)
+        hard.applyUsage(baseThreshold)
+        XCTAssertEqual(hard.state.active?.stageIndex, 0, "2.0x: 같은 양으론 진화 못 한다")
+    }
+
+    /// 표시값(tokensToNext/progress)이 상태 전이와 같은 임계를 쓰는가 — 둘이 어긋나면
+    /// "다음 단계까지" 문구만 바뀌고 실제 진화는 안 바뀌는 표면적 구현이 된다.
+    func testDisplayedTokensToNextMatchesTheThresholdThatActuallyEvolves() async {
+        let s = await hatched(growth: 0.5)
+        let shown = s.tokensToNext
+        XCTAssertEqual(shown, PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0) / 2,
+                       "표시값이 배율을 반영")
+        // 표시된 양보다 1 적게 주면 진화 안 하고, 딱 맞추면 진화한다 → 표시 = 실제 임계.
+        s.applyUsage(shown - 1)
+        XCTAssertEqual(s.state.active?.stageIndex, 0)
+        XCTAssertEqual(s.tokensToNext, 1, "남은 양도 배율 기준으로 줄어든다")
+        s.applyUsage(1)
+        XCTAssertEqual(s.state.active?.stageIndex, 1, "표시된 양을 채우면 실제로 진화한다")
+    }
+
+    // MARK: 2. 부화 — 알이 실제로 깨지는 지점이 바뀌는가
+
+    func testEggHatchPointMovesWithDifficulty() async {
+        let half = PokemonBalance.eggHatchThreshold / 2
+
+        let normal = store(growth: 1.0)
+        normal.update(todayTokensByProvider: ["t": 0], todayDate: "d1", monthTotal: 0,
+                      burnTier: .idle, limitWarning: false, hasUsageData: true)
+        normal.update(todayTokensByProvider: ["t": half], todayDate: "d1", monthTotal: 0,
+                      burnTier: .idle, limitWarning: false, hasUsageData: true)
+        await normal.hatchIfNeeded()
+        XCTAssertNil(normal.state.active, "1.0x: 절반으론 안 깨진다")
+
+        let easy = store(growth: 0.5)
+        easy.update(todayTokensByProvider: ["t": 0], todayDate: "d1", monthTotal: 0,
+                    burnTier: .idle, limitWarning: false, hasUsageData: true)
+        easy.update(todayTokensByProvider: ["t": half], todayDate: "d1", monthTotal: 0,
+                    burnTier: .idle, limitWarning: false, hasUsageData: true)
+        await easy.hatchIfNeeded()
+        XCTAssertNotNil(easy.state.active, "0.5x: 같은 양으로 부화")
+    }
+
+    // MARK: 3. 상점 — 결제 금액과 구매 가능 판정이 바뀌는가
+
+    func testShopGateAndChargedAmountFollowDifficulty() async {
+        let halfPrice = RareCandy.price / 2
+
+        let normal = await hatched(shop: 1.0, used: halfPrice)
+        XCTAssertFalse(normal.canBuy(.rareCandy), "1.0x: 절반 잔액으론 못 산다")
+
+        let cheap = await hatched(shop: 0.5, used: halfPrice)
+        XCTAssertTrue(cheap.canBuy(.rareCandy), "0.5x: 같은 잔액으로 살 수 있다")
+        XCTAssertTrue(cheap.buy(.rareCandy))
+        XCTAssertEqual(cheap.state.spentTokens, halfPrice, "실제 차감액도 배율 적용")
+        XCTAssertEqual(cheap.itemCount(.rareCandy), 1, "물건이 실제로 들어왔는가")
+    }
+
+    func testEggPriceScalesAndIsActuallyCharged() async {
+        let s = await hatched(shop: 0.5, used: FreshEgg.price)
+        XCTAssertEqual(s.price(of: .egg(nil)), FreshEgg.price / 2)
+        XCTAssertTrue(s.buyEgg(nil))
+        XCTAssertEqual(s.state.spentTokens, FreshEgg.price / 2)
+    }
+
+    // MARK: 4. 두 슬라이더는 서로 독립인가 (등급 알 가격이 graduationTotal 비율에서 파생되므로 중요)
+
+    func testGrowthSliderDoesNotMoveShopPricesAndViceVersa() async {
+        let growthOnly = await hatched(growth: 0.1, shop: 1.0)
+        XCTAssertEqual(growthOnly.price(of: .item(.rareCandy)), RareCandy.price, "성장 배율이 가격을 건드리면 안 된다")
+        XCTAssertEqual(growthOnly.price(of: .egg(.rare)), FreshEgg.price(guaranteeing: .rare))
+
+        let shopOnly = await hatched(growth: 1.0, shop: 0.1)
+        XCTAssertEqual(shopOnly.tokensToNext,
+                       PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0),
+                       "상점 배율이 성장 임계를 건드리면 안 된다")
+    }
+
+    /// 등급 알의 상대 가격비(1 : 2.5 : 4)는 배율과 무관하게 보존돼야 한다.
+    func testGradedEggRatioSurvivesScaling() async {
+        let s = await hatched(shop: 0.4)
+        let plain = Double(s.price(of: .egg(nil)))
+        XCTAssertEqual(Double(s.price(of: .egg(.uncommon))) / plain, 2.5, accuracy: 0.001)
+        XCTAssertEqual(Double(s.price(of: .egg(.rare))) / plain, 4.0, accuracy: 0.001)
+    }
+
+    // MARK: 5. 라이브 반영 — 재시작 없이 그 자리에서
+
+    func testLoweringDifficultyLiveTriggersEvolutionImmediately() async {
+        let s = await hatched(growth: 1.0)
+        let baseThreshold = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0)
+        s.applyUsage(baseThreshold - 1)
+        XCTAssertEqual(s.state.active?.stageIndex, 0, "아직 진화 전")
+
+        s.setGrowthDifficulty(0.5)   // 슬라이더를 내리는 순간
+        XCTAssertEqual(s.state.active?.stageIndex, 1, "폴링을 기다리지 않고 즉시 진화")
+    }
+
+    func testShopPriceChangesLiveWithoutRestart() async {
+        let s = await hatched(shop: 1.0)
+        XCTAssertEqual(s.price(of: .item(.rareCandy)), RareCandy.price)
+        s.setShopDifficulty(0.5)
+        XCTAssertEqual(s.price(of: .item(.rareCandy)), RareCandy.price / 2)
+    }
+
+    func testDifficultyPersistsToDefaults() async {
+        let s = await hatched()
+        s.setGrowthDifficulty(0.3)
+        s.setShopDifficulty(1.7)
+        XCTAssertEqual(s.growthDifficulty, 0.3, accuracy: 0.0001)
+        XCTAssertEqual(s.shopDifficulty, 1.7, accuracy: 0.0001)
+    }
+
+    // MARK: 6. 클램프 — 외부에서 쓰인 쓰레기 값
+
+    /// 경계값은 상수에서 파생한다 — 범위를 조정해도 테스트가 같이 따라오게(하드코딩 드리프트 방지).
+    func testGarbageDefaultsAreClamped() {
+        let lo = PokemonBalance.difficultyRange.lowerBound
+        let hi = PokemonBalance.difficultyRange.upperBound
+        XCTAssertEqual(PokemonBalance.clampDifficulty(0), lo, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.clampDifficulty(-5), lo, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.clampDifficulty(hi * 10), hi, accuracy: 1e-9)
+        // 유한하지 않은 값은 "아주 어려움"이 아니라 손상된 값 → 상·하한이 아니라 기본값으로 되돌린다.
+        XCTAssertEqual(PokemonBalance.clampDifficulty(.nan), PokemonBalance.defaultDifficulty, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.clampDifficulty(.infinity), PokemonBalance.defaultDifficulty, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.clampDifficulty(-.infinity), PokemonBalance.defaultDifficulty, accuracy: 1e-9)
+    }
+
+    /// 배율 0 이 저장돼 있어도 임계가 0 이 되지 않는다(진행률 0 나눗셈·퇴화 루프 방지).
+    func testZeroInDefaultsCannotProduceZeroThreshold() async {
+        let s = await hatched(growth: 0)
+        XCTAssertEqual(s.growthDifficulty, PokemonBalance.difficultyRange.lowerBound, accuracy: 1e-9)
+        XCTAssertGreaterThan(s.tokensToNext, 0)
+        XCTAssertGreaterThan(s.eggTokensToHatch, 0)
+    }
+
+    /// 가장 낮은 배율에서도 어떤 임계·가격도 0 으로 무너지지 않는다(가장 작은 기준값이 알 5M).
+    func testNothingCollapsesToZeroAtMinimumDifficulty() async {
+        let lo = PokemonBalance.difficultyRange.lowerBound
+        XCTAssertGreaterThan(PokemonBalance.scaled(PokemonBalance.eggHatchThreshold, by: lo), 0)
+        for rarity in [Rarity.common, .uncommon, .rare, .legendary] {
+            for k in 1...3 {
+                for i in 0..<k {
+                    let t = PokemonBalance.scaled(
+                        PokemonBalance.phaseThreshold(rarity: rarity, totalForms: k, stageIndex: i), by: lo)
+                    XCTAssertGreaterThan(t, 0, "rarity=\(rarity) k=\(k) i=\(i)")
+                }
+            }
+        }
+        let s = await hatched(shop: lo)
+        for entry in s.shopEntries { XCTAssertGreaterThan(s.price(of: entry), 0, "\(entry)") }
+    }
+
+    // MARK: 7. 슬라이더 위치 매핑 (로그) + 퍼센트 표기
+
+    func testPositionRoundTripsThroughDifficulty() {
+        for value in [0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 20.0] {
+            let back = PokemonBalance.difficulty(atPosition: PokemonBalance.difficultyPosition(value))
+            XCTAssertEqual(back, value, accuracy: value * 0.02, "value=\(value)")
+        }
+    }
+
+    func testPositionEndpointsMapToRangeBounds() {
+        XCTAssertEqual(PokemonBalance.difficulty(atPosition: 0),
+                       PokemonBalance.difficultyRange.lowerBound, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.difficulty(atPosition: 1),
+                       PokemonBalance.difficultyRange.upperBound, accuracy: 1e-6)
+        XCTAssertEqual(PokemonBalance.difficultyPosition(PokemonBalance.difficultyRange.lowerBound), 0, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.difficultyPosition(PokemonBalance.difficultyRange.upperBound), 1, accuracy: 1e-9)
+    }
+
+    /// 로그 슬라이더에서도 기본값(100%)으로 되돌릴 수 있어야 한다 — 스냅이 없으면 도달 불가.
+    func testDefaultIsReachableByDragging() {
+        let exactPosition = PokemonBalance.difficultyPosition(1.0)
+        for offset in [-0.009, -0.005, 0.0, 0.005, 0.009] {
+            XCTAssertEqual(PokemonBalance.difficulty(atPosition: exactPosition + offset), 1.0,
+                           accuracy: 1e-9, "offset=\(offset) 에서 100% 로 붙어야 한다")
+        }
+    }
+
+    /// 스냅 결과는 유효숫자 2자리 — 표시가 1.0473 같은 값으로 지저분해지지 않는다.
+    func testSnapKeepsTwoSignificantDigits() {
+        XCTAssertEqual(PokemonBalance.snapDifficulty(1.234), 1.2, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.snapDifficulty(15.7), 16, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.snapDifficulty(0.0123), 0.012, accuracy: 1e-9)
+    }
+
+    func testPercentFormatting() {
+        let l = L(.en)
+        XCTAssertEqual(l.difficultyValue(1.0), "100%")
+        XCTAssertEqual(l.difficultyValue(0.5), "50%")
+        XCTAssertEqual(l.difficultyValue(20), "2000%")
+        XCTAssertEqual(l.difficultyValue(0.05), "5.0%")
+        // 작은 쪽이 전부 "0%" 로 뭉개지지 않는가 — 범위 하한이 0.01% 라 자릿수가 필요하다.
+        XCTAssertEqual(l.difficultyValue(0.0001), "0.01%")
+        XCTAssertNotEqual(l.difficultyValue(0.0001), l.difficultyValue(0.0005))
+    }
+}
+
+// MARK: 스텁
+
+private struct StubDiffProvider: PokeProviding {
+    let value: EvoLine
+    func line(baseSpeciesID: Int) async throws -> EvoLine { value }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: value.baseID, captureRate: 255)] }
+}
+
+private struct SeededDiffRNG: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+// MARK: 알 스폰 (설정 — 종 지정)
+
+@MainActor
+final class SpawnEggTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func line(base: Int) -> EvoLine {
+        EvoLine(baseID: base,
+                tree: EvoNode(speciesID: base, children: []),
+                rarity: .common, names: [base: ["en": "P\(base)", "ko": "포\(base)"]])
+    }
+
+    private func store(bases: [BaseSpecies] = [], hatchTo base: Int = 25) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("spawn-\(UUID().uuidString).json")
+        let suite = UserDefaults(suiteName: "spawn-\(UUID().uuidString)")!
+        return CompanionStore(provider: SpawnStubProvider(value: line(base: base), index: bases),
+                              clock: { self.now }, fileURL: url, rng: SeededSpawnRNG(seed: 3),
+                              dittoDisguiseRollingEnabled: false, defaults: suite)
+    }
+
+    /// 핵심: 스폰한 알은 **지정한 종으로** 부화한다(랜덤 롤이 아니라).
+    func testSpawnedEggHatchesIntoTheChosenSpecies() async {
+        let s = store(hatchTo: 25)
+        s.spawnEgg(baseID: 25)
+        XCTAssertEqual(s.state.pendingHatchID, 25, "pre-roll 이 고정된다")
+        s.update(todayTokensByProvider: ["t": 0], todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        s.update(todayTokensByProvider: ["t": PokemonBalance.eggHatchThreshold], todayDate: "d1",
+                 monthTotal: 0, burnTier: .idle, limitWarning: false, hasUsageData: true)
+        await s.hatchIfNeeded()
+        XCTAssertEqual(s.state.active?.baseID, 25, "고른 종으로 부화")
+    }
+
+    /// 스폰은 즉시 부화가 아니다 — 알로 놓이고 인큐베이션을 다시 채워야 한다.
+    func testSpawnLeavesAnEggThatStillNeedsIncubation() async {
+        let s = store(hatchTo: 25)
+        await s.hatch(baseID: 25)
+        XCTAssertNotNil(s.state.active)
+        s.spawnEgg(baseID: 25)
+        XCTAssertNil(s.state.active, "현재 개체는 치워진다")
+        XCTAssertEqual(s.state.eggUsage, 0, "인큐베이션은 처음부터")
+        await s.hatchIfNeeded()
+        XCTAssertNil(s.state.active, "임계 미달이면 아직 안 깨진다")
+    }
+
+    /// 폐기지 졸업이 아니다 — 도감·분기 가중에 흔적을 남기지 않는다("뽑은 적 없던 것처럼").
+    func testSpawnDiscardsWithoutPokedexCredit() async {
+        let s = store(hatchTo: 25)
+        await s.hatch(baseID: 25)
+        let dexBefore = s.state.dex.count
+        let finalsBefore = s.state.collectedFinals
+        s.spawnEgg(baseID: 133)
+        XCTAssertEqual(s.state.dex.count, dexBefore, "도감에 추가되지 않는다")
+        XCTAssertEqual(s.state.collectedFinals, finalsBefore, "분기 가중도 그대로")
+    }
+
+    /// 스폰은 지갑을 건드리지 않는다(구매가 아니다).
+    func testSpawnIsFree() async {
+        let s = store(hatchTo: 25)
+        await s.hatch(baseID: 25)
+        let spent = s.state.spentTokens
+        s.spawnEgg(baseID: 133)
+        XCTAssertEqual(s.state.spentTokens, spent)
+    }
+
+    /// 알 상태에서도 다시 스폰해 종을 바꿀 수 있다(buyEgg 와 달리 활성 개체를 요구하지 않는다).
+    func testSpawnWorksFromEggStateAndRepins() {
+        let s = store()
+        s.spawnEgg(baseID: 1)
+        XCTAssertEqual(s.state.pendingHatchID, 1)
+        s.spawnEgg(baseID: 4)
+        XCTAssertEqual(s.state.pendingHatchID, 4, "다시 고르면 pre-roll 이 갈린다")
+    }
+
+    /// 스폰은 등급 보증을 남기지 않는다 — 남아 있으면 hatchCore 의 보증 관문이 고정 종을 버린다.
+    func testSpawnClearsAnyGuaranteeSoThePinSurvivesHatch() async {
+        let s = store(hatchTo: 25)
+        await s.hatch(baseID: 25)
+        s.spawnEgg(baseID: 25)
+        XCTAssertNil(s.state.eggTier, "보증이 남으면 고정 종이 버려질 수 있다")
+    }
+
+    /// 세대 교체가 일어나야 한다 — 진행 중이던 비동기 부화·라인 로드가 새 알을 덮어쓰지 않도록.
+    func testSpawnAdvancesGenerationAndClearsLine() async {
+        let s = store(hatchTo: 25)
+        await s.hatch(baseID: 25)
+        XCTAssertNotNil(s.currentLine)
+        s.spawnEgg(baseID: 133)
+        XCTAssertNil(s.currentLine, "이전 개체의 라인이 남지 않는다")
+    }
+
+    /// 목록은 부화 후보와 같은 인덱스에서 온다(메타몽 제외 등 규칙이 자동으로 따라온다).
+    func testSpawnableBasesLoadFromTheSameIndexAndSortByDexNumber() async {
+        let s = store(bases: [BaseSpecies(id: 7, captureRate: 45),
+                              BaseSpecies(id: 1, captureRate: 45, names: ["en": "Bulbasaur", "ko": "이상해씨"])])
+        await s.loadSpawnableBases()
+        XCTAssertEqual(s.spawnableBases.map(\.id), [1, 7], "도감 번호순")
+    }
+
+    func testSpawnableLabelUsesCurrentLanguageAndFallsBackToNumber() async {
+        let s = store(bases: [BaseSpecies(id: 1, captureRate: 45, names: ["en": "Bulbasaur", "ko": "이상해씨"]),
+                              BaseSpecies(id: 7, captureRate: 45)])
+        await s.loadSpawnableBases()
+        s.setLanguage(.ko)
+        XCTAssertEqual(s.spawnableLabel(s.spawnableBases[0]), "#1 이상해씨")
+        s.setLanguage(.en)
+        XCTAssertEqual(s.spawnableLabel(s.spawnableBases[0]), "#1 Bulbasaur")
+        // 이름 없는 항목(REST 폴백·구버전 캐시)은 번호만 — 번호가 두 번 나오면 안 된다.
+        XCTAssertEqual(s.spawnableLabel(s.spawnableBases[1]), "#7")
+        XCTAssertFalse(s.spawnableLabel(s.spawnableBases[1]).contains("#7 #7"))
+    }
+
+    /// [회귀] 이름 필드가 생기기 전 캐시는 만료로 취급해 다시 받아야 한다. `names` 를 옵셔널로 둬
+    /// 옛 스냅샷이 *디코딩*은 되게 만든 것이 원인이었다 — 그대로 읽히니 30일 TTL 이 끝날 때까지
+    /// 목록이 전부 "#id" 로 남았다(디코딩 호환 ≠ 캐시 무효화).
+    func testIndexCacheWithoutNamesIsTreatedAsExpired() {
+        let old = [BaseSpecies(id: 1, captureRate: 45), BaseSpecies(id: 4, captureRate: 45)]
+        XCTAssertTrue(PokeAPIClient.indexPredatesNames(old), "이름 없는 캐시 → 재요청")
+
+        let new = [BaseSpecies(id: 1, captureRate: 45, names: ["en": "Bulbasaur"]),
+                   BaseSpecies(id: 4, captureRate: 45)]
+        XCTAssertFalse(PokeAPIClient.indexPredatesNames(new), "이름이 있으면 캐시 그대로 사용")
+
+        // 빈 dict 는 이름이 채워진 게 아니다 — "있는 척"으로 통과하면 안 된다.
+        XCTAssertTrue(PokeAPIClient.indexPredatesNames([BaseSpecies(id: 1, captureRate: 45, names: [:])]))
+    }
+
+    /// 인덱스를 못 받아오면 빈 목록 — UI 가 그걸로 비활성/안내를 판단한다(크래시·부분상태 금지).
+    func testSpawnableBasesEmptyWhenIndexUnavailable() async {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("spawn-\(UUID().uuidString).json")
+        let s = CompanionStore(provider: FailingIndexProvider(), clock: { self.now }, fileURL: url,
+                               rng: SeededSpawnRNG(seed: 3), dittoDisguiseRollingEnabled: false,
+                               defaults: UserDefaults(suiteName: "spawn-\(UUID().uuidString)")!)
+        await s.loadSpawnableBases()
+        XCTAssertTrue(s.spawnableBases.isEmpty)
+    }
+}
+
+private struct SpawnStubProvider: PokeProviding {
+    let value: EvoLine
+    let index: [BaseSpecies]
+    func line(baseSpeciesID: Int) async throws -> EvoLine { value }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { index }
+}
+
+private struct FailingIndexProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine { throw URLError(.notConnectedToInternet) }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { throw URLError(.notConnectedToInternet) }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { nil }
+}
+
+private struct SeededSpawnRNG: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -146,11 +146,45 @@ final class FloatingPetEnergyTests: XCTestCase {
         XCTAssertTrue(FloatingPetController.shouldAnimate(lowPower: false))
     }
 
-    /// [회귀] 펫은 반드시 fps 캡이 걸려야 한다 — frameFloor 가 0 으로 돌아가면(네이티브 fps) 메뉴바에서
-    /// 고친 wakeup 회귀가 재발한다. 뷰가 실제로 넘기는 상수를 그대로 가드한다(리터럴 유실 방지).
+    /// [회귀] 절전 모드(부드러움 끔)의 fps 캡 상수는 그대로 유지돼야 한다 — 0 으로 돌아가면
+    /// 메뉴바에서 고친 wakeup 회귀가 절전 경로에서까지 재발한다.
+    ///
+    /// **주의**: 이 상수만으로는 "펫이 실제로 캡을 쓴다"를 더는 보장하지 않는다(부드러움 설정이
+    /// 생기면서 적용 여부가 갈린다) — 실제 적용은 아래 effectiveFrameFloor 테스트가 잠근다.
     func testPetFrameFloorIsCapped() {
         XCTAssertGreaterThan(FloatingPetView.frameFloor, 0, "펫 fps 캡이 해제되면 idle wakeup 회귀")
         XCTAssertEqual(FloatingPetView.frameFloor, 0.4, accuracy: 1e-9, "메뉴바와 동일한 0.4s≈2.5fps 캡")
+    }
+
+    /// 푸터 눈 아이콘은 **현재 상태**를 그린다 — 뒤집히면 "숨김"인데 켜진 것처럼 보인다.
+    /// 아이콘/툴팁이 설정창 스위치와 같은 값에서 파생되는지는 두 곳 모두 store.floatingPetEnabled 를
+    /// 읽는 것으로 보장되고(별도 상태 없음), 여기선 그 값 → 심볼 매핑만 잠근다.
+    func testFooterEyeSymbolFollowsVisibility() {
+        XCTAssertEqual(FloatingPetView.visibilitySymbol(visible: true), "eye")
+        XCTAssertEqual(FloatingPetView.visibilitySymbol(visible: false), "eye.slash")
+    }
+
+    /// 부드러움 설정이 실제로 프레임 하한을 가른다 — 켜면 네이티브(팝오버와 동일), 끄면 배터리 캡.
+    /// 두 분기를 모두 잠근다: 한쪽만 보면 설정이 상수에 묶여 버린 회귀를 못 잡는다.
+    func testSmoothSettingSelectsFrameFloor() {
+        XCTAssertEqual(FloatingPetView.effectiveFrameFloor(smooth: true), 0, accuracy: 1e-9,
+                       "켜짐 = 네이티브 fps(팝오버와 동일)")
+        XCTAssertEqual(FloatingPetView.effectiveFrameFloor(smooth: false), FloatingPetView.frameFloor,
+                       accuracy: 1e-9, "꺼짐 = 배터리 캡")
+    }
+
+    /// 부드러움이 켜져도 프레임 지속은 GIF 원본 delay 그대로여야 한다(하한 0 = 캡 없음).
+    /// 팝오버가 쓰는 경로와 같은 계산인지 확인 — 두 표면이 같은 규칙을 쓰는 게 이 설정의 목적이다.
+    func testSmoothPetUsesTheSameDelayAsThePopover() {
+        for native in [0.05, 0.062, 0.1, 0.5] {
+            XCTAssertEqual(SpriteView.frameDelay(base: native,
+                                                 floor: FloatingPetView.effectiveFrameFloor(smooth: true)),
+                           SpriteView.frameDelay(base: native, floor: 0), accuracy: 1e-9)
+        }
+        // 꺼짐: 네이티브가 캡보다 빠른 구간은 캡으로 눌린다(절전 경로가 살아 있는지).
+        XCTAssertEqual(SpriteView.frameDelay(base: 0.1,
+                                             floor: FloatingPetView.effectiveFrameFloor(smooth: false)),
+                       0.4, accuracy: 1e-9)
     }
 
     /// Bubble needs headroom + width beyond the square pet size — otherwise content is clipped.

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -376,6 +376,15 @@ read_when:
   (팝오버 `popoverDidClose` 패턴). 회귀 가드: `FloatingPetEnergyTests`(fps 하한 clamp·`frameFloor>0`·팝오버 불변·
   low-power 정적화 순수 판정 — SwiftUI `.task` 타이밍 자체는 호스트 없이 xctest 불가라 순수 경로만 잠금). occlusion 게이팅은
   all-spaces/`.floating` 펫이 실제로 거의 안 가려져 메뉴바와 동일 수확체감으로 미도입. (#102 리뷰 지적 반영, 2026-07-22.)
+- **fps 하한은 이제 무조건이 아니라 사용자 설정이다** (`UsageStore.floatingPetSmoothAnimation`, 기본 켬).
+  실측 배경: 펫은 0.4s 캡 때문에 2.5fps 인데 스프라이트 원본은 10~16fps 라 4~6배 느리고, 여기에 sleep
+  `tolerance`(delay×0.5) 지터가 겹쳐 "버벅인다"는 인상이 된다 — 팝오버(하한 0)와 나란히 두면 차이가 명확하다.
+  켜면 하한 0(팝오버와 동일), 끄면 기존 0.4s 캡. **`frameFloor` 상수만 보는 가드로는 더 이상 "펫이 캡을
+  쓴다"가 보장되지 않는다** — 적용 분기는 `FloatingPetView.effectiveFrameFloor(smooth:)` 이고
+  `testSmoothSettingSelectsFrameFloor` 가 두 분기를 잠근다. 저전력 모드 정적화(`shouldAnimate`)는 이
+  설정과 무관하게 항상 우선한다. 함정: 프레임 루프는 **시작 시점의 하한을 들고 도는** 구조라
+  `SpriteView` 의 `.task(id:)` 에 `minFrameDelay` 를 넣지 않으면 설정을 바꿔도 다음 스프라이트 교체
+  전까지 옛 fps 로 계속 돌아 "설정이 안 먹는" 것처럼 보인다. (2026-08-20.)
 
 ## 알림
 


### PR DESCRIPTION
Four related controls for tuning and inspecting the companion, plus the plumbing each needed.

## Difficulty multipliers (Settings)

Two independent multipliers — **growth** (egg incubation, evolution, graduation) and **shop prices** — applied live, no restart.

- Scaling happens at the **consumption sites** in `CompanionStore`, not on the constant tables. This matters: graded egg prices derive from a *ratio* of `graduationTotal`, so scaling that table in place would let the growth slider silently move shop pricing. Consumption-site scaling keeps the two independent and leaves every existing balance test valid.
- Persisted in `UserDefaults` with the other Settings preferences, **not** in `CompanionState`. Difficulty is a preference, not save data — keeping it out means save export/import can't carry someone else's difficulty, and `SaveTransfer` is untouched.
- Lowering growth re-evaluates evolution and hatching immediately rather than waiting for the next usage poll.
- `RareCandy.xp` is deliberately **not** scaled. Scaling it would cancel against the thresholds and make candy the one thing immune to difficulty.
- The slider is **log-mapped**. The range spans several orders of magnitude, where a linear track puts the default at ~5% of the width and makes exactly 1.0 unreachable. Values snap to two significant figures, and a position-space window keeps 100% selectable by drag.

## Spawn egg (Settings)

Releases the current companion and pins the next hatch to a chosen species, using the existing `pendingHatchID` pre-roll — no new hatch path.

- Hatching still follows normal rules: incubation must be refilled, and shiny/nature/branch still roll at hatch. It pins the species only.
- Discard semantics match buying an egg: no Pokédex credit, no effect on branch weighting.
- `buyEgg`'s discard transition is extracted into `resetToFreshEgg` so both paths share it. Duplicating it invites drift in exactly the easy-to-forget parts (generation bump, representative reconcile) that cause async-overwrite bugs.
- The base index GraphQL query now carries localized names in the **same request**, so the picker shows real names for all 328 base species with no extra round trips. 329 flat menu items is unusable, so they're grouped into Gen 1–5 submenus.
- Snapshots written before that field are treated as **expired**. Lenient decoding kept them readable but nameless, which would have left the picker showing bare numbers until the 30-day TTL elapsed — decodable is not the same as correct.

## Floating pet animation (Settings)

The pet was capped at 0.4s/frame (2.5fps) while sprites run at 10–16fps natively, with sleep-tolerance jitter on top — so it read as stuttering next to the popover, which runs uncapped.

- The cap is now a toggle, defaulting to smooth. Turning it off restores the original battery cap from the energy work in #102.
- `minFrameDelay` is included in `SpriteView`'s `.task(id:)`. The frame loop holds the floor captured at start, so without this the setting would appear dead until the next sprite change.
- Low-power mode still freezes the pet regardless of this setting.

## Popover footer

An eye button toggles desktop pet visibility. It reads and writes the same `floatingPetEnabled` property the Settings switch is bound to, so the two cannot diverge — no mirrored state.

## Tests

`DifficultyTests` (30 tests) covers scaling **behaviourally** — same token input to stores differing only in multiplier, asserting on state transitions rather than displayed strings — plus slider mapping and egg spawning.

Verified by mutation rather than by passing: stripping the multipliers out of the seams fails 8 tests, and making the species pin a no-op fails 4. That check mattered — the spawn stub returns a fixed line, so one test could have passed vacuously.

The pet frame-floor guard no longer proves the cap is *applied* now that it's conditional, so the applied branch is covered separately and the original test notes its narrowed scope rather than reading stronger than it is.

`docs/reference/defect-log.md` records the fps cap becoming user-selectable and the task-id trap, so the documented invariant doesn't go stale.

## Notes

- `LocalAdditionalUsageTests.testHermesAcceptsMillisecondStartedAt` fails on this branch, but it **also fails on a clean `main`** — a timezone-dependent date assertion, unrelated to these changes. Everything else passes (765 tests, 8 skipped), with zero build warnings.
- Eggs disappear from the Shop while you're in egg state. That's pre-existing (`hasActive` gate) and unchanged here, but Spawn Egg makes egg state far easier to reach, so it surfaces more often.

---

# 한국어

컴패니언을 조절하고 들여다보기 위한 네 가지 컨트롤과, 각각에 필요한 배선을 더한다.

## 난이도 배율 (설정)

**성장**(알 인큐베이션·진화·졸업)과 **상점 가격**, 서로 독립인 두 배율. 재시작 없이 즉시 반영된다.

- 스케일은 상수표가 아니라 `CompanionStore` 의 **소비 지점**에서 곱한다. 이게 중요한 이유: 등급 알 가격이 `graduationTotal` 의 *비율*에서 파생되므로, 표를 직접 스케일하면 성장 배율이 상점 가격까지 조용히 끌고 간다. 소비 지점 스케일이라야 두 배율이 독립으로 남고, 기존 밸런스 테스트도 전부 그대로 유효하다.
- `CompanionState` 가 아니라 다른 설정값들과 함께 **`UserDefaults`** 에 저장한다. 난이도는 진행 상황이 아니라 취향 설정이다 — 세이브에서 빼두면 남의 세이브를 불러올 때 내 난이도가 바뀌는 일이 없고, `SaveTransfer` 는 아예 건드리지 않는다.
- 성장 배율을 내리면 다음 사용량 폴링을 기다리지 않고 그 자리에서 진화·부화를 다시 판정한다.
- `RareCandy.xp` 는 **의도적으로 스케일하지 않는다.** 함께 곱하면 임계와 서로 상쇄돼 사탕만 난이도를 안 타게 된다.
- 슬라이더는 **로그 매핑**이다. 범위가 여러 자릿수를 넘어서 선형 트랙이면 기본값이 폭의 5% 지점에 몰리고 정확히 1.0 을 고를 수 없다. 값은 유효숫자 2자리로 스냅하고, 위치 기준 창을 둬서 드래그로 100% 를 집을 수 있게 했다.

## 알 스폰 (설정)

현재 컴패니언을 놓아주고, 기존 `pendingHatchID` pre-roll 을 이용해 다음 부화 종을 고정한다 — 새 부화 경로를 만들지 않는다.

- 부화 자체는 평소 규칙 그대로다: 인큐베이션을 다시 채워야 하고, 이로치·성격·분기는 여전히 부화 순간 롤된다. 종만 고정할 뿐이다.
- 폐기 의미는 알 구매와 동일하다 — 도감에 남지 않고, 분기 가중에도 영향이 없다.
- `buyEgg` 의 폐기 전이를 `resetToFreshEgg` 로 뽑아 두 경로가 공유하게 했다. 복제해 두면 빠뜨리기 쉬운 부분(세대 증가, 대표 종 복구)에서 어긋나고, 그게 비동기 덮어쓰기 결함의 원인이 된다.
- base 인덱스 GraphQL 쿼리가 **같은 요청에** 다국어 이름을 함께 실어 온다 — 추가 왕복 없이 328종 전부 실제 이름으로 보인다. 329개를 평면 메뉴에 쏟으면 고를 수 없어서 1~5세대 서브메뉴로 나눴다.
- 이 필드 이전에 저장된 스냅샷은 **만료로 취급**한다. 관대 디코딩 덕에 읽히기는 하지만 이름이 없어서, 그대로 두면 30일 TTL 이 끝날 때까지 목록이 번호만 나온다 — 디코딩이 된다는 것과 맞다는 것은 다르다.

## 플로팅 펫 애니메이션 (설정)

펫은 0.4s/프레임(2.5fps)로 묶여 있었는데 스프라이트 원본은 10~16fps 라, 여기에 sleep tolerance 지터까지 겹쳐 캡이 없는 팝오버 옆에 두면 버벅이는 것처럼 보였다.

- 이제 캡이 토글이고 기본은 부드러움이다. 끄면 #102 에너지 작업에서 온 원래 배터리 캡으로 돌아간다.
- `minFrameDelay` 를 `SpriteView` 의 `.task(id:)` 에 포함했다. 프레임 루프는 시작 시점의 하한을 들고 돌기 때문에, 이게 없으면 다음 스프라이트 교체 전까지 설정이 안 먹는 것처럼 보인다.
- 저전력 모드의 정적화는 이 설정과 무관하게 항상 우선한다.

## 팝오버 푸터

눈 아이콘으로 데스크톱 펫 표시를 토글한다. 설정창 스위치가 묶여 있는 것과 **같은** `floatingPetEnabled` 를 읽고 쓰므로 둘이 어긋날 수 없다 — 별도 미러 상태가 없다.

## 테스트

`DifficultyTests`(30개)는 스케일을 **동작으로** 검증한다 — 배율만 다른 스토어에 같은 토큰을 넣고, 표시 문자열이 아니라 상태 전이를 단언한다. 슬라이더 매핑과 알 스폰도 함께 덮는다.

통과가 아니라 **변이(mutation)로 검증**했다: 배율을 빼면 8개가, 종 고정을 무력화하면 4개가 깨진다. 이 확인이 실제로 의미가 있었다 — 스폰 스텁은 고정된 라인을 돌려주므로 한 테스트는 그냥 통과해 버릴 수도 있었다.

펫 프레임 하한 가드는 캡이 조건부가 된 지금 "실제로 적용된다"를 더는 증명하지 못한다. 그래서 적용 분기를 따로 덮고, 원래 테스트에는 실제보다 강해 보이지 않도록 범위가 좁아졌음을 명시했다.

`docs/reference/defect-log.md` 에 fps 캡이 사용자 선택이 된 사실과 task-id 함정을 기록해, 문서에 적힌 불변식이 낡지 않게 했다.

## 참고

- `LocalAdditionalUsageTests.testHermesAcceptsMillisecondStartedAt` 가 이 브랜치에서 실패하지만, **깨끗한 `main` 에서도 똑같이 실패한다** — 타임존에 의존하는 날짜 단언이고 이번 변경과 무관하다. 그 외에는 전부 통과한다(765개, 8개 skip). 빌드 경고 0.
- 알 상태에서는 상점에서 알이 사라진다. 이건 기존 동작(`hasActive` 게이트)이고 여기서 바꾸지 않았지만, 알 스폰 때문에 알 상태에 훨씬 쉽게 들어가게 돼서 더 자주 눈에 띈다.
