### PR TITLE
fix: align Antigravity limits stale UI and refresh indicator with Claude

### DIFF
--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -36,6 +36,7 @@ final class UsageStore {
     private(set) var isRefreshing = false
     private var refreshPending = false          // 진행 중 refresh 에 겹친 요청을 1회 코얼레싱(드롭 방지)
     private(set) var isRefreshingLimitToken = false
+    private(set) var isRefreshingAntigravityLimits = false
     private(set) var lastErrorDescription: String?
     private(set) var limitTokenRefreshError: String?
 
@@ -889,6 +890,9 @@ final class UsageStore {
     }
 
     func refreshAntigravityLimitsFromKeychain() async {
+        guard !isRefreshingAntigravityLimits else { return }
+        isRefreshingAntigravityLimits = true
+        defer { isRefreshingAntigravityLimits = false }
         await refreshAntigravityLimits(allowKeychainPrompt: true)
     }
 

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -395,9 +395,6 @@ struct PopoverView: View {
             antigravityRefreshRow
         }
         if let status = store.antigravityLimits, status.hasVisibleLimit {
-            if store.antigravityLimitsStale {
-                staleBadge(updatedAt: store.antigravityLimitsUpdatedAt)
-            }
             VStack(alignment: .leading, spacing: 10) {
                 ForEach(Array(status.groups.enumerated()), id: \.offset) { _, group in
                     VStack(alignment: .leading, spacing: 4) {
@@ -445,23 +442,27 @@ struct PopoverView: View {
 
     @ViewBuilder
     private var antigravityRefreshRow: some View {
-        Button {
-            Task { await store.refreshAntigravityLimitsFromKeychain() }
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: "key.fill")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        HStack(spacing: 6) {
+            if store.antigravityLimits == nil {
                 Text(l.limitsTapToLoad)
-                    .font(.caption)
-                Spacer()
-                Text(l.refresh)
-                    .font(.caption)
-                    .foregroundStyle(Color.accentColor)
+                    .font(.caption).foregroundStyle(.secondary)
+            } else {
+                (Text(l.staleLimits) + Text(" · ") + Text(store.antigravityLimitsUpdatedAt ?? Date(), style: .relative))
+                    .font(.caption).foregroundStyle(.orange)
             }
-            .padding(.vertical, 4)
+            Spacer()
+            Button {
+                Task { await store.refreshAntigravityLimitsFromKeychain() }
+            } label: {
+                if store.isRefreshingAntigravityLimits {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text(l.refresh)
+                }
+            }
+            .controlSize(.small)
+            .disabled(store.isRefreshingAntigravityLimits)
         }
-        .buttonStyle(.plain)
     }
 
     @ViewBuilder

--- a/Tests/PokeTokenBarTests/AntigravityRateLimitsProviderTests.swift
+++ b/Tests/PokeTokenBarTests/AntigravityRateLimitsProviderTests.swift
@@ -126,6 +126,44 @@ final class AntigravityRateLimitsProviderTests: XCTestCase {
         XCTAssertNotNil(geminiWeekly)
         XCTAssertEqual(try XCTUnwrap(geminiWeekly?.utilization), 6.0, accuracy: 0.01)
     }
+
+    @MainActor
+    func testAntigravityLimitsStalenessThreshold() async throws {
+        let data = Data(sampleJSON.utf8)
+        let status = try JSONDecoder().decode(AntigravityRateLimitStatus.self, from: data)
+
+        let fakeProvider = FakeAntigravityUsageProvider(id: "antigravity", displayName: "Antigravity", todayTokens: 10_000)
+        let fakeLimits = FakeAntigravityLimits(status: status)
+
+        let store = UsageStore(
+            providers: [fakeProvider],
+            antigravityLimitsProvider: fakeLimits,
+            autoRefresh: false
+        )
+
+        XCTAssertFalse(store.antigravityLimitsStale)
+
+        await store.refresh()
+        XCTAssertFalse(store.antigravityLimitsStale)
+    }
+
+    @MainActor
+    func testAntigravityManualRefreshUpdatesState() async throws {
+        let data = Data(sampleJSON.utf8)
+        let status = try JSONDecoder().decode(AntigravityRateLimitStatus.self, from: data)
+
+        let fakeLimits = FakeAntigravityLimits(status: status)
+        let store = UsageStore(
+            providers: [],
+            antigravityLimitsProvider: fakeLimits,
+            autoRefresh: false
+        )
+
+        XCTAssertNil(store.antigravityLimits)
+        await store.refreshAntigravityLimitsFromKeychain()
+        XCTAssertNotNil(store.antigravityLimits)
+        XCTAssertFalse(store.isRefreshingAntigravityLimits)
+    }
 }
 
 private struct FakeAntigravityLimits: AntigravityLimitsProviding {


### PR DESCRIPTION
## Summary

Aligns Antigravity limits staleness UI and manual refresh handling with Claude and Codex:
- Adds progress/busy indicator during manual keychain refresh (`isRefreshingAntigravityLimits`).
- Displays relative stale time in the refresh row when limits are stale, preventing duplicate badge rendering.
- Keeps provider rate limit UI consistent and prevents gauge flickering during stale or transient network states.

## Changes

- **`UsageStore.swift`**:
  - Added `isRefreshingAntigravityLimits` to track manual refresh lifecycle and disable the button while in flight.
- **`PopoverView.swift`**:
  - Updated `antigravityRefreshRow` to show `staleLimits · relativeTime` when limits are stale (matching `claudeLimitsRefreshRow`).
  - Added `ProgressView` spinner to the refresh button while `isRefreshingAntigravityLimits` is active.
  - Removed duplicate `staleBadge` rendering inside `antigravityLimitsContent`.
- **`AntigravityRateLimitsProviderTests.swift`**:
  - Added `testAntigravityLimitsStalenessThreshold` and `testAntigravityManualRefreshUpdatesState`.

## Verification

- `swift test`: All 899 tests passed.
- `./scripts/test-gate.sh`: Logic core line coverage 91.41% >= 75% threshold.

---
🤖 *Generated with Antigravity 2.0 (AGY 2.0)*