### PR TITLE
feat: auto-enable floating pet when a representative is pinned from the dex

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -44,6 +44,8 @@ final class CompanionStore {
     private let dittoDisguiseRollingEnabled: Bool
     /// 세션 내 활성 개체 교체 감지용. await 뒤 이전 개체의 결과가 새 개체를 덮지 않게 한다.
     private var activeGeneration = 0
+    /// 도감에서 대표지정했을 때(nil 해제 제외) 호출. AppDelegate 가 플로팅 펫을 자동 on
+    var onRepresentativeSet: (() -> Void)?
 
     init(provider: any PokeProviding = PokeAPIClient.shared,
          clock: @escaping () -> Date = Date.init,
@@ -123,6 +125,7 @@ final class CompanionStore {
         if let id, !state.ownsSpecies(id) { return false }
         state.representativeSpeciesID = id
         save()
+        if id != nil { onRepresentativeSet?() }
         return true
     }
 

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -61,6 +61,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         updater = UpdateChecker()
         store.localizationLanguage = companion.language   // 알림 현지화용 미러 시드
         store.onRefresh = { [weak self] in self?.onStoreRefreshed() }   // 한도 로드 후 companion·사탕 지급
+        // 도감에서 대표 포켓몬을 지정하면 플로팅 펫이 꺼져 있어도 자동으로 켜지도록
+        companion.onRepresentativeSet = { [weak self] in self?.store.floatingPetEnabled = true }
         floatingPet = FloatingPetController(
             store: store, companion: companion,
             onOpenPopover: { [weak self] in self?.openPopover() },

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -407,6 +407,18 @@ final class CompanionStoreTests: XCTestCase {
                        CompanionStore.RepresentativeSubject(speciesID: 2, isShiny: true))
     }
 
+    /// 대표 포켓몬을 지정하면 플로팅 펫이 꺼져 있어도 자동으로 켜지도록
+    func testSettingRepresentativeFiresOnRepresentativeSetCallbackButClearingDoesNot() async {
+        let s = store(linear3)
+        await s.hatch(baseID: 1)
+        var fireCount = 0
+        s.onRepresentativeSet = { fireCount += 1 }
+        XCTAssertTrue(s.setRepresentativeSpeciesID(1))
+        XCTAssertEqual(fireCount, 1)
+        XCTAssertTrue(s.setRepresentativeSpeciesID(nil))
+        XCTAssertEqual(fireCount, 1, "해제는 자동 on 을 트리거하면 안 된다")
+    }
+
     /// 현재 개체에서 고른 종도 졸업 순간 같은 체인이 영구 dex 로 이동하므로 대표 선택이 끊기지 않는다.
     func testRepresentativeSelectionSurvivesGraduation() async {
         let s = store(linear3)


### PR DESCRIPTION
## Summary

Picking a representative Pokémon in the dex previously had no visible effect if the floating pet toggle in Settings was off, since the two UIs don't know about each other. 
CompanionStore now exposes an `onRepresentativeSet` callback, fired only when a species is actually pinned (not when clearing back to auto-follow), which AppDelegate wires to flip `UsageStore.floatingPetEnabled` on. 
so pinning a Pokémon from the dex makes it show up on the desktop immediately.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes
No UI files changed


## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed 
- [x] Tests were added or updated for this change
