### PR TITLE
fix: keep released Pokémon in the Pokédex

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -459,11 +459,19 @@ struct DexEntry: Codable, Sendable, Identifiable {
     /// 도감의 단계별 스프라이트 밑 이름 표시가 네트워크 없이 즉시 + 언어 전환 대응. 구버전 저장분엔
     /// 없어(nil) 뷰가 line fetch 로 조회 후 백필한다.
     var names: [Int: [String: String]]?
+    /// 놓아준 시각 — 알을 새로 사서 육성을 포기한 기록. nil = 졸업분(구버전 저장분 포함).
+    ///
+    /// 두 기록을 한 배열에 두는 이유: 도감(`dexSpecies`)은 종이 어떻게 확보됐는지와 무관하게
+    /// **보유 종**을 접는다. 놓아준 개체를 여기 넣지 않으면 그 종이 도감에서 사라진다 —
+    /// 수집 화면이 "쌓이기만 한다"는 약속을 깨는 유일한 경로였다.
+    var releasedAt: Date?
+    /// 졸업이 아니라 놓아준 기록인가 — 포획 로그가 뱃지를 가르는 판정.
+    var isReleased: Bool { releasedAt != nil }
 
     init(id: String = UUID().uuidString,
          baseID: Int, finalID: Int, chainOrder: [Int], rarity: Rarity,
          caughtAt: Date?, isShiny: Bool = false, nature: PokemonNature? = nil,
-         names: [Int: [String: String]]? = nil) {
+         names: [Int: [String: String]]? = nil, releasedAt: Date? = nil) {
         self.id = id
         self.baseID = baseID
         self.finalID = finalID
@@ -473,6 +481,7 @@ struct DexEntry: Codable, Sendable, Identifiable {
         self.isShiny = isShiny
         self.nature = nature
         self.names = names
+        self.releasedAt = releasedAt
     }
 
     // 하위호환 디코딩 (MonState 와 동일 이유).
@@ -489,6 +498,8 @@ struct DexEntry: Codable, Sendable, Identifiable {
         // try? — 구버전(최종체 단일 [String:String]) 형식이 남아 있어도 종별 맵 디코딩 실패 시 nil 로
         // 강등(항목 전체 로드는 유지). 뷰가 line 조회로 백필한다.
         names = (try? c.decodeIfPresent([Int: [String: String]].self, forKey: .names)) ?? nil
+        // 이 필드 이전에 저장된 항목은 전부 졸업분이다 — nil 이 곧 "졸업"이라 마이그레이션이 필요 없다.
+        releasedAt = try c.decodeIfPresent(Date.self, forKey: .releasedAt)
     }
 }
 

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -194,6 +194,34 @@ final class CompanionStore {
         )
     }
 
+    /// 놓아준 개체의 영구 기록 — 알을 새로 사서 육성을 포기하는 순간 만든다.
+    ///
+    /// **도달한 형태만 담는다**(`pathIDs.prefix(stageIndex + 1)`). 도감이 육성 중 보여주던 범위와
+    /// 같아야 놓아준 뒤에도 칸 구성이 그대로 유지된다 — `plannedPathIDs` 나 `pathIDs` 전체를 쓰면
+    /// 도달한 적 없는 진화형까지 보유로 잡힌다(`dexSpecies` 가 같은 prefix 규칙을 쓴다).
+    ///
+    /// 이로치는 `currentIsShiny` — 위장 중인 메타몽은 리빌 전까지 숨긴다(`activeDexEntry` 와 단일 판정).
+    /// `caughtAt` 은 놓아준 시각이다: 포획 로그가 그 값으로 정렬하므로 기록이 남은 시점과 일치해야 한다.
+    private func releasedDexEntry(from a: MonState) -> DexEntry {
+        // stageIndex 가 음수·범위 밖이어도 최소 한 형태는 남긴다(손상 상태 파일 방어 — MonState.currentID 와 같은 태도).
+        let reached = Array(a.pathIDs.prefix(max(1, a.stageIndex + 1)))
+        let chain = reached.isEmpty ? [a.baseID] : reached
+        let now = clock()
+        return DexEntry(
+            baseID: a.baseID,
+            finalID: chain.last ?? a.baseID,
+            chainOrder: chain,
+            rarity: a.rarity,
+            caughtAt: now,
+            isShiny: currentIsShiny,
+            nature: a.nature,
+            names: currentLine.map { line in
+                Dictionary(uniqueKeysWithValues:
+                    chain.compactMap { id in line.names[id].map { (id, $0) } })
+            },
+            releasedAt: now)
+    }
+
     var dexEntries: [DexEntry] {
         guard let activeDexEntry else { return state.dex }
         return state.dex + [activeDexEntry]
@@ -729,9 +757,11 @@ final class CompanionStore {
         return hasActive && availableTokens >= FreshEgg.price(guaranteeing: tier)
     }
 
-    /// 알 구매 — 현재 포켓몬을 폐기하고 처음부터 인큐베이션하는 새 알로. 지갑에서 가격 차감.
-    /// graduate() 의 알-리셋만 미러링하고 dex/collectedFinals(도감·확률 가중)는 손대지 않는다
-    /// → "뽑은 적 없던 것처럼". 성장(usedAtStage)은 소멸(추가 비용).
+    /// 알 구매 — 현재 포켓몬을 놓아주고 처음부터 인큐베이션하는 새 알로. 지갑에서 가격 차감.
+    /// graduate() 의 알-리셋을 미러링하되, 놓아준 개체는 **도감에 남긴다**(`releasedDexEntry`).
+    /// 도감은 "쌓이기만 한다"는 약속을 주는데, 여기가 종이 사라질 수 있던 유일한 경로였다.
+    /// `collectedFinals`(최종체 완성·분기 가중)는 여전히 손대지 않는다 — 끝까지 키운 게 아니다.
+    /// 성장(usedAtStage)은 소멸(추가 비용).
     ///
     /// 여기서 종을 롤하지 않는다 — 롤에는 네트워크가 필요해서 오프라인이면 토큰만 사라진다. 보증만
     /// 상태(`eggTier`)에 적고, 실제 롤은 프리패치/부화 경로가 그 보증을 읽어 수행한다.
@@ -739,8 +769,13 @@ final class CompanionStore {
     func buyEgg(_ tier: Rarity?) -> Bool {
         guard canBuyEgg(tier) else { return false }
         state.spentTokens += FreshEgg.price(guaranteeing: tier)
-        state.active = nil            // 폐기 (졸업 아님 — dex/collectedFinals 미변경)
-        state.reconcileRepresentativeSelection()   // 미졸업 개체에만 있던 대표 종은 자동 추적으로 복귀
+        if let a = state.active {
+            state.dex.append(releasedDexEntry(from: a))   // 놓아줌 기록 — 도감에서 종이 사라지지 않게
+        }
+        state.active = nil            // 놓아줌 (졸업 아님 — collectedFinals 는 미변경)
+        // 놓아준 종도 이제 dex 에 있으므로 대표 선택은 유지된다. 손상 상태 파일 등으로 정말 보유가
+        // 끊긴 경우만 자동 추적으로 복귀한다.
+        state.reconcileRepresentativeSelection()
         activeGeneration += 1
         currentLine = nil
         state.eggUsage = 0            // 새 알은 처음부터 인큐베이션(재부화에 5M 필요)

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -475,6 +475,8 @@ struct L {
     var dexPagePrev: String { t("이전 페이지", "Previous page", "前のページ", "Página anterior", "Page précédente", "Página anterior") }
     var dexPageNext: String { t("다음 페이지", "Next page", "次のページ", "Página siguiente", "Page suivante", "Próxima página") }
     var dexRaising: String { t("키우는 중", "Raising", "育成中", "Criando", "En élevage", "Treinando") }
+    /// 포획 로그에서 졸업분과 놓아준 개체를 가르는 표식. 종은 도감에 남고 개체 기록만 이 뱃지를 단다.
+    var dexReleased: String { t("놓아줌", "Released", "逃がした", "Liberado", "Relâché", "Solto") }
     var rarityCommon: String { t("일반", "Common", "ノーマル", "Común", "Commun", "Comum") }
     var rarityUncommon: String { t("고급", "Uncommon", "アンコモン", "Poco común", "Peu commun", "Incomum") }
     var rarityRare: String { t("희귀", "Rare", "レア", "Raro", "Rare", "Raro") }

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -1122,6 +1122,15 @@ private struct DexEntryRow: View {
                         .background(Color.accentColor.opacity(0.14))
                         .foregroundStyle(Color.accentColor)
                         .clipShape(Capsule())
+                } else if entry.isReleased {
+                    // 놓아준 개체 — 종은 도감에 남지만 이 개체는 끝까지 키우지 않았다.
+                    // 중립색(secondary)으로 둔다: 실패가 아니라 다른 종류의 기록이라 경고색은 과하다.
+                    Text(store.l.dexReleased.uppercased())
+                        .font(.system(size: 8, weight: .bold))
+                        .padding(.horizontal, 5).padding(.vertical, 1)
+                        .background(Color.secondary.opacity(0.14))
+                        .foregroundStyle(Color.secondary)
+                        .clipShape(Capsule())
                 }
                 if entry.isShiny {
                     // 이모지는 스크린리더가 일관되게 읽지 못해 명사 라벨을 붙인다(도감 칸과 동일 규칙).

--- a/Tests/PokeTokenBarTests/CompanionTests.swift
+++ b/Tests/PokeTokenBarTests/CompanionTests.swift
@@ -452,9 +452,11 @@ final class CompanionStoreTests: XCTestCase {
         XCTAssertEqual(s.representativeSubject.speciesID, 20)
     }
 
-    /// Fresh Egg 는 미졸업 개체를 도감에 남기지 않는다. 그 개체만 근거였던 대표 종도 함께 해제돼
-    /// 존재하지 않는 종을 계속 그리지 않고 기본값(현재 개체/알 추적)으로 돌아간다.
-    func testFreshEggClearsRaisingOnlyRepresentativeSelection() throws {
+    /// Fresh Egg 로 놓아준 개체도 이제 도감에 남으므로, 그 종을 가리키던 대표 선택은 **유지된다**.
+    ///
+    /// 예전에는 여기서 선택이 해제됐다 — 놓아주면 종이 도감에서 사라져 존재하지 않는 종을 가리키게
+    /// 됐기 때문이다. 종이 남는 지금 해제하면 오히려 사용자가 고른 대표가 이유 없이 풀린다.
+    func testFreshEggKeepsRepresentativeSelectionOfReleasedSpecies() throws {
         let active = MonState(baseID: 1, pathIDs: [1], stageIndex: 0, usedAtStage: 0,
                               rarity: .common, totalForms: 3)
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
@@ -466,8 +468,8 @@ final class CompanionStoreTests: XCTestCase {
                                fileURL: url, rng: SeededRNG(seed: 7))
         XCTAssertEqual(s.representativeSpeciesID, 1)
         XCTAssertTrue(s.buyFreshEgg())
-        XCTAssertNil(s.representativeSpeciesID)
-        XCTAssertNil(s.representativeSubject.speciesID, "자동 추적 + active 없음 = 알")
+        XCTAssertEqual(s.representativeSpeciesID, 1, "놓아준 종도 보유분이라 선택이 유지된다")
+        XCTAssertEqual(s.representativeSubject.speciesID, 1, "메뉴바도 그 종을 계속 그린다")
     }
 
     /// 외부에서 손편집했거나 다른 상태와 잘못 합쳐진 선택은 로드 경계에서 제거한다.
@@ -597,6 +599,57 @@ final class CompanionStoreTests: XCTestCase {
         let s = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow },
                                fileURL: url, rng: SeededRNG(seed: 7))
         XCTAssertEqual(s.dexSpecies.map(\.isRaising), [false, true, false])
+    }
+
+    // MARK: 놓아줌 (알 구매로 포기한 개체의 영구 기록)
+
+    /// [회귀·트리거] 3단 라인을 2단까지 키우다 놓아주면 **도달한 두 형태만** 남는다.
+    ///
+    /// 트리거 분기: `pathIDs` 는 실현 경로, `plannedPathIDs` 는 전체 계획이다. 놓아줌 기록에
+    /// 계획을 쓰면 한 번도 본 적 없는 최종 진화형이 보유로 잡힌다 — 알을 사서 포기하는 것이
+    /// 도감을 채우는 지름길이 된다. `dexSpecies` 가 육성 중 쓰는 prefix 규칙과 같아야 한다.
+    func testReleasingMidChainCreditsOnlyReachedForms() throws {
+        let active = MonState(baseID: 1, pathIDs: [1, 2], plannedPathIDs: [1, 2, 3], stageIndex: 1,
+                              usedAtStage: 0, rarity: .common, totalForms: 3)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
+        let activeJSON = String(decoding: try JSONEncoder().encode(active), as: UTF8.self)
+        try Data(#"{"active":\#(activeJSON),"usedSinceInstall":5000000000}"#.utf8).write(to: url)
+
+        let s = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow },
+                               fileURL: url, rng: SeededRNG(seed: 7))
+        XCTAssertEqual(s.dexSpecies.map(\.id), [1, 2], "육성 중 도달분")
+        XCTAssertTrue(s.buyFreshEgg())
+
+        XCTAssertEqual(s.dexSpecies.map(\.id), [1, 2], "놓아준 뒤에도 같은 두 종")
+        let released = try XCTUnwrap(s.state.dex.last)
+        XCTAssertEqual(released.chainOrder, [1, 2])
+        XCTAssertEqual(released.finalID, 2, "도달한 마지막 형태")
+        XCTAssertFalse(s.dexSpecies.contains { $0.id == 3 }, "미도달 진화형은 보유가 아니다")
+    }
+
+    /// 위장 중인 메타몽을 놓아주면 이로치는 계속 숨겨진다 — `currentIsShiny` 단일 판정을 따른다.
+    /// 기록에 `a.isShiny` 를 그대로 쓰면 놓아주는 것이 리빌 수단이 된다.
+    func testReleasingDisguisedDittoKeepsShinyHidden() throws {
+        let active = MonState(baseID: 1, pathIDs: [1], stageIndex: 0, usedAtStage: 0,
+                              rarity: .common, totalForms: 3, isShiny: true,
+                              dittoDisguise: 1, dittoRevealed: false)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("poke-\(UUID().uuidString).json")
+        let activeJSON = String(decoding: try JSONEncoder().encode(active), as: UTF8.self)
+        try Data(#"{"active":\#(activeJSON),"usedSinceInstall":5000000000}"#.utf8).write(to: url)
+
+        let s = CompanionStore(provider: StubProvider(value: linear3), clock: { fixedNow },
+                               fileURL: url, rng: SeededRNG(seed: 7))
+        XCTAssertTrue(s.buyFreshEgg())
+        let released = try XCTUnwrap(s.state.dex.last)
+        XCTAssertFalse(released.isShiny, "위장 중이면 리빌 전까지 숨김")
+    }
+
+    /// 이 필드 이전에 저장된 항목은 전부 졸업분으로 읽힌다 — 별도 마이그레이션 없이 nil = 졸업.
+    func testLegacyDexEntriesDecodeAsGraduated() throws {
+        let json = #"{"baseID":1,"finalID":3,"chainOrder":[1,2,3],"rarity":"common"}"#
+        let entry = try JSONDecoder().decode(DexEntry.self, from: Data(json.utf8))
+        XCTAssertNil(entry.releasedAt)
+        XCTAssertFalse(entry.isReleased, "구버전 저장분은 졸업분")
     }
 
     /// 졸업분만 있고 현재 개체가 없으면 표식은 하나도 없다(모두 영구 기록).

--- a/Tests/PokeTokenBarTests/FreshEggTests.swift
+++ b/Tests/PokeTokenBarTests/FreshEggTests.swift
@@ -29,8 +29,10 @@ final class FreshEggTests: XCTestCase {
 
     func testPriceIsOneBillion() { XCTAssertEqual(FreshEgg.price, 1_000_000_000) }
 
-    /// [핵심] 리롤 = 폐기: active 사라지고 새 알(eggUsage 0). **도감·확률(collectedFinals) 불변** = "뽑은 적 없던 것처럼".
-    func testBuyFreshEggDiscardsWithoutDexOrProbabilityImpact() {
+    /// [핵심] 리롤 = 놓아줌: active 사라지고 새 알(eggUsage 0).
+    /// 도감에는 **놓아줌 기록으로 남고**, 확률 가중(collectedFinals)은 여전히 불변이다 —
+    /// 끝까지 키운 게 아니므로 최종체 완성으로 세지 않는다.
+    func testBuyFreshEggReleasesIntoDexWithoutProbabilityImpact() {
         let s = store(used: 5_000_000_000, spent: 0)
         let persistedDexBefore = s.state.dex
         let collectedBefore = s.state.collectedFinals
@@ -38,17 +40,38 @@ final class FreshEggTests: XCTestCase {
                        "현재 포켓몬은 졸업 전에도 도감 화면에 표시")
         XCTAssertTrue(s.hasActive)
         XCTAssertTrue(s.buyFreshEgg())
-        XCTAssertNil(s.state.active, "현재 포켓몬 폐기")
+        XCTAssertNil(s.state.active, "현재 포켓몬은 더 이상 활성이 아니다")
         XCTAssertTrue(s.isEgg)
         XCTAssertEqual(s.state.eggUsage, 0, "새 알은 처음부터 인큐베이션")
         XCTAssertNil(s.state.pendingHatchID)
-        XCTAssertEqual(s.state.dex.map(\.id), persistedDexBefore.map(\.id),
-                       "영구 도감 불변 — 졸업이 아니라 폐기")
-        XCTAssertEqual(s.dexEntries.count, persistedDexBefore.count,
-                       "폐기한 현재 포켓몬의 화면용 엔트리는 제거")
+
+        XCTAssertEqual(s.state.dex.count, persistedDexBefore.count + 1,
+                       "놓아준 개체가 영구 기록으로 추가된다")
+        let released = try? XCTUnwrap(s.state.dex.last)
+        XCTAssertEqual(released?.baseID, 10)
+        XCTAssertTrue(released?.isReleased ?? false, "졸업분과 구분되는 놓아줌 기록")
+        XCTAssertEqual(released?.chainOrder, [10], "도달한 형태만 — stageIndex 0 이라 1형태")
+        XCTAssertEqual(s.dexEntries.count, persistedDexBefore.count + 1,
+                       "합성 엔트리는 사라지고 영구 기록이 그 자리를 대신한다")
+
         XCTAssertEqual(s.state.collectedFinals, collectedBefore, "확률 가중(collectedFinals) 불변")
         XCTAssertEqual(s.state.spentTokens, FreshEgg.price, "지갑에서 1B 차감")
         XCTAssertEqual(s.availableTokens, 5_000_000_000 - FreshEgg.price)
+    }
+
+    /// [회귀] 놓아준 종은 도감에서 사라지지 않는다.
+    ///
+    /// 이게 이 기능의 존재 이유다. 도감은 "쌓이기만 한다"는 약속을 주는데, 알 구매가 유일하게
+    /// 그 약속을 깨는 경로였다 — 현재 개체에서만 오던 종이 통째로 빠져 종 수가 줄었다.
+    /// `state.dex` 에 남기는 대신 `state.active = nil` 만 하면 이 테스트가 실패한다(주입 확인함).
+    func testReleasedSpeciesStaysInTheDex() {
+        let s = store()
+        XCTAssertTrue(s.dexSpecies.contains { $0.id == 10 }, "육성 중엔 도감에 보인다")
+        XCTAssertTrue(s.buyFreshEgg())
+        XCTAssertTrue(s.dexSpecies.contains { $0.id == 10 },
+                      "놓아준 뒤에도 남는다 — 도감 종 수는 줄지 않는다")
+        XCTAssertFalse(s.dexSpecies.first { $0.id == 10 }?.isRaising ?? true,
+                       "더 이상 키우는 중이 아니므로 Raising 뱃지는 없다")
     }
 
     /// 폐기한 개체(baseID 10)의 종은 collectedFinals 에 들어가지 않는다(이후 부화 확률에 영향 없음).

--- a/Tests/PokeTokenBarTests/PremiumEggTests.swift
+++ b/Tests/PokeTokenBarTests/PremiumEggTests.swift
@@ -180,9 +180,12 @@ final class PremiumEggTests: XCTestCase {
         XCTAssertEqual(s.state.eggTier, .rare, "보증이 상태에 기록됨")
         XCTAssertEqual(s.eggGuarantee, .rare)
         XCTAssertEqual(s.state.spentTokens, FreshEgg.price(guaranteeing: .rare))
-        XCTAssertNil(s.state.active, "현재 포켓몬 폐기")
+        XCTAssertNil(s.state.active, "현재 포켓몬은 더 이상 활성이 아니다")
         XCTAssertEqual(s.state.eggUsage, 0, "새 알은 처음부터 인큐베이션")
-        XCTAssertTrue(s.state.dex.isEmpty, "폐기는 졸업이 아니다 — 도감 불변")
+        // 등급 알도 새 알과 같은 놓아줌 경로를 쓴다 — 종은 남기되 졸업으로 세지는 않는다.
+        XCTAssertEqual(s.state.dex.count, 1, "놓아준 개체가 기록으로 남는다")
+        XCTAssertTrue(s.state.dex.first?.isReleased ?? false, "졸업이 아니라 놓아줌")
+        XCTAssertTrue(s.state.collectedFinals.isEmpty, "최종체 완성으로 세지 않는다")
     }
 
     /// 알 상태에선 등급 알도 못 산다 — 기존 새 알과 게이트 통일.

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -378,6 +378,19 @@ read_when:
   이전 형태의 휘발성을 안내해야 한다면 `키우는 중`을 재사용하지 말고 별도 개념으로 설계한다. 회귀는
   2단계 도달 상태의 `[false, true]`, 졸업한 라인을 다시 키우는 상태의 `[false, true, false]`, 현재 개체가
   없는 졸업 기록의 전부 `false`를 함께 고정한다.
+- **뱃지로 설명하려던 휘발성은 애초에 없애는 게 답이었다.** 위 항목이 남긴 숙제 — "이전 형태의 휘발성을
+  안내해야 한다면 별도 개념으로" — 의 결론은 새 뱃지가 아니라 **휘발 자체를 제거**하는 것이다. `buyEgg` 가
+  `active` 만 버리고 `dex` 를 안 건드린 탓에, 현재 개체에서만 오던 종이 통째로 도감에서 빠져 종 수가 줄었다.
+  수집 화면이 "쌓이기만 한다"는 약속을 주는데 이게 그 약속을 깨는 유일한 경로였다. 이제 놓아준 개체를
+  `releasedAt` 을 단 `DexEntry` 로 `state.dex` 에 남긴다 — 도감(`dexSpecies`)이 `state.dex` 를 접으므로 종
+  보존은 자동으로 따라오고, 포획 로그만 `놓아줌` 뱃지로 졸업분과 구분한다. 규칙 셋: ① **도달분만 기록**
+  (`pathIDs.prefix(stageIndex + 1)` — `plannedPathIDs` 를 쓰면 알을 사서 포기하는 게 도감을 채우는 지름길이
+  된다) ② 이로치는 `currentIsShiny`(위장 메타몽은 리빌 전까지 숨김 — 놓아주기가 리빌 수단이 되면 안 된다)
+  ③ `collectedFinals` 는 그대로 — 끝까지 키운 게 아니므로 최종체 완성·분기 가중에 넣지 않는다.
+  `releasedAt == nil` 이 곧 "졸업분"이라 구버전 저장분에 마이그레이션이 필요 없다. 부수 효과로, 놓아준 종을
+  가리키던 **대표 선택이 이제 유지된다**(예전엔 종이 사라져 `reconcileRepresentativeSelection` 이 해제했다).
+  가드: `testReleasedSpeciesStaysInTheDex`·`testReleasingMidChainCreditsOnlyReachedForms`·
+  `testReleasingDisguisedDittoKeepsShinyHidden` — 기록을 빼거나 `plannedPathIDs` 로 바꾸면 실패한다(주입 확인).
 
 - **컴팩트 표시는 오늘 사용한 프로바이더만.** 메뉴바(`menuLines`) 등 좁은 표시에서 한도·상태를 보일 땐
   `snapshots` 의 오늘 토큰>0 으로 게이트한다 — 설치만 되고 오늘 안 쓴 프로바이더(Codex 등)를 노출하지


### PR DESCRIPTION
## Summary

Follow-up to #211. That PR narrowed the `Raising` badge to the current evolution stage, which was right, but it left the underlying problem in place: the badge existed to warn that those cells could disappear, and they still could.

Buying an egg discarded the active companion without touching `dex`, so a species backed only by that companion vanished from the Pokédex. That was the single path where the collection screen could shrink — and the screen promises the opposite.

`buyEgg` now records the released companion as a `DexEntry` carrying `releasedAt`. The Pokédex folds `state.dex`, so species retention follows automatically; only the capture log tells the two apart, with a `Released` badge beside the existing `Raising` one.

Three rules the record follows:

- **Only reached forms are credited** (`pathIDs.prefix(stageIndex + 1)`, the same rule the Pokédex already uses while raising). Recording `plannedPathIDs` would turn buying an egg into a shortcut for filling the Pokédex with evolutions never reached.
- **Shiny follows `currentIsShiny`**, so releasing a disguised Ditto does not reveal it early.
- **`collectedFinals` is untouched.** A released companion was not raised to its final form, so it must not count toward completion or branch weighting.

`releasedAt == nil` means "graduated", so existing saves need no migration.

One deliberate behavior change beyond the fix: a representative pinned to a released species now survives the release. Previously the selection was cleared because the species disappeared; now that it is still owned, clearing it would drop the user's choice for no reason.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

| Before | After |
| ------ | ----- |
| Buying an egg removed the companion's species from the Pokédex grid, so the species count could go down. The capture log showed the entry only while it was active. | The species stays in the grid permanently. The capture log keeps the individual with a neutral `Released` badge, distinct from `Raising` (accent) and from graduated entries (no badge). |

The badge reuses the existing capsule styling in `DexEntryRow` and is rendered in a secondary tint rather than a warning colour — a release is a different kind of record, not a failure. No README change: the badges themselves are not documented there.

## Checklist

- [x] `swift build` and `swift test` pass locally (0 failures; `scripts/test-gate.sh` logic-core line coverage 90.96% >= 75%)
- [x] PR title and description are written in English
- [x] UI changes are described above
- [x] No copyrighted assets, secrets, or private tooling references are committed
- [x] Tests were added or updated for this change

New guards were verified by injection rather than by passing: removing the `dex` record fails `testReleasedSpeciesStaysInTheDex` and three others, and swapping the reached-forms prefix for `plannedPathIDs` fails `testReleasingMidChainCreditsOnlyReachedForms` on all four of its assertions.

Three existing tests asserted the old contract (`dex` unchanged after a discard, and the representative being cleared). They were updated rather than deleted, so the new contract is now the one under test.
