### PR TITLE
feat: label popover cost as API-equivalent on Max/Pro/Team (#200)

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -123,6 +123,8 @@ struct L {
     var menuBarItems: String { t("메뉴바 표시 항목 (복수 선택)", "Menu bar items (multi-select)", "メニューバー表示項目（複数選択）", "Elementos de la barra de menús (selección múltiple)", "Éléments de la barre des menus (sélection multiple)", "Itens da barra de menus (seleção múltipla)") }
     var todayTokensShort: String { t("오늘 토큰", "Today's tokens", "本日のトークン", "Tokens de hoy", "Tokens du jour", "Tokens de hoje") }
     var todayCost: String { t("오늘 비용 ($)", "Today's cost ($)", "本日のコスト ($)", "Coste de hoy ($)", "Coût du jour ($)", "Custo de hoje ($)") }
+    /// Max/Pro/Team 팝오버 비용 접미사 — 숫자가 API 환산가임을 표시. 짧아야 캡션 폭에 들어간다.
+    var apiEquivalentCaption: String { t("(API 환산)", "(API-equiv.)", "(API換算)", "(equiv. API)", "(éq. API)", "(equiv. API)") }
     var limitPercent: String { t("한도 %", "Limit %", "上限 %", "Límite %", "Limite %", "Limite %") }
     var limitDisplayModeLabel: String { t("한도 표시 방식", "Limit display", "上限の表示", "Visualización del límite", "Affichage de la limite", "Exibição do limite") }
     var limitDisplayUsed: String { t("사용량", "Used", "使用量", "Usado", "Utilisé", "Usado") }

--- a/Sources/PokeTokenBar/Core/Models.swift
+++ b/Sources/PokeTokenBar/Core/Models.swift
@@ -227,6 +227,17 @@ struct LimitStatus: Decodable, Sendable {
         return base
     }
 
+    /// Max/Pro/Team 은 정액 구독이라 ModelPricing × tokens 가 청구서가 아니다.
+    /// Free·API 키(`subscriptionType` 없음)는 그 숫자가 비용에 가깝다.
+    /// 자격증명 JSON 이라 대소문자 섞임을 허용한다. 범용 합계 경로에 providerID 분기를
+    /// 넣지 않기 위해 판정은 플랜이 실리는 이 타입에만 둔다.
+    var labelsCostAsAPIEquivalent: Bool {
+        switch subscriptionType?.lowercased() {
+        case "max", "pro", "team": return true
+        default: return false
+        }
+    }
+
     /// 계정 라벨 — "email · 조직명". 개인 플랜의 자동 생성 조직명("<email>'s Organization")은
     /// 이메일과 중복 정보라 생략한다(조직명에 이메일이 포함되는지로 판정). 이메일 없으면 nil —
     /// 조직명만으로는 어느 로그인인지 특정되지 않아 부분 라벨을 만들지 않는다.

--- a/Sources/PokeTokenBar/Core/TokenFormatter.swift
+++ b/Sources/PokeTokenBar/Core/TokenFormatter.swift
@@ -30,8 +30,10 @@ enum TokenFormatter {
         return f.string(from: NSNumber(value: value)) ?? "\(value)"
     }
 
-    static func cost(_ usd: Double) -> String {
-        String(format: "$%.2f", usd)
+    static func cost(_ usd: Double, labeled suffix: String? = nil) -> String {
+        let figure = String(format: "$%.2f", usd)
+        guard let suffix, !suffix.isEmpty else { return figure }
+        return "\(figure) \(suffix)"
     }
 
     /// 메뉴바용 짧은 비용 표기: $9.5 / $311 / $1.2K

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -253,6 +253,11 @@ final class UsageStore {
     /// Whether any connected provider reports real spend — gates menu/header `$0.00` for flat-rate-only setups.
     var showsCost: Bool { !costingSnapshots.isEmpty }
 
+    /// Max/Pro/Team — ModelPricing dollars are API-equivalent, not a bill.
+    /// The plan lives on official Claude limits; this does not branch generic
+    /// totals on `providerID` (provider-extension rule).
+    var labelsCostAsAPIEquivalent: Bool { limits?.labelsCostAsAPIEquivalent == true }
+
     var todayCostTotal: Double {
         let todayKey = LocalUsageReader.todayKey()
         return costingSnapshots.reduce(0) { $0 + ($1.today?.date == todayKey ? ($1.today?.totalCost ?? 0) : 0) }

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -144,7 +144,7 @@ struct PopoverView: View {
                     .monospacedDigit()
                 Spacer()
                 if store.showsCost {
-                    Text(TokenFormatter.cost(todayCost))
+                    Text(costText(todayCost))
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
@@ -193,7 +193,7 @@ struct PopoverView: View {
                 .font(.caption.weight(.semibold))
                 .monospacedDigit()
             if let cost {
-                Text(TokenFormatter.cost(cost))
+                Text(costText(cost))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -202,6 +202,12 @@ struct PopoverView: View {
 
     private var todayCost: Double {
         store.costingSnapshots.reduce(0) { $0 + ($1.today?.totalCost ?? 0) }
+    }
+
+    /// Max/Pro/Team 이면 `$12.34 (API-equiv.)`. API 키·Free 는 숫자만.
+    /// 접미사는 L 에서 오고, 판정은 스토어(공식 한도의 플랜)에 둔다.
+    private func costText(_ usd: Double) -> String {
+        TokenFormatter.cost(usd, labeled: store.labelsCostAsAPIEquivalent ? l.apiEquivalentCaption : nil)
     }
 
     private func providerRow(snapshot: ProviderSnapshot, today: DailyUsage) -> some View {
@@ -214,7 +220,7 @@ struct PopoverView: View {
                     .font(.callout)
                     .monospacedDigit()
                 if snapshot.reportsCost {
-                    Text(TokenFormatter.cost(today.totalCost))
+                    Text(costText(today.totalCost))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageCacheTests.swift
@@ -774,6 +774,7 @@ final class LocalUsageCacheTests: XCTestCase {
         // 구분기호가 지역 설정을 따르는지 — locale 인자가 무시되면 여기서 걸린다.
         XCTAssertEqual(TokenFormatter.grouped(253_412_890, locale: Locale(identifier: "es_ES")), "253.412.890")
         XCTAssertEqual(TokenFormatter.cost(48.104), "$48.10")
+        XCTAssertEqual(TokenFormatter.cost(48.104, labeled: "(API-equiv.)"), "$48.10 (API-equiv.)")
         XCTAssertEqual(TokenFormatter.costCompact(9.54), "$9.5")     // < 100 → 소수 1자리
         XCTAssertEqual(TokenFormatter.costCompact(311.4), "$311")    // < 10K → 정수
         XCTAssertEqual(TokenFormatter.costCompact(12_340), "$12.3K") // ≥ 10K → K

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -289,6 +289,68 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertNil(status.planDisplay)
     }
 
+    /// Max/Pro/Team 은 정액 구독이라 ModelPricing 달러가 청구액이 아니다 → API 환산 라벨.
+    /// Free·API 키(값 없음)는 그 숫자가 비용에 가깝다. 외부 JSON 이라 대소문자를 접는다.
+    /// A=false(free/nil) 만 검증하면 구독 분기가 죽은 채 통과하므로 B=true(max/pro/team) 도 잠근다.
+    func testLabelsCostAsAPIEquivalent() throws {
+        var status = try JSONDecoder().decode(LimitStatus.self, from: Data("{}".utf8))
+
+        for plan in ["max", "pro", "team", "MAX", "Pro"] {
+            status.subscriptionType = plan
+            XCTAssertTrue(status.labelsCostAsAPIEquivalent, "\(plan) is a flat-rate subscription")
+        }
+
+        for plan in ["free", "api", "", nil] as [String?] {
+            status.subscriptionType = plan
+            XCTAssertFalse(status.labelsCostAsAPIEquivalent,
+                           "\(plan ?? "nil") is billed like API (or unknown) — no qualifier")
+        }
+    }
+
+    /// `$610.30 (API-equiv.)` — 숫자 포맷은 그대로, 접미사만 붙는다. 빈 접미사는 무라벨.
+    func testCostLabeledAsAPIEquivalent() {
+        XCTAssertEqual(TokenFormatter.cost(610.3), "$610.30")
+        XCTAssertEqual(TokenFormatter.cost(610.3, labeled: "(API-equiv.)"), "$610.30 (API-equiv.)")
+        XCTAssertEqual(TokenFormatter.cost(610.3, labeled: nil), "$610.30")
+        XCTAssertEqual(TokenFormatter.cost(610.3, labeled: ""), "$610.30",
+                       "empty suffix must not add a trailing space")
+    }
+
+    /// 팝오버 비용 행만 라벨을 타고, 메뉴바 costCompact 경로는 접미사를 모른다.
+    /// (이슈 #200 의 두 번째 설계 질문 — 메뉴바는 후속.)
+    func testPopoverCostRowsUseAPIEquivalentLabelAndMenuBarDoesNot() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let popover = try String(contentsOf: root.appendingPathComponent("Sources/PokeTokenBar/UI/PopoverView.swift"), encoding: .utf8)
+        XCTAssertTrue(popover.contains("labelsCostAsAPIEquivalent"),
+                      "popover cost rows must consult the subscription predicate")
+        XCTAssertTrue(popover.contains("apiEquivalentCaption"),
+                      "qualifier copy must come from L, not a hardcoded English suffix")
+        XCTAssertFalse(popover.contains("TokenFormatter.costCompact"),
+                       "compact menu-bar cost must not leak into the popover")
+
+        let store = try String(contentsOf: root.appendingPathComponent("Sources/PokeTokenBar/Core/UsageStore.swift"), encoding: .utf8)
+        let compactIdx = try XCTUnwrap(store.range(of: "TokenFormatter.costCompact"),
+                                       "menu bar still uses costCompact")
+        let window = store[compactIdx.lowerBound...].prefix(180)
+        XCTAssertFalse(window.contains("labeled:"),
+                       "menu-bar costCompact must stay unlabeled (#200 follow-up)")
+        XCTAssertFalse(window.contains("apiEquivalentCaption"),
+                       "menu bar must not grow the qualifier")
+    }
+
+    /// 접미사는 모든 언어에 "API" 가 남고 괄호로 한정어임을 표시한다.
+    /// `allCases` 라야 언어가 늘어도 커버가 조용히 멈추지 않는다.
+    func testAPIEquivalentCaptionMentionsAPIInEveryLanguage() {
+        for lang in AppLanguage.allCases {
+            let s = L(lang).apiEquivalentCaption
+            XCTAssertTrue(s.contains("API"), "\(lang.rawValue): \(s)")
+            XCTAssertTrue(s.hasPrefix("(") && s.hasSuffix(")"), "\(lang.rawValue): \(s) should be parenthetical")
+        }
+    }
+
     /// 자격증명 파싱이 subscriptionType/rateLimitTier 를 추출하는지 — 실 keychain JSON 형태 기반.
     func testCredentialParsesPlanFields() throws {
         let json = Data("""

--- a/Tests/PokeTokenBarTests/UsageStoreTests.swift
+++ b/Tests/PokeTokenBarTests/UsageStoreTests.swift
@@ -990,6 +990,34 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshots.count, 2, "Both providers should have snapshots")
     }
 
+    /// 팝오버 API 환산 라벨은 스토어가 들고 있는 Claude 플랜을 따른다.
+    /// 한도가 아직 없거나 Free 면 꺼지고, Max/Pro/Team 이면 켜진다 — 뷰가 구독 문자열을 직접 파싱하지 않게.
+    func testAPIEquivalentCostLabelFollowsClaudeSubscription() async {
+        let claude = FakeUsageProvider(id: "claude_code", displayName: "Claude Code", daily: todayDaily(1_000))
+
+        var maxPlan = claudeLimits(fiveHourUtil: 10)
+        maxPlan.subscriptionType = "max"
+        let maxStore = makeStore(providers: [claude], claude: maxPlan)
+        await maxStore.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(maxStore.labelsCostAsAPIEquivalent, "Max → qualifier on")
+
+        var teamPlan = claudeLimits(fiveHourUtil: 10)
+        teamPlan.subscriptionType = "team"
+        let teamStore = makeStore(providers: [claude], claude: teamPlan)
+        await teamStore.refresh(scheduleEmptyRetry: false)
+        XCTAssertTrue(teamStore.labelsCostAsAPIEquivalent, "Team → qualifier on")
+
+        var freePlan = claudeLimits(fiveHourUtil: 10)
+        freePlan.subscriptionType = "free"
+        let freeStore = makeStore(providers: [claude], claude: freePlan)
+        await freeStore.refresh(scheduleEmptyRetry: false)
+        XCTAssertFalse(freeStore.labelsCostAsAPIEquivalent, "Free → no qualifier")
+
+        let unknown = makeStore(providers: [claude], claude: nil)
+        await unknown.refresh(scheduleEmptyRetry: false)
+        XCTAssertFalse(unknown.labelsCostAsAPIEquivalent, "no limits loaded → no qualifier")
+    }
+
     func testCursorContributesZeroToTodayCostTotal() async {
         let claude = FakeUsageProvider(
             id: "claude_code", displayName: "Claude Code",


### PR DESCRIPTION
## Summary

- When the Claude credential reports a **Max / Pro / Team** plan, popover cost figures (`$610.30`) now read `$610.30 (API-equiv.)` so they are not mistaken for a bill. The number is unchanged — it is still `ModelPricing` × tokens.
- API-key accounts, Free, and providers that already set `reportsCost = false` (Codex / Cursor / Copilot / …) keep today's presentation.
- **Out of scope** (the two design questions on #200): Settings field for monthly plan price / leverage `Z×`, and the menu-bar compact cost. Happy to follow up once those are decided.

Predicate lives on `LimitStatus` (where `subscriptionType` already lives) so generic today/week/month totals do not grow a `providerID ==` branch.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

| Before | After |
| ------ | ----- |
| Popover today / week / month / Claude row: `$610.30` on Max/Pro/Team | Same figures with `(API-equiv.)` (localized). API-key and Free unchanged. Menu bar `$9.5` unchanged. |

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change

## Tests

- `LimitStatus.labelsCostAsAPIEquivalent` — max/pro/team (incl. case fold) on; free/api/empty/nil off. A=false and B=true both locked.
- `TokenFormatter.cost(_:labeled:)` — suffix appended; nil/empty suffix does not add a trailing space.
- `UsageStore.labelsCostAsAPIEquivalent` — follows the injected Claude plan after refresh (Max/Team on, Free and no-limits off).
- Source lock: popover consults the predicate + `L.apiEquivalentCaption`; menu-bar `costCompact` stays unlabeled.
- Caption contains `API` and is parenthetical in every `AppLanguage.allCases` (ko/en/ja/es/fr/pt).

`./scripts/test-gate.sh`: **786 pass, 10 skipped, 0 failures**. Logic-core line coverage **90.52%**.

## How to verify

On a Max/Pro/Team Claude login with official limits loaded, open the popover: today / week / month (and the Claude row) should show `(API-equiv.)` next to `$`. Switch the language in Settings — the qualifier localizes; the `$` figure does not. Menu bar cost toggle should still be the compact `$9.5` / `$311` form.

Label-only slice of #200 (Settings price / leverage and menu-bar labeling left for a follow-up).