### PR TITLE
feat: add difficulty multipliers and a popover toggle for the floating pet

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -128,6 +128,60 @@ enum PokemonBalance {
         let denom = Double(kk * (kk + 1)) / 2.0
         return Int((total * Double(i) / denom).rounded())
     }
+
+    // MARK: 난이도 배율 (설정 슬라이더)
+
+    /// 사용자 조절 배율의 허용 범위. 1 미만이면 기본보다 빠르고·싸며, 1 초과면 느리고·비싸다.
+    static let difficultyRange: ClosedRange<Double> = 0.0001...20.0
+    /// 기본값 — 이 값에서 모든 밸런스가 위 상수표 그대로다(기존 동작과 동일).
+    static let defaultDifficulty: Double = 1.0
+
+    /// 저장값을 허용 범위로 조인다. UserDefaults 는 `defaults write` 로 외부에서 쓸 수 있어
+    /// 0·음수·NaN 이 실제로 들어올 수 있고, 배율 0 은 임계 0(진행률 0 나눗셈·퇴화한 진화 루프)이 된다.
+    static func clampDifficulty(_ value: Double) -> Double {
+        guard value.isFinite else { return defaultDifficulty }
+        return min(max(value, difficultyRange.lowerBound), difficultyRange.upperBound)
+    }
+
+    /// 기본값 × 난이도 — 임계·가격 공통. **상수표 자체는 스케일하지 않는다**: 등급 알 가격이
+    /// `graduationTotal` 의 *비율*로 파생되므로(FreshEgg.price), 표를 건드리면 성장 배율이 상점
+    /// 가격까지 끌고 간다. 소비 지점에서만 곱해 두 배율을 서로 독립으로 유지한다.
+    static func scaled(_ base: Int, by difficulty: Double) -> Int {
+        Int((Double(base) * clampDifficulty(difficulty)).rounded())
+    }
+
+    // MARK: 슬라이더 위치 ↔ 배율 (로그 매핑)
+    //
+    // 범위가 다섯 자릿수를 넘어 선형 슬라이더로는 못 쓴다 — 1.0(기본)이 트랙의 5% 지점에 몰려
+    // 실사용 구간을 손으로 집을 수 없고, 0.1 미만은 전부 한 틱에 뭉갠다. 위치를 로그로 매핑해
+    // "배율 10배당 이동거리"를 일정하게 만든다.
+
+    /// 기본값(100%)이 트랙에서 차지하는 폭. 로그축이라 1.0 근처 1px 이 배율 7% 에 해당해서,
+    /// 값 기준으로 스냅하면 창이 1px 보다 좁아져 드래그가 100% 를 그냥 지나친다 —
+    /// 되돌릴 수단이 없어지므로 창을 **위치 기준**으로 잡는다(트랙의 ±1%).
+    private static let defaultSnapWidth = 0.01
+
+    /// 슬라이더 위치(0…1) → 배율.
+    static func difficulty(atPosition position: Double) -> Double {
+        let lo = difficultyRange.lowerBound, hi = difficultyRange.upperBound
+        let p = min(max(position, 0), 1)
+        if abs(p - difficultyPosition(defaultDifficulty)) < defaultSnapWidth { return defaultDifficulty }
+        return snapDifficulty(lo * pow(hi / lo, p))
+    }
+
+    /// 배율 → 슬라이더 위치(0…1).
+    static func difficultyPosition(_ value: Double) -> Double {
+        let lo = difficultyRange.lowerBound, hi = difficultyRange.upperBound
+        return log(clampDifficulty(value) / lo) / log(hi / lo)
+    }
+
+    /// 로그 슬라이더에서 나온 값을 유효숫자 2자리로 정리한다 — 없으면 1.0473 같은 값이 그대로 표시된다.
+    /// 기본값 되돌리기는 여기가 아니라 `difficulty(atPosition:)` 의 위치 스냅이 담당한다.
+    static func snapDifficulty(_ value: Double) -> Double {
+        guard value > 0 else { return difficultyRange.lowerBound }
+        let magnitude = pow(10, (log10(value)).rounded(.down) - 1)
+        return ((value / magnitude).rounded() * magnitude)
+    }
 }
 
 /// 인벤토리 아이템 종류 — 확장 대비 enum(현재 이상한 사탕 1종). rawValue 로 CompanionState.inventory 에 저장.

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -42,19 +42,38 @@ final class CompanionStore {
     private let fileURL: URL
     private var rng: any RandomNumberGenerator
     private let dittoDisguiseRollingEnabled: Bool
+    private let defaults: UserDefaults
     /// 세션 내 활성 개체 교체 감지용. await 뒤 이전 개체의 결과가 새 개체를 덮지 않게 한다.
     private var activeGeneration = 0
+
+    // MARK: 난이도 배율 (설정 — UserDefaults)
+    //
+    // 세이브(CompanionState)가 아니라 UserDefaults 에 둔다. 이건 진행 상황이 아니라 취향 설정이고
+    // (설정창의 다른 슬라이더와 같은 자리), 세이브에 넣으면 남의 세이브를 불러올 때 내 난이도가 조용히
+    // 바뀌며 SaveTransfer 의 관대 디코딩·검증까지 새 수치 필드를 떠안는다.
+
+    /// 성장 배율 — 알 부화 임계 + 진화/졸업 임계에 곱한다. 낮을수록 빨리 자란다.
+    /// 사탕 XP(RareCandy.xp)는 스케일하지 않는다 — 함께 곱하면 서로 상쇄돼 사탕만 난이도를 안 탄다.
+    private(set) var growthDifficulty: Double
+    /// 상점 배율 — 아이템·알 가격에 곱한다. 낮을수록 싸다.
+    private(set) var shopDifficulty: Double
 
     init(provider: any PokeProviding = PokeAPIClient.shared,
          clock: @escaping () -> Date = Date.init,
          fileURL: URL? = nil,
          rng: any RandomNumberGenerator = SystemRandomNumberGenerator(),
-         dittoDisguiseRollingEnabled: Bool = AppEnv.isBundledApp) {
+         dittoDisguiseRollingEnabled: Bool = AppEnv.isBundledApp,
+         defaults: UserDefaults = .standard) {
         self.provider = provider
         self.clock = clock
         self.fileURL = fileURL ?? Self.defaultURL()
         self.rng = rng
         self.dittoDisguiseRollingEnabled = dittoDisguiseRollingEnabled
+        self.defaults = defaults
+        growthDifficulty = PokemonBalance.clampDifficulty(
+            defaults.object(forKey: "growthDifficulty") as? Double ?? PokemonBalance.defaultDifficulty)
+        shopDifficulty = PokemonBalance.clampDifficulty(
+            defaults.object(forKey: "shopDifficulty") as? Double ?? PokemonBalance.defaultDifficulty)
         load()
         refreshRepresentativeSubject()
         if state.active != nil { displayState = .idle }
@@ -71,6 +90,54 @@ final class CompanionStore {
 
     var language: AppLanguage { state.language }
     func setLanguage(_ lang: AppLanguage) { state.language = lang; save() }
+
+    // MARK: 난이도 — 설정에서 조절, 즉시 반영(재시작 불필요)
+
+    /// 성장 배율 변경. 배율을 내리면 이미 쌓인 진행도가 그 자리에서 임계를 넘을 수 있으므로,
+    /// 다음 사용량 폴링(기본 120s)까지 기다리지 않고 여기서 진화·부화 판정을 다시 돌린다.
+    /// `applyUsage(0)` 은 메타몽 리빌·라인 로드 뒤 재평가에 쓰는 기존 킥과 같은 형태이며,
+    /// 내부에서 save() 까지 수행한다(활성 개체가 없으면 no-op).
+    func setGrowthDifficulty(_ value: Double) {
+        let clamped = PokemonBalance.clampDifficulty(value)
+        guard clamped != growthDifficulty else { return }
+        growthDifficulty = clamped
+        defaults.set(clamped, forKey: "growthDifficulty")
+        applyUsage(0)
+        if state.active == nil, state.eggUsage >= eggHatchThreshold, !isHatching {
+            Task { await hatchIfNeeded() }
+        }
+    }
+
+    /// 상점 배율 변경 — 가격은 순수 읽기(파생값)라 재평가할 상태가 없다.
+    func setShopDifficulty(_ value: Double) {
+        let clamped = PokemonBalance.clampDifficulty(value)
+        guard clamped != shopDifficulty else { return }
+        shopDifficulty = clamped
+        defaults.set(clamped, forKey: "shopDifficulty")
+    }
+
+    /// 난이도를 반영한 알 부화 임계.
+    private var eggHatchThreshold: Int {
+        PokemonBalance.scaled(PokemonBalance.eggHatchThreshold, by: growthDifficulty)
+    }
+
+    /// 난이도를 반영한 단계 임계. **`PokemonBalance.phaseThreshold` 를 직접 부르지 않는다** —
+    /// 배율을 빠뜨린 호출부가 생기면 그 경로만 조용히 기본 난이도로 돌아간다.
+    private func stageThreshold(rarity: Rarity, totalForms: Int, stageIndex: Int) -> Int {
+        PokemonBalance.scaled(
+            PokemonBalance.phaseThreshold(rarity: rarity, totalForms: totalForms, stageIndex: stageIndex),
+            by: growthDifficulty)
+    }
+
+    /// 상점 표시·결제에 쓰는 실제 가격 — 기본가 × 상점 난이도. 미판매면 nil.
+    func price(of kind: ItemKind) -> Int? {
+        kind.shopPrice.map { PokemonBalance.scaled($0, by: shopDifficulty) }
+    }
+
+    /// 알을 포함한 상점 한 줄의 실제 가격.
+    func price(of entry: ShopEntry) -> Int {
+        PokemonBalance.scaled(entry.price, by: shopDifficulty)
+    }
     /// 앱 전체 UI 문자열 — language 변경 시 자동 재렌더.
     var l: L { L(language) }
 
@@ -118,8 +185,8 @@ final class CompanionStore {
     // 알 인큐베이션 (active 없을 때)
     var isEgg: Bool { state.active == nil }
     var eggStarted: Bool { state.eggUsage > 0 }
-    var eggProgress: Double { min(1, max(0, Double(state.eggUsage) / Double(PokemonBalance.eggHatchThreshold))) }
-    var eggTokensToHatch: Int { max(0, PokemonBalance.eggHatchThreshold - state.eggUsage) }
+    var eggProgress: Double { min(1, max(0, Double(state.eggUsage) / Double(eggHatchThreshold))) }
+    var eggTokensToHatch: Int { max(0, eggHatchThreshold - state.eggUsage) }
 
     var displayName: String {
         guard let a = state.active, let line = currentLine else { return "Token Egg" }
@@ -136,7 +203,7 @@ final class CompanionStore {
     }
     var threshold: Int {
         guard let a = state.active else { return 1 }
-        return PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: a.stageIndex)
+        return stageThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: a.stageIndex)
     }
     var progress: Double {
         guard let a = state.active, threshold > 0 else { return 0 }
@@ -454,7 +521,7 @@ final class CompanionStore {
             Task { await ensureEggPrefetch() }
         }
         // 알이 부화 임계에 도달하면 부화
-        if state.active == nil, state.eggUsage >= PokemonBalance.eggHatchThreshold, !isHatching {
+        if state.active == nil, state.eggUsage >= eggHatchThreshold, !isHatching {
             Task { await hatchIfNeeded() }
         }
         // active 인데 라인 미로딩(앱 재시작) → 로드
@@ -464,7 +531,7 @@ final class CompanionStore {
         // 위장 메타몽이 첫 진화 임계 도달 → 리빌(재시작 등 applyUsage 킥을 못 탄 경우 백업 트리거)
         if let a = state.active, a.dittoDisguise != nil, !a.dittoRevealed, currentLine != nil,
            !isHatching, !isRevealingDitto,
-           a.usedAtStage >= PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0) {
+           a.usedAtStage >= stageThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0) {
             Task { await revealDitto() }
         }
         displayState = computeState(burnTier: burnTier, limitWarning: limitWarning,
@@ -483,7 +550,7 @@ final class CompanionStore {
         while state.active != nil, guardCount < 50 {
             guardCount += 1
             let a = state.active!
-            let thr = PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: a.stageIndex)
+            let thr = stageThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: a.stageIndex)
             guard a.usedAtStage >= thr else { break }
             guard let node = line.tree.node(withID: a.currentID) else { break }
             // 위장체는 부화 때는 다형태지만, 에셋 정규화/마이그레이션 뒤 leaf가 될 수 있다.
@@ -706,7 +773,7 @@ final class CompanionStore {
             let aDone = isPurchasedPassive(a)
             let bDone = isPurchasedPassive(b)
             if aDone != bDone { return !aDone }
-            return a.price < b.price
+            return price(of: a) < price(of: b)
         }
     }
 
@@ -718,7 +785,7 @@ final class CompanionStore {
 
     /// 구매 가능 — 잔액이 그 아이템 가격 이상(상점 미판매면 false). 활성/알 무관(재고는 미리 쌓아둘 수 있음).
     func canBuy(_ kind: ItemKind) -> Bool {
-        guard let price = kind.shopPrice else { return false }
+        guard let price = price(of: kind) else { return false }
         if kind.isPassive && itemCount(kind) > 0 { return false }   // 보유형은 1회만(재구매 불가)
         return availableTokens >= price
     }
@@ -727,7 +794,7 @@ final class CompanionStore {
     /// 무영향(지출 원장만 증가). 잔액 부족/미판매면 no-op(false).
     @discardableResult
     func buy(_ kind: ItemKind) -> Bool {
-        guard let price = kind.shopPrice, availableTokens >= price else { return false }
+        guard let price = price(of: kind), availableTokens >= price else { return false }
         if kind.isPassive && itemCount(kind) > 0 { return false }   // 보유형 중복 구매 방지(방어)
         state.spentTokens += price
         state.inventory[kind.rawValue, default: 0] += 1
@@ -754,7 +821,7 @@ final class CompanionStore {
         // 새 알 구매는 `hasActive` 에 막혀 되돌릴 수단이 없다. 가격만 계산되면 값이 빠져나가므로
         // 판매 목록을 여기서 강제한다(호출부 하나가 실수하면 토큰이 통째로 사라진다).
         guard FreshEgg.shopTiers.contains(tier) else { return false }
-        return hasActive && availableTokens >= FreshEgg.price(guaranteeing: tier)
+        return hasActive && availableTokens >= price(of: .egg(tier))
     }
 
     /// 알 구매 — 현재 포켓몬을 놓아주고 처음부터 인큐베이션하는 새 알로. 지갑에서 가격 차감.
@@ -768,7 +835,7 @@ final class CompanionStore {
     @discardableResult
     func buyEgg(_ tier: Rarity?) -> Bool {
         guard canBuyEgg(tier) else { return false }
-        state.spentTokens += FreshEgg.price(guaranteeing: tier)
+        state.spentTokens += price(of: .egg(tier))
         if let a = state.active {
             state.dex.append(releasedDexEntry(from: a))   // 놓아줌 기록 — 도감에서 종이 사라지지 않게
         }
@@ -858,7 +925,7 @@ final class CompanionStore {
     // MARK: 부화
 
     func hatchIfNeeded() async {
-        guard state.active == nil, !isHatching, state.eggUsage >= PokemonBalance.eggHatchThreshold else { return }
+        guard state.active == nil, !isHatching, state.eggUsage >= eggHatchThreshold else { return }
         // 프리패치가 "종 롤 중"(pending 미확정)일 때만 대기 — 이중 rng 소비 방지.
         // pending 확정 후의 예열(라인/스프라이트)과는 동시 진행해도 안전하다.
         guard state.pendingHatchID != nil || !prefetchInFlight else { return }
@@ -978,7 +1045,7 @@ final class CompanionStore {
         }
         currentLine = line
         // 부화 임계 초과분은 부화체 성장에 이월(낭비 없음).
-        let overflow = max(0, state.eggUsage - PokemonBalance.eggHatchThreshold)
+        let overflow = max(0, state.eggUsage - eggHatchThreshold)
         state.eggUsage = 0
         state.eggTier = nil   // 보증은 이 부화로 소비된다(다음 알은 다시 무보증)
         // 개체 롤 — shiny(1/64)·성격(25종)은 부화 순간 확정, 진화해도 유지.
@@ -1017,7 +1084,7 @@ final class CompanionStore {
     private func revealDitto() async {
         guard let a = state.active, a.dittoDisguise != nil, !a.dittoRevealed, !isRevealingDitto else { return }
         let generation = activeGeneration
-        let firstEvoThr = PokemonBalance.phaseThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0)
+        let firstEvoThr = stageThreshold(rarity: a.rarity, totalForms: a.totalForms, stageIndex: 0)
         guard a.usedAtStage >= firstEvoThr else { return }   // 임계 미달 방어
         isRevealingDitto = true
         defer { isRevealingDitto = false }
@@ -1026,7 +1093,7 @@ final class CompanionStore {
         }
         guard activeGeneration == generation,
               var m = state.active, m.dittoDisguise != nil, !m.dittoRevealed else { return }
-        let latestFirstEvoThr = PokemonBalance.phaseThreshold(rarity: m.rarity, totalForms: m.totalForms, stageIndex: 0)
+        let latestFirstEvoThr = stageThreshold(rarity: m.rarity, totalForms: m.totalForms, stageIndex: 0)
         guard m.usedAtStage >= latestFirstEvoThr else { return }
         let disguiseName = currentLine?.localizedName(m.baseID, state.language) ?? "#\(m.baseID)"
         let carryOver = max(0, m.usedAtStage - latestFirstEvoThr)   // 위장체 첫 진화 초과분 → 메타몽 성장 이월

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -157,6 +157,27 @@ struct L {
         t("대표로 설정", "Set as representative", "代表ポケモンに設定", "Establecer como representante", "Définir comme représentatif", "Definir como representante", "Als repräsentativ festlegen")
     }
     var representativeBadge: String { t("대표", "Representative", "代表", "Representante", "Représentatif", "Representante", "Repräsentativ") }
+    // MARK: 난이도
+    var difficultySectionTitle: String { t("난이도", "Difficulty", "難易度", "Dificultad", "Difficulté", "Dificuldade", "Schwierigkeit") }
+    var difficultyGrowthLabel: String { t("성장", "Growth", "成長", "Crecimiento", "Croissance", "Crescimento", "Wachstum") }
+    var difficultyShopLabel: String { t("상점 가격", "Shop prices", "ショップ価格", "Precios de la tienda", "Prix de la boutique", "Preços da loja", "Shop-Preise") }
+    var difficultyHint: String {
+        t("기본값 100% 기준이에요 — 낮추면 빨리 자라고 싸지고, 높이면 그 반대예요",
+          "Percentages of the default balance — lower grows faster and costs less, higher does the opposite",
+          "標準バランスに対する割合です — 下げると早く育ち安くなり、上げるとその逆になります",
+          "Porcentajes del balance predeterminado: si los bajas, crece más rápido y cuesta menos; si los subes, al revés",
+          "Pourcentages de l'équilibrage par défaut — plus bas, la croissance est plus rapide et les prix baissent ; plus haut, l'inverse",
+          "Porcentagens do balanceamento padrão — reduzir faz crescer mais rápido e custar menos; aumentar faz o contrário",
+          "Prozentwerte der Standardbalance — niedriger wächst schneller und kostet weniger, höher bewirkt das Gegenteil")
+    }
+    /// 슬라이더 옆 현재 배율 — 퍼센트 표기(1.0 = 100%). 범위가 0.01%~2000% 라 작은 쪽은 자릿수를
+    /// 더 보여준다(고정 소수점이면 0.01% 와 0.05% 가 똑같이 "0%" 로 뭉갠다).
+    func difficultyValue(_ value: Double) -> String {
+        let percent = value * 100
+        if percent >= 10 { return String(format: "%.0f%%", percent) }
+        if percent >= 1 { return String(format: "%.1f%%", percent) }
+        return String(format: "%.2f%%", percent)
+    }
     // MARK: 플로팅 펫
     var floatingPetSectionTitle: String { t("플로팅 펫", "Floating Pet", "フローティングペット", "Mascota flotante", "Compagnon flottant", "Mascote flutuante", "Schwebendes Pokémon") }
     var floatingPetEnableLabel: String { t("플로팅 펫 표시", "Show floating pet", "フローティングペットを表示", "Mostrar mascota flotante", "Afficher le compagnon flottant", "Mostrar mascote flutuante", "Schwebendes Pokémon anzeigen") }
@@ -170,6 +191,11 @@ struct L {
           "Dein Pokémon schwebt über dem Bildschirm – zieh es an die gewünschte Stelle")
     }
     var floatingPetSizeLabel: String { t("크기", "Size", "サイズ", "Tamaño", "Taille", "Tamanho", "Größe") }
+    /// 푸터 눈 아이콘의 툴팁(켜져 있을 때) — 켜는 쪽 문구는 floatingPetEnableLabel 을 그대로 쓴다.
+    var floatingPetHideLabel: String {
+        t("플로팅 펫 숨기기", "Hide floating pet", "フローティングペットを隠す", "Ocultar mascota flotante",
+          "Masquer le compagnon flottant", "Ocultar mascote flutuante", "Schwebendes Pokémon ausblenden")
+    }
     /// 지금은 한도 알림만 말풍선으로 뜨지만, 알림 종류가 늘어도 이 라벨은 그대로 쓴다.
     var floatingPetBubbleAlertsLabel: String {
         t("말풍선으로 알림 받기", "Show notifications as bubbles", "通知を吹き出しで表示", "Mostrar notificaciones como globos", "Afficher les notifications en bulles", "Mostrar notificações em balões", "Benachrichtigungen als Sprechblasen anzeigen")

--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -444,6 +444,8 @@ final class PetHostingView: NSHostingView<AnyView> {
 
 @MainActor
 struct FloatingPetView: View {
+    /// 푸터 토글의 SF Symbol — 지금 상태를 그린다(보이는 중 = 뜬 눈). 순수 판정이라 뒤집힘을 테스트로 잠근다.
+    static func visibilitySymbol(visible: Bool) -> String { visible ? "eye" : "eye.slash" }
     var animated: Bool = true
     @Environment(UsageStore.self) private var store
     @Environment(CompanionStore.self) private var companion

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -747,6 +747,15 @@ struct PopoverView: View {
                 }
             }
             Spacer()
+            // 데스크톱 펫 표시 토글 — 설정창의 스위치와 **같은 값**(store.floatingPetEnabled)을 읽고 쓴다.
+            // @Observable 이라 어느 쪽에서 바꾸든 다른 쪽이 즉시 따라온다(별도 동기화 없음).
+            Button {
+                store.floatingPetEnabled.toggle()
+            } label: {
+                Image(systemName: FloatingPetView.visibilitySymbol(visible: store.floatingPetEnabled))
+            }
+            .buttonStyle(.borderless)
+            .help(store.floatingPetEnabled ? l.floatingPetHideLabel : l.floatingPetEnableLabel)
             Button {
                 nav.showSettings = true
             } label: {

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -65,6 +65,7 @@ struct SettingsView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     generalGroup(store)
+                    difficultyGroup
                     menuBarGroup(store)
                     floatingPetGroup(store)
                     notificationsGroup(store)
@@ -224,6 +225,37 @@ struct SettingsView: View {
                         }
                     }
             }
+        }
+    }
+
+    /// 난이도 — 성장(부화·진화·졸업 임계)과 상점 가격에 각각 곱하는 배율. 즉시 반영된다.
+    private var difficultyGroup: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            settingsSection(l.difficultySectionTitle) {
+                difficultyRow(l.difficultyGrowthLabel, value: companion.growthDifficulty,
+                              position: Binding(
+                                get: { PokemonBalance.difficultyPosition(companion.growthDifficulty) },
+                                set: { companion.setGrowthDifficulty(PokemonBalance.difficulty(atPosition: $0)) }))
+                Divider()
+                difficultyRow(l.difficultyShopLabel, value: companion.shopDifficulty,
+                              position: Binding(
+                                get: { PokemonBalance.difficultyPosition(companion.shopDifficulty) },
+                                set: { companion.setShopDifficulty(PokemonBalance.difficulty(atPosition: $0)) }))
+            }
+            Text(l.difficultyHint).font(.caption2).foregroundStyle(.tertiary).padding(.leading, 4)
+        }
+    }
+
+    /// 배율 슬라이더 한 줄 — 플로팅 펫 크기 행과 같은 형태(라벨 / 슬라이더 / 우측 고정폭 수치).
+    /// 슬라이더가 움직이는 건 배율이 아니라 **로그 위치(0…1)** 다(PokemonBalance 주석 참조).
+    /// step 을 두지 않는다 — 눈금 간격이 배율 단위로 일정하지 않고, 스냅은 값 쪽에서 한다.
+    private func difficultyRow(_ label: String, value: Double,
+                               position: Binding<Double>) -> some View {
+        groupRow {
+            Text(label).font(.callout).frame(width: 76, alignment: .leading)
+            Slider(value: position, in: 0...1)
+            Text(l.difficultyValue(value))
+                .font(.caption).monospacedDigit().frame(width: 52, alignment: .trailing)
         }
     }
 

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -53,7 +53,7 @@ private struct ShopItemCard: View {
     let kind: ItemKind
     @State private var confirming = false
 
-    private var price: Int { kind.shopPrice ?? 0 }
+    private var price: Int { store.price(of: kind) ?? 0 }
 
     var body: some View {
         let l = store.l
@@ -136,7 +136,7 @@ private struct EggCard: View {
     @State private var stage: Stage = .idle
     private enum Stage { case idle, confirm, shinyConfirm }
 
-    private var price: Int { FreshEgg.price(guaranteeing: tier) }
+    private var price: Int { store.price(of: .egg(tier)) }
 
     var body: some View {
         let l = store.l

--- a/Tests/PokeTokenBarTests/DifficultyTests.swift
+++ b/Tests/PokeTokenBarTests/DifficultyTests.swift
@@ -1,0 +1,279 @@
+import XCTest
+@testable import PokeTokenBar
+
+/// 난이도 배율 — 검증 배율이 표시가 아니라 **실제 동작**을 바꾸는지 확인한다.
+/// 핵심 형태: 같은 토큰 입력에 배율만 다르게 줘서 결과(진화/부화/구매 성사)가 갈리는지 본다.
+@MainActor
+final class DifficultyTests: XCTestCase {
+
+    private func line() -> EvoLine {
+        var names: [Int: [String: String]] = [:]
+        for id in [1, 2, 3] { names[id] = ["en": "P\(id)"] }
+        return EvoLine(baseID: 1,
+                       tree: EvoNode(speciesID: 1, children: [EvoNode(speciesID: 2, children: [EvoNode(speciesID: 3, children: [])])]),
+                       rarity: .common, names: names)
+    }
+
+    /// `used` 를 주면 지갑 잔액이 시드된 상태 파일로 시작한다(ShopTests 와 같은 JSON 시드 패턴).
+    private func store(growth: Double = 1.0, shop: Double = 1.0, used: Int = 0) -> CompanionStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("ptb-diff-\(UUID().uuidString).json")
+        let json = "{\"installBaselineSet\":true,\"usedSinceInstall\":\(used),\"spentTokens\":0,"
+            + "\"lastDate\":\"d\",\"dex\":[],\"collectedFinals\":[]}"
+        try? json.data(using: .utf8)!.write(to: url)
+        let suite = UserDefaults(suiteName: "ptb-diff-\(UUID().uuidString)")!
+        suite.set(growth, forKey: "growthDifficulty")
+        suite.set(shop, forKey: "shopDifficulty")
+        return CompanionStore(provider: StubDiffProvider(value: line()),
+                              clock: { Date(timeIntervalSince1970: 1_700_000_000) },
+                              fileURL: url, rng: SeededDiffRNG(seed: 7),
+                              dittoDisguiseRollingEnabled: false,
+                              defaults: suite)
+    }
+
+    private func hatched(growth: Double = 1.0, shop: Double = 1.0, used: Int = 0) async -> CompanionStore {
+        let s = store(growth: growth, shop: shop, used: used)
+        await s.hatch(baseID: 1)
+        return s
+    }
+
+    // MARK: 1. 진화 — 같은 토큰, 다른 결과 (표시가 아니라 상태 전이)
+
+    func testSameTokensEvolveOnlyWhenDifficultyLowered() async {
+        let baseThreshold = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0)
+        let half = baseThreshold / 2
+
+        let normal = await hatched(growth: 1.0)
+        normal.applyUsage(half)
+        XCTAssertEqual(normal.state.active?.stageIndex, 0, "1.0x: 절반으론 진화하면 안 된다")
+        XCTAssertEqual(normal.state.active?.currentID, 1)
+
+        let easy = await hatched(growth: 0.5)
+        easy.applyUsage(half)
+        XCTAssertEqual(easy.state.active?.stageIndex, 1, "0.5x: 같은 절반으로 진화해야 한다")
+        XCTAssertEqual(easy.state.active?.currentID, 2, "실제 종이 바뀌었는가(표시가 아니라 상태)")
+    }
+
+    func testHarderDifficultyBlocksEvolutionThatWouldOtherwiseHappen() async {
+        let baseThreshold = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0)
+
+        let normal = await hatched(growth: 1.0)
+        normal.applyUsage(baseThreshold)
+        XCTAssertEqual(normal.state.active?.stageIndex, 1, "1.0x: 정확히 임계면 진화")
+
+        let hard = await hatched(growth: 2.0)
+        hard.applyUsage(baseThreshold)
+        XCTAssertEqual(hard.state.active?.stageIndex, 0, "2.0x: 같은 양으론 진화 못 한다")
+    }
+
+    /// 표시값(tokensToNext/progress)이 상태 전이와 같은 임계를 쓰는가 — 둘이 어긋나면
+    /// "다음 단계까지" 문구만 바뀌고 실제 진화는 안 바뀌는 표면적 구현이 된다.
+    func testDisplayedTokensToNextMatchesTheThresholdThatActuallyEvolves() async {
+        let s = await hatched(growth: 0.5)
+        let shown = s.tokensToNext
+        XCTAssertEqual(shown, PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0) / 2,
+                       "표시값이 배율을 반영")
+        // 표시된 양보다 1 적게 주면 진화 안 하고, 딱 맞추면 진화한다 → 표시 = 실제 임계.
+        s.applyUsage(shown - 1)
+        XCTAssertEqual(s.state.active?.stageIndex, 0)
+        XCTAssertEqual(s.tokensToNext, 1, "남은 양도 배율 기준으로 줄어든다")
+        s.applyUsage(1)
+        XCTAssertEqual(s.state.active?.stageIndex, 1, "표시된 양을 채우면 실제로 진화한다")
+    }
+
+    // MARK: 2. 부화 — 알이 실제로 깨지는 지점이 바뀌는가
+
+    func testEggHatchPointMovesWithDifficulty() async {
+        let half = PokemonBalance.eggHatchThreshold / 2
+
+        let normal = store(growth: 1.0)
+        normal.update(todayTokensByProvider: ["t": 0], todayDate: "d1", monthTotal: 0,
+                      burnTier: .idle, limitWarning: false, hasUsageData: true)
+        normal.update(todayTokensByProvider: ["t": half], todayDate: "d1", monthTotal: 0,
+                      burnTier: .idle, limitWarning: false, hasUsageData: true)
+        await normal.hatchIfNeeded()
+        XCTAssertNil(normal.state.active, "1.0x: 절반으론 안 깨진다")
+
+        let easy = store(growth: 0.5)
+        easy.update(todayTokensByProvider: ["t": 0], todayDate: "d1", monthTotal: 0,
+                    burnTier: .idle, limitWarning: false, hasUsageData: true)
+        easy.update(todayTokensByProvider: ["t": half], todayDate: "d1", monthTotal: 0,
+                    burnTier: .idle, limitWarning: false, hasUsageData: true)
+        await easy.hatchIfNeeded()
+        XCTAssertNotNil(easy.state.active, "0.5x: 같은 양으로 부화")
+    }
+
+    // MARK: 3. 상점 — 결제 금액과 구매 가능 판정이 바뀌는가
+
+    func testShopGateAndChargedAmountFollowDifficulty() async {
+        let halfPrice = RareCandy.price / 2
+
+        let normal = await hatched(shop: 1.0, used: halfPrice)
+        XCTAssertFalse(normal.canBuy(.rareCandy), "1.0x: 절반 잔액으론 못 산다")
+
+        let cheap = await hatched(shop: 0.5, used: halfPrice)
+        XCTAssertTrue(cheap.canBuy(.rareCandy), "0.5x: 같은 잔액으로 살 수 있다")
+        XCTAssertTrue(cheap.buy(.rareCandy))
+        XCTAssertEqual(cheap.state.spentTokens, halfPrice, "실제 차감액도 배율 적용")
+        XCTAssertEqual(cheap.itemCount(.rareCandy), 1, "물건이 실제로 들어왔는가")
+    }
+
+    func testEggPriceScalesAndIsActuallyCharged() async {
+        let s = await hatched(shop: 0.5, used: FreshEgg.price)
+        XCTAssertEqual(s.price(of: .egg(nil)), FreshEgg.price / 2)
+        XCTAssertTrue(s.buyEgg(Rarity?.none))
+        XCTAssertEqual(s.state.spentTokens, FreshEgg.price / 2)
+    }
+
+    // MARK: 4. 두 슬라이더는 서로 독립인가 (등급 알 가격이 graduationTotal 비율에서 파생되므로 중요)
+
+    func testGrowthSliderDoesNotMoveShopPricesAndViceVersa() async {
+        let growthOnly = await hatched(growth: 0.1, shop: 1.0)
+        XCTAssertEqual(growthOnly.price(of: .item(.rareCandy)), RareCandy.price, "성장 배율이 가격을 건드리면 안 된다")
+        XCTAssertEqual(growthOnly.price(of: .egg(.rare)), FreshEgg.price(guaranteeing: .rare))
+
+        let shopOnly = await hatched(growth: 1.0, shop: 0.1)
+        XCTAssertEqual(shopOnly.tokensToNext,
+                       PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0),
+                       "상점 배율이 성장 임계를 건드리면 안 된다")
+    }
+
+    /// 등급 알의 상대 가격비(1 : 2.5 : 4)는 배율과 무관하게 보존돼야 한다.
+    func testGradedEggRatioSurvivesScaling() async {
+        let s = await hatched(shop: 0.4)
+        let plain = Double(s.price(of: .egg(nil)))
+        XCTAssertEqual(Double(s.price(of: .egg(.uncommon))) / plain, 2.5, accuracy: 0.001)
+        XCTAssertEqual(Double(s.price(of: .egg(.rare))) / plain, 4.0, accuracy: 0.001)
+    }
+
+    // MARK: 5. 라이브 반영 — 재시작 없이 그 자리에서
+
+    func testLoweringDifficultyLiveTriggersEvolutionImmediately() async {
+        let s = await hatched(growth: 1.0)
+        let baseThreshold = PokemonBalance.phaseThreshold(rarity: .common, totalForms: 3, stageIndex: 0)
+        s.applyUsage(baseThreshold - 1)
+        XCTAssertEqual(s.state.active?.stageIndex, 0, "아직 진화 전")
+
+        s.setGrowthDifficulty(0.5)   // 슬라이더를 내리는 순간
+        XCTAssertEqual(s.state.active?.stageIndex, 1, "폴링을 기다리지 않고 즉시 진화")
+    }
+
+    func testShopPriceChangesLiveWithoutRestart() async {
+        let s = await hatched(shop: 1.0)
+        XCTAssertEqual(s.price(of: .item(.rareCandy)), RareCandy.price)
+        s.setShopDifficulty(0.5)
+        XCTAssertEqual(s.price(of: .item(.rareCandy)), RareCandy.price / 2)
+    }
+
+    func testDifficultyPersistsToDefaults() async {
+        let s = await hatched()
+        s.setGrowthDifficulty(0.3)
+        s.setShopDifficulty(1.7)
+        XCTAssertEqual(s.growthDifficulty, 0.3, accuracy: 0.0001)
+        XCTAssertEqual(s.shopDifficulty, 1.7, accuracy: 0.0001)
+    }
+
+    // MARK: 6. 클램프 — 외부에서 쓰인 쓰레기 값
+
+    /// 경계값은 상수에서 파생한다 — 범위를 조정해도 테스트가 같이 따라오게(하드코딩 드리프트 방지).
+    func testGarbageDefaultsAreClamped() {
+        let lo = PokemonBalance.difficultyRange.lowerBound
+        let hi = PokemonBalance.difficultyRange.upperBound
+        XCTAssertEqual(PokemonBalance.clampDifficulty(0), lo, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.clampDifficulty(-5), lo, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.clampDifficulty(hi * 10), hi, accuracy: 1e-9)
+        // 유한하지 않은 값은 "아주 어려움"이 아니라 손상된 값 → 상·하한이 아니라 기본값으로 되돌린다.
+        XCTAssertEqual(PokemonBalance.clampDifficulty(.nan), PokemonBalance.defaultDifficulty, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.clampDifficulty(.infinity), PokemonBalance.defaultDifficulty, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.clampDifficulty(-.infinity), PokemonBalance.defaultDifficulty, accuracy: 1e-9)
+    }
+
+    /// 배율 0 이 저장돼 있어도 임계가 0 이 되지 않는다(진행률 0 나눗셈·퇴화 루프 방지).
+    func testZeroInDefaultsCannotProduceZeroThreshold() async {
+        let s = await hatched(growth: 0)
+        XCTAssertEqual(s.growthDifficulty, PokemonBalance.difficultyRange.lowerBound, accuracy: 1e-9)
+        XCTAssertGreaterThan(s.tokensToNext, 0)
+        XCTAssertGreaterThan(s.eggTokensToHatch, 0)
+    }
+
+    /// 가장 낮은 배율에서도 어떤 임계·가격도 0 으로 무너지지 않는다(가장 작은 기준값이 알 5M).
+    func testNothingCollapsesToZeroAtMinimumDifficulty() async {
+        let lo = PokemonBalance.difficultyRange.lowerBound
+        XCTAssertGreaterThan(PokemonBalance.scaled(PokemonBalance.eggHatchThreshold, by: lo), 0)
+        for rarity in [Rarity.common, .uncommon, .rare, .legendary] {
+            for k in 1...3 {
+                for i in 0..<k {
+                    let t = PokemonBalance.scaled(
+                        PokemonBalance.phaseThreshold(rarity: rarity, totalForms: k, stageIndex: i), by: lo)
+                    XCTAssertGreaterThan(t, 0, "rarity=\(rarity) k=\(k) i=\(i)")
+                }
+            }
+        }
+        let s = await hatched(shop: lo)
+        for entry in s.shopEntries { XCTAssertGreaterThan(s.price(of: entry), 0, "\(entry)") }
+    }
+
+    // MARK: 7. 슬라이더 위치 매핑 (로그) + 퍼센트 표기
+
+    func testPositionRoundTripsThroughDifficulty() {
+        for value in [0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 20.0] {
+            let back = PokemonBalance.difficulty(atPosition: PokemonBalance.difficultyPosition(value))
+            XCTAssertEqual(back, value, accuracy: value * 0.02, "value=\(value)")
+        }
+    }
+
+    func testPositionEndpointsMapToRangeBounds() {
+        XCTAssertEqual(PokemonBalance.difficulty(atPosition: 0),
+                       PokemonBalance.difficultyRange.lowerBound, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.difficulty(atPosition: 1),
+                       PokemonBalance.difficultyRange.upperBound, accuracy: 1e-6)
+        XCTAssertEqual(PokemonBalance.difficultyPosition(PokemonBalance.difficultyRange.lowerBound), 0, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.difficultyPosition(PokemonBalance.difficultyRange.upperBound), 1, accuracy: 1e-9)
+    }
+
+    /// 로그 슬라이더에서도 기본값(100%)으로 되돌릴 수 있어야 한다 — 스냅이 없으면 도달 불가.
+    func testDefaultIsReachableByDragging() {
+        let exactPosition = PokemonBalance.difficultyPosition(1.0)
+        for offset in [-0.009, -0.005, 0.0, 0.005, 0.009] {
+            XCTAssertEqual(PokemonBalance.difficulty(atPosition: exactPosition + offset), 1.0,
+                           accuracy: 1e-9, "offset=\(offset) 에서 100% 로 붙어야 한다")
+        }
+    }
+
+    /// 스냅 결과는 유효숫자 2자리 — 표시가 1.0473 같은 값으로 지저분해지지 않는다.
+    func testSnapKeepsTwoSignificantDigits() {
+        XCTAssertEqual(PokemonBalance.snapDifficulty(1.234), 1.2, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.snapDifficulty(15.7), 16, accuracy: 1e-9)
+        XCTAssertEqual(PokemonBalance.snapDifficulty(0.0123), 0.012, accuracy: 1e-9)
+    }
+
+    func testPercentFormatting() {
+        let l = L(.en)
+        XCTAssertEqual(l.difficultyValue(1.0), "100%")
+        XCTAssertEqual(l.difficultyValue(0.5), "50%")
+        XCTAssertEqual(l.difficultyValue(20), "2000%")
+        XCTAssertEqual(l.difficultyValue(0.05), "5.0%")
+        // 작은 쪽이 전부 "0%" 로 뭉개지지 않는가 — 범위 하한이 0.01% 라 자릿수가 필요하다.
+        XCTAssertEqual(l.difficultyValue(0.0001), "0.01%")
+        XCTAssertNotEqual(l.difficultyValue(0.0001), l.difficultyValue(0.0005))
+    }
+}
+
+// MARK: 스텁
+
+private struct StubDiffProvider: PokeProviding {
+    let value: EvoLine
+    func line(baseSpeciesID: Int) async throws -> EvoLine { value }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: value.baseID, captureRate: 255)] }
+}
+
+private struct SeededDiffRNG: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -247,6 +247,14 @@ final class FloatingPetEnergyTests: XCTestCase {
         XCTAssertTrue(UsageStore.AnimationQuality.allCases.allSatisfy { $0.frameFloor > 0 })
     }
 
+    /// 푸터 눈 아이콘은 **현재 상태**를 그린다 — 뒤집히면 "숨김"인데 켜진 것처럼 보인다.
+    /// 아이콘/툴팁이 설정창 스위치와 같은 값에서 파생되는지는 두 곳 모두 store.floatingPetEnabled 를
+    /// 읽는 것으로 보장되고(별도 상태 없음), 여기선 그 값 → 심볼 매핑만 잠근다.
+    func testFooterEyeSymbolFollowsVisibility() {
+        XCTAssertEqual(FloatingPetView.visibilitySymbol(visible: true), "eye")
+        XCTAssertEqual(FloatingPetView.visibilitySymbol(visible: false), "eye.slash")
+    }
+
     /// Bubble needs headroom + width beyond the square pet size — otherwise content is clipped.
     func testPanelGrowsForBubbleWithoutChangingPetOrigin() {
         let pet: CGFloat = 96


### PR DESCRIPTION
Two independent, opt-in controls. Both default to current behaviour, so an existing install sees no change until the user touches them.

## Difficulty multipliers (Settings)

Two independent multipliers: **growth** (egg incubation, evolution and graduation thresholds) and **shop prices**.

- Applied at the consumption sites in `CompanionStore` rather than to the constant tables. Graded egg prices derive from a ratio of `graduationTotal`, so scaling that table in place would let the growth slider move shop pricing as a side effect.
- Thresholds go through private `eggHatchThreshold` / `stageThreshold` helpers instead of calling `PokemonBalance` directly, so a call site that forgets the multiplier can't silently fall back to default difficulty.
- Persisted in `UserDefaults` next to the other Settings preferences, **not** in `CompanionState`. Difficulty is a preference, not save data, so it stays out of save export/import and `SaveTransfer` is untouched.
- Values are clamped on read. `UserDefaults` is writable from outside via `defaults write`, so 0, negative and NaN can genuinely arrive — and a multiplier of 0 would produce a zero threshold (division by zero in progress, degenerate evolution loop).
- Applied live: lowering growth re-evaluates evolution and hatching immediately rather than waiting for the next usage poll.
- `RareCandy.xp` is deliberately **not** scaled — scaling it would cancel against the thresholds and make candy the one thing immune to difficulty.
- The slider is log-mapped. The range spans five orders of magnitude; on a linear track 1.0 sits at 5% of the track and everything under 0.1 collapses into one tick. The 100% snap window is defined in *position* space, because on a log axis 1px near 1.0 is worth ~7% of multiplier — a value-space window would be narrower than a pixel and drag would skip the default with no way back.

## Popover footer

An eye button toggles floating pet visibility. It reads and writes the same `store.floatingPetEnabled` as the Settings switch, so the two can't diverge — `@Observable` propagates each to the other with no explicit syncing.

## Test plan

- `swift test` — 917 tests, 0 failures.
- `./scripts/test-gate.sh` — passes, logic-core line coverage 91.41% (threshold 75%).
- Difficulty is covered **behaviourally** (same token input, different outcome) rather than by asserting arithmetic: evolution and hatch points move with growth, shop gates and charged amounts move with price, and neither multiplier moves the other's outcome.
- Clamping is covered for the values that can actually reach it from defaults (0, negative, NaN, out of range), including that a stored 0 cannot produce a zero threshold.
- Slider mapping is covered by round-trip, endpoints, and drag-reachability of the 100% default.
- The footer eye symbol is asserted in both states — an inverted icon is the failure mode that reads as "hidden but looks on".
- Per `defect-log.md`'s note that the coverage gate is line-based and not evidence on its own, new conditional branches were checked with `llvm-cov --show-regions`. Three `^0` regions remain, all deliberate: `snapDifficulty`'s `value > 0` guard is unreachable from production (its only caller passes `lo * pow(hi/lo, p)` with `lo = 0.0001` and `p` clamped to `[0,1]`), and the two early returns in `setGrowthDifficulty` / `setShopDifficulty` are no-op performance guards — confirmed by mutation, since deleting both breaks no test because `applyUsage(0)` is idempotent.

---

## 한국어

독립적인 옵트인 컨트롤 두 가지입니다. 둘 다 기본값이 현재 동작과 같아서, 사용자가 직접 건드리기 전까지 기존 설치에는 아무 변화가 없습니다.

### 난이도 배율 (설정)

독립적인 배율 두 개 — **성장**(알 인큐베이션, 진화·졸업 임계)과 **상점 가격**.

- 상수표가 아니라 `CompanionStore` 의 **소비 지점**에서 곱합니다. 등급 알 가격이 `graduationTotal` 의 비율로 파생되므로, 표를 직접 스케일하면 성장 슬라이더가 상점 가격까지 끌고 가 버립니다.
- 임계값은 `PokemonBalance` 를 직접 부르지 않고 private `eggHatchThreshold` / `stageThreshold` 를 거칩니다. 배율을 빠뜨린 호출부가 생겨도 그 경로만 조용히 기본 난이도로 돌아가는 일이 없게 하기 위함입니다.
- `CompanionState` 가 아니라 **`UserDefaults`** 에, 다른 설정 항목들 옆에 저장합니다. 난이도는 진행 상황이 아니라 취향 설정이므로 세이브 export/import 대상이 아니고, `SaveTransfer` 는 손대지 않았습니다.
- 읽을 때 범위를 clamp 합니다. `UserDefaults` 는 `defaults write` 로 외부에서 쓸 수 있어 0·음수·NaN 이 실제로 들어올 수 있고, 배율 0 은 임계 0(진행률 0 나눗셈, 퇴화한 진화 루프)이 됩니다.
- 즉시 반영됩니다. 성장 배율을 낮추면 다음 사용량 폴링을 기다리지 않고 그 자리에서 진화·부화를 다시 판정합니다.
- `RareCandy.xp` 는 **의도적으로** 스케일하지 않습니다. 함께 곱하면 임계와 서로 상쇄돼 사탕만 난이도의 영향을 안 받게 됩니다.
- 슬라이더는 로그 매핑입니다. 범위가 다섯 자릿수를 넘어, 선형 트랙에서는 1.0 이 트랙의 5% 지점에 몰리고 0.1 미만은 전부 한 틱에 뭉갭니다. 100% 스냅 창을 **위치** 공간에 정의한 이유는, 로그축에서 1.0 근처의 1px 이 배율 약 7% 에 해당해 값 기준 창은 1px 보다 좁아지고 드래그가 기본값을 그냥 지나쳐 되돌릴 수단이 없어지기 때문입니다.

### 팝오버 푸터

눈 아이콘 버튼으로 플로팅 펫 표시를 토글합니다. 설정창 스위치와 **같은** `store.floatingPetEnabled` 를 읽고 쓰므로 둘이 어긋날 수 없습니다 — `@Observable` 이 별도 동기화 없이 양쪽을 따라오게 합니다.

### 테스트

- `swift test` — 917개 통과, 실패 0.
- `./scripts/test-gate.sh` — 통과, 로직 코어 라인 커버리지 91.41% (임계값 75%).
- 난이도는 산술을 단정하는 대신 **동작으로** 검증합니다(같은 토큰 입력, 다른 결과): 진화·부화 시점이 성장 배율을 따라 움직이고, 상점 게이트와 실제 청구액이 가격 배율을 따라 움직이며, 한쪽 배율이 다른 쪽 결과를 건드리지 않습니다.
- clamp 는 defaults 로 실제 도달 가능한 값들(0·음수·NaN·범위 밖)에 대해 검증했고, 저장된 0 이 임계 0 을 만들지 못한다는 것까지 포함합니다.
- 슬라이더 매핑은 왕복·양 끝점·100% 기본값의 드래그 도달 가능성으로 검증합니다.
- 푸터 눈 심볼은 두 상태 모두 단정합니다 — 뒤집힘은 "숨김인데 켜진 것처럼 보이는" 실패 형태입니다.
- 커버리지 게이트가 line 기반이라 그 숫자만으로는 증거가 아니라는 `defect-log.md` 의 지적에 따라, 새 조건 분기는 `llvm-cov --show-regions` 로 직접 확인했습니다. 남은 `^0` 은 셋이며 모두 의도된 것입니다: `snapDifficulty` 의 `value > 0` 가드는 프로덕션에서 도달 불가하고(유일한 호출부가 `lo = 0.0001`, `p` 는 `[0,1]` 로 clamp 된 `lo * pow(hi/lo, p)` 를 넘깁니다), `setGrowthDifficulty` / `setShopDifficulty` 의 조기 반환 두 개는 no-op 성능 가드입니다 — 둘을 지워도 실패하는 테스트가 없다는 것을 뮤테이션으로 확인했고, 이는 `applyUsage(0)` 이 멱등이기 때문입니다.
