### PR TITLE
fix: add the French strings the Antigravity limits merge left out

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -92,8 +92,8 @@ struct L {
     }
 
     /// Antigravity 한도 그룹 및 윈도우 이름
-    var antigravityGeminiGroup: String { t("Gemini 모델군", "Gemini Models", "Gemini モデル群", "Modelos Gemini") }
-    var antigravityThirdPartyGroup: String { t("Claude & GPT 모델군", "Claude & GPT Models", "Claude & GPT モデル群", "Modelos Claude y GPT") }
+    var antigravityGeminiGroup: String { t("Gemini 모델군", "Gemini Models", "Gemini モデル群", "Modelos Gemini", "Modèles Gemini") }
+    var antigravityThirdPartyGroup: String { t("Claude & GPT 모델군", "Claude & GPT Models", "Claude & GPT モデル群", "Modelos Claude y GPT", "Modèles Claude et GPT") }
     func antigravityWindow(window: String?, bucketId: String) -> String {
         if window == "5h" || bucketId.contains("5h") {
             return fiveHourSession
@@ -101,7 +101,7 @@ struct L {
         if window == "weekly" || bucketId.contains("weekly") {
             return weekly
         }
-        return t("한도", "Limit", "上限", "Límite")
+        return t("한도", "Limit", "上限", "Límite", "Limite")
     }
 
     // MARK: 푸터


### PR DESCRIPTION
## Summary

`main` does not compile.

#185 made `L.t` five-argument at 14:45:33. #210 merged four-argument Antigravity limit strings at 14:47:17 — 104 seconds later. The two changes never touch the same lines, so GitHub reported the merge as clean and neither PR's CI had the other in its base. `de6c996` fails with 24 `missing argument for parameter #5` errors.

This adds `fr` to the three strings #210 introduced:

| en | fr |
| --- | --- |
| Gemini Models | Modèles Gemini |
| Claude & GPT Models | Modèles Claude et GPT |
| Limit | Limite |

No behaviour change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation

## UI changes

None beyond French now rendering these three labels instead of failing to build.

## Tests

`swift test`: 766 passed, 9 skipped, 0 failures.
