### PR TITLE
fix: resolve the codex binary bundled inside ChatGPT.app for limit display

### DIFF
--- a/Sources/PokeTokenBar/Core/CodexRateLimitsProvider.swift
+++ b/Sources/PokeTokenBar/Core/CodexRateLimitsProvider.swift
@@ -21,6 +21,10 @@ struct CodexRateLimitsProvider: CodexLimitsProviding {
             "\(home)/.codex/bin/codex",
             "/opt/homebrew/bin/codex",
             "/usr/local/bin/codex",
+            // ChatGPT.app bundles the codex CLI; users on the desktop app often have
+            // no standalone install, so this is the only resolvable path for them.
+            // Listed last so dedicated installs win over the bundled copy.
+            "/Applications/ChatGPT.app/Contents/Resources/codex",
         ]
     }
 


### PR DESCRIPTION
## Problem

Users who run Codex through the ChatGPT desktop app see Codex **usage** in the popover but no Codex **limit** row.

## Cause

Usage and limits come from different sources:

- Usage: parsed from `~/.codex/sessions` logs — works for any Codex install form, since the desktop app writes session logs there too.
- Limits: fetched by spawning the codex CLI (`codex app-server --stdio` → `account/rateLimits/read`). `CodexRateLimitsProvider.defaultBinaryCandidates` covers `Codex.app`, `~/.codex/bin`, Homebrew paths, version-manager shims, and login-shell PATH — but not the CLI bundled inside ChatGPT.app. With no standalone install, resolution fails and the app logs `codex limits skipped: codex binary not found` on every refresh, so the limit row never renders.

## Fix

Add `/Applications/ChatGPT.app/Contents/Resources/codex` as the **last** static candidate. Dedicated installs (Codex.app bundle, `~/.codex/bin`, Homebrew) keep precedence; the bundled copy is only a fallback for desktop-app-only users.

## Verification

- Probed the bundled binary (codex-cli 0.149.0-alpha.4.3) with the exact JSON-RPC sequence the provider sends: it answers `account/rateLimits/read` with a normal snapshot (usedPercent, 7-day window, plan type).
- `swift build` + full test suite: 905 tests, 0 failures.
- Resolution logic is a sequential `isExecutableFile` scan, so an existing bundled binary is picked up with no other behavior change. Class sweep: `BinaryLocator.resolve` has only one other call site (`brew` in UpdateChecker), which has no GUI-bundled variant.
