### PR TITLE
fix(claude): scope Claude Code keychain lookup by macOS username (#229)

### DIFF
--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -237,15 +237,8 @@ private actor OAuthAccessTokenCache {
         if KeychainAccessGate.isDisabled {
             throw LimitsError.keychainAccessDisabled
         }
-        var query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: OAuthCredentialData.claudeKeychainService,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        if !allowKeychainPrompt {
-            KeychainNoUIQuery.apply(to: &query)
-        }
+        let query = OAuthCredentialData.claudeKeychainQuery(
+            allowKeychainPrompt: allowKeychainPrompt)
 
         var item: CFTypeRef?
         let status = KeychainReader.copyMatching(query, &item)
@@ -267,6 +260,23 @@ private actor OAuthAccessTokenCache {
 
 enum OAuthCredentialData {
     static let claudeKeychainService = "Claude Code-credentials"
+
+    static func claudeKeychainQuery(
+        account: String = NSUserName(),
+        allowKeychainPrompt: Bool
+    ) -> [String: Any] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: claudeKeychainService,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        if !allowKeychainPrompt {
+            KeychainNoUIQuery.apply(to: &query)
+        }
+        return query
+    }
 
     struct Credential {
         let accessToken: String

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -493,4 +493,35 @@ final class OAuthCredentialDataTests: XCTestCase {
 
         XCTAssertEqual(OAuthCredentialData.credential(from: data)?.accessToken, "token-1")
     }
+
+    #if os(macOS)
+    func testClaudeKeychainQueryScopesByAccount() {
+        let defaultQuery = OAuthCredentialData.claudeKeychainQuery(allowKeychainPrompt: true)
+        XCTAssertEqual(
+            defaultQuery[kSecClass as String] as? String,
+            kSecClassGenericPassword as String)
+        XCTAssertEqual(
+            defaultQuery[kSecAttrService as String] as? String,
+            OAuthCredentialData.claudeKeychainService)
+        XCTAssertEqual(defaultQuery[kSecAttrAccount as String] as? String, NSUserName())
+        XCTAssertEqual(defaultQuery[kSecReturnData as String] as? Bool, true)
+        XCTAssertEqual(
+            defaultQuery[kSecMatchLimit as String] as? String,
+            kSecMatchLimitOne as String)
+
+        let customQuery = OAuthCredentialData.claudeKeychainQuery(
+            account: "custom-user",
+            allowKeychainPrompt: true)
+        XCTAssertEqual(customQuery[kSecAttrAccount as String] as? String, "custom-user")
+    }
+
+    func testClaudeKeychainQueryAppliesNoUIWhenPromptDisallowed() {
+        let query = OAuthCredentialData.claudeKeychainQuery(allowKeychainPrompt: false)
+        XCTAssertNotNil(query[kSecUseAuthenticationContext as String])
+        XCTAssertEqual(
+            query[kSecUseAuthenticationUI as String] as? String,
+            KeychainNoUIQuery.uiFailPolicyForTesting())
+    }
+    #endif
 }
+


### PR DESCRIPTION
## Summary

Fixes #229.

Scopes the Keychain generic-password query for Claude Code credentials (`Claude Code-credentials`) by `kSecAttrAccount: NSUserName()`.

### Root Cause
Previously, `readClaudeKeychain` in `OAuthLimitsProvider.swift` queried solely by `kSecAttrService: "Claude Code-credentials"` with `kSecMatchLimitOne`, without specifying `kSecAttrAccount`. If multiple items existed under that service in Keychain (e.g. current macOS user item vs a stale or MCP-only item with account `unknown`), `SecItemCopyMatching` could arbitrarily pick the non-account item, throwing `LimitsError.credentialMissingAccountOAuth` and showing a misleading "re-login required" banner that could never be resolved by `claude login`.

Claude Code CLI itself queries and writes using `-a <macOS username>`:
```bash
security find-generic-password -a <macOS username> -w -s "Claude Code-credentials"
```

### Changes
- Added `kSecAttrAccount as String: NSUserName()` to the Keychain query dictionary via `OAuthCredentialData.claudeKeychainQuery`.
- Added unit tests in `PokeTokenBarTests.swift` verifying query attributes, account scoping, and no-UI flag behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change