### PR TITLE
perf: swap menu bar sprite frames through a layer instead of button.image

### DIFF
--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -29,11 +29,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // 프레임 = 이미 22px 로 합성된 이미지 + delay. egg/static 은 2프레임 bob, animated 는 GIF 실제 프레임.
     private var menuSpriteKey: String?   // menuSpriteKey(id:shiny:floor:) 결과 — 바뀌면 재로딩
     private var menuFrames: [(image: NSImage, delay: TimeInterval)] = []
+    /// `menuFrames` 와 인덱스 대응하는 레이어용 비트맵. 프레임 준비 시 한 번만 변환한다.
+    /// 비어 있으면(변환 실패) `setStatusImage` 가 `button.image` 폴백 경로를 탄다.
+    private var menuLayerFrames: [CGImage] = []
     private var menuIndex = 0
     private var menuTimer: Timer?
     private var menuLoadGen = 0     // async 로드 경합 방지
     private var displayAwake = true     // 디스플레이 켜짐 여부 (꺼지면 메뉴 애니메이션 정지 — 배터리)
     private var powerObserver: NSObjectProtocol?   // 저전력 토글 → 유효 fps 하한 재평가
+
+    /// 스프라이트 전용 서브레이어 — 프레임 교체의 드로잉 비용을 없앤다.
+    ///
+    /// `button.image` 대입은 레이어 백드 `NSStatusBarButton` 전체를 재드로잉시킨다. 거기엔 스프라이트
+    /// 22px 뿐 아니라 **매 프레임 다시 그려지는 2줄 attributedTitle 텍스트**가 포함돼, 5fps 루프에서
+    /// 그 비용이 상시로 깔린다. 대신 이 레이어의 `contents` 만 갈아끼우면 이미 업로드된 비트맵을
+    /// 바꿔 끼우는 것뿐이라 드로잉 경로(`_NSViewDrawRect`)를 아예 타지 않는다.
+    ///
+    /// 실측(A/B 프로브 — 같은 타이머·5fps·2줄 타이틀·60초×2라운드 평균):
+    /// `button.image`+CATransaction 2.00ms/프레임 → `layer.contents` 0.27ms/프레임(−86%).
+    /// 라이브 앱 `sample` 전후로도 타이머 경로 1.37% → 0.20%, `_NSViewDrawRect` 105 → 0 샘플.
+    /// (`button.image` 를 CATransaction 밖에서 대입하면 3.51ms 로 되레 악화 — 기존 전환 억제 규칙은
+    /// 그대로 유효하다. 근거는 defect-log '에너지' 절.)
+    private let spriteLayer = CALayer()
+    /// 폭 확보용 투명 `button.image` 의 현재 크기 — 바뀔 때만 재대입해 레이아웃 유발을 줄인다.
+    private var placeholderSize: NSSize?
+    /// 버튼 폭(=텍스트 길이)이나 스프라이트 크기가 변하면 레이어를 이미지 자리에 다시 맞춰야 한다.
+    private var needsSpriteLayout = true
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // 로그인 에이전트 등록(plist 의 RunAtLoad)이 이미 떠 있는 앱을 한 번 더 실행한다 — 나중에 뜬
@@ -71,12 +92,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem.button {
-            setStatusImage(Self.eggImage(up: false))   // 초기 알도 전환 억제 경로로 통일(불변식)
             button.imagePosition = .imageLeading
             button.font = .monospacedDigitSystemFont(ofSize: 13, weight: .regular)
             button.cell?.usesSingleLineMode = false   // 사용량/한도를 2줄로 세로 스택 가능하게
             button.action = #selector(togglePopover)
             button.target = self
+            prepareSpriteLayer(on: button)   // 프레임 교체를 레이어 contents 로 — 설정이 먼저다
+            let egg = Self.eggImage(up: false)
+            setStatusImage(egg, cgFrame: Self.cgFrame(from: egg))   // 초기 알도 같은 경로로(불변식)
         }
 
         popover.behavior = .transient
@@ -144,6 +167,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private func applyState() {
         guard let button = statusItem.button else { return }
         Self.applyMenuText(store.menuLines, to: button)
+        needsSpriteLayout = true   // 텍스트 길이가 바뀌면 버튼 폭이 변해 이미지 자리도 움직인다
         // stale 시각 dim 제거 — 슬립/런치 직후 refresh 완료 전 몇 초간 회색으로 보여 '고장/비활성'
         // 으로 오인되던 것 방지(사용자 반복 지적). 데이터가 오래됐다는 신호가 필요하면 팝오버
         // (limitsUpdatedAt 등)에서 제공하고, 메뉴바 아이콘·숫자는 흐리게 하지 않는다.
@@ -152,6 +176,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         updateCompanion()
         ensureMenuAnimation()
         syncMenuAnimation()   // 가시성 상태 주기적 재평가(occlusion 이 잘못 멈춰도 자가 복구)
+        // 같은 프레임이면 setStatusImage 가 diff-gate 로 조기 반환해 재배치를 못 했을 수 있다.
+        if needsSpriteLayout { layoutSpriteLayer() }
     }
 
     /// 메뉴바 버튼 텍스트 반영 — 1줄이면 기본 title(13pt), 2줄 이상이면 세로 스택.
@@ -290,24 +316,102 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     private func setMenuFrames(_ frames: [(image: NSImage, delay: TimeInterval)]) {
         menuFrames = frames
+        // 레이어용 비트맵은 프레임을 준비할 때 한 번만 만든다 — 프레임마다 변환하면 절감분이 사라진다.
+        let converted = frames.compactMap { Self.cgFrame(from: $0.image) }
+        menuLayerFrames = converted.count == frames.count ? converted : []   // 하나라도 실패하면 폴백
         menuIndex = 0
         advanceMenu()
     }
 
     private var lastStatusImage: NSImage?
 
-    /// 상태아이템 이미지 교체. ① **diff-gate**: 같은 이미지 재대입이면 스킵 — 레이어 dirty → CA 커밋 →
+    /// 스프라이트 레이어를 버튼에 얹는다. 스프라이트는 픽셀아트라 보간 없이(nearest) 그린다 —
+    /// `menuBarImage` 가 `imageInterpolation = .none` 으로 합성하는 것과 같은 이유.
+    private func prepareSpriteLayer(on button: NSStatusBarButton) {
+        button.wantsLayer = true
+        spriteLayer.magnificationFilter = .nearest
+        spriteLayer.minificationFilter = .nearest
+        spriteLayer.contentsGravity = .resizeAspect   // 자리 rect 와 종횡비가 어긋나도 찌그러지지 않게
+        button.layer?.addSublayer(spriteLayer)
+    }
+
+    /// 프레임 NSImage → 레이어 `contents` 용 비트맵. 실패하면 nil = `button.image` 폴백.
+    nonisolated static func cgFrame(from image: NSImage) -> CGImage? {
+        var rect = CGRect(origin: .zero, size: image.size)
+        return image.cgImage(forProposedRect: &rect, context: nil, hints: nil)
+    }
+
+    /// 레이어 `contentsScale` — **화면 스케일이 아니라 비트맵이 합성된 스케일**을 따른다.
+    /// 프레임은 `menuBarImage` 가 `lockFocus` 로 합성해 그때의 백킹 스케일로 픽셀이 굳는다. 표시
+    /// 스케일을 현재 화면에서 가져오면 2x 로 합성된 프레임을 1x 외부 모니터에 올렸을 때 스프라이트가
+    /// 두 배로 보인다 — 비트맵 자신의 픽셀/포인트 비율을 쓰면 어느 화면에서도 캔버스 포인트 크기와
+    /// 같게 유지된다. 순수·테스트용: `testSpriteContentsScaleFollowsTheBitmapNotTheScreen`.
+    nonisolated static func spriteContentsScale(pixelWidth: Int, pointWidth: CGFloat) -> CGFloat {
+        max(1, CGFloat(pixelWidth) / max(pointWidth, 1))
+    }
+
+    /// 폭만 확보하는 투명 자리표시자 — 실제 픽셀은 `spriteLayer` 가 그린다.
+    /// 이미지를 아예 비우지 않는 이유: `imagePosition`·텍스트 배치·상태아이템 폭 계산을 그대로
+    /// AppKit 에 맡기기 위해서다(직접 length 를 잡으면 2줄 타이틀 배치가 어긋난다).
+    private static func transparentImage(size: NSSize) -> NSImage {
+        let img = NSImage(size: size)
+        img.lockFocus()
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        img.unlockFocus()
+        return img
+    }
+
+    /// 스프라이트 레이어를 "버튼이 이미지를 그리려던 자리"에 맞춘다. 버튼 폭은 텍스트 길이에 따라
+    /// 변하므로 텍스트를 갱신한 뒤에도 다시 불러야 한다(`applyState`).
+    private func layoutSpriteLayer() {
+        guard let button = statusItem.button, let host = button.layer else { return }
+        let bounds = button.bounds
+        guard bounds.width > 1, bounds.height > 1 else { return }   // 레이아웃 전 — 다음 갱신에 재시도
+        let rect = (button.cell as? NSButtonCell)?.imageRect(forBounds: bounds) ?? bounds
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        if spriteLayer.superlayer !== host { host.addSublayer(spriteLayer) }
+        spriteLayer.frame = rect
+        CATransaction.commit()
+        needsSpriteLayout = false
+    }
+
+    /// 상태아이템 프레임 교체. ① **diff-gate**: 같은 이미지 재대입이면 스킵 — 레이어 dirty → CA 커밋 →
     /// WindowServer 디스플레이 사이클 왕복(= idle wakeup)을 제거한다(배터리). 단일프레임 스프라이트·중복
     /// advanceMenu 패스에서 같은 프레임을 반복 대입하던 것을 걸러낸다(애니메이션 프레임은 서로 다른 객체라
     /// 정상 통과). ② **암묵적 CA 전환 억제**: 레이어 백드 NSStatusBarButton 은 대입마다 NSStatusItemScene
     /// 전환 애니메이션을 돌려 상태바를 재합성한다(측정: idle CPU 주범) → setDisableActions 로 전환 없이 즉시 반영.
-    private func setStatusImage(_ image: NSImage?) {
+    /// ③ **드로잉 경로 회피**: 프레임 픽셀은 `button.image` 가 아니라 `spriteLayer.contents` 로 넣는다.
+    /// `button.image` 대입은 버튼 전체(2줄 타이틀 텍스트 포함)를 다시 그리게 하지만 contents 교체는
+    /// 비트맵을 바꿔 끼울 뿐이다 — 실측 2.00ms → 0.27ms/프레임(`spriteLayer` 주석). ②는 그대로 유지된다:
+    /// 자리표시자 대입과 레이어 변경 모두 전환 억제 트랜잭션 안에서 일어난다.
+    private func setStatusImage(_ image: NSImage?, cgFrame: CGImage?) {
         guard image !== lastStatusImage else { return }
         lastStatusImage = image
+        guard let button = statusItem.button else { return }
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        statusItem.button?.image = image
-        CATransaction.commit()
+        defer { CATransaction.commit() }
+
+        guard let image, let cgFrame else {
+            // 이미지 없음/변환 실패 — 기존 button.image 경로로 폴백하고 레이어는 비운다.
+            spriteLayer.isHidden = true
+            spriteLayer.contents = nil
+            placeholderSize = nil
+            button.image = image
+            return
+        }
+        if placeholderSize != image.size {   // 폭이 바뀔 때만 자리표시자 재대입 → 레이아웃 유발 최소화
+            placeholderSize = image.size
+            button.image = Self.transparentImage(size: image.size)
+            needsSpriteLayout = true
+        }
+        spriteLayer.isHidden = false
+        spriteLayer.contentsScale = Self.spriteContentsScale(
+            pixelWidth: cgFrame.width, pointWidth: image.size.width)
+        spriteLayer.contents = cgFrame
+        if needsSpriteLayout { layoutSpriteLayer() }
     }
 
     /// 현재 프레임을 메뉴바에 올리고, 그 프레임의 delay 후 다음 프레임 예약(자기 재예약).
@@ -315,8 +419,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         menuTimer?.invalidate()
         menuTimer = nil
         guard !menuFrames.isEmpty else { return }
-        let frame = menuFrames[menuIndex % menuFrames.count]
-        setStatusImage(frame.image)   // 현재 프레임은 항상 반영(정지 중에도 올바른 스프라이트). 전환 억제 대입.
+        let index = menuIndex % menuFrames.count
+        let frame = menuFrames[index]
+        // 현재 프레임은 항상 반영(정지 중에도 올바른 스프라이트). 전환 억제 + 레이어 contents 교체.
+        setStatusImage(frame.image, cgFrame: menuLayerFrames.indices.contains(index) ? menuLayerFrames[index] : nil)
         // 화면 꺼짐/메뉴바 가림(occlusion) 또는 단일 프레임이면 다음 프레임 예약 안 함 → 정지(낭비 제거).
         guard menuShouldAnimate, menuFrames.count > 1 else { return }
         let timer = Timer(timeInterval: frame.delay, repeats: false) { [weak self] _ in

--- a/Tests/PokeTokenBarTests/SpriteAspectRatioTests.swift
+++ b/Tests/PokeTokenBarTests/SpriteAspectRatioTests.swift
@@ -121,6 +121,39 @@ final class SpriteAspectRatioTests: XCTestCase {
         XCTAssertEqual(composed.size.height, expected.height, accuracy: 0.001)
     }
 
+    /// Menu bar frames are handed to `spriteLayer.contents`, which is what keeps a frame swap off the
+    /// view drawing path (measured 2.00ms -> 0.27ms per frame). If the conversion ever returns nil,
+    /// `setStatusImage` falls back to `button.image` and that saving disappears **silently** — the
+    /// animation still looks correct, so nothing but this test would catch it.
+    @MainActor
+    func testMenuBarFramesConvertToLayerBitmaps() {
+        for source in [Self.spoinkGIF, Self.pikachuGIF, Self.staticPNG] {
+            for up in [false, true] {
+                let composed = AppDelegate.menuBarImage(from: Self.solidImage(size: source), up: up)
+                guard let bitmap = AppDelegate.cgFrame(from: composed) else {
+                    XCTFail("cgFrame nil for \(source) up=\(up) — the layer path would fall back")
+                    continue
+                }
+                XCTAssertGreaterThanOrEqual(CGFloat(bitmap.width), composed.size.width - 0.001,
+                                           "bitmap must hold at least 1 pixel per point (source=\(source))")
+            }
+        }
+        // Fault injection: the assertion above is only meaningful if the conversion *can* fail.
+        // An empty image has no representation to rasterize, so nil is reachable.
+        XCTAssertNil(AppDelegate.cgFrame(from: NSImage(size: .zero)),
+                     "if this ever converts, the guard above stopped being able to fail")
+    }
+
+    /// `contentsScale` must follow the bitmap's own pixel/point density, not the current screen.
+    /// Frames are baked by `lockFocus` at the backing scale in effect when they were composed, so
+    /// reading the scale off the screen would double the sprite after a move to a 1x display.
+    func testSpriteContentsScaleFollowsTheBitmapNotTheScreen() {
+        XCTAssertEqual(AppDelegate.spriteContentsScale(pixelWidth: 44, pointWidth: 22), 2, accuracy: 0.001)
+        XCTAssertEqual(AppDelegate.spriteContentsScale(pixelWidth: 22, pointWidth: 22), 1, accuracy: 0.001)
+        // A zero-width canvas must not yield 0 (a 0 scale makes the layer vanish) or divide by zero.
+        XCTAssertEqual(AppDelegate.spriteContentsScale(pixelWidth: 0, pointWidth: 0), 1, accuracy: 0.001)
+    }
+
     /// `SpriteView` sizes its image through the same helper, so the popover header, evolution line
     /// and dex thumbnails cannot drift from the menu bar.
     @MainActor

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -494,6 +494,29 @@ read_when:
   이고, 더 부드러운 쪽은 opt-in 이다).
   배터리-vs-AC/thermal 적응·CADisplayLink
   전환은 1인 로컬 노트북 기준 수확체감으로 판정, 미도입(필요 시 Agent Team 계획 참조). (Agent Team 조사 + 실측, 2026-07-22.)
+- **프레임 교체는 `button.image` 대입이 아니라 `spriteLayer.contents` 로 한다 — 전환 억제와 다른 축이다.**
+  `setDisableActions` 는 NSStatusItemScene *전환 애니메이션* 을 없앨 뿐, 대입 자체가 유발하는 **버튼
+  재드로잉**(`NSViewBackingLayer display` → `_NSViewDrawRect`)은 그대로 남는다. 그 재드로잉에는 스프라이트
+  22px 뿐 아니라 **2줄 attributedTitle 텍스트 렌더**가 통째로 포함돼, 5fps 루프에서 상시로 깔린다.
+  프레임 픽셀을 전용 서브레이어(`AppDelegate.spriteLayer`)의 `contents` 로 넣으면 이미 업로드된 비트맵을
+  바꿔 끼우는 것뿐이라 드로잉 경로를 아예 타지 않는다. `button.image` 는 폭 확보용 **투명 자리표시자**만
+  두고(크기가 바뀔 때만 재대입) `imagePosition`·텍스트 배치·상태아이템 폭 계산은 AppKit 에 그대로 맡긴다.
+  **실측** — ① A/B 프로브(같은 타이머·5fps·2줄 타이틀·60초×2라운드, `/tmp/ptb-probe.swift` 형태):
+  `button.image`+CATransaction 2.00ms/프레임 · CATransaction 없이 3.51ms · **`layer.contents` 0.27ms**.
+  ② 라이브 앱 `sample` 전후(메인스레드 샘플 비중): 타이머 경로 235/17212(1.37%) → 33/16581(0.20%),
+  `CA::Transaction::commit` 163 → 14, `_NSViewDrawRect` 105 → **0**. 타이틀을 끄고 재면 2.00 → 1.43ms 라
+  텍스트 렌더는 기여분의 일부일 뿐이고 나머지는 뷰 드로잉 왕복 자체다(= 텍스트만 손봐선 안 없어진다).
+  `contentsScale` 은 화면이 아니라 **비트맵 자신의 픽셀/포인트 비율**을 따라야 한다 — 프레임은 `lockFocus`
+  합성 시점의 백킹 스케일로 픽셀이 굳으므로, 화면에서 읽으면 1x 외부 모니터에서 스프라이트가 2배가 된다.
+  **5-whys(왜 여태 안 보였나):** ① 14%→2% 를 만든 주범(CA 전환·팝오버 상주)이 워낙 커서, 남은 2% 는
+  "프레임 수에 비례하는 어쩔 수 없는 비용"으로 읽혔다 — 실제로는 성격이 다른 축이 하나 더 있었다.
+  ② 판정을 CPU% 로만 해서 "2% 면 충분히 낮다"에서 멈췄다. 콜스택을 뜨자 그 2% 안에서 드로잉 경로가
+  단일 최대 항목으로 드러났다(추정이 아니라 `sample` 로 봐야 보이는 층). ③ fps·tolerance 처럼 *얼마나
+  자주* 축만 튜닝 대상으로 보고, *한 번에 얼마나 비싼가* 축은 손댈 수 없는 상수로 취급했다.
+  **회귀 방지:** 변환이 실패하면 `setStatusImage` 가 조용히 `button.image` 폴백으로 떨어져 애니메이션은
+  멀쩡해 보이는 채로 절감만 사라진다(무성 실패) → `testMenuBarFramesConvertToLayerBitmaps` 가 전 스프라이트
+  형태·bob 위상에서 변환을 못 박고, 빈 이미지로 **nil 이 실제 도달 가능함**까지 함께 단언한다(주입 검증).
+  스케일은 `testSpriteContentsScaleFollowsTheBitmapNotTheScreen`. (실측 2026-09-01.)
 - **fps 캡은 hold 가 아니라 decimate 다 — `max(floor, delay)` 는 애니메이션을 슬로모션으로 만든다.**
   프레임 delay 에 하한을 걸면(`max(floor, delay)`) 프레임 *수* 는 그대로라 각 프레임이 늘어나고, 결과적으로
   **루프 전체가 느려진다.** Gen-V 스프라이트는 55프레임×0.05s(=2.75s, 20fps)라 floor 0.4s 에서 22s 루프


### PR DESCRIPTION
## Problem

Profiling the live app with `sample` showed **235 of 17212 main-thread samples (1.37%)** sitting in the menu bar animation timer, and **163 of those** in `CA::Transaction::commit()` → `NSViewBackingLayer display` → `_NSViewDrawRect`.

Assigning `button.image` redraws the entire `NSStatusBarButton`. That redraw includes the **two-line attributed title**, not just the 22px sprite — so at the default `balanced` setting (5fps) the usage text is re-rendered five times a second, forever.

This is a **different axis** from the existing `setDisableActions` rule in `defect-log.md`. That rule removes the `NSStatusItemScene` *transition animation* and is still necessary; it does nothing about the redraw itself. Because the earlier 14% → 2% fix was so large, the remainder read as "cost proportional to frame count" and the drawing path was never separated out.

## Change

Frame pixels now go to a dedicated sublayer's `contents` instead of `button.image`:

- `spriteLayer` holds the frame bitmap; swapping `contents` never enters the view drawing path.
- `button.image` keeps a **transparent placeholder** so AppKit still owns `imagePosition`, title layout and status item width. It is reassigned only when the sprite size changes.
- Bitmaps are converted once when frames are prepared, not per frame (converting per frame measured 0.54 ms — double).
- `contentsScale` follows the **bitmap's own pixel/point ratio**, not the screen, so a frame composed at 2x is not doubled after a move to a 1x display.

Everything that already controlled this surface is kept: transition suppression, the diff-gate, display-sleep / popover-open gating, the fps floor and its Low Power Mode cap.

## Measurements

A/B probe — same timer, 5fps, two-line title, 60s × 2 rounds, only the assignment path differs:

| path | per frame |
|---|---|
| `button.image` + CATransaction (before) | 2.00 ms |
| `button.image` alone | 3.51 ms |
| **`layer.contents`** | **0.27 ms** |

Live app before/after (`sample`, main thread):

| | before | after |
|---|---|---|
| timer path | 235/17212 (1.37%) | **33/16581 (0.20%)** |
| `CA::Transaction::commit` | 163 | **14** |
| `_NSViewDrawRect` | 105 | **0** |

Process CPU: 1.55% (17h average, includes interaction) → **0.486%** (7 min idle window). The conditions differ, so the controlled −85% above is the number to trust.

Note that **wakeup frequency is unchanged** — the timer still runs at the user's chosen fps. What dropped is the work done per wakeup.

## Visual verification

No visual change. Sprite bounding box measured from menu bar captures: **21×36 px before, 20×37 px after** (2x pixels) — the 1px difference is bob phase, not size. Text layout and the limit line render identically.

## Tests

`swift test` — 905 passing, 0 failures (903 existing + 2 new).

If `cgFrame` conversion ever returns nil, `setStatusImage` falls back to `button.image` and the saving disappears **while the animation still looks correct** — a silent failure nothing else would catch. `testMenuBarFramesConvertToLayerBitmaps` pins the conversion for every sprite shape and bob phase, and asserts nil is genuinely reachable (empty image) so the guard cannot quietly stop being able to fail. `testSpriteContentsScaleFollowsTheBitmapNotTheScreen` covers the scale rule.
