### PR TITLE
fix: keep the automatic poll out of the Keychain for Antigravity

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -99,7 +99,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 - **代表ポケモン** — 図鑑で所有している種を選び、育成中のポケモンとは別にメニューバーと任意のフローティングペットへ固定。固定中はメニューバーがタマゴ・孵化・進化を追わなくなりますが、育成の進行は Home で引き続き確認できます。
 - **インタラクティブなフローティングペット** — ホバーで今日の使用量、クリックでメイン画面、右クリックでメニュー、上限アラートは吹き出しで表示。
 - **サービス別タブ** — Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI のうち2つ以上が検出されると、小さなタブでサービス別の詳細を切替（今日の合計は合算のまま）。
-- **公式の上限** — Claude・Codex の5時間／週間使用率とリセットのカウントダウンを、今日の数字のすぐ下に。
+- **公式の上限** — Claude・Codex・Antigravity の5時間／週間使用率とリセットのカウントダウンを、今日の数字のすぐ下に。
 - **消費予測** — 現在の5時間ウィンドウが100%に達する時刻を予測。
 - **アプリ内アップデート** — ワンクリックの更新確認、設定に現在のバージョンを表示。
 
@@ -110,7 +110,7 @@ PokeTokenBar は、あなたがすでに使っている AI コーディングト
 | **Claude Code** | 今日 · 5時間ブロック · 週 · 月 | ✅ 5時間／週間 |
 | **Codex** | 今日 · 週 · 月 | ✅ 5時間／週間 |
 | **Gemini CLI** | 今日 · 週 · 月 | — |
-| **Antigravity** | 今日 · 5時間ブロック · 週 · 月 | — |
+| **Antigravity** | 今日 · 5時間ブロック · 週 · 月 | ✅ 5時間／週間 |
 | **OpenCode** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Hermes Agent** | 今日 · 5時間ブロック · 週 · 月 | — |
 | **Cursor** | 今日 · 5時間ブロック · 週 · 月 | — |
@@ -179,7 +179,7 @@ swift test                   # ユニットテスト
 ## プライバシー & 権限
 
 - **オンデバイス。** トークン使用量はローカルの Claude Code・Codex・Gemini CLI・Antigravity・OpenCode・Hermes Agent・Cursor・Grok CLI・Copilot CLI・Kiro CLI データから直接読み取ります。使用量のアップロードも、モデルの推論実行も行いません。
-- **外部リクエスト。** 本アプリは完全オフラインではありません。7つのホストに接続します — `pokeapi.co`・`graphql.pokeapi.co`（種・進化）、`raw.githubusercontent.com`（スプライト）、`api.anthropic.com`（Claude 公式の上限）、`status.claude.com`・`status.openai.com`（障害バナー — 設定でオフ可）、`api.github.com`（アップデート確認）。**いずれのリクエストにも使用量・トークン・プロンプト・プロジェクトのパスは含まれません** — 送られるのはリクエストそのものだけです。
+- **外部リクエスト。** 本アプリは完全オフラインではありません。10のホストに接続します — `pokeapi.co`・`graphql.pokeapi.co`（種・進化）、`raw.githubusercontent.com`（スプライト）、`api.anthropic.com`（Claude 公式の上限）、`cloudcode-pa.googleapis.com`・`daily-cloudcode-pa.googleapis.com`（Antigravity 公式の上限）と `oauth2.googleapis.com`（トークン更新）、`status.claude.com`・`status.openai.com`（障害バナー — 設定でオフ可）、`api.github.com`（アップデート確認）。**いずれのリクエストにも使用量・トークン・プロンプト・プロジェクトのパスは含まれません** — 送られるのはリクエストそのものだけです。
 - **Keychain（任意）。** Claude OAuth 資格情報は**更新ボタンを押した時のみ**読み取ります（設定、またはポップオーバーの上限行）。自動更新では Keychain に触れないためパスワードのプロンプトは表示されず、`~/.claude/.credentials.json` があればそちらから取得します。トークンはメモリ上にのみ保持し、**アプリ自身の Keychain 項目は作成しません。** トークンが期限切れになると、上限は更新するまで以前の値（stale）として表示されます。設定でオフにすると上限セクションが非表示になります。
 - **ポケモンのアセット** はランタイムに PokéAPI から取得し、`~/Library/Application Support/PokeTokenBar/` にのみキャッシュされます。アプリのバイナリおよびリリース成果物にポケモンのアセットは含まれません。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -99,7 +99,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 - **대표 포켓몬** — 도감에서 보유한 종을 골라 현재 키우는 포켓몬과 별개로 메뉴바와 선택적 플로팅 펫에 고정. 고정 중에는 메뉴바가 알·부화·진화를 따라가지 않지만, 육성 과정은 Home에서 계속 확인할 수 있습니다.
 - **인터랙티브 플로팅 펫** — 호버로 오늘 사용량, 클릭으로 메인 창, 우클릭 메뉴, 한도 알림은 말풍선으로 표시.
 - **서비스별 탭** — Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 중 2개 이상 감지되면 작은 탭으로 상세를 서비스별 전환(오늘 합계는 통합 유지).
-- **공식 한도** — Claude·Codex 5시간/주간 사용률 + 리셋 카운트다운을 오늘 숫자 바로 아래에.
+- **공식 한도** — Claude·Codex·Antigravity 5시간/주간 사용률 + 리셋 카운트다운을 오늘 숫자 바로 아래에.
 - **소진 예측** — 현재 5시간 창이 100%에 도달할 시각 예측.
 - **인앱 업데이트** — 원클릭 업데이트 확인, 설정에 현재 버전 표시.
 
@@ -110,7 +110,7 @@ PokeTokenBar는 당신이 이미 태우고 있는 AI 코딩 토큰(Claude Code �
 | **Claude Code** | 오늘 · 5시간 블록 · 주 · 월 | ✅ 5시간 / 주간 |
 | **Codex** | 오늘 · 주 · 월 | ✅ 5시간 / 주간 |
 | **Gemini CLI** | 오늘 · 주 · 월 | — |
-| **Antigravity** | 오늘 · 5시간 블록 · 주 · 월 | — |
+| **Antigravity** | 오늘 · 5시간 블록 · 주 · 월 | ✅ 5시간 / 주간 |
 | **OpenCode** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Hermes Agent** | 오늘 · 5시간 블록 · 주 · 월 | — |
 | **Cursor** | 오늘 · 5시간 블록 · 주 · 월 | — |
@@ -179,7 +179,7 @@ swift test                   # 단위 테스트
 ## 프라이버시 & 권한
 
 - **온디바이스.** 토큰 사용량은 로컬 Claude Code·Codex·Gemini CLI·Antigravity·OpenCode·Hermes Agent·Cursor·Grok CLI·Copilot CLI·Kiro CLI 데이터에서 직접 읽습니다. 사용량을 업로드하거나 모델 turn을 실행하지 않습니다.
-- **외부 요청.** 앱은 완전 오프라인이 아닙니다. 7개 호스트에 접속합니다 — `pokeapi.co`·`graphql.pokeapi.co`(종·진화), `raw.githubusercontent.com`(스프라이트), `api.anthropic.com`(Claude 공식 한도), `status.claude.com`·`status.openai.com`(장애 배너 — 설정에서 끌 수 있음), `api.github.com`(업데이트 확인). **어느 요청에도 사용량·토큰·프롬프트·프로젝트 경로는 담기지 않습니다** — 요청 자체만 나갑니다.
+- **외부 요청.** 앱은 완전 오프라인이 아닙니다. 10개 호스트에 접속합니다 — `pokeapi.co`·`graphql.pokeapi.co`(종·진화), `raw.githubusercontent.com`(스프라이트), `api.anthropic.com`(Claude 공식 한도), `cloudcode-pa.googleapis.com`·`daily-cloudcode-pa.googleapis.com`(Antigravity 공식 한도)와 `oauth2.googleapis.com`(토큰 갱신), `status.claude.com`·`status.openai.com`(장애 배너 — 설정에서 끌 수 있음), `api.github.com`(업데이트 확인). **어느 요청에도 사용량·토큰·프롬프트·프로젝트 경로는 담기지 않습니다** — 요청 자체만 나갑니다.
 - **Keychain(선택).** Claude OAuth 자격증명은 **갱신 버튼을 누를 때만** 읽습니다(설정, 또는 팝오버의 한도 행). 자동 폴링은 Keychain 을 건드리지 않으므로 비밀번호 프롬프트가 뜨지 않고, `~/.claude/.credentials.json` 이 있으면 그쪽에서 가져옵니다. 토큰은 메모리에만 두며 **앱 자체 Keychain 항목은 만들지 않습니다.** 토큰이 만료되면 한도는 갱신 전까지 이전 값(stale)으로 표시됩니다. 설정에서 끄면 한도 섹션만 숨겨집니다.
 - **포켓몬 에셋**은 런타임에 PokéAPI에서 받아오며 `~/Library/Application Support/PokeTokenBar/`에만 캐시됩니다. 앱 바이너리와 릴리스 아티팩트에는 포켓몬 에셋이 포함되지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 - **Representative Pokémon** — pin any owned Pokédex species to the menu bar and optional floating pet, independently of the companion you're raising. While pinned, the menu bar stops following egg, hatch, and evolution changes; raising progress remains visible on Home.
 - **Interactive floating pet** — hover for today's usage, click to open the main window, right-click for a menu, and show limit alerts as speech bubbles.
 - **Per-service tabs** — when two or more of Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI are detected, compact tabs switch between them; today's total stays combined.
-- **Official limits** — Claude & Codex 5-hour / weekly utilization with reset countdowns, right under today's numbers.
+- **Official limits** — Claude, Codex & Antigravity 5-hour / weekly utilization with reset countdowns, right under today's numbers.
 - **Burn-rate forecast** — projects when the current 5h window hits 100%.
 - **In-app updates** — one-click update check; current version shown in Settings.
 
@@ -110,7 +110,7 @@ The tokens you've already used are your currency. Spend them in the new <b>Shop<
 | **Claude Code** | today · 5h block · week · month | ✅ 5h / weekly |
 | **Codex** | today · week · month | ✅ 5h / weekly |
 | **Gemini CLI** | today · week · month | — |
-| **Antigravity** | today · 5h block · week · month | — |
+| **Antigravity** | today · 5h block · week · month | ✅ 5h / weekly |
 | **OpenCode** | today · 5h block · week · month | — |
 | **Hermes Agent** | today · 5h block · week · month | — |
 | **Cursor** | today · 5h block · week · month | — |
@@ -179,7 +179,7 @@ If a provider's logs live **outside** those built-in paths, add the folder in **
 ## Privacy & permissions
 
 - **On-device.** Token usage is read directly from local Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, Hermes Agent, Cursor, Grok CLI, Copilot CLI, and Kiro CLI data. The app never uploads usage or runs model turns.
-- **Outbound requests.** The app is not fully offline. It talks to seven hosts: `pokeapi.co` and `graphql.pokeapi.co` (species/evolution), `raw.githubusercontent.com` (sprites), `api.anthropic.com` (Claude official limits), `status.claude.com` and `status.openai.com` (incident banner — off switch in Settings), and `api.github.com` (update check). **None of them carry your usage, tokens, prompts, or project paths** — only the request itself.
+- **Outbound requests.** The app is not fully offline. It talks to ten hosts: `pokeapi.co` and `graphql.pokeapi.co` (species/evolution), `raw.githubusercontent.com` (sprites), `api.anthropic.com` (Claude official limits), `cloudcode-pa.googleapis.com` and `daily-cloudcode-pa.googleapis.com` (Antigravity official limits) plus `oauth2.googleapis.com` (their token refresh), `status.claude.com` and `status.openai.com` (incident banner — off switch in Settings), and `api.github.com` (update check). **None of them carry your usage, tokens, prompts, or project paths** — only the request itself.
 - **Keychain (optional).** The Claude OAuth credential is read **only when you press a refresh button** (Settings, or the limits row in the popover). Automatic polling never touches the Keychain, so it never raises a password prompt; when available, the credential is taken from `~/.claude/.credentials.json` instead. The token is held in memory only — the app creates no Keychain item of its own. Once the token expires, limits stay visible but stale until you refresh. Turn it off in Settings — the limits section simply hides.
 - **Pokémon assets** are fetched at runtime from PokéAPI and cached only under `~/Library/Application Support/PokeTokenBar/`. The app binary and its release artifacts contain no Pokémon assets.
 

--- a/Sources/PokeTokenBar/Core/AntigravityRateLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/AntigravityRateLimitsProvider.swift
@@ -84,30 +84,36 @@ private actor AntigravityTokenCache {
             return cachedCredential.accessToken
         }
 
-        // 1. 파일 크리덴셜 확인 (~/.gemini/jetski-standalone-oauth-token)
+        // 1. 파일 크리덴셜(~/.gemini/jetski-standalone-oauth-token) — 키체인 무관, 프롬프트 없음.
+        //    파일로 답할 수 있으면 여기서 끝낸다. 이 return 이 없으면 유효한 파일 토큰이 있어도
+        //    매 호출이 키체인까지 내려간다(프롬프트를 피할 수 있는 경로를 두고 쓰지 않는 셈).
         if let fileToken = Self.readTokenFile() {
             if cachedCredential?.accessToken != fileToken {
                 cachedCredential = AntigravityOAuthCredential(
                     accessToken: fileToken, refreshToken: nil, expiresAt: nil)
             }
+            return fileToken
         }
 
-        // 2. 키체인 읽기
-        if allowKeychainPrompt {
-            if let cred = Self.readKeychainSilently() {
-                return try await resolveValidToken(from: cred)
-            }
-            let cred = try Self.readKeychain(allowKeychainPrompt: true)
-            return try await resolveValidToken(from: cred)
-        } else {
-            if let cred = Self.readKeychainSilently() {
-                return try await resolveValidToken(from: cred)
-            }
-            if let cached = cachedCredential, !cached.isExpired {
-                return cached.accessToken
+        // 2. 자동(타이머) 경로는 Keychain 을 일절 읽지 않는다. no-UI 쿼리(kSecUseAuthenticationUIFail
+        //    /LAContext)로도 잠긴·미승인 login 키체인의 '암호 입력' 다이얼로그는 억제되지 않는다 —
+        //    OAuthLimitsProvider 가 같은 이유로 자동 경로에서 키체인을 열지 않는다(실측: 캐시 만료 폴
+        //    도중 SecItemCopyMatching 이 13초간 블록하며 팝업). 캐시가 살아있으면 그 토큰으로 계속
+        //    갱신하고, 없으면 한도를 stale 로 두고 사용자가 갱신을 누를 때 재취득한다.
+        guard allowKeychainPrompt else {
+            if let cachedCredential, !cachedCredential.isExpired {
+                return cachedCredential.accessToken
             }
             throw LimitsError.keychainInteractionNotAllowed
         }
+
+        // 3. 사용자 동작 경로: 무프롬프트로 먼저 시도(과거 '항상 허용'했다면 조용히 성공), 안 되면
+        //    프롬프트를 동반해 읽어 최초 1회 '항상 허용'을 유도한다.
+        if let cred = Self.readKeychainSilently() {
+            return try await resolveValidToken(from: cred)
+        }
+        let cred = try Self.readKeychain(allowKeychainPrompt: true)
+        return try await resolveValidToken(from: cred)
     }
 
     private func resolveValidToken(from cred: AntigravityOAuthCredential) async throws -> String {
@@ -201,7 +207,7 @@ private actor AntigravityTokenCache {
         }
 
         var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        let status = KeychainReader.copyMatching(query, &item)
         if status == errSecInteractionNotAllowed {
             throw LimitsError.keychainInteractionNotAllowed
         }

--- a/Sources/PokeTokenBar/Core/KeychainAccess.swift
+++ b/Sources/PokeTokenBar/Core/KeychainAccess.swift
@@ -14,6 +14,26 @@ enum KeychainAccessGate {
         UserDefaults.standard.bool(forKey: "disableKeychainAccess")
 }
 
+/// 모든 Keychain 조회의 단일 통로.
+///
+/// `allowKeychainPrompt: false` 는 "프롬프트를 띄우지 않는다"가 아니라 **"Keychain 을 아예
+/// 조회하지 않는다"** 는 계약이다 — no-UI 쿼리로도 잠긴·미승인 login 키체인의 암호 다이얼로그는
+/// 억제되지 않기 때문이다(`OAuthLimitsProvider` 의 실측: 13초 블록 + 팝업).
+///
+/// 그 계약을 규약이 아니라 가드로 만들려면 조회 횟수를 셀 수 있어야 한다. 프로바이더가
+/// `SecItemCopyMatching` 을 각자 직접 부르면 "자동 경로는 0회" 를 행동으로 검증할 방법이 없고,
+/// 실제로 그 틈으로 자동 폴링이 키체인을 읽는 구현이 스위트 초록인 채 들어왔다(#210).
+enum KeychainReader {
+    nonisolated(unsafe) private(set) static var queryCount = 0
+
+    static func resetQueryCountForTesting() { queryCount = 0 }
+
+    static func copyMatching(_ query: [String: Any], _ result: inout CFTypeRef?) -> OSStatus {
+        queryCount += 1
+        return SecItemCopyMatching(query as CFDictionary, &result)
+    }
+}
+
 enum KeychainNoUIQuery {
     private static let uiFailPolicy = resolveUIFailPolicy()
 

--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -248,7 +248,7 @@ private actor OAuthAccessTokenCache {
         }
 
         var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        let status = KeychainReader.copyMatching(query, &item)
         if status == errSecInteractionNotAllowed {
             throw LimitsError.keychainInteractionNotAllowed
         }

--- a/Tests/PokeTokenBarTests/KeychainAutoPathTests.swift
+++ b/Tests/PokeTokenBarTests/KeychainAutoPathTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// 회귀 가드: `allowKeychainPrompt: false` 는 "프롬프트를 안 띄운다"가 아니라
+/// **"Keychain 을 아예 조회하지 않는다"** 는 계약이다. no-UI 쿼리(`kSecUseAuthenticationUIFail`
+/// /`LAContext`)로도 잠긴·미승인 login 키체인의 '암호 입력' 다이얼로그는 억제되지 않는다 —
+/// 실측: 캐시 만료 폴 도중 `SecItemCopyMatching` 이 13초간 블록하며 팝업을 띄웠다.
+///
+/// 왜 store 쪽 가드로는 부족한가: `UsageStoreTests.testAutoRefreshUsesNoPromptPathManualUsesPromptPath`
+/// 는 store 가 **넘기는 플래그 값**만 본다. 자동 경로에 `false` 를 올바르게 넘기면서 프로바이더
+/// 안에서 키체인을 읽는 구현은 그 가드를 통과한다(#210 이 그렇게 들어왔다 — 스위트 초록,
+/// 실측 조회 2회/폴). 이 테스트는 프로바이더 쪽 계약을 조회 횟수로 센다.
+///
+/// 프로바이더가 늘면 `automaticProbes` 에 한 줄 추가한다.
+final class KeychainAutoPathTests: XCTestCase {
+
+    func testAutomaticPathNeverQueriesTheKeychain() async {
+        // 게이트가 켜져 있으면 조회 전에 throw 되어 이 테스트는 구조상 실패할 수 없다.
+        // 강제로 내려서 "가드가 있어서 0" 과 "게이트가 막아서 0" 을 구분한다.
+        let savedGate = KeychainAccessGate.isDisabled
+        KeychainAccessGate.isDisabled = false
+        defer { KeychainAccessGate.isDisabled = savedGate }
+
+        for probe in Self.automaticProbes {
+            KeychainReader.resetQueryCountForTesting()
+            await probe.run()
+            XCTAssertEqual(
+                KeychainReader.queryCount, 0,
+                """
+                \(probe.name): 자동 폴링이 Keychain 을 \(KeychainReader.queryCount)회 조회했다. \
+                자동 경로는 파일 크리덴셜·캐시로만 답하고, 없으면 stale 로 두어야 한다 — \
+                키체인 조회는 사용자가 갱신을 누른 경로(allowKeychainPrompt: true)에서만.
+                """)
+        }
+    }
+
+    /// 사용자 동작 경로는 반대로 키체인을 **읽어야** 한다. 이게 없으면 위 단언은
+    /// "아무도 키체인을 안 읽는다" 로도 만족되어 무엇도 지키지 않는다.
+    func testManualPathDoesQueryTheKeychain() async {
+        let savedGate = KeychainAccessGate.isDisabled
+        KeychainAccessGate.isDisabled = false
+        defer { KeychainAccessGate.isDisabled = savedGate }
+
+        KeychainReader.resetQueryCountForTesting()
+        _ = try? await AntigravityRateLimitsProvider().fetch(allowKeychainPrompt: true)
+        XCTAssertGreaterThan(
+            KeychainReader.queryCount, 0,
+            "사용자 갱신 경로는 키체인을 읽어야 한다 — 0 이면 위 자동경로 단언이 공허해진다")
+    }
+
+    private struct Probe {
+        let name: String
+        let run: @Sendable () async -> Void
+    }
+
+    private static let automaticProbes: [Probe] = [
+        Probe(name: "claude_code") {
+            _ = try? await OAuthLimitsProvider().fetch(allowKeychainPrompt: false)
+        },
+        Probe(name: "antigravity") {
+            _ = try? await AntigravityRateLimitsProvider().fetch(allowKeychainPrompt: false)
+        },
+    ]
+}


### PR DESCRIPTION
## Summary

Follow-up to #210. The Antigravity limits provider queries the Keychain on the automatic poll, which is the one thing the Claude path is deliberately built to avoid.

`allowKeychainPrompt: false` is not "do not show a prompt", it is **"do not query the Keychain at all"**. A no-UI query (`kSecUseAuthenticationUIFail` / `LAContext`) does not suppress the password dialog for a locked or unapproved login keychain — measured previously at a 13-second block plus a popup, several times a day. That is why `OAuthLimitsProvider` returns before `SecItemCopyMatching` on the automatic path.

The Antigravity provider took the silent read on **both** branches. Measured on the merged code, same call on the same machine:

```
antigravity auto-path keychain reads = 2
claude      auto-path keychain reads = 0
```

Two, not one, because `fetch` retries with `bypassCache: true` after a 401.

The file credential also never short-circuited: a valid token was read, cached, and then the code fell through to the Keychain regardless.

## Why the suite stayed green

`UsageStoreTests.testAutoRefreshUsesNoPromptPathManualUsesPromptPath` asserts on the **flag the store passes**, and #210 passed `false` correctly. The provider-side half of the contract had no guard at all.

This routes both `SecItemCopyMatching` call sites through `KeychainReader` so the contract is countable, and adds `KeychainAutoPathTests`:

- `testAutomaticPathNeverQueriesTheKeychain` — every limits provider, zero queries. Verified by injection: restoring the pre-fix shape fails it with `("2") is not equal to ("0")`.
- `testManualPathDoesQueryTheKeychain` — the paired assertion, so "nobody reads the Keychain" cannot satisfy the first one.

The test forces `KeychainAccessGate.isDisabled = false` and restores it, so a disabled gate cannot make it pass vacuously.

## Docs

#210 shipped a menu bar line and popover UI without touching the READMEs. Antigravity still read as having no official limits, and the outbound-request paragraph named seven hosts by name — a claim about network behaviour that the quota API made wrong by three (`cloudcode-pa.googleapis.com`, `daily-cloudcode-pa.googleapis.com`, `oauth2.googleapis.com`).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation

## UI changes

None. Behaviour change is that an automatic poll with no file credential now leaves the limits stale until the user hits refresh, instead of blocking on a Keychain dialog.

## Tests

`swift test`: 768 passed, 9 skipped, 0 failures.
