### PR TITLE
feat: keep the menu bar animating in Low Power Mode, capped at Power saver

### DIFF
--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -96,6 +96,14 @@ final class UsageStore {
             case .smooth:     0.1   // ≈10fps
             }
         }
+
+        /// macOS 저전력 모드를 반영한 유효 하한 — **저장된 선택은 건드리지 않는 파생값**이다.
+        /// 저전력이면 powerSaver 하한까지 늦추고(이미 더 느린 선택은 그대로), 해제되면 선택값으로
+        /// 돌아온다. "복원"이 계산 자체라 이전 값을 저장·복구할 상태가 없다 — 저전력 중 앱이
+        /// 종료되거나 사용자가 설정을 바꿔도 충돌할 복원 로직이 존재하지 않는다.
+        func effectiveFrameFloor(lowPower: Bool) -> TimeInterval {
+            lowPower ? max(frameFloor, Self.powerSaver.frameFloor) : frameFloor
+        }
     }
     var animationQuality: AnimationQuality {
         didSet { defaults.set(animationQuality.rawValue, forKey: "animationQuality") }

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -33,6 +33,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var menuTimer: Timer?
     private var menuLoadGen = 0     // async 로드 경합 방지
     private var displayAwake = true     // 디스플레이 켜짐 여부 (꺼지면 메뉴 애니메이션 정지 — 배터리)
+    private var powerObserver: NSObjectProtocol?   // 저전력 토글 → 유효 fps 하한 재평가
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // 로그인 에이전트 등록(plist 의 RunAtLoad)이 이미 떠 있는 앱을 한 번 더 실행한다 — 나중에 뜬
@@ -84,6 +85,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         observeStore()
         observeCompanionSprite()
         observeDisplaySleep()
+        observePowerState()
         applyState()
     }
 
@@ -120,6 +122,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 self.ensureMenuAnimation()
                 self.syncMenuAnimation()
                 self.observeCompanionSprite()
+            }
+        }
+    }
+
+    /// 저전력 모드 토글을 즉시 반영 — 유효 하한(`menuFrameFloor`)이 바뀌면 `menuSpriteKey` 가
+    /// 달라져 `ensureMenuAnimation()` 이 재구성한다(선택이 powerSaver 면 하한 불변 → 재구성 없음,
+    /// 이미 그 프레임률이라 옳다). 플로팅 펫은 자체 관측(`FloatingPetController`)으로 따로 처리.
+    private func observePowerState() {
+        powerObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.NSProcessInfoPowerStateDidChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                self.ensureMenuAnimation()
+                self.syncMenuAnimation()
             }
         }
     }
@@ -204,7 +221,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// 솎아내 적용한다. 하한 자체는 없어질 수 없다 — 근거는 그 enum 과 defect-log '에너지' 절.
     /// 히스토리: 0.4s 고정 → 프리셋(0.4/0.2/0.1) 중 사용자 선택. 기기·스프라이트마다 체감과
     /// 배터리 영향이 갈려 하나의 값으로 수렴하지 못했다 — 기본값은 고정 캡과 같은 0.4s 다.
-    private var menuFrameFloor: TimeInterval { store.animationQuality.frameFloor }
+    /// 저전력 모드에선 powerSaver 하한으로 캡된다(`effectiveFrameFloor` — 저장 설정 무변경 파생,
+    /// 해제 시 자동 복귀). 이 값이 `menuSpriteKey` 에 들어가므로 저전력 토글 → 키 변화 → 재구성.
+    private var menuFrameFloor: TimeInterval {
+        store.animationQuality.effectiveFrameFloor(
+            lowPower: ProcessInfo.processInfo.isLowPowerModeEnabled)
+    }
 
     /// `Timer.tolerance` 배수 — wakeup 코얼레싱(다른 wakeup 과 합쳐 배터리 절약)의 강도.
     ///
@@ -217,7 +239,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// 대표 포켓몬에 맞춰 메뉴바 프레임을 준비. 종이 바뀐 경우에만 재로딩.
     /// 정적 스프라이트로 먼저 보여주고, animated GIF 가 받아지면 교체한다(메뉴바도 GIF로 움직임).
     /// 에너지 통제는 ① delay 하한 `menuFrameFloor` ② 안 보이면 정지(menuShouldAnimate) ③ 저전력 모드
-    /// 에선 GIF 생략(가벼운 bob)로 처리한다 — 통제된 저프레임 + 비가시 시 정지로 저전력.
+    /// 에선 하한을 powerSaver 로 강제 캡(`effectiveFrameFloor`)한다 — GIF 를 생략(bob)하는 대신
+    /// 프레임률만 낮춰, 애니메이션을 유지한 채 절전한다(bob 2회/s ↔ powerSaver ≤2.5회/s 로 근접).
     private func ensureMenuAnimation() {
         let subject = companion.representativeSubject
         let id = subject.speciesID
@@ -245,8 +268,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             }
         }
 
-        // 풀 GIF 애니메이션(저전력 모드에서는 생략하고 bob 유지). delay 하한 `menuFrameFloor` 로 redraw 통제.
-        guard !ProcessInfo.processInfo.isLowPowerModeEnabled else { return }
+        // 풀 GIF 애니메이션. delay 하한 `menuFrameFloor` 로 redraw 통제 — 저전력 모드에선 이 하한이
+        // powerSaver 로 캡되므로(GIF 생략 대신) 실제 애니메이션을 유지한 채 절전한다.
         Task { @MainActor [weak self] in
             guard let self, gen == self.menuLoadGen else { return }
             // shiny GIF 미제공 종이면 일반 GIF 폴백

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -219,6 +219,42 @@ final class FloatingPetEnergyTests: XCTestCase {
         XCTAssertGreaterThan(q.balanced.frameFloor, q.smooth.frameFloor)
     }
 
+    /// 저전력 모드의 유효 하한 — 파생값이라 "복귀"는 lowPower=false 계산 그 자체다.
+    /// 저전력이면 어떤 프리셋도 powerSaver 보다 빠르게 돌 수 없고(캡), 아니면 선택값 그대로.
+    /// 프리셋이 늘어도 자동으로 걸리도록 개별 상수 대신 전 케이스를 돈다.
+    func testLowPowerCapsEffectiveFloorAtPowerSaverAndDerivationRestoresChoice() {
+        let saver = UsageStore.AnimationQuality.powerSaver.frameFloor
+        for q in UsageStore.AnimationQuality.allCases {
+            XCTAssertGreaterThanOrEqual(q.effectiveFrameFloor(lowPower: true), saver,
+                                        "\(q.rawValue): 저전력에서 powerSaver 보다 빠르면 절전 실패")
+            XCTAssertGreaterThanOrEqual(q.effectiveFrameFloor(lowPower: true), q.frameFloor,
+                                        "\(q.rawValue): 저전력이 애니메이션을 더 빠르게 만들 수는 없다")
+            XCTAssertEqual(q.effectiveFrameFloor(lowPower: false), q.frameFloor,
+                           "\(q.rawValue): 저전력이 아니면 사용자 선택 그대로(자동 복귀)")
+        }
+    }
+
+    /// [회귀] 저전력 토글이 메뉴바 재구성으로 이어지는 기계 — 유효 하한이 `menuSpriteKey` 에
+    /// 들어가므로 smooth 사용자의 저전력 진입/해제는 키를 바꾼다. 키가 안 바뀌면 관측자가
+    /// 재호출해도 `ensureMenuAnimation` 이 조기 반환해 옛 fps 로 계속 돈다(설계 시 확인된 함정과
+    /// 같은 부류 — `testIdentityKeysIncludeTheFrameFloor`).
+    func testLowPowerToggleChangesMenuSpriteKeyForFasterPresets() {
+        let smooth = UsageStore.AnimationQuality.smooth
+        XCTAssertNotEqual(
+            AppDelegate.menuSpriteKey(id: 41, shiny: false,
+                                      floor: smooth.effectiveFrameFloor(lowPower: true)),
+            AppDelegate.menuSpriteKey(id: 41, shiny: false,
+                                      floor: smooth.effectiveFrameFloor(lowPower: false)),
+            "smooth: 저전력 토글이 키를 못 바꾸면 재구성이 일어나지 않는다")
+        // powerSaver 선택자는 저전력 전후 키가 같아야 한다 — 이미 그 프레임률이라 재구성 자체가 낭비.
+        let saver = UsageStore.AnimationQuality.powerSaver
+        XCTAssertEqual(
+            AppDelegate.menuSpriteKey(id: 41, shiny: false,
+                                      floor: saver.effectiveFrameFloor(lowPower: true)),
+            AppDelegate.menuSpriteKey(id: 41, shiny: false,
+                                      floor: saver.effectiveFrameFloor(lowPower: false)))
+    }
+
     /// [회귀] 설정을 바꾸면 **즉시** 반영돼야 한다. 두 표면 모두 "정체성이 바뀌면 재로딩" 기계로
     /// 프레임을 갱신하는데, 그 정체성 키에 하한이 빠져 있으면 종이 바뀔 때까지 옛 fps 로 계속 돈다
     /// (`menuSpriteKey` = "id-shiny", `SpriteView.task(id:)` = "id-shiny" 였다 — 설계 시 확인된 함정).


### PR DESCRIPTION
## What

In Low Power Mode the menu bar companion now keeps its real GIF animation, capped at the Power saver preset (2.5 fps), instead of degrading to the two-frame bob. When Low Power Mode ends, the animation returns to the preset chosen in Settings — immediately, no restart or polling wait.

## Why the bob is no longer the right trade

The bob predates the animation quality setting (#212): back then the GIF always ran at the fixed 0.4 s floor, and Low Power Mode picked the only cheaper option. Power saver *is* that historical frame rate, so the real animation now costs at most +0.5 status-bar recomposites per second over the bob (≤2.5/s vs 2/s), through the same `setStatusImage` diff-gated render path.

## Design — derived, not mutate-and-restore

The stored `animationQuality` is never touched. The consumption site derives an effective floor:

```swift
func effectiveFrameFloor(lowPower: Bool) -> TimeInterval {
    lowPower ? max(frameFloor, Self.powerSaver.frameFloor) : frameFloor
}
```

"Restoring on exit" is the derivation itself — there is no saved previous value to lose if the app quits mid-Low-Power, and a manual preset change during Low Power Mode cannot fight a restore step. Settings keeps showing the user's real choice throughout.

## Also fixes: the mode toggle was never observed

`isLowPowerModeEnabled` was only consulted while building frames, and nothing rebuilt on a power-state change:

- entering Low Power Mode mid-session left an already-built GIF running at the chosen preset (Smooth stayed 10 fps);
- leaving it kept the bob until the next species/quality change or restart.

A `NSProcessInfoPowerStateDidChange` observer (the same notification the floating pet already uses) re-runs `ensureMenuAnimation()`. The effective floor is part of `menuSpriteKey`, so a toggle changes the key and the frames rebuild; for a user already on Power saver the key is unchanged and no rebuild happens — correct, since the frames are already right.

The floating pet's Low Power behaviour (fully static) is unchanged: it renders in a regular window where frames cost more, so a full stop remains the right trade there.

## Behaviour

| Energy mode | Menu bar animation |
|---|---|
| Low Power | real GIF, capped at Power saver (2.5 fps) |
| Automatic / High Power | the preset chosen in Settings |

macOS exposes only the Low Power boolean, so Automatic and High Power are indistinguishable to the app — both mean "the user's preset". The bob remains only as the loading / no-animated-sprite fallback.

## Tests

- `testLowPowerCapsEffectiveFloorAtPowerSaverAndDerivationRestoresChoice` — every preset × both power states: Low Power can never run faster than Power saver nor faster than the user's own choice; not-low-power returns the choice verbatim (the "restore").
- `testLowPowerToggleChangesMenuSpriteKeyForFasterPresets` — the rebuild mechanism: a toggle changes the key for Smooth, and does **not** for Power saver (no wasted rebuild).
- Fault-injection check: removing the cap makes both tests fail (3 failures), so they guard the behaviour rather than mirroring the implementation.
- Full suite: 903 tests, 0 failures.
