### PR TITLE
fix: split the Claude Keychain read so it stops failing with errSecParam (-50)

### DIFF
--- a/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/OAuthLimitsProvider.swift
@@ -259,41 +259,55 @@ actor OAuthAccessTokenCache {
         if KeychainAccessGate.isDisabled {
             throw LimitsError.keychainAccessDisabled
         }
-        var query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: OAuthCredentialData.claudeKeychainService,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-        ]
-        if !allowKeychainPrompt {
-            KeychainNoUIQuery.apply(to: &query)
-        }
-
-        var item: CFTypeRef?
-        let status = KeychainReader.copyMatching(query, &item)
-        if status == errSecInteractionNotAllowed {
-            throw LimitsError.keychainInteractionNotAllowed
-        }
-        guard status == errSecSuccess, let item else {
-            throw LimitsError.keychainUnavailable(status)
-        }
-
-        let dataItems = OAuthCredentialData.extractDataItems(from: item)
-        guard !dataItems.isEmpty else {
-            throw LimitsError.keychainUnavailable(status)
-        }
-
-        // 여러 키체인 항목(예: acct="unknown" MCP 전용 + acct="<user>" 계정 토큰) 중
-        // 유효한 claudeAiOauth 계정 토큰이 있는 자격증명을 먼저 찾는다.
-        for data in dataItems {
-            if let credential = OAuthCredentialData.credential(from: data) {
-                return credential
+        // 두 단계로 나눈다: ① 계정 목록을 **속성만** 받아 열거 ② 계정별로 데이터를 하나씩 읽기.
+        // 한 번에 `kSecMatchLimitAll` + `kSecReturnData` 로 받을 수 없다 — macOS 는 그 조합을
+        // errSecParam(-50) 으로 거절하며, 항목 존재 여부·ACL 승인과 무관하게 실패한다(실측).
+        // 그래서 이 조합은 "여러 항목 중 고르기"를 아예 불가능하게 만들었다.
+        var accounts: [String] = []
+        var enumerateStatus = errSecSuccess
+        do {
+            var item: CFTypeRef?
+            let query = OAuthCredentialData.claudeKeychainAccountsQuery(
+                allowKeychainPrompt: allowKeychainPrompt)
+            enumerateStatus = KeychainReader.copyMatching(query, &item)
+            if enumerateStatus == errSecInteractionNotAllowed {
+                throw LimitsError.keychainInteractionNotAllowed
+            }
+            if enumerateStatus == errSecSuccess {
+                accounts = OAuthCredentialData.accountNames(from: item)
             }
         }
 
-        // 모든 항목에 유효한 계정 토큰이 없는 경우:
+        // 계정 속성을 못 얻으면(구 키체인·속성 미반환) 스코프 없는 단건 읽기로 폴백한다 —
+        // 항목이 하나뿐인 흔한 경우는 이 경로로 그대로 동작한다.
+        let candidates: [String?] = accounts.isEmpty ? [nil] : accounts.map { $0 }
+
+        var sawAccountOAuthMissing = false
+        var lastStatus = enumerateStatus
+        for account in candidates {
+            var item: CFTypeRef?
+            let query = OAuthCredentialData.claudeKeychainDataQuery(
+                account: account, allowKeychainPrompt: allowKeychainPrompt)
+            let status = KeychainReader.copyMatching(query, &item)
+            if status == errSecInteractionNotAllowed {
+                throw LimitsError.keychainInteractionNotAllowed
+            }
+            lastStatus = status
+            guard status == errSecSuccess, let data = item as? Data else { continue }
+            // 여러 항목(예: acct="unknown" MCP 전용 + acct="<user>" 계정 토큰) 중
+            // 유효한 claudeAiOauth 계정 토큰이 있는 자격증명을 먼저 찾는다.
+            if let credential = OAuthCredentialData.credential(from: data) {
+                return credential
+            }
+            if OAuthCredentialData.isAccountOAuthMissing(data) { sawAccountOAuthMissing = true }
+        }
+
+        // 읽어낸 데이터가 하나도 없으면 자격증명 문제가 아니라 키체인 접근 문제다.
+        guard lastStatus == errSecSuccess || sawAccountOAuthMissing else {
+            throw LimitsError.keychainUnavailable(lastStatus)
+        }
         // 항목은 있는데 계정 OAuth 만 없는 상태(MCP OAuth 전용)는 재로그인 안내 대상이라 구분한다.
-        throw dataItems.contains(where: { OAuthCredentialData.isAccountOAuthMissing($0) })
+        throw sawAccountOAuthMissing
             ? LimitsError.credentialMissingAccountOAuth
             : LimitsError.credentialFormat
     }
@@ -302,28 +316,49 @@ actor OAuthAccessTokenCache {
 enum OAuthCredentialData {
     static let claudeKeychainService = "Claude Code-credentials"
 
-    /// SecItemCopyMatching 결과(단일 Data 또는 [Data] 등)에서 [Data] 목록을 추출한다.
-    static func extractDataItems(from item: Any?) -> [Data] {
-        guard let item else { return [] }
-        if let data = item as? Data {
-            return [data]
-        }
-        if let array = item as? [Data] {
-            return array
-        }
-        if let array = item as? [Any] {
-            var result: [Data] = []
-            for element in array {
-                if let data = element as? Data {
-                    result.append(data)
-                } else if let dict = element as? [String: Any], let data = dict[kSecValueData as String] as? Data {
-                    result.append(data)
-                }
-            }
-            return result
-        }
-        return []
+    /// 계정 열거용 쿼리 — **데이터를 요청하지 않는다.**
+    ///
+    /// `kSecMatchLimitAll` 은 `kSecReturnData` 와 함께 쓸 수 없다. macOS 는 그 조합을
+    /// errSecParam(-50) 으로 거절하는데, 이건 항목이 없어서가 아니라 파라미터가 무효라서라
+    /// ACL 승인이나 항목 존재 여부로는 우회되지 않는다. 속성만 받아 계정 이름을 얻고,
+    /// 데이터는 `claudeKeychainDataQuery` 로 계정별 단건 조회한다.
+    /// 가드: `testAllItemsQueryNeverAsksForDataAndIsAcceptedBySecurityFramework`.
+    static func claudeKeychainAccountsQuery(allowKeychainPrompt: Bool) -> [String: Any] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: claudeKeychainService,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+        ]
+        if !allowKeychainPrompt { KeychainNoUIQuery.apply(to: &query) }
+        return query
     }
+
+    /// 자격증명 데이터 단건 조회 — `kSecMatchLimitOne` 고정.
+    /// `account` 가 nil 이면 서비스 전체에서 한 건(계정 속성을 못 얻은 폴백 경로).
+    static func claudeKeychainDataQuery(account: String?, allowKeychainPrompt: Bool) -> [String: Any] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: claudeKeychainService,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        if let account { query[kSecAttrAccount as String] = account }
+        if !allowKeychainPrompt { KeychainNoUIQuery.apply(to: &query) }
+        return query
+    }
+
+    /// 속성 조회 결과에서 `acct` 목록을 뽑는다(순서 유지, 중복 제거).
+    static func accountNames(from item: Any?) -> [String] {
+        let rows: [[String: Any]]
+        if let array = item as? [[String: Any]] { rows = array }
+        else if let one = item as? [String: Any] { rows = [one] }
+        else { return [] }
+        var seen = Set<String>()
+        return rows.compactMap { $0[kSecAttrAccount as String] as? String }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
 
     struct Credential {
         let accessToken: String

--- a/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
+++ b/Tests/PokeTokenBarTests/PokeTokenBarTests.swift
@@ -494,45 +494,75 @@ final class OAuthCredentialDataTests: XCTestCase {
         XCTAssertEqual(OAuthCredentialData.credential(from: data)?.accessToken, "token-1")
     }
 
-    func testExtractDataItemsHandlesSingleAndMultipleFormats() {
-        let data1 = "data1".data(using: .utf8)!
-        let data2 = "data2".data(using: .utf8)!
-
-        // 단일 Data
-        XCTAssertEqual(OAuthCredentialData.extractDataItems(from: data1), [data1])
-
-        // [Data] 배열
-        XCTAssertEqual(OAuthCredentialData.extractDataItems(from: [data1, data2]), [data1, data2])
-
-        // [[String: Any]] (kSecValueData 포함)
-        let dictArray: [[String: Any]] = [
-            [kSecValueData as String: data1],
-            [kSecValueData as String: data2],
-        ]
-        XCTAssertEqual(OAuthCredentialData.extractDataItems(from: dictArray), [data1, data2])
-
-        // nil / 빈 값
-        XCTAssertEqual(OAuthCredentialData.extractDataItems(from: nil), [])
+    /// [회귀] **Security 프레임워크가 실제로 받아들이는 쿼리인가.** `kSecMatchLimitAll` 을
+    /// `kSecReturnData` 와 같이 넣으면 macOS 는 errSecParam(-50) 을 낸다 — 항목이 없어서가
+    /// 아니라 파라미터가 무효라서라, ACL 승인·항목 존재로는 절대 우회되지 않는다. 그렇게
+    /// 출고되면 Keychain 에만 자격증명이 있는 사용자는 공식 한도가 **영구히** 안 뜬다.
+    ///
+    /// 존재하지 않는 서비스명으로 던지므로 매칭이 0건이고, ACL·프롬프트 경로에 닿지 않는다.
+    /// 기대값은 "성공"이 아니라 "파라미터는 유효하다"(errSecItemNotFound)다.
+    /// 딕셔너리 모양만 단정하는 테스트로는 이 부류를 못 잡는다 — 실제 API 가 판정해야 한다.
+    func testKeychainQueriesAreAcceptedBySecurityFramework() throws {
+        #if os(macOS)
+        for allowPrompt in [false, true] {
+            for (label, q) in [
+                ("accounts", OAuthCredentialData.claudeKeychainAccountsQuery(allowKeychainPrompt: allowPrompt)),
+                ("data(nil)", OAuthCredentialData.claudeKeychainDataQuery(account: nil, allowKeychainPrompt: allowPrompt)),
+                ("data(acct)", OAuthCredentialData.claudeKeychainDataQuery(account: "someone", allowKeychainPrompt: allowPrompt)),
+            ] {
+                var probe = q
+                probe[kSecAttrService as String] = "PTB-NoSuchService-\(UUID().uuidString)"
+                var item: CFTypeRef?
+                let status = SecItemCopyMatching(probe as CFDictionary, &item)
+                XCTAssertNotEqual(status, errSecParam,
+                                  "\(label)/prompt=\(allowPrompt): 무효한 파라미터 조합 (-50)")
+                XCTAssertEqual(status, errSecItemNotFound,
+                               "\(label)/prompt=\(allowPrompt): 매칭 0건이어야 한다 (status=\(status))")
+            }
+        }
+        #endif
     }
 
-    func testMultipleKeychainItemsPicksValidAccountOAuthOverMCPOAuth() {
-        let mcpOnlyData = """
+    /// 데이터 조회는 반드시 단건이다 — 위 조합 금지의 다른 한쪽 면.
+    func testDataQueryAsksForOneItemAndAccountsQueryAsksForNoData() {
+        let data = OAuthCredentialData.claudeKeychainDataQuery(account: "u", allowKeychainPrompt: true)
+        XCTAssertEqual(data[kSecMatchLimit as String] as? String, kSecMatchLimitOne as String)
+        XCTAssertEqual(data[kSecReturnData as String] as? Bool, true)
+        XCTAssertEqual(data[kSecAttrAccount as String] as? String, "u")
+
+        let accounts = OAuthCredentialData.claudeKeychainAccountsQuery(allowKeychainPrompt: true)
+        XCTAssertEqual(accounts[kSecMatchLimit as String] as? String, kSecMatchLimitAll as String)
+        XCTAssertNil(accounts[kSecReturnData as String], "전체 조회는 데이터를 요청하면 안 된다")
+        XCTAssertEqual(accounts[kSecReturnAttributes as String] as? Bool, true)
+    }
+
+    /// 계정 열거 — 배열/단건 응답 모두 받고, 빈 값·중복은 버린다(순서 유지).
+    func testAccountNamesHandlesArrayAndSingleAndDedupes() {
+        let acct = kSecAttrAccount as String
+        XCTAssertEqual(
+            OAuthCredentialData.accountNames(from: [[acct: "a"], [acct: "b"], [acct: "a"], [acct: ""]]),
+            ["a", "b"])
+        XCTAssertEqual(OAuthCredentialData.accountNames(from: [acct: "solo"]), ["solo"])
+        XCTAssertEqual(OAuthCredentialData.accountNames(from: nil), [])
+    }
+
+    /// #229 가 고치려던 것 — MCP 전용 항목과 계정 항목이 함께 있을 때 유효한 쪽을 고른다.
+    /// 이제 항목별 단건 조회로 순회하므로, 선택 규칙은 파싱 결과로만 판정된다.
+    func testValidAccountOAuthIsPreferredOverMCPOnlyEntry() {
+        let mcpOnly = Data("""
         {"mcpOAuth":{"linear":{"accessToken":"linear-tok"}}}
-        """.data(using: .utf8)!
-
-        let accountData = """
+        """.utf8)
+        let account = Data("""
         {"claudeAiOauth":{"accessToken":"account-tok","subscriptionType":"max","rateLimitTier":"default_claude_max_20x"}}
-        """.data(using: .utf8)!
+        """.utf8)
 
-        let items = OAuthCredentialData.extractDataItems(from: [mcpOnlyData, accountData])
-        XCTAssertEqual(items.count, 2)
+        XCTAssertNil(OAuthCredentialData.credential(from: mcpOnly))
+        XCTAssertTrue(OAuthCredentialData.isAccountOAuthMissing(mcpOnly))
 
-        // 첫 번째 항목(MCP 전용)은 credential nil이지만, 두 번째 항목에서 정상 파싱
-        let validCredential = items.compactMap { OAuthCredentialData.credential(from: $0) }.first
-        XCTAssertNotNil(validCredential)
-        XCTAssertEqual(validCredential?.accessToken, "account-tok")
-        XCTAssertEqual(validCredential?.subscriptionType, "max")
-        XCTAssertEqual(validCredential?.rateLimitTier, "default_claude_max_20x")
+        let picked = [mcpOnly, account].compactMap { OAuthCredentialData.credential(from: $0) }.first
+        XCTAssertEqual(picked?.accessToken, "account-tok")
+        XCTAssertEqual(picked?.subscriptionType, "max")
+        XCTAssertEqual(picked?.rateLimitTier, "default_claude_max_20x")
     }
 }
 

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -280,6 +280,23 @@ read_when:
   `jetski-standalone-oauth-token` 은 파일 로드 시 `expiresAt=nil` 이라 캐시가 만료로 풀리지 않는다.
   회귀: `testClaudeAutoPollPicksUpInPlaceAccountSwitch`·`testAntigravityAutoPollPicksUpTokenFileSwitch`.
   캐시-우선 early return 을 되돌리면 이 두 테스트가 실패해야 한다.
+- **`kSecMatchLimitAll` 과 `kSecReturnData` 는 같이 못 쓴다 — macOS 가 errSecParam(-50) 으로 거절한다.**
+  "서비스에 항목이 여럿일 수 있으니 전부 받아서 유효한 걸 고르자"는 발상 자체는 옳지만(#229), 한 번의
+  `SecItemCopyMatching` 으로 *모든 항목의 데이터*를 받는 쿼리는 **파라미터 단계에서** 거절된다. 항목이
+  없어서가 아니라 조합이 무효라서라, ACL 승인·항목 존재·재로그인 어느 것으로도 우회되지 않는다.
+  결과는 조용한 전면 실패였다 — Keychain 에만 자격증명이 있는 사용자(파일 `~/.claude/.credentials.json`
+  없음)는 수동 갱신을 눌러도 `keychainUnavailable(-50)` 만 나고 공식 한도가 **영구히** 안 떴다.
+  → 두 단계로 나눈다: ① `kSecMatchLimitAll` + `kSecReturnAttributes` 로 `acct` 목록만 열거
+  ② 계정마다 `kSecMatchLimitOne` + `kSecReturnData` 로 단건 조회. 계정 속성을 못 얻으면 스코프 없는
+  단건 읽기로 폴백한다(항목이 하나뿐인 흔한 경우).
+  **5-whys(왜 못 걸렀나):** 테스트가 `extractDataItems(from:)` 라는 순수 파서만 합성 배열로 검증했다.
+  결함은 그 함수가 아니라 **그 함수에 값을 넘겨주는 쿼리**에 있었고, `SecItemCopyMatching` 은 테스트
+  경로에 아예 없었다 — 결함 트리거와 다른 경로로 통과하는 전형이다. 딕셔너리 모양만 단정하는 테스트도
+  같은 이유로 부족하다: 어떤 키 조합이 무효인지는 **Security 프레임워크만 안다.**
+  가드: `testKeychainQueriesAreAcceptedBySecurityFramework` — 존재하지 않는 서비스명(매칭 0건이라
+  ACL·프롬프트에 안 닿음)으로 프로덕션 쿼리를 실제 API 에 던져 `errSecParam` 이 아님을 단정한다.
+  기대값이 "성공"이 아니라 **"파라미터가 유효하다"(`errSecItemNotFound`)** 인 게 요점이다.
+  `kSecMatchLimitAll` 을 데이터 쿼리에 되돌리면 이 테스트가 빨개진다(주입 확인 완료).
 - **자격증명 "없음"과 "계정 로그인 없음"은 다른 안내다.** Claude Code 2.1.x 의 `Claude Code-credentials`
   항목이 MCP 서버 OAuth(`mcpOAuth`) 상태만 담고 계정 토큰(`claudeAiOauth`)은 안 담는 경우가 있다. 이때
   파싱 실패를 형식 오류로 뭉뚱그리면 "재로그인하면 된다"를 안내 못 해 한도 섹션이 원인 불명으로 사라진다.


### PR DESCRIPTION
## Summary

Fixes a regression from #232: official Claude limits fail with `keychainUnavailable(-50)` for every user whose credentials live only in the Keychain.

`kSecMatchLimitAll` cannot be combined with `kSecReturnData` — macOS rejects that pair with `errSecParam` (-50) during parameter validation, before it ever looks for items. So the query introduced in #232 could never succeed: not with an approved ACL, not after re-login, not with a single matching item. Users who have `~/.claude/.credentials.json` were unaffected, because that path never touches the Keychain, which is why it got through review.

Measured on a real install: 24 consecutive `-50` failures and zero successes, starting the moment the build landed.

## Fix

Split the read into two steps, keeping #232's intent — pick the entry that actually carries `claudeAiOauth` when several share the service name:

1. `kSecMatchLimitAll` + `kSecReturnAttributes` — enumerate `acct` names only, no data.
2. Per account, `kSecMatchLimitOne` + `kSecReturnData` — read and parse one item.

Falls back to an unscoped single read when no account attributes come back, so the common single-item case is unchanged. Error discrimination is preserved: `credentialMissingAccountOAuth` still fires when entries exist but none carry account OAuth.

Verified against a real Keychain with a no-UI query: both new queries return `errSecSuccess`, while the #232 query still returns -50.

## Why the tests missed it

`extractDataItems(from:)` was tested with synthetic arrays, but the defect was in the *query that feeds it* — `SecItemCopyMatching` was never on the test path. Asserting the dictionary's shape would not have helped either: which key combinations are invalid is knowledge only the Security framework has.

So the new guard calls the real API. It aims the production queries at a service name that cannot exist, so nothing matches and no ACL or prompt is involved, and asserts the status is not `errSecParam`. The expectation is not "succeeds" but "the parameters are valid" (`errSecItemNotFound`). Reverting the data query to `kSecMatchLimitAll` turns it red — confirmed by injection.

`extractDataItems` is removed together with its tests; it no longer has a production caller, and leaving it green would protect nothing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

None.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change
