### PR TITLE
feat(kun): add Kun CLI usage provider

### DIFF
--- a/Sources/PokeTokenBar/Core/CustomScanRoots.swift
+++ b/Sources/PokeTokenBar/Core/CustomScanRoots.swift
@@ -104,6 +104,8 @@ enum CustomScanRoots {
         case "omp":
             return CustomScanRoots.union(
                 defaults: LocalUsageReader.computeOmpSessionRoots(), extraRaw: nil)
+        case "kun":
+            return LocalAdditionalUsageReader.kunRoots(customRootsValue: nil)
         default:
             return []
         }

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -7,6 +7,7 @@ private enum LocalAdditionalSource: String, Sendable {
     case cursor
     case copilot
     case kiro
+    case kun
 }
 
 /// OpenCode usage from its local SQLite database and legacy message files.
@@ -107,6 +108,22 @@ struct LocalKiroProvider: UsageProvider {
     }
 }
 
+/// Kun usage from local SQLite database index.sqlite3.
+struct LocalKunProvider: UsageProvider {
+    let id = "kun"
+    let displayName = "Kun"
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .kun)
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey())
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .kun)
+        return enrichment(entries: entries)
+    }
+}
+
 private func enrichment(entries: [LocalUsageReader.Entry]) -> ProviderEnrichment {
     let now = Date()
     let monthStart = LocalUsageReader.startOfMonth(now)
@@ -193,7 +210,7 @@ private actor LocalAdditionalUsageCache {
             // only the rows written since the last scan.
             since = periodStart
             afterRowIDByPath = previous?.highWaterByPath ?? [:]
-        case .hermes:
+        case .hermes, .kun:
             since = periodStart
             afterRowIDByPath = [:]
         case .kiro:
@@ -217,6 +234,8 @@ private actor LocalAdditionalUsageCache {
                 return ScanResult(entries: LocalUsageReader.dedupKeepMax(existing + loaded))
             case .hermes:
                 return ScanResult(entries: LocalAdditionalUsageReader.hermesEntries(modifiedSince: since))
+            case .kun:
+                return ScanResult(entries: LocalAdditionalUsageReader.kunEntries(modifiedSince: since))
             case .kiro:
                 let loaded = LocalAdditionalUsageReader.kiroEntries(
                     modifiedSince: since, knownSignatures: knownKiro)
@@ -309,6 +328,20 @@ enum LocalAdditionalUsageReader {
         return CustomScanRoots.union(defaults: curated, extraRaw: customRootsValue)
     }
 
+    static var defaultKunRoots: [URL] {
+        environmentPaths("KUN_DATA_DIR")
+            ?? [FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".kun/data/index.sqlite3")]
+    }
+
+    static func kunRoots(
+        customRootsValue: String? = nil,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> [URL] {
+        let curated = environmentPaths("KUN_DATA_DIR")
+            ?? [home.appendingPathComponent(".kun/data/index.sqlite3")]
+        return CustomScanRoots.union(defaults: curated, extraRaw: customRootsValue)
+    }
+
     static func openCodeEntries(
         modifiedSince: Date,
         roots: [URL]? = nil
@@ -342,6 +375,26 @@ enum LocalAdditionalUsageReader {
         for root in sourceRoots {
             let database = root.pathExtension == "db" ? root : root.appendingPathComponent("state.db")
             for entry in hermesDatabaseEntries(database, modifiedSince: modifiedSince)
+            where entry.date >= modifiedSince {
+                if seen.insert(entry.id).inserted { entries.append(entry) }
+            }
+        }
+        return entries
+    }
+
+    static func kunEntries(
+        modifiedSince: Date,
+        roots: [URL]? = nil
+    ) -> [LocalUsageReader.Entry] {
+        let sourceRoots = roots ?? kunRoots(
+            customRootsValue: CustomScanRoots.storedValue(for: "kun"))
+        var seen = Set<String>()
+        var entries: [LocalUsageReader.Entry] = []
+        for root in sourceRoots {
+            let database = (root.pathExtension == "sqlite3" || root.pathExtension == "db")
+                ? root
+                : root.appendingPathComponent("index.sqlite3")
+            for entry in kunDatabaseEntries(database, modifiedSince: modifiedSince)
             where entry.date >= modifiedSince {
                 if seen.insert(entry.id).inserted { entries.append(entry) }
             }
@@ -443,6 +496,94 @@ enum LocalAdditionalUsageReader {
                 cacheRead: columnInt(statement, 7),
                 cost: actualCost > 0 ? actualCost : estimatedCost)
         } ?? []
+    }
+
+    // MARK: Kun database
+
+    private static func kunDatabaseEntries(
+        _ database: URL,
+        modifiedSince: Date
+    ) -> [LocalUsageReader.Entry] {
+        guard FileManager.default.fileExists(atPath: database.path) else { return [] }
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(database.path, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nil) == SQLITE_OK,
+              let db else {
+            return []
+        }
+        defer { sqlite3_close(db) }
+
+        var statement: OpaquePointer?
+        let sql = """
+        SELECT thread_id, seq, timestamp, model, usage_json
+        FROM usage_events
+        ORDER BY thread_id ASC, seq ASC
+        """
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            return []
+        }
+        defer { sqlite3_finalize(statement) }
+
+        struct ThreadCumulativeStats {
+            var promptTokens: Int = 0
+            var completionTokens: Int = 0
+            var cachedTokens: Int = 0
+            var totalTokens: Int = 0
+            var costUsd: Double = 0.0
+        }
+
+        var prevByThread: [String: ThreadCumulativeStats] = [:]
+        var result: [LocalUsageReader.Entry] = []
+
+        while sqlite3_step(statement) == SQLITE_ROW {
+            autoreleasepool {
+                guard let threadID = columnText(statement, 0)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !threadID.isEmpty,
+                      let timestampStr = columnText(statement, 2),
+                      let date = parseISO8601(timestampStr),
+                      let usageJSON = columnText(statement, 4),
+                      let object = jsonObject(data: Data(usageJSON.utf8)) else { return }
+                let seq = sqlite3_column_int64(statement, 1)
+                let model = columnText(statement, 3)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "unknown"
+
+                let curPrompt = intValue(object["promptTokens"])
+                let curComp = intValue(object["completionTokens"])
+                let curCached = intValue(object["cachedTokens"]) != 0 ? intValue(object["cachedTokens"]) : intValue(object["cacheHitTokens"])
+                let curTotal = intValue(object["totalTokens"])
+                let curCost = doubleValue(object["costUsd"]) ?? 0.0
+
+                let prev = prevByThread[threadID] ?? ThreadCumulativeStats()
+                let deltaPrompt = max(0, curPrompt - prev.promptTokens)
+                let deltaComp = max(0, curComp - prev.completionTokens)
+                let deltaCached = max(0, curCached - prev.cachedTokens)
+                let deltaTotal = max(0, curTotal - prev.totalTokens)
+                let deltaCost = max(0.0, curCost - prev.costUsd)
+
+                prevByThread[threadID] = ThreadCumulativeStats(
+                    promptTokens: curPrompt,
+                    completionTokens: curComp,
+                    cachedTokens: curCached,
+                    totalTokens: curTotal,
+                    costUsd: curCost
+                )
+
+                guard date >= modifiedSince else { return }
+
+                let netInput = max(0, deltaPrompt - deltaCached)
+                if let entry = makeEntry(
+                    id: "kun|\(threadID)|\(seq)",
+                    date: date,
+                    model: "kun/\(model)",
+                    input: netInput,
+                    output: deltaComp,
+                    cacheWrite: 0,
+                    cacheRead: deltaCached,
+                    total: deltaTotal,
+                    cost: deltaCost > 0 ? deltaCost : nil) {
+                    result.append(entry)
+                }
+            }
+        }
+        return result
     }
 
     // MARK: Incremental SQLite stores

--- a/Sources/PokeTokenBar/Core/UsageEnvironment.swift
+++ b/Sources/PokeTokenBar/Core/UsageEnvironment.swift
@@ -30,6 +30,7 @@ enum UsageEnvironment {
         "KIRO_HOME",           // ~/.kiro — JSONL sessions live under <this>/sessions
         "CURSOR_DATA_DIR",     // Cursor user-data dir override
         "OMP_CODING_AGENT_DIR", // omp (oh-my-pi) config/session base directory
+        "KUN_DATA_DIR",        // Kun CLI data directory override
     ]
 
     /// `name` 의 값. 프로세스 환경이 우선이고, 없으면 로그인 셸에서 읽은 값을 쓴다.

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -497,6 +497,7 @@ final class UsageStore {
         LocalCursorProvider(), LocalGrokProvider(), LocalCopilotProvider(), LocalKiroProvider(),
         LocalPiProvider(),
         LocalOmpProvider(),
+        LocalKunProvider(),
     ],
          // 세션 키 우선, 없거나 죽었으면 기존 Keychain/파일 OAuth 경로. 두 인자는 같은
          // SessionKeyLimitsProvider 인스턴스를 봐야 한다 — 설정 화면이 고른 조직을 조회 경로가 써야 하므로.

--- a/Tests/PokeTokenBarTests/KunUsageTests.swift
+++ b/Tests/PokeTokenBarTests/KunUsageTests.swift
@@ -1,0 +1,129 @@
+import SQLite3
+import XCTest
+@testable import PokeTokenBar
+
+final class KunUsageTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PokeTokenBar-KunUsageTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+        temporaryDirectory = nil
+    }
+
+    func testKunDatabaseParsing() throws {
+        let dbURL = temporaryDirectory.appendingPathComponent("index.sqlite3")
+        try createKunDatabase(at: dbURL)
+
+        let usageJSON = """
+        {"promptTokens":1000,"completionTokens":200,"cachedTokens":300,"totalTokens":1200,"costUsd":0.05}
+        """
+        try insertEvent(at: dbURL, threadID: "thr_test_1", seq: 1, timestamp: "2026-08-20T10:00:00.000Z", model: "deepseek-v4-pro", usageJSON: usageJSON)
+
+        let entries = LocalAdditionalUsageReader.kunEntries(modifiedSince: .distantPast, roots: [dbURL])
+        XCTAssertEqual(entries.count, 1)
+
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entry.id, "kun|thr_test_1|1")
+        XCTAssertEqual(entry.model, "kun/deepseek-v4-pro")
+        XCTAssertEqual(entry.input, 700) // 1000 - 300
+        XCTAssertEqual(entry.output, 200)
+        XCTAssertEqual(entry.cacheRead, 300)
+        XCTAssertEqual(entry.total, 1200)
+        XCTAssertEqual(entry.explicitCost, 0.05)
+    }
+
+    func testKunDatabaseFiltersByModifiedSince() throws {
+        let dbURL = temporaryDirectory.appendingPathComponent("index.sqlite3")
+        try createKunDatabase(at: dbURL)
+
+        let usageJSON = """
+        {"promptTokens":100,"completionTokens":50,"cachedTokens":0,"totalTokens":150,"costUsd":0.01}
+        """
+        try insertEvent(at: dbURL, threadID: "thr_old", seq: 1, timestamp: "2026-08-01T10:00:00.000Z", model: "deepseek-v4-pro", usageJSON: usageJSON)
+        try insertEvent(at: dbURL, threadID: "thr_new", seq: 2, timestamp: "2026-08-20T10:00:00.000Z", model: "deepseek-v4-pro", usageJSON: usageJSON)
+
+        let cutoff = ISO8601DateFormatter().date(from: "2026-08-15T00:00:00Z")!
+        let entries = LocalAdditionalUsageReader.kunEntries(modifiedSince: cutoff, roots: [dbURL])
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.id, "kun|thr_new|2")
+    }
+
+    func testKunDatabaseComputesTurnDeltasForCumulativeEvents() throws {
+        let dbURL = temporaryDirectory.appendingPathComponent("index.sqlite3")
+        try createKunDatabase(at: dbURL)
+
+        let turn1 = """
+        {"promptTokens":1000,"completionTokens":200,"cachedTokens":300,"totalTokens":1200,"costUsd":0.05}
+        """
+        let turn2 = """
+        {"promptTokens":2500,"completionTokens":500,"cachedTokens":800,"totalTokens":3000,"costUsd":0.12}
+        """
+        try insertEvent(at: dbURL, threadID: "thr_multi", seq: 1, timestamp: "2026-08-20T10:00:00.000Z", model: "deepseek-v4-pro", usageJSON: turn1)
+        try insertEvent(at: dbURL, threadID: "thr_multi", seq: 2, timestamp: "2026-08-20T10:05:00.000Z", model: "deepseek-v4-pro", usageJSON: turn2)
+
+        let entries = LocalAdditionalUsageReader.kunEntries(modifiedSince: .distantPast, roots: [dbURL])
+        XCTAssertEqual(entries.count, 2)
+
+        let e1 = entries[0]
+        XCTAssertEqual(e1.total, 1200)
+        XCTAssertEqual(e1.output, 200)
+        XCTAssertEqual(e1.explicitCost, 0.05)
+
+        let e2 = entries[1]
+        XCTAssertEqual(e2.total, 1800) // 3000 - 1200
+        XCTAssertEqual(e2.output, 300) // 500 - 200
+        XCTAssertEqual(e2.cacheRead, 500) // 800 - 300
+        XCTAssertEqual(e2.explicitCost ?? 0, 0.07, accuracy: 0.001) // 0.12 - 0.05
+    }
+
+    @MainActor
+    func testDefaultRegistryIncludesKun() {
+        let suite = "KunUsageTests.registry.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = UsageStore(autoRefresh: false, defaults: defaults)
+        XCTAssertTrue(store.registeredProviderIDs.contains("kun"))
+    }
+
+    // MARK: - SQLite Helpers
+
+    private func createKunDatabase(at url: URL) throws {
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        let sql = """
+        CREATE TABLE usage_events (
+            thread_id TEXT NOT NULL,
+            seq INTEGER NOT NULL,
+            timestamp TEXT NOT NULL,
+            turn_id TEXT,
+            model TEXT,
+            usage_json TEXT NOT NULL,
+            PRIMARY KEY(thread_id, seq)
+        );
+        """
+        XCTAssertEqual(sqlite3_exec(db, sql, nil, nil, nil), SQLITE_OK)
+    }
+
+    private func insertEvent(at url: URL, threadID: String, seq: Int64, timestamp: String, model: String, usageJSON: String) throws {
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        let sql = "INSERT INTO usage_events (thread_id, seq, timestamp, model, usage_json) VALUES (?, ?, ?, ?, ?)"
+        var stmt: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(db, sql, -1, &stmt, nil), SQLITE_OK)
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, threadID, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        sqlite3_bind_int64(stmt, 2, seq)
+        sqlite3_bind_text(stmt, 3, timestamp, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        sqlite3_bind_text(stmt, 4, model, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        sqlite3_bind_text(stmt, 5, usageJSON, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        XCTAssertEqual(sqlite3_step(stmt), SQLITE_DONE)
+    }
+}

--- a/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
+++ b/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
@@ -137,7 +137,7 @@ final class LocalAdditionalUsageTests: XCTestCase {
         XCTAssertEqual(
             Set(store.registeredProviderIDs),
             Set(["claude_code", "codex", "gemini", "antigravity",
-                 "opencode", "hermes", "cursor", "grok", "copilot", "kiro", "pi", "omp"]))
+                 "opencode", "hermes", "cursor", "grok", "copilot", "kiro", "pi", "omp", "kun"]))
     }
 
     func testPrintRealOpenCodeAggregate() throws {

--- a/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
@@ -22,7 +22,7 @@ final class ProviderTabLayoutTests: XCTestCase {
         [("claude_code", "Claude Code"), ("codex", "Codex"), ("gemini", "Gemini"),
          ("antigravity", "Antigravity"), ("opencode", "OpenCode"), ("hermes", "Hermes Agent"),
          ("cursor", "Cursor"), ("grok", "Grok"), ("copilot", "Copilot"), ("kiro", "Kiro"),
-         ("pi", "Pi"), ("omp", "omp")]
+         ("pi", "Pi"), ("omp", "omp"), ("kun", "Kun")]
             .map { snapshot($0.0, $0.1) }
     }
 

--- a/Tests/PokeTokenBarTests/UsageEnvironmentTests.swift
+++ b/Tests/PokeTokenBarTests/UsageEnvironmentTests.swift
@@ -164,7 +164,7 @@ final class UsageEnvironmentTests: XCTestCase {
             "CLOUD_CODE_URL", "PI_CODING_AGENT_DIR", "PI_CODING_AGENT_SESSION_DIR",
             "CURSOR_SESSION_TOKEN", "CURSOR_USAGE_API",
             "KIRO_CLI_HOME", "KIRO_HOME", "CURSOR_DATA_DIR",
-            "OMP_CODING_AGENT_DIR",
+            "OMP_CODING_AGENT_DIR", "KUN_DATA_DIR",
         ] {
             XCTAssertTrue(UsageEnvironment.names.contains(name), "\(name) 이 조회 대상에서 빠졌다")
         }


### PR DESCRIPTION
## Summary

Adds Kun CLI (`kun`) as a 13th local usage source. Kun persists session usage in an SQLite database under `~/.kun/data/index.sqlite3` in the `usage_events` table with `(thread_id, seq, timestamp, model, usage_json)`.

Key details:
- **Per-turn delta computation**: Kun records cumulative session stats in `usage_json` (`promptTokens`, `completionTokens`, `cachedTokens`, `totalTokens`, `costUsd`); the reader calculates per-turn token and cost deltas across sequential events in each thread.
- **Durable roots & environment**: Default root is `~/.kun/data/index.sqlite3` with `KUN_DATA_DIR` override support registered in `UsageEnvironment`, `CustomScanRoots`, and tests.
- **Extension contract compliance**: Implements `UsageProvider` and registers in `UsageStore.init` `providers:` array without provider-specific logic in generic paths.

## Type of change

- [x] New feature

## UI changes

No UI structure changes. Users with a Kun database get a `Kun` capsule in the provider tab bar and an entry in Settings → Additional scan folders; Kun token usage and cost join today's aggregate totals.

## Checklist

- [x] `swift build` and `swift test` pass locally (907 tests, 0 failures)
- [x] PR title and description are written in English
- [x] Tests added in `KunUsageTests.swift` and registry tests updated