### PR TITLE
chore: drop stale ccusage references from runtime comments

### DIFF
--- a/Sources/PokeTokenBar/Core/BinaryLocator.swift
+++ b/Sources/PokeTokenBar/Core/BinaryLocator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// CLI 바이너리(ccusage, codex 등) 절대경로 탐색.
+/// CLI 바이너리(codex, brew 등) 절대경로 탐색.
 /// GUI 앱(launchd 실행)은 사용자 셸 PATH 를 상속하지 않아, Homebrew 외 버전매니저
 /// (mise/nvm/fnm/asdf/volta/bun)로 설치한 도구를 하드코딩 경로만으로는 못 찾는다.
 /// 전략: 수동 지정(UserDefaults "<binary>Path") → 정적 경로(빠름) → 로그인+인터랙티브 셸 PATH 해석.

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -554,7 +554,7 @@ final class UsageStore {
         ) { [weak self] _ in
             Task { @MainActor in await self?.refresh() }
         }
-        // 디스플레이 꺼짐 → 폴링(ccusage 서브프로세스 spawn) 일시정지, 켜짐 → 재개 + 즉시 갱신 (배터리)
+        // 디스플레이 꺼짐 → 폴링(로그 파싱 + 한도 조회 + codex 서브프로세스) 일시정지, 켜짐 → 재개 + 즉시 갱신 (배터리)
         NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.screensDidSleepNotification, object: nil, queue: .main
         ) { [weak self] _ in
@@ -583,7 +583,7 @@ final class UsageStore {
         timer = t
     }
 
-    /// 디스플레이 꺼짐 → 폴링 타이머 정지(예약된 ccusage 서브프로세스 spawn 중단).
+    /// 디스플레이 꺼짐 → 폴링 타이머 정지(예약된 로그 파싱·한도 조회 중단).
     private func suspendPolling() {
         pollingSuspended = true
         timer?.invalidate()
@@ -606,7 +606,7 @@ final class UsageStore {
         // Claude 한도가 다음 수동 액션까지 빈 채로 남던 회귀 방지.
         if isRefreshing { refreshPending = true; return }
         isRefreshing = true
-        // App Nap 방지 — 백그라운드 스로틀로 ccusage 가 타임아웃되는 것을 막는다 (시스템 슬립은 허용)
+        // App Nap 방지 — 백그라운드 스로틀로 로그 파싱·codex 조회가 타임아웃되는 것을 막는다 (시스템 슬립은 허용)
         let activity = ProcessInfo.processInfo.beginActivity(
             options: .userInitiatedAllowingIdleSystemSleep, reason: "PokeTokenBar usage refresh")
         defer {


### PR DESCRIPTION
## What

ccusage was dropped in b762be9 (shipped in **v2.1.0**) and the app has parsed local logs directly ever since. Four comments still describe the refresh path as spawning it.

| file | before | after |
|---|---|---|
| `UsageStore.swift:557` | 폴링(**ccusage 서브프로세스 spawn**) 일시정지 | 폴링(로그 파싱 + 한도 조회 + codex 서브프로세스) 일시정지 |
| `UsageStore.swift:586` | 예약된 **ccusage 서브프로세스 spawn** 중단 | 예약된 로그 파싱·한도 조회 중단 |
| `UsageStore.swift:609` | 백그라운드 스로틀로 **ccusage**가 타임아웃 | 로그 파싱·codex 조회가 타임아웃 |
| `BinaryLocator.swift:3` | CLI 바이너리(**ccusage**, codex 등) | CLI 바이너리(codex, brew 등) |

`BinaryLocator` resolves `codex` and `brew` — it has no ccusage call site.

## Why it matters

These are load-bearing comments: they explain why polling is suspended on display sleep and why App Nap is disabled, so a reader takes them at face value. During a battery investigation they sent me looking for a per-refresh ccusage spawn that does not exist.

## Deliberately kept

Twelve other ccusage mentions stay — each records *why* a value or shape is what it is, and deleting them loses that:

- `ModelPricing` — the pricing table was reverse-derived from ccusage (0.000% fit error)
- `Models` — the JSON shapes originated there
- `LocalUsageProvider` / `LocalUsageReader` — "replaces ccusage" context
- `scripts/parity-check.sh` — an intentional cross-check tool
- `Tests/BinaryLocatorTests` — ccusage paths are just fixture input for a generic resolver

## Note on the release gate

`scripts/release.sh` already warns about removed-dependency residue, but scans `README*.md` only, so it never saw these. **Widening it to sources is not recommended** — the twelve legitimate mentions above would fire as false positives on every release, which is how a gate turns into a formality. The user-facing scope it has now is the right one.
