### PR TITLE
fix: resolve Claude account OAuth across multiple Keychain entries

### DIFF
--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -241,7 +241,7 @@ private actor OAuthAccessTokenCache {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: OAuthCredentialData.claudeKeychainService,
             kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecMatchLimit as String: kSecMatchLimitAll,
         ]
         if !allowKeychainPrompt {
             KeychainNoUIQuery.apply(to: &query)
@@ -252,21 +252,56 @@ private actor OAuthAccessTokenCache {
         if status == errSecInteractionNotAllowed {
             throw LimitsError.keychainInteractionNotAllowed
         }
-        guard status == errSecSuccess, let data = item as? Data else {
+        guard status == errSecSuccess, let item else {
             throw LimitsError.keychainUnavailable(status)
         }
-        guard let credential = OAuthCredentialData.credential(from: data) else {
-            // 항목은 있는데 계정 OAuth 만 없는 상태(MCP OAuth 전용)는 재로그인 안내 대상이라 구분한다.
-            throw OAuthCredentialData.isAccountOAuthMissing(data)
-                ? LimitsError.credentialMissingAccountOAuth
-                : LimitsError.credentialFormat
+
+        let dataItems = OAuthCredentialData.extractDataItems(from: item)
+        guard !dataItems.isEmpty else {
+            throw LimitsError.keychainUnavailable(status)
         }
-        return credential
+
+        // 여러 키체인 항목(예: acct="unknown" MCP 전용 + acct="<user>" 계정 토큰) 중
+        // 유효한 claudeAiOauth 계정 토큰이 있는 자격증명을 먼저 찾는다.
+        for data in dataItems {
+            if let credential = OAuthCredentialData.credential(from: data) {
+                return credential
+            }
+        }
+
+        // 모든 항목에 유효한 계정 토큰이 없는 경우:
+        // 항목은 있는데 계정 OAuth 만 없는 상태(MCP OAuth 전용)는 재로그인 안내 대상이라 구분한다.
+        throw dataItems.contains(where: { OAuthCredentialData.isAccountOAuthMissing($0) })
+            ? LimitsError.credentialMissingAccountOAuth
+            : LimitsError.credentialFormat
     }
 }
 
 enum OAuthCredentialData {
     static let claudeKeychainService = "Claude Code-credentials"
+
+    /// SecItemCopyMatching 결과(단일 Data 또는 [Data] 등)에서 [Data] 목록을 추출한다.
+    static func extractDataItems(from item: Any?) -> [Data] {
+        guard let item else { return [] }
+        if let data = item as? Data {
+            return [data]
+        }
+        if let array = item as? [Data] {
+            return array
+        }
+        if let array = item as? [Any] {
+            var result: [Data] = []
+            for element in array {
+                if let data = element as? Data {
+                    result.append(data)
+                } else if let dict = element as? [String: Any], let data = dict[kSecValueData as String] as? Data {
+                    result.append(data)
+                }
+            }
+            return result
+        }
+        return []
+    }
 
     struct Credential {
         let accessToken: String

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -493,4 +493,46 @@ final class OAuthCredentialDataTests: XCTestCase {
 
         XCTAssertEqual(OAuthCredentialData.credential(from: data)?.accessToken, "token-1")
     }
+
+    func testExtractDataItemsHandlesSingleAndMultipleFormats() {
+        let data1 = "data1".data(using: .utf8)!
+        let data2 = "data2".data(using: .utf8)!
+
+        // 단일 Data
+        XCTAssertEqual(OAuthCredentialData.extractDataItems(from: data1), [data1])
+
+        // [Data] 배열
+        XCTAssertEqual(OAuthCredentialData.extractDataItems(from: [data1, data2]), [data1, data2])
+
+        // [[String: Any]] (kSecValueData 포함)
+        let dictArray: [[String: Any]] = [
+            [kSecValueData as String: data1],
+            [kSecValueData as String: data2],
+        ]
+        XCTAssertEqual(OAuthCredentialData.extractDataItems(from: dictArray), [data1, data2])
+
+        // nil / 빈 값
+        XCTAssertEqual(OAuthCredentialData.extractDataItems(from: nil), [])
+    }
+
+    func testMultipleKeychainItemsPicksValidAccountOAuthOverMCPOAuth() {
+        let mcpOnlyData = """
+        {"mcpOAuth":{"linear":{"accessToken":"linear-tok"}}}
+        """.data(using: .utf8)!
+
+        let accountData = """
+        {"claudeAiOauth":{"accessToken":"account-tok","subscriptionType":"max","rateLimitTier":"default_claude_max_20x"}}
+        """.data(using: .utf8)!
+
+        let items = OAuthCredentialData.extractDataItems(from: [mcpOnlyData, accountData])
+        XCTAssertEqual(items.count, 2)
+
+        // 첫 번째 항목(MCP 전용)은 credential nil이지만, 두 번째 항목에서 정상 파싱
+        let validCredential = items.compactMap { OAuthCredentialData.credential(from: $0) }.first
+        XCTAssertNotNil(validCredential)
+        XCTAssertEqual(validCredential?.accessToken, "account-tok")
+        XCTAssertEqual(validCredential?.subscriptionType, "max")
+        XCTAssertEqual(validCredential?.rateLimitTier, "default_claude_max_20x")
+    }
 }
+


### PR DESCRIPTION
## Summary

Fixes #229: Claude Code official rate limits fail to resolve when multiple entries exist under the service `Claude Code-credentials` in macOS Keychain (e.g. MCP OAuth entries with `acct="unknown"` alongside Claude AI account OAuth with `acct="<username>"`).

## Background & Root Cause

1. Claude Code or MCP servers can register multiple keychain items under `Claude Code-credentials` with different account attributes (e.g. `acct="unknown"` containing only `mcpOAuth`, and `acct="<username>"` containing `claudeAiOauth`).
2. `OAuthAccessTokenCache.readClaudeKeychain` previously queried with `kSecMatchLimitOne`. When Keychain returned the MCP-only entry first, `OAuthCredentialData.isAccountOAuthMissing` triggered and threw `credentialMissingAccountOAuth`, ignoring the valid `claudeAiOauth` credentials in subsequent entries.

## Changes

- **`OAuthLimitsProvider.swift`**:
  - Changed Keychain search limit from `kSecMatchLimitOne` to `kSecMatchLimitAll`.
  - Added `OAuthCredentialData.extractDataItems(from:)` to safely handle single or multiple `Data` / dictionary results from `SecItemCopyMatching`.
  - Iterates through returned entries to select the first valid credential containing `claudeAiOauth`.
  - Preserves error discrimination: throws `credentialMissingAccountOAuth` if no valid account token is found but at least one entry has missing account OAuth (MCP-only).
- **`PokeTokenBarTests.swift`**:
  - Added `testExtractDataItemsHandlesSingleAndMultipleFormats` testing extraction across multiple return formats.
  - Added `testMultipleKeychainItemsPicksValidAccountOAuthOverMCPOAuth` simulating MCP-only followed by account OAuth item.

## Relationship to #231

This PR was prepared concurrently with #231.
- **#231** scopes the query to `kSecAttrAccount: NSUserName()`.
- **#232 (this PR)** uses `kSecMatchLimitAll` to iterate and dynamically pick the valid `claudeAiOauth` entry regardless of the exact account name attribute format (handling custom username mappings or multi-account setups without assuming `acct == NSUserName()`).

Feel free to adopt whichever approach fits the project architecture best!

## Verification

- `swift test`: All 783 tests passed.
- `KeychainAutoPathTests`: Verified automatic poll never queries the keychain (`0` queries).
- `./scripts/test-gate.sh`: Logic core line coverage 90.52% >= 75% threshold.

---
🤖 *Generated with Antigravity 2.0 (AGY 2.0)*