### PR TITLE
feat: add Ollama usage provider

### DIFF
--- a/Sources/PokeTokenBar/Core/CustomScanRoots.swift
+++ b/Sources/PokeTokenBar/Core/CustomScanRoots.swift
@@ -101,6 +101,8 @@ enum CustomScanRoots {
         case "pi":
             return CustomScanRoots.union(
                 defaults: LocalUsageReader.computePiSessionRoots(), extraRaw: nil)
+        case "ollama":
+            return LocalOllamaUsageReader.roots(customRootsValue: nil)
         default:
             return []
         }

--- a/Sources/PokeTokenBar/Core/LocalOllamaUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalOllamaUsageProvider.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// Usage captured by the transparent local Ollama proxy.
+///
+/// Ollama returns exact prompt/completion counts in the final response object, but it does
+/// not persist a usage ledger. The companion proxy writes those response counts as JSONL
+/// under `~/.ollama/usage`; this provider keeps PokeTokenBar decoupled from the proxy itself
+/// and treats that ledger like every other local usage source.
+struct LocalOllamaProvider: UsageProvider {
+    let id = "ollama"
+    let displayName = "Ollama"
+    let reportsCost = false
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let entries = LocalOllamaUsageReader.entries(
+            modifiedSince: Calendar.current.startOfDay(for: Date()))
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey())
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let now = Date()
+        let entries = LocalOllamaUsageReader.entries(
+            modifiedSince: LocalUsageReader.enrichmentScanStart(now: now))
+        let formatter = LocalUsageReader.localDayFormatter()
+        let weekStart = LocalUsageReader.startOfWeek(now)
+        let monthStart = LocalUsageReader.startOfMonth(now)
+        var result = ProviderEnrichment()
+        result.activeBlock = LocalUsageReader.activeBlock(entries: entries, now: now)
+        result.blocksOK = true
+        result.weekTotal = LocalUsageReader.period(
+            entries: entries,
+            periodKey: formatter.string(from: weekStart),
+            fromDay: formatter.string(from: weekStart),
+            toDay: formatter.string(from: now))
+        result.monthTotal = LocalUsageReader.period(
+            entries: entries,
+            periodKey: LocalUsageReader.monthKey(now),
+            fromDay: formatter.string(from: monthStart),
+            toDay: formatter.string(from: now))
+        result.periodsOK = true
+        return result
+    }
+}
+
+enum LocalOllamaUsageReader {
+    static var defaultRoot: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ollama/usage", isDirectory: true)
+    }
+
+    static func roots(customRootsValue: String? = CustomScanRoots.storedValue(for: "ollama")) -> [URL] {
+        CustomScanRoots.union(defaults: [defaultRoot], extraRaw: customRootsValue)
+    }
+
+    static func entries(modifiedSince: Date, roots: [URL]? = nil) -> [LocalUsageReader.Entry] {
+        let formatter = LocalUsageReader.localDayFormatter()
+        let minimumDay = formatter.string(from: modifiedSince)
+        var entries: [LocalUsageReader.Entry] = []
+        for root in roots ?? self.roots() {
+            for file in usageFiles(root: root, minimumDay: minimumDay) {
+                forEachLine(in: file) { lineNumber, line in
+                    if let entry = parse(line: line, file: file.path, lineNumber: lineNumber,
+                                         formatter: formatter),
+                       entry.date >= modifiedSince {
+                        entries.append(entry)
+                    }
+                }
+            }
+        }
+        return entries
+    }
+
+    private static func usageFiles(root: URL, minimumDay: String) -> [URL] {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]) else { return [] }
+        var files: [URL] = []
+        for case let url as URL in enumerator where url.pathExtension.lowercased() == "jsonl" {
+            // The proxy names files by local day, so old files can be rejected before reading.
+            let day = url.deletingPathExtension().lastPathComponent
+            if day >= minimumDay { files.append(url) }
+        }
+        return files.sorted { $0.path < $1.path }
+    }
+
+    static func parse(
+        line: Data, file: String, lineNumber: Int, formatter: DateFormatter
+    ) -> LocalUsageReader.Entry? {
+        guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+              let timestamp = object["ts"] as? String,
+              let date = ISO8601Parser.date(from: timestamp) else { return nil }
+        let prompt = tokenValue(object["prompt_tokens"])
+        let completion = tokenValue(object["completion_tokens"])
+        let reportedTotal = tokenValue(object["total_tokens"])
+        let partsTotal = safeAdd(prompt, completion)
+        let total = max(partsTotal, reportedTotal)
+        guard total > 0 else { return nil }
+
+        // Retain a writer-reported total even if a future Ollama response adds a token class.
+        let output = safeAdd(completion, max(0, total - partsTotal))
+        return LocalUsageReader.Entry(
+            id: "ollama|\(file)|\(lineNumber)",
+            date: date,
+            localDay: formatter.string(from: date),
+            model: (object["model"] as? String) ?? "ollama",
+            input: prompt,
+            output: output,
+            cacheWrite: 0,
+            cacheRead: 0)
+    }
+
+    private static let maximumTokenValue = 1_000_000_000_000_000
+
+    private static func tokenValue(_ value: Any?) -> Int {
+        guard !(value is NSNull) else { return 0 }
+        let number: Double
+        if let value = value as? NSNumber { number = value.doubleValue }
+        else if let value = value as? String, let parsed = Double(value) { number = parsed }
+        else { return 0 }
+        guard number.isFinite, number > 0 else { return 0 }
+        return number >= Double(maximumTokenValue) ? maximumTokenValue : Int(number)
+    }
+
+    private static func safeAdd(_ lhs: Int, _ rhs: Int) -> Int {
+        lhs > maximumTokenValue - rhs ? maximumTokenValue : lhs + rhs
+    }
+
+    /// Stream unbounded JSONL files so a long-running Ollama installation cannot make the
+    /// menu-bar process mirror the entire ledger in memory.
+    private static func forEachLine(in url: URL, body: (Int, Data) -> Void) {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return }
+        defer { try? handle.close() }
+        var pending = Data()
+        var lineNumber = 0
+        while true {
+            let chunk = autoreleasepool { try? handle.read(upToCount: 64 * 1024) }
+            guard let chunk, !chunk.isEmpty else { break }
+            pending.append(chunk)
+            while let newline = pending.firstIndex(of: 0x0A) {
+                let line = Data(pending[..<newline])
+                pending.removeSubrange(...newline)
+                lineNumber += 1
+                autoreleasepool { body(lineNumber, line) }
+            }
+        }
+        if !pending.isEmpty {
+            lineNumber += 1
+            autoreleasepool { body(lineNumber, pending) }
+        }
+    }
+}

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -456,7 +456,7 @@ final class UsageStore {
         LocalClaudeProvider(), LocalCodexProvider(), LocalGeminiProvider(),
         LocalAntigravityProvider(), LocalOpenCodeProvider(), LocalHermesProvider(),
         LocalCursorProvider(), LocalGrokProvider(), LocalCopilotProvider(), LocalKiroProvider(),
-        LocalPiProvider(),
+        LocalPiProvider(), LocalOllamaProvider(),
     ],
          claudeLimitsProvider: any ClaudeLimitsProviding = OAuthLimitsProvider(),
          codexLimitsProvider: any CodexLimitsProviding = CodexRateLimitsProvider(),

--- a/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
+++ b/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
@@ -134,7 +134,7 @@ final class LocalAdditionalUsageTests: XCTestCase {
         XCTAssertEqual(
             Set(store.registeredProviderIDs),
             Set(["claude_code", "codex", "gemini", "antigravity",
-                 "opencode", "hermes", "cursor", "grok", "copilot", "kiro", "pi"]))
+                 "opencode", "hermes", "cursor", "grok", "copilot", "kiro", "pi", "ollama"]))
     }
 
     func testPrintRealOpenCodeAggregate() throws {

--- a/Tests/PokeTokenBarTests/OllamaUsageTests.swift
+++ b/Tests/PokeTokenBarTests/OllamaUsageTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import PokeTokenBar
+
+final class OllamaUsageTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PokeTokenBar-OllamaUsageTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+        directory = nil
+    }
+
+    func testReadsProxyLedgerAndPreservesExactReportedTotal() throws {
+        let timestamp = "2026-08-25T16:45:00Z"
+        let date = try XCTUnwrap(ISO8601Parser.date(from: timestamp))
+        let day = LocalUsageReader.localDayFormatter().string(from: date)
+        let ledger = directory.appendingPathComponent("\(day).jsonl")
+        let contents = """
+        {"ts":"\(timestamp)","source":"ollama","endpoint":"/api/chat","model":"qwen3.6:35b","prompt_tokens":100,"completion_tokens":25,"total_tokens":130}
+        {"ts":"\(timestamp)","source":"ollama","endpoint":"/api/embed","model":"qwen3-embedding:0.6b","prompt_tokens":7,"completion_tokens":0,"total_tokens":7}
+        not-json
+
+        """
+        try contents.write(to: ledger, atomically: true, encoding: .utf8)
+
+        let entries = LocalOllamaUsageReader.entries(
+            modifiedSince: date.addingTimeInterval(-1), roots: [directory])
+
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].input, 100)
+        XCTAssertEqual(entries[0].output, 30, "a future/unclassified token class must not be dropped")
+        XCTAssertEqual(entries[0].total, 130)
+        XCTAssertEqual(entries[1].total, 7)
+        let daily = try XCTUnwrap(LocalUsageReader.daily(entries: entries, localDay: day))
+        XCTAssertEqual(daily.totalTokens, 137)
+        XCTAssertEqual(daily.totalCost, 0)
+    }
+
+    func testExternalCountsAreClampedAndNullIsNotAValue() throws {
+        let formatter = LocalUsageReader.localDayFormatter()
+        let line = Data("""
+        {"ts":"2026-08-25T16:45:00Z","model":"bad","prompt_tokens":null,"completion_tokens":1e30,"total_tokens":-4}
+        """.utf8)
+
+        let entry = try XCTUnwrap(LocalOllamaUsageReader.parse(
+            line: line, file: "fixture", lineNumber: 1, formatter: formatter))
+
+        XCTAssertEqual(entry.input, 0)
+        XCTAssertEqual(entry.output, 1_000_000_000_000_000)
+        XCTAssertEqual(entry.total, 1_000_000_000_000_000)
+    }
+
+    func testProviderIsTokenOnly() {
+        let provider = LocalOllamaProvider()
+        XCTAssertEqual(provider.id, "ollama")
+        XCTAssertEqual(provider.displayName, "Ollama")
+        XCTAssertFalse(provider.reportsCost)
+    }
+}

--- a/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
@@ -22,7 +22,7 @@ final class ProviderTabLayoutTests: XCTestCase {
         [("claude_code", "Claude Code"), ("codex", "Codex"), ("gemini", "Gemini"),
          ("antigravity", "Antigravity"), ("opencode", "OpenCode"), ("hermes", "Hermes Agent"),
          ("cursor", "Cursor"), ("grok", "Grok"), ("copilot", "Copilot"), ("kiro", "Kiro"),
-         ("pi", "Pi")]
+         ("pi", "Pi"), ("ollama", "Ollama")]
             .map { snapshot($0.0, $0.1) }
     }
 


### PR DESCRIPTION
### What
Adds a local **Ollama** usage provider, following the exact pattern of the existing local providers (`LocalClaudeProvider`, `LocalCodexProvider`, …):

- **`LocalOllamaUsageProvider.swift`** — `LocalOllamaProvider: UsageProvider` (`id "ollama"`, `displayName "Ollama"`, `reportsCost = false`, since local inference is free). It reads a JSONL ledger and reuses `LocalUsageReader` for daily totals, active-block, and week/month enrichment — no new counting logic.
- **`UsageStore.swift`** — registers `LocalOllamaProvider()` in the provider list.
- **`CustomScanRoots.swift`** — adds the `"ollama"` case so the existing **Additional scan folders** feature works for Ollama too.
- **`OllamaUsageTests.swift`** — unit tests for the reader/parser.

### Where the data comes from (the honest caveat)
Ollama reports exact `prompt_tokens` / `completion_tokens` on its final response object, but **does not persist a usage ledger** of its own. This provider reads NDJSON written under **`~/.ollama/usage/YYYY-MM-DD.jsonl`** by a small transparent logging proxy that sits in front of the Ollama daemon and records each completed request, e.g.:

```json
{"ts":"2026-08-27T10:25:57+00:00","source":"ollama","endpoint":"/api/chat","model":"qwen3.6:35b","prompt_tokens":35065,"completion_tokens":172,"total_tokens":35237}
```

The provider is intentionally **decoupled from the proxy** — it just treats that directory as a local usage source, and shows nothing if the ledger is absent (no crash, no error). Users who don't run such a proxy simply see no Ollama data, like any other provider whose logs aren't present.

**Open question for the maintainer:** how would you like the proxy dependency handled? (a) document the expected `~/.ollama/usage` NDJSON format in the README and leave the proxy to the user; (b) I can contribute a tiny reference proxy in a follow-up; (c) if Ollama adds native usage persistence later, the provider can point at that with no interface change. Happy to go whichever way fits the project.

### Notes
- No dependency changes; matches existing provider conventions and the local-day/`totalTokens` accounting used across providers.
- Tested locally against a real `~/.ollama/usage` ledger; the app builds clean via `scripts/build-app.sh`.
