### PR TITLE
fix: restore the build by giving the Antigravity limit strings a French value

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -92,8 +92,8 @@ struct L {
     }
 
     /// Antigravity 한도 그룹 및 윈도우 이름
-    var antigravityGeminiGroup: String { t("Gemini 모델군", "Gemini Models", "Gemini モデル群", "Modelos Gemini") }
-    var antigravityThirdPartyGroup: String { t("Claude & GPT 모델군", "Claude & GPT Models", "Claude & GPT モデル群", "Modelos Claude y GPT") }
+    var antigravityGeminiGroup: String { t("Gemini 모델군", "Gemini Models", "Gemini モデル群", "Modelos Gemini", "Modèles Gemini") }
+    var antigravityThirdPartyGroup: String { t("Claude & GPT 모델군", "Claude & GPT Models", "Claude & GPT モデル群", "Modelos Claude y GPT", "Modèles Claude et GPT") }
     func antigravityWindow(window: String?, bucketId: String) -> String {
         if window == "5h" || bucketId.contains("5h") {
             return fiveHourSession
@@ -101,7 +101,7 @@ struct L {
         if window == "weekly" || bucketId.contains("weekly") {
             return weekly
         }
-        return t("한도", "Limit", "上限", "Límite")
+        return t("한도", "Limit", "上限", "Límite", "Limite")
     }
 
     // MARK: 푸터


### PR DESCRIPTION
## Summary

`main` does not compile. `t()` takes a French argument now, and three Antigravity
limit strings still pass four:

```
Localization.swift:95:120: error: missing argument for parameter #5 in call
Localization.swift:96:148: error: missing argument for parameter #5 in call
Localization.swift:104:56:  error: missing argument for parameter #5 in call
```

The two changes never touched the same line, so git merged them without a conflict and
the branch reported clean. Its checks had run against a base that had no French column,
and nothing rebuilt the combined tree before it landed. Textual mergeability is not
build compatibility when one side widens a shared signature.

## Changes

French for the three strings, matching the vocabulary already used elsewhere in the file
(`Limite` also appears in `Limite atteinte`, `Limite de dépense personnelle`):

| String | French |
| --- | --- |
| `antigravityGeminiGroup` | Modèles Gemini |
| `antigravityThirdPartyGroup` | Modèles Claude et GPT |
| `antigravityWindow` fallback | Limite |

No behaviour change beyond the missing translations.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `swift build` and `swift test` pass locally — 766 tests, 9 skipped, 0 failures
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change — existing localization guards cover the strings; the compiler is the guard for argument count
