### PR TITLE
feat: keep shop egg cards visible during the egg stage with a disabled buy button

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -691,9 +691,13 @@ final class CompanionStore {
             }
     }
 
-    /// 상점 표시 순서 — 판매 아이템 + (활성 포켓몬 있을 때) 알 3종을 하나의 가격 오름차순 목록으로 병합.
+    /// 상점 표시 순서 — 판매 아이템 + 알 3종을 하나의 가격 오름차순 목록으로 병합.
     /// 정렬 규칙은 purchasableItems 와 동일: 구매 완료한 보유형은 맨 아래, 나머지는 가격 저렴한 순.
     /// 알은 즉시 액션이라 '보유' 개념이 없어 가격 순서에만 참여한다.
+    ///
+    /// 알은 활성 포켓몬이 없어도(알 상태) 목록에 남는다 — 구매는 `canBuyEgg` 의 `hasActive` 게이트가
+    /// 막고, EggCard 가 비활성 버튼 + 사유 한 줄로 보여준다. 목록에서 통째로 빼면 "상점에 알이 원래
+    /// 없다"로 읽혀서, 게이트는 유지하되 존재는 계속 보이게 한다.
     ///
     /// 등급 알끼리 붙여 '티어 사다리'로 묶어 보이게 하는 안도 검토했으나 채택하지 않았다 — 지금의 순수
     /// 가격 오름차순은 "알이 무조건 맨 아래로 append 돼 더 비싼 부적보다 아래에 놓이던" 표시 회귀를
@@ -701,7 +705,7 @@ final class CompanionStore {
     /// 카드의 등급 배지로 읽히게 한다.
     var shopEntries: [ShopEntry] {
         var entries: [ShopEntry] = purchasableItems.map { ShopEntry.item($0) }
-        if hasActive { entries += FreshEgg.shopTiers.map { ShopEntry.egg($0) } }
+        entries += FreshEgg.shopTiers.map { ShopEntry.egg($0) }
         return entries.sorted { a, b in
             let aDone = isPurchasedPassive(a)
             let bDone = isPurchasedPassive(b)
@@ -748,6 +752,7 @@ final class CompanionStore {
     /// 알 구매 가능 — 폐기할 활성 포켓몬이 있고 지갑이 그 티어 가격 이상일 때만.
     /// 알 상태에서도 살 수 있게 하는 안은 채택하지 않았다(기존 새 알과 게이트 통일) — 알끼리 교체하는
     /// 동작을 새로 만들지 않고, 상점의 알은 언제나 "지금 개체를 놓아주고 다시 뽑는다"는 한 가지 의미만 갖는다.
+    /// 항목 자체는 알 상태에서도 상점에 남는다(shopEntries) — 이 게이트는 구매만 막는다.
     func canBuyEgg(_ tier: Rarity?) -> Bool {
         // 파는 티어인지 먼저 확인한다 — 만족 불가능한 보증(전설: capture_rate 로 표현 불가)을 사면
         // 두 롤 경로 모두 후보가 0개라 알이 영영 안 깨지고, 부화가 없으니 보증도 안 풀리며,

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -854,6 +854,16 @@ struct L {
                  "Solte seu Pokémon atual e ganhe um ovo que garante \(r) ou melhor.",
                  "Verabschiede dein aktuelles Pokémon und erhalte ein Ei, aus dem garantiert ein Pokémon der Seltenheitsstufe \(r) oder höher schlüpft.")
     }
+    /// 알 상태의 상점 알 카드 비활성 사유 — 항목은 보이되 구매 버튼 아래에 한 줄로 붙는다(EggCard).
+    var eggShopLockedHint: String {
+        t("지금 품고 있는 알이 부화하면 살 수 있어요.",
+          "Available once your current egg hatches.",
+          "いま抱えているタマゴが孵ると購入できます。",
+          "Disponible cuando eclosione tu huevo actual.",
+          "Disponible une fois ton œuf actuel éclos.",
+          "Disponível quando seu ovo atual chocar.",
+          "Verfügbar, sobald dein aktuelles Ei geschlüpft ist.")
+    }
     /// 인큐베이션 중 표시하는 보증 배지 — 어떤 알을 품고 있는지 한 줄로.
     func eggGuaranteeHint(_ tier: Rarity) -> String {
         let r = rarityLabel(tier)

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -15,7 +15,8 @@ struct ShopView: View {
             VStack(alignment: .leading, spacing: 10) {
                 walletHeader(l)
                 // shopEntries = 판매 아이템 + 알 3종(보증 없음·고급 이상·희귀 이상)을 가격 오름차순으로
-                // 병합한 단일 목록. 알은 활성 포켓몬이 있을 때만 포함된다(즉시 액션이라 ItemKind 가 아님).
+                // 병합한 단일 목록. 알은 항상 포함되고(즉시 액션이라 ItemKind 가 아님), 알 상태에선
+                // EggCard 가 구매만 비활성으로 보여준다.
                 ForEach(store.shopEntries, id: \.self) { entry in
                     switch entry {
                     case .item(let kind):
@@ -125,6 +126,7 @@ private struct ShopItemCard: View {
 
 /// 알 카드 — 구매 = 즉시 현재 포켓몬 폐기 후 새 알로. `tier` 는 보증 등급 하한(nil = 보증 없는 기본 알).
 /// 인라인 2단계 확인: 일반은 1회, 이로치면 한 번 더(사고 폐기 방지). 성공하면 Home 으로 전환해 새 알을 보여준다.
+/// 알 상태(활성 없음)에서도 카드는 노출하되 구매 버튼만 비활성 + 사유 한 줄(eggShopLockedHint).
 ///
 /// 등급 알의 시각 구분은 **카드의 등급 배지**로만 한다 — 알 스프라이트는 한 장뿐이고, 메뉴바·플로팅 펫은
 /// 기존 알 그대로 둔다(새 에셋 없이 구분이 서는 최소 범위).
@@ -174,15 +176,27 @@ private struct EggCard: View {
     private func controls(_ l: L) -> some View {
         switch stage {
         case .idle:
-            HStack {
-                Text("\(l.shopPriceLabel) \(TokenFormatter.compact(price))")
-                    .font(.caption2).foregroundStyle(.tertiary).monospacedDigit()
-                Spacer()
-                if store.canBuyEgg(tier) {
-                    Button(l.buy) { stage = .confirm }
-                        .buttonStyle(.bordered).controlSize(.small)
-                } else {
-                    Text(l.notEnoughTokens).font(.caption2).foregroundStyle(.tertiary)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("\(l.shopPriceLabel) \(TokenFormatter.compact(price))")
+                        .font(.caption2).foregroundStyle(.tertiary).monospacedDigit()
+                    Spacer()
+                    if !store.hasActive {
+                        // 알 상태 — 리롤 대상이 없어 구매만 막는다(canBuyEgg 게이트). 항목을 숨기는 대신
+                        // 비활성 버튼으로 "상점에 있긴 하다"를 보이고, 사유는 아래 한 줄로.
+                        Button(l.buy) {}
+                            .buttonStyle(.bordered).controlSize(.small).disabled(true)
+                    } else if store.canBuyEgg(tier) {
+                        Button(l.buy) { stage = .confirm }
+                            .buttonStyle(.bordered).controlSize(.small)
+                    } else {
+                        Text(l.notEnoughTokens).font(.caption2).foregroundStyle(.tertiary)
+                    }
+                }
+                if !store.hasActive {
+                    Text(l.eggShopLockedHint)
+                        .font(.caption2).foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
         case .confirm:

--- a/Tests/PokeTokenBarTests/ShopTests.swift
+++ b/Tests/PokeTokenBarTests/ShopTests.swift
@@ -169,14 +169,24 @@ final class ShopTests: XCTestCase {
         XCTAssertEqual(prices, prices.sorted(), "가격 상수가 바뀌어도 오름차순 불변식 유지")
     }
 
-    /// 활성 포켓몬이 없으면(알 상태) 리롤 대상이 없어 알은 **등급 알까지 전부** 목록에서 빠진다.
-    /// 프리미엄 알만 알 상태에서 살 수 있게 하는 안은 채택하지 않았다 — 기존 새 알과 게이트를 통일한다.
-    func testShopEntriesOmitsFreshEggWhenNoActive() {
-        let s = store(used: 5_000_000_000)   // active 없음
+    /// 활성 포켓몬이 없어도(알 상태) 알 3종은 목록에 **남는다** — 숨기면 "상점에 알이 원래 없다"로
+    /// 읽힌다. 대신 구매는 `canBuyEgg` 의 `hasActive` 게이트가 전부 막는다(EggCard 는 비활성 버튼 +
+    /// 사유 한 줄). 잔액이 충분한 상태로 검증해 게이트가 잔액이 아니라 hasActive 에서 걸림을 확인한다.
+    func testShopEntriesKeepsEggsVisibleButUnbuyableWhenNoActive() {
+        let s = store(used: 5_000_000_000)   // active 없음, 잔액은 전 티어 가격 이상
         XCTAssertFalse(s.hasActive)
-        XCTAssertEqual(s.shopEntries, [.item(.mint), .item(.rareCandy), .item(.shinyCharm)])
+        XCTAssertEqual(s.shopEntries,
+                       [.item(.mint),        // 100M
+                        .item(.rareCandy),   // 500M
+                        .egg(nil),           // 1B
+                        .egg(.uncommon),     // 2.5B
+                        .item(.shinyCharm),  // 3B
+                        .egg(.rare)])        // 4B
         for tier in FreshEgg.shopTiers {
-            XCTAssertFalse(s.shopEntries.contains(.egg(tier)), "알 상태에선 \(tier?.rawValue ?? "기본") 알도 미노출")
+            XCTAssertTrue(s.shopEntries.contains(.egg(tier)), "알 상태에서도 \(tier?.rawValue ?? "기본") 알은 노출 유지")
+            XCTAssertFalse(s.canBuyEgg(tier), "노출은 되지만 \(tier?.rawValue ?? "기본") 알 구매는 hasActive 게이트로 차단")
+            XCTAssertFalse(s.buyEgg(tier), "buyEgg 도 no-op — 토큰이 빠져나가면 안 된다")
         }
+        XCTAssertEqual(s.availableTokens, 5_000_000_000, "차단된 구매 시도로 잔액이 줄지 않는다")
     }
 }


### PR DESCRIPTION
## What

During the egg stage the shop dropped all three egg cards from the list entirely, which read as "the shop doesn't sell eggs" rather than "you can't buy one right now". The egg cards now stay visible at all times; only the purchase is gated.

The purchase gate itself is intended and unchanged: a shop egg always means "release the current Pokemon and reroll", so there is nothing to reroll while incubating. `canBuyEgg` still requires an active Pokemon, and a blocked `buyEgg` remains a no-op that never touches the wallet.

## Changes

- `CompanionStore.shopEntries` no longer filters eggs by `hasActive`; the price-ascending merge order is unchanged.
- `EggCard` shows a disabled Buy button during the egg stage, with a one-line reason underneath ("Available once your current egg hatches."), localized in all seven languages (en/ko/ja/es/fr/pt/de). The state reason takes priority over the insufficient-balance label.
- The old "eggs omitted when no active" test is replaced by one pinning the new contract: eggs stay visible, `canBuyEgg`/`buyEgg` stay blocked for every tier, and a blocked attempt does not change the balance. The store is seeded with enough tokens so the gate demonstrably trips on `hasActive`, not on price.

## UI

Egg-stage shop card, per egg tier:

- Price row unchanged on the left.
- Buy button rendered disabled (instead of the card disappearing).
- Caption line below the row: "Available once your current egg hatches."

With an active Pokemon the card behaves exactly as before (enabled Buy, or "Not enough tokens" when the balance is short).

## Verification

- Full test suite: 905 tests, 0 failures.
- Rendered the egg-stage ShopView offscreen and visually confirmed the three egg cards, the dimmed Buy buttons, and the hint line.

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>
