### PR TITLE
feat: back up the save to iCloud Drive and restore it on another Mac

### DIFF
--- a/Sources/PokeTokenBar/Core/AppStatePaths.swift
+++ b/Sources/PokeTokenBar/Core/AppStatePaths.swift
@@ -4,16 +4,42 @@ import Foundation
 /// `PTB_STATE_DIR` overrides the default for development/QA isolation.
 enum AppStatePaths {
     static func directory() -> URL {
-        let override = (ProcessInfo.processInfo.environment["PTB_STATE_DIR"] ?? "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let dir: URL
-        if !override.isEmpty {
-            dir = URL(fileURLWithPath: override, isDirectory: true)
-        } else {
-            dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-                .appendingPathComponent("PokeTokenBar")
-        }
+        let dir = overrideDirectory("PTB_STATE_DIR") ?? FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("PokeTokenBar")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
+    }
+
+    /// iCloud Drive 안의 세이브 백업 폴더. `PTB_ICLOUD_DIR` 은 두 번째 기기 없이 동기화를 확인하기
+    /// 위한 개발/QA override 다(`PTB_STATE_DIR` 과 같은 규약).
+    ///
+    /// 여기 두는 이유는 위치가 아니라 **테스트 게이트**다 — `UsageEnvironmentTests`
+    /// `.testNoProviderReadsUsageLocationEnvDirectly` 가 `Sources/` 를 스캔해 프로세스 환경 직독을
+    /// 실패시키고, 그 허용 목록에 이 파일이 이미 들어 있다. 새 파일에서 읽으면 그 스캔에 걸린다.
+    ///
+    /// `directory()` 와 달리 **폴더를 만들지 않는다.** 동기화를 켜지 않은 사용자의 iCloud Drive 에
+    /// 빈 폴더를 남기지 않기 위해서다 — 생성은 실제로 쓰는 시점(`ICloudSaveMirror`)에서 한다.
+    /// 반환 nil = iCloud Drive 가 꺼져 있음(그 경로 자체가 없다).
+    static func iCloudDirectory() -> URL? {
+        if let override = overrideDirectory("PTB_ICLOUD_DIR") {
+            return override.appendingPathComponent("PokeTokenBar")
+        }
+        // 엔타이틀먼트가 없으므로 `FileManager.url(forUbiquityContainerIdentifier:)` 는 쓸 수 없다
+        // (프로비저닝 프로파일이 필요해 자체서명 빌드에서는 nil 을 돌려준다). 샌드박스가 아니라서
+        // iCloud Drive 실경로에 그냥 쓰면 되고, 그 폴더의 존재가 곧 "iCloud Drive 켜짐"이다.
+        let root = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Mobile Documents/com~apple~CloudDocs")
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDir), isDir.boolValue else {
+            return nil
+        }
+        return root.appendingPathComponent("PokeTokenBar")
+    }
+
+    private static func overrideDirectory(_ name: String) -> URL? {
+        let value = (ProcessInfo.processInfo.environment[name] ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : URL(fileURLWithPath: value, isDirectory: true)
     }
 }

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -42,6 +42,8 @@ final class CompanionStore {
     private let fileURL: URL
     private var rng: any RandomNumberGenerator
     private let dittoDisguiseRollingEnabled: Bool
+    /// iCloud Drive 자동 백업. 게이트(켜짐·간격·내용 변경)는 전부 이 객체 안에 있다.
+    let iCloudMirror: ICloudSaveMirror
     /// 세션 내 활성 개체 교체 감지용. await 뒤 이전 개체의 결과가 새 개체를 덮지 않게 한다.
     private var activeGeneration = 0
 
@@ -49,12 +51,14 @@ final class CompanionStore {
          clock: @escaping () -> Date = Date.init,
          fileURL: URL? = nil,
          rng: any RandomNumberGenerator = SystemRandomNumberGenerator(),
-         dittoDisguiseRollingEnabled: Bool = AppEnv.isBundledApp) {
+         dittoDisguiseRollingEnabled: Bool = AppEnv.isBundledApp,
+         iCloudMirror: ICloudSaveMirror = ICloudSaveMirror()) {
         self.provider = provider
         self.clock = clock
         self.fileURL = fileURL ?? Self.defaultURL()
         self.rng = rng
         self.dittoDisguiseRollingEnabled = dittoDisguiseRollingEnabled
+        self.iCloudMirror = iCloudMirror
         load()
         refreshRepresentativeSubject()
         if state.active != nil { displayState = .idle }
@@ -1242,5 +1246,10 @@ final class CompanionStore {
         refreshRepresentativeSubject()
         guard let data = try? JSONEncoder().encode(state) else { return }
         try? data.write(to: fileURL, options: .atomic)   // 부분 쓰기 손상 방지(펫 상태)
+        // iCloud 백업은 로컬 저장 **뒤**에 온다 — 로컬 파일이 원본이고, 백업 실패가 저장을 막으면 안 된다.
+        // 여기 `data` 를 넘기지 않는 이유는 ICloudSaveMirror.canonicalStateEncoding 주석 참조
+        // (기본 JSONEncoder 는 키 순서를 보장하지 않아 변경 판정에 못 쓴다).
+        iCloudMirror.mirror(state: state, appVersion: SaveTransfer.appVersion,
+                            deviceName: SaveTransfer.deviceName, now: clock())
     }
 }

--- a/Sources/PokeTokenBar/Core/ICloudSaveMirror.swift
+++ b/Sources/PokeTokenBar/Core/ICloudSaveMirror.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Observation
+
+/// iCloud Drive 세이브 백업 — 이 Mac 의 진행을 iCloud Drive 폴더에 자동으로 복사해 두고,
+/// 다른 Mac 이 **사용자가 명시적으로 누를 때** 그걸 복원한다.
+///
+/// ## 왜 CloudKit 이 아닌 그냥 파일인가
+/// CloudKit·`NSUbiquitousKeyValueStore`·`FileManager.url(forUbiquityContainerIdentifier:)` 는 모두
+/// 엔타이틀먼트를 요구하고, macOS 는 그걸 **유료 개발자 팀의 프로비저닝 프로파일**로 검증한다.
+/// 이 앱의 서명 신원은 `scripts/create-signing-cert.sh` 가 만드는 자체서명 인증서라(팀 ID 없음)
+/// 그 엔타이틀먼트를 실을 수 없고, 실어도 조용히 no-op 가 된다. 대신 이 앱은 **샌드박스가 아니라서**
+/// `~/Library/Mobile Documents/com~apple~CloudDocs/` 에 그냥 쓸 수 있고 iCloud Drive 데몬이 그걸
+/// 동기화한다. 엔타이틀먼트 0개로 되는 유일한 경로다.
+///
+/// ## 왜 자동 병합이 아닌가
+/// `CompanionState` 에는 병합할 수 없는 필드가 있다 — `active`(포켓몬은 하나), `eggTier`,
+/// `pendingHatchID` 는 단일값이고 `inventory`·`spentTokens` 는 개수라 델타 추적 없이 합치면
+/// 이중지출이 된다. 원격 세이브를 자동 적용하면 `defect-log.md`(프로세스·인스턴스)가 이미 기록한
+/// "저장이 last-writer-wins 가 되고 진화·사용량이 조용히 덮인다"를 **기기 사이에서**, 그것도
+/// `SingleInstance` 같은 방어 없이 재생산한다. 그래서 복원은 항상 사용자 동작이고 기존 불러오기
+/// 확인창·백업 경로를 그대로 지난다.
+///
+/// ## 왜 기기마다 파일이 따로인가
+/// 두 Mac 이 같은 파일명을 쓰면 iCloud 가 충돌 사본(`save 2.json`)을 만든다. 기기별 파일이면 충돌이
+/// **구조적으로** 불가능하고, 복원 목록이 "어느 Mac 의 세이브인지"를 말해 줄 수 있다.
+@MainActor
+@Observable
+final class ICloudSaveMirror {
+    /// 동기화 켜짐 여부(기본 꺼짐 — 게임 상태가 나가는 새 경로라 옵트인이어야 한다).
+    static let enabledKey = "iCloudSyncEnabled"
+    /// 이 Mac 의 파일명을 정하는 안정 식별자. 사용자가 Mac 이름을 바꿔도 파일이 갈라지지 않게
+    /// 표시용 이름(`SaveEnvelope.sourceDevice`)과 분리한다.
+    static let deviceIDKey = "iCloudDeviceID"
+
+    nonisolated static let fileNamePrefix = "save-"
+    nonisolated static let fileNameSuffix = ".json"
+
+    /// 쓰기 최소 간격. `CompanionStore.save()` 는 120초 새로고침마다 무조건 호출되므로 그대로 따라
+    /// 쓰면 사용량이 도는 동안 하루 최대 720회, 수백 KB 씩 올라간다.
+    ///
+    /// 별도의 트레일링 타이머는 두지 않는다 — 그 120초 하트비트 자체가 트레일링 역할을 해서, 창 안에
+    /// 생긴 변경은 창이 끝난 뒤 다음 틱에 올라간다.
+    ///
+    /// ponytail: 변경 후 5분 안에 앱을 끄면 그 변경은 다음 실행의 첫 `save()` 까지 안 올라간다.
+    /// 로컬 파일이 원본이고 백업이 한 창 + 한 번의 실행만큼 늦는 것뿐이라 감수한다. 이 앱에는
+    /// `applicationWillTerminate` 자체가 없고(`PokeTokenBarApp.swift`), 이것 때문에 만들 값은 없다.
+    /// 더 촘촘해야 하면 종료 훅이 아니라 이 상수를 내린다.
+    static let minimumWriteInterval: TimeInterval = 300
+
+    /// 복원 목록의 한 줄 — 다른 Mac 이 남긴 세이브 하나.
+    ///
+    /// 봉투를 **그대로 들고 있는다.** 목록을 만들 때 이미 읽고 검증했으므로, 복원 시점에 파일을 다시
+    /// 읽으면 코드만 늘고 위험이 붙는다 — 그 재읽기는 메인 액터에서 일어나고, 그 사이 파일이 evict
+    /// 되면 다운로드만큼 UI 가 멈춘다. 목록 만들기는 이미 액터 밖이다.
+    struct RemoteSave: Identifiable, Sendable {
+        var id: String { url.path }
+        var url: URL
+        var envelope: SaveEnvelope
+
+        var deviceName: String { envelope.sourceDevice }
+        var exportedAt: Date { envelope.exportedAt }
+        var summary: SaveSummary { SaveSummary(state: envelope.state) }
+    }
+
+    private let directory: URL?
+    private let defaults: UserDefaults
+    /// 마지막으로 올린 상태의 정규 인코딩. 변경 없는 틱을 걸러내는 게이트.
+    private var lastMirroredState: Data?
+    private var lastMirroredAt: Date?
+
+    /// 기본 디렉터리를 `AppEnv.isBundledApp` 뒤에 두는 건 **테스트 격리**다. 이게 없으면 xctest 가
+    /// 개발자의 실제 `UserDefaults` 토글과 실제 iCloud Drive 폴더를 집어, 스위트를 도는 것만으로
+    /// 본인 세이브 백업을 덮어쓴다. 주입 생성자를 쓰는 테스트는 그대로 동작한다.
+    init(directory: URL? = AppEnv.isBundledApp ? AppStatePaths.iCloudDirectory() : nil,
+         defaults: UserDefaults = .standard) {
+        self.directory = directory
+        self.defaults = defaults
+        isEnabled = defaults.object(forKey: Self.enabledKey) as? Bool ?? false
+    }
+
+    /// iCloud Drive 가 켜져 있나(그 경로가 존재하나).
+    var isAvailable: Bool { directory != nil }
+
+    /// 동기화 토글. 저장 규약은 `UsageStore` 의 다른 설정들과 같다(`didSet` 으로 기록, init 에서 읽기).
+    var isEnabled: Bool {
+        didSet { defaults.set(isEnabled, forKey: Self.enabledKey) }
+    }
+
+    /// 이 Mac 의 식별자. 처음 필요할 때 한 번 만들어 두고 계속 쓴다.
+    var deviceID: String {
+        if let existing = defaults.string(forKey: Self.deviceIDKey), !existing.isEmpty { return existing }
+        let fresh = UUID().uuidString
+        defaults.set(fresh, forKey: Self.deviceIDKey)
+        return fresh
+    }
+
+    var ownFileURL: URL? {
+        directory?.appendingPathComponent(Self.fileNamePrefix + deviceID + Self.fileNameSuffix)
+    }
+
+    /// 상태를 iCloud 폴더에 복사한다. 게이트를 통과하지 못하면 아무 일도 하지 않는다.
+    /// 반환값은 실제로 썼는지 — 테스트가 게이트를 단언하는 지점이다.
+    @discardableResult
+    func mirror(state: CompanionState, appVersion: String, deviceName: String, now: Date) -> Bool {
+        guard isEnabled, let target = ownFileURL else { return false }
+        // 간격을 **인코딩보다 먼저** 본다. 창 안에서는 정규 인코딩 비용도 안 치른다(흔한 경로).
+        if let last = lastMirroredAt, now.timeIntervalSince(last) < Self.minimumWriteInterval { return false }
+        guard let canonical = Self.canonicalStateEncoding(state) else { return false }
+        guard canonical != lastMirroredState else { return false }
+
+        let directory = target.deletingLastPathComponent()
+        do {
+            // 폴더 생성은 여기서만 — 동기화를 안 켠 사용자의 iCloud Drive 에 빈 폴더를 남기지 않는다.
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let data = try SaveTransfer.encode(state: state, appVersion: appVersion,
+                                               deviceName: deviceName, now: now)
+            // `.atomic` = 임시 파일 + rename. 파일 프로바이더가 rename 을 온전한 교체로 보므로
+            // `NSFileCoordinator` 없이도 부분 업로드가 안 생긴다.
+            try data.write(to: target, options: .atomic)
+        } catch {
+            AppLog.write("icloud mirror write failed: \(error)")
+            return false
+        }
+        lastMirroredState = canonical
+        lastMirroredAt = now
+        return true
+    }
+
+    /// 변경 판정용 정규 인코딩.
+    ///
+    /// `CompanionStore.save()` 가 만든 바이트를 그냥 쓰면 안 된다 — 기본 `JSONEncoder` 는 키 순서를
+    /// 보장하지 않아 `inventory`·`candyGrantTier`·`collectedFinals` 가 같은 내용으로도 다른 바이트를
+    /// 내놓는다(변경 없는데 매번 업로드). 봉투를 비교해도 안 된다 — `exportedAt` 이 호출마다 달라
+    /// 비교가 **항상** 다르다고 나온다. 그래서 상태만, 정렬된 키로.
+    static func canonicalStateEncoding(_ state: CompanionState) -> Data? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try? encoder.encode(state)
+    }
+
+    /// 다른 Mac 들이 남긴 세이브 목록(최신 순). 이 Mac 자신의 파일은 뺀다.
+    ///
+    /// **메인 액터에서 부르지 마라.** iCloud 가 파일을 내려둔 상태(evicted)면 읽는 순간 다운로드가
+    /// 걸려 네트워크만큼 블록한다. 호출부는 `Task.detached` 로 감싼다.
+    nonisolated static func remoteSaves(in directory: URL?, excludingDeviceID ownID: String) -> [RemoteSave] {
+        guard let directory,
+              let names = try? FileManager.default.contentsOfDirectory(atPath: directory.path) else { return [] }
+        let ownName = fileNamePrefix + ownID + fileNameSuffix
+        var found: [RemoteSave] = []
+        for name in names {
+            // evicted 항목은 `.save-<id>.json.icloud` 라는 플레이스홀더 이름으로 보인다. 원래 이름으로
+            // 읽으면 머티리얼라이즈가 걸리므로, 판정과 읽기 모두 복원된 이름으로 한다.
+            let resolved = materializedName(name)
+            guard resolved.hasPrefix(fileNamePrefix), resolved.hasSuffix(fileNameSuffix),
+                  resolved != ownName else { continue }
+            let url = directory.appendingPathComponent(resolved)
+            guard let data = try? Data(contentsOf: url),
+                  let envelope = try? SaveTransfer.decode(data) else { continue }
+            found.append(RemoteSave(url: url, envelope: envelope))
+        }
+        return found.sorted { $0.exportedAt > $1.exportedAt }
+    }
+
+    /// `.save-x.json.icloud` 플레이스홀더 → `save-x.json`. 그 형태가 아니면 그대로.
+    nonisolated static func materializedName(_ name: String) -> String {
+        guard name.hasPrefix("."), name.hasSuffix(".icloud") else { return name }
+        return String(name.dropFirst().dropLast(".icloud".count))
+    }
+}

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -324,6 +324,47 @@ struct L {
           "Wähle eine auf einem anderen Mac exportierte Datei aus und mach hier weiter")
     }
     var importSaveButton: String { t("불러오기…", "Import…", "読み込む…", "Importar…", "Importer…", "Importar…", "Importieren…") }
+    var iCloudSyncLabel: String { t("iCloud 백업", "iCloud backup", "iCloudバックアップ", "Copia en iCloud", "Sauvegarde iCloud", "Backup no iCloud", "iCloud-Sicherung") }
+    var iCloudSyncHint: String {
+        t("이 Mac의 진행을 iCloud Drive에 자동으로 백업해요. 다른 Mac에서는 아래에서 골라 불러옵니다",
+          "Backs this Mac's progress up to iCloud Drive automatically. On another Mac, restore it below",
+          "このMacの進行をiCloud Driveに自動でバックアップします。他のMacでは下から選んで復元します",
+          "Copia el progreso de este Mac en iCloud Drive automáticamente. En otro Mac, restáuralo abajo",
+          "Sauvegarde automatiquement la progression de ce Mac sur iCloud Drive. Sur un autre Mac, restaure-la ci-dessous",
+          "Faz backup automático do progresso deste Mac no iCloud Drive. Em outro Mac, restaure abaixo",
+          "Sichert den Fortschritt dieses Macs automatisch in iCloud Drive. Auf einem anderen Mac unten wiederherstellen")
+    }
+    var iCloudUnavailableHint: String {
+        t("iCloud Drive가 꺼져 있어요. 시스템 설정 → Apple 계정 → iCloud Drive를 켜면 사용할 수 있어요",
+          "iCloud Drive is off. Turn it on in System Settings → Apple Account → iCloud Drive to use this",
+          "iCloud Driveがオフです。システム設定 → Appleアカウント → iCloud Driveをオンにすると使えます",
+          "iCloud Drive está desactivado. Actívalo en Ajustes del Sistema → Cuenta de Apple → iCloud Drive",
+          "iCloud Drive est désactivé. Active-le dans Réglages Système → Compte Apple → iCloud Drive",
+          "O iCloud Drive está desligado. Ative em Ajustes do Sistema → Conta Apple → iCloud Drive",
+          "iCloud Drive ist aus. Aktiviere es unter Systemeinstellungen → Apple-Account → iCloud Drive")
+    }
+    var iCloudRestoreLabel: String { t("iCloud에서 불러오기", "Restore from iCloud", "iCloudから復元", "Restaurar desde iCloud", "Restaurer depuis iCloud", "Restaurar do iCloud", "Aus iCloud wiederherstellen") }
+    var iCloudNoRemoteSaves: String {
+        t("다른 Mac의 백업이 아직 없어요",
+          "No backups from another Mac yet",
+          "他のMacのバックアップはまだありません",
+          "Aún no hay copias de otro Mac",
+          "Aucune sauvegarde d’un autre Mac pour l’instant",
+          "Ainda não há backups de outro Mac",
+          "Noch keine Sicherungen von einem anderen Mac")
+    }
+    var iCloudRestoreButton: String { t("불러오기", "Restore", "復元", "Restaurar", "Restaurer", "Restaurar", "Wiederherstellen") }
+    /// 원격 백업 한 줄의 부제 — 어느 Mac 것이고 언제 것인지, 도감·누적이 얼마인지.
+    func iCloudRemoteSaveDetail(exportedAt: String, dex: Int, tokens: String) -> String {
+        t("\(exportedAt) · 도감 \(dex)마리 · 누적 \(tokens)",
+          "\(exportedAt) · \(dex) in Pokédex · \(tokens) lifetime",
+          "\(exportedAt) · 図鑑\(dex)匹 · 累計\(tokens)",
+          "\(exportedAt) · \(dex) en la Pokédex · \(tokens) acumulados",
+          "\(exportedAt) · \(dex) dans le Pokédex · \(tokens) cumulés",
+          "\(exportedAt) · \(dex) na Pokédex · \(tokens) acumulados",
+          "\(exportedAt) · \(dex) im Pokédex · \(tokens) gesamt")
+    }
+
     var importConfirmTitle: String {
         t("이 Mac의 진행을 대체할까요?", "Replace this Mac's progress?", "このMacの進行を置き換えますか？", "¿Reemplazar el progreso de este Mac?", "Remplacer la progression de ce Mac ?", "Substituir o progresso deste Mac?", "Fortschritt auf diesem Mac ersetzen?")
     }

--- a/Sources/PokeTokenBar/Core/SaveTransfer.swift
+++ b/Sources/PokeTokenBar/Core/SaveTransfer.swift
@@ -72,6 +72,17 @@ enum SaveTransfer {
     /// 이 값끼리 더하고 빼도 Int64 범위 안에 머문다.
     static let maxTokenValue = 1_000_000_000_000_000
 
+    /// 세이브 봉투에 남길 출처 표기 — 어느 Mac 에서 나온 파일인지 나중에 알아보기 위한 것.
+    /// 표시용이라 이름이 바뀌어도 무방하다(파일명은 `ICloudSaveMirror.deviceID` 가 따로 고정한다).
+    static var deviceName: String {
+        Host.current().localizedName ?? ProcessInfo.processInfo.hostName
+    }
+
+    /// 현재 앱 버전 — 봉투에 기록하고 설정창 하단에도 표기한다.
+    static var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
+    }
+
     /// 내보내기 파일명 — 날짜가 들어가야 여러 번 내보내도 덮어쓰지 않는다.
     static func suggestedFileName(date: Date) -> String {
         "PokeTokenBar-Save-\(dayStamp(date)).json"

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -33,6 +33,10 @@ struct SettingsView: View {
     @State private var customScanMatchTask: Task<Void, Never>?
     @State private var customScanMatchGeneration = 0
     @FocusState private var customScanFocused: Bool
+    /// 다른 Mac 의 iCloud 백업 목록. 비동기로 채운다 — evicted 파일은 읽는 순간 다운로드가 걸려
+    /// 메인 스레드를 네트워크만큼 잡는다.
+    @State private var remoteSaves: [ICloudSaveMirror.RemoteSave] = []
+    @State private var isLoadingRemoteSaves = false
     private var l: L { companion.l }
 
     private var isBundledApp: Bool { AppEnv.isBundledApp }
@@ -45,15 +49,10 @@ struct SettingsView: View {
         return "#\(species.id) \(species.name)\(species.isShiny ? " ✨" : "")"
     }
 
-    /// 세이브 봉투에 남길 출처 표기 — 어느 Mac에서 내보낸 파일인지 나중에 알아보기 위한 것.
-    private static var deviceName: String {
-        Host.current().localizedName ?? ProcessInfo.processInfo.hostName
-    }
-
-    /// 현재 앱 버전 — 업데이트 적용 여부 확인용으로 설정창 하단에 표기.
-    private static var appVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
-    }
+    /// 봉투의 출처 표기와 앱 버전. `ICloudSaveMirror` 도 같은 값을 봉투에 쓰므로 한 곳에 둔다 —
+    /// 수동 내보내기와 자동 백업이 서로 다른 기기 이름을 적으면 복원 목록에서 같은 Mac 이 둘로 보인다.
+    private static var deviceName: String { SaveTransfer.deviceName }
+    private static var appVersion: String { SaveTransfer.appVersion }
 
     // MARK: 레이아웃 — 헤더 고정 / 본문 스크롤 / 푸터 고정
 
@@ -70,6 +69,7 @@ struct SettingsView: View {
                     notificationsGroup(store)
                     updateGroup(store)
                     transferGroup(store)
+                        .task(id: companion.iCloudMirror.isEnabled) { await reloadRemoteSaves() }
                     advancedGroup(store)
                     aboutSupportGroup
                 }
@@ -370,7 +370,70 @@ struct SettingsView: View {
                 Spacer()
                 Button(l.importSaveButton) { importSave(store) }
             }
+            Divider()
+            iCloudRows(store)
         }
+    }
+
+    /// iCloud Drive 백업 — 켜면 이 Mac 의 진행이 자동으로 올라가고, 다른 Mac 의 백업은 아래 목록에서
+    /// **사용자가 골라** 복원한다. 자동 적용이 아닌 이유는 `ICloudSaveMirror` 주석 참조(병합 불가 필드).
+    @ViewBuilder
+    private func iCloudRows(_ store: UsageStore) -> some View {
+        @Bindable var mirror = companion.iCloudMirror
+        groupRow {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(l.iCloudSyncLabel)
+                Text(mirror.isAvailable ? l.iCloudSyncHint : l.iCloudUnavailableHint)
+                    .font(.caption2).foregroundStyle(.tertiary)
+            }
+            Spacer()
+            Toggle("", isOn: $mirror.isEnabled).labelsHidden().toggleStyle(.switch)
+                .controlSize(.small).disabled(!mirror.isAvailable)
+        }
+        if mirror.isAvailable && mirror.isEnabled {
+            Divider()
+            groupRow {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(l.iCloudRestoreLabel)
+                    if remoteSaves.isEmpty && !isLoadingRemoteSaves {
+                        Text(l.iCloudNoRemoteSaves).font(.caption2).foregroundStyle(.tertiary)
+                    }
+                }
+                Spacer()
+                if isLoadingRemoteSaves { ProgressView().controlSize(.small) }
+            }
+            ForEach(remoteSaves) { remote in
+                Divider()
+                groupRow {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(remote.deviceName)
+                        Text(l.iCloudRemoteSaveDetail(
+                            exportedAt: Self.exportedAtText(remote.exportedAt),
+                            dex: remote.summary.dexCount,
+                            tokens: TokenFormatter.compact(remote.summary.lifetimeTokens)))
+                            .font(.caption2).foregroundStyle(.tertiary)
+                    }
+                    Spacer()
+                    Button(l.iCloudRestoreButton) { restoreFromICloud(remote, store) }
+                }
+            }
+        }
+    }
+
+    /// 목록 새로고침. `Task.detached` 로 빼는 이유는 파일 읽기가 iCloud 다운로드를 유발할 수 있어서다.
+    private func reloadRemoteSaves() async {
+        let mirror = companion.iCloudMirror
+        guard mirror.isAvailable, mirror.isEnabled else {
+            remoteSaves = []
+            return
+        }
+        isLoadingRemoteSaves = true
+        defer { isLoadingRemoteSaves = false }
+        let directory = mirror.ownFileURL?.deletingLastPathComponent()
+        let ownID = mirror.deviceID
+        remoteSaves = await Task.detached {
+            ICloudSaveMirror.remoteSaves(in: directory, excludingDeviceID: ownID)
+        }.value
     }
 
     /// claude.ai 세션 키 — Keychain 을 안 읽는 한도 조회 경로. 붙여넣고 저장하면 즉시 검증한다.
@@ -733,6 +796,18 @@ struct SettingsView: View {
             presentAlert(title: l.importSaveLabel, message: l.importErrorMessage(error), style: .warning)
             return
         }
+        confirmAndApply(envelope, title: l.importSaveLabel, store: store)
+    }
+
+    /// iCloud 백업 하나를 이 Mac 에 복원. 파일 선택창만 없을 뿐 그 뒤는 수동 불러오기와 **같은 경로**다 —
+    /// 확인창·백업·기기 기준 재정렬을 우회하는 두 번째 적용 경로를 만들지 않기 위해 함수를 공유한다.
+    /// 봉투는 목록을 만들 때 이미 읽고 검증했으므로 여기서 파일을 다시 열지 않는다.
+    private func restoreFromICloud(_ remote: ICloudSaveMirror.RemoteSave, _ store: UsageStore) {
+        confirmAndApply(remote.envelope, title: l.iCloudRestoreLabel, store: store)
+    }
+
+    /// 검증된 봉투를 적용하기 전 마지막 관문. 파일에서 왔든 iCloud 에서 왔든 여기를 지난다.
+    private func confirmAndApply(_ envelope: SaveEnvelope, title: String, store: UsageStore) {
         let incoming = SaveSummary(state: envelope.state)
 
         // 고른 즉시 덮어쓰지 않는다 — 무엇이 대체되는지 수치로 보여주고 한 번 더 확인받는다.
@@ -763,10 +838,10 @@ struct SettingsView: View {
                                     todayDate: LocalUsageReader.todayKey(),
                                     hasUsageData: store.hasUsageData)
         } catch {
-            presentAlert(title: l.importSaveLabel, message: l.importErrorMessage(error), style: .warning)
+            presentAlert(title: title, message: l.importErrorMessage(error), style: .warning)
             return
         }
-        presentAlert(title: l.importSaveLabel,
+        presentAlert(title: title,
                      message: l.importSaveDone(dex: incoming.dexCount,
                                                tokens: TokenFormatter.compact(incoming.lifetimeTokens)),
                      style: .informational)

--- a/Tests/PokeTokenBarTests/ICloudSaveMirrorTests.swift
+++ b/Tests/PokeTokenBarTests/ICloudSaveMirrorTests.swift
@@ -15,9 +15,12 @@ private struct MirrorOfflineProvider: PokeProviding {
 @MainActor
 final class ICloudSaveMirrorTests: XCTestCase {
 
-    private var dir: URL!
-    private var defaults: UserDefaults!
-    private var suiteName: String!
+    /// nonisolated(unsafe): @MainActor 클래스의 sync setUp/tearDown 은 릴리스 Swift 에서 nonisolated 로
+    /// 취급돼 main-actor 프로퍼티 접근이 컴파일 에러가 된다(CI 6.1.2 는 실패, 로컬 6.3+ 는 통과).
+    /// XCTest 는 인스턴스별로 직렬 실행하므로 안전 — `UsageStoreTests` 와 같은 규약.
+    nonisolated(unsafe) private var dir: URL!
+    nonisolated(unsafe) private var defaults: UserDefaults!
+    nonisolated(unsafe) private var suiteName: String!
 
     override func setUp() {
         super.setUp()
@@ -133,7 +136,7 @@ final class ICloudSaveMirrorTests: XCTestCase {
 
     /// 토글은 재시작을 건너 살아남아야 한다(같은 defaults 로 새 인스턴스).
     func testEnabledFlagPersistsAcrossInstances() {
-        makeMirror(enabled: true)
+        _ = makeMirror(enabled: true)
         XCTAssertTrue(ICloudSaveMirror(directory: dir, defaults: defaults).isEnabled)
     }
 

--- a/Tests/PokeTokenBarTests/ICloudSaveMirrorTests.swift
+++ b/Tests/PokeTokenBarTests/ICloudSaveMirrorTests.swift
@@ -1,0 +1,281 @@
+import XCTest
+@testable import PokeTokenBar
+
+private let mirrorNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+private enum MirrorStubError: Error { case unavailable }
+
+/// 진화 라인은 이 테스트와 무관하다 — 전부 실패시켜 네트워크 없는 경로로 고정한다.
+private struct MirrorOfflineProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine { throw MirrorStubError.unavailable }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { throw MirrorStubError.unavailable }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { throw MirrorStubError.unavailable }
+}
+
+@MainActor
+final class ICloudSaveMirrorTests: XCTestCase {
+
+    private var dir: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ptb-icloud-\(UUID().uuidString)", isDirectory: true)
+        suiteName = "ptb.icloud.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: dir)
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    private func makeMirror(enabled: Bool = true) -> ICloudSaveMirror {
+        let mirror = ICloudSaveMirror(directory: dir, defaults: defaults)
+        mirror.isEnabled = enabled
+        return mirror
+    }
+
+    private func mirror(_ m: ICloudSaveMirror, _ state: CompanionState, at now: Date) -> Bool {
+        m.mirror(state: state, appVersion: "9.9.9", deviceName: "Test Mac", now: now)
+    }
+
+    private func state(dexCount: Int = 0, tokens: Int = 0) -> CompanionState {
+        var s = CompanionState()
+        s.usedSinceInstall = tokens
+        s.dex = (0..<dexCount).map { i in
+            DexEntry(baseID: i + 1, finalID: i + 1, chainOrder: [i + 1],
+                     rarity: .common, caughtAt: mirrorNow, isShiny: false, nature: .hardy,
+                     names: [:])
+        }
+        return s
+    }
+
+    // MARK: 쓰기 게이트
+
+    func testFirstMirrorWritesTheEnvelope() throws {
+        let m = makeMirror()
+        XCTAssertTrue(mirror(m, state(dexCount: 2, tokens: 500), at: mirrorNow))
+
+        let url = try XCTUnwrap(m.ownFileURL)
+        let envelope = try SaveTransfer.decode(try Data(contentsOf: url))
+        XCTAssertEqual(envelope.sourceDevice, "Test Mac")
+        XCTAssertEqual(envelope.appVersion, "9.9.9")
+        XCTAssertEqual(envelope.state.dex.count, 2)
+        XCTAssertEqual(envelope.state.usedSinceInstall, 500)
+    }
+
+    /// 내용 게이트. 120초 하트비트가 상태를 안 바꾼 채 계속 부르는 흔한 경로 — 여기서 안 걸러내면
+    /// 사용량이 없어도 하루 수백 번 업로드된다.
+    func testUnchangedStateIsNotRewrittenEvenAfterTheInterval() {
+        let m = makeMirror()
+        let s = state(dexCount: 1, tokens: 10)
+        XCTAssertTrue(mirror(m, s, at: mirrorNow))
+        let later = mirrorNow.addingTimeInterval(ICloudSaveMirror.minimumWriteInterval + 60)
+        XCTAssertFalse(mirror(m, s, at: later), "상태가 그대로면 간격이 지나도 다시 쓰지 않는다")
+    }
+
+    /// 간격 게이트의 **트리거 브랜치** — 상태가 실제로 바뀌었는데도 창 안이면 안 쓴다.
+    /// (내용 게이트만 있으면 이 케이스가 통과해 버려 상한이 사라진다.)
+    func testChangedStateInsideTheIntervalIsHeld() {
+        let m = makeMirror()
+        XCTAssertTrue(mirror(m, state(tokens: 10), at: mirrorNow))
+        let inside = mirrorNow.addingTimeInterval(ICloudSaveMirror.minimumWriteInterval - 1)
+        XCTAssertFalse(mirror(m, state(tokens: 999), at: inside), "창 안이면 변경돼도 보류한다")
+    }
+
+    /// 그리고 창이 끝나면 그 변경이 실제로 올라간다 — 보류가 유실이 되지 않는지.
+    func testChangedStateAfterTheIntervalIsWritten() throws {
+        let m = makeMirror()
+        XCTAssertTrue(mirror(m, state(tokens: 10), at: mirrorNow))
+        let after = mirrorNow.addingTimeInterval(ICloudSaveMirror.minimumWriteInterval)
+        XCTAssertTrue(mirror(m, state(tokens: 999), at: after))
+
+        let url = try XCTUnwrap(m.ownFileURL)
+        let envelope = try SaveTransfer.decode(try Data(contentsOf: url))
+        XCTAssertEqual(envelope.state.usedSinceInstall, 999)
+    }
+
+    func testDisabledMirrorNeverWrites() {
+        let m = makeMirror(enabled: false)
+        XCTAssertFalse(mirror(m, state(tokens: 10), at: mirrorNow))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: dir.path),
+                       "꺼져 있으면 iCloud Drive 에 폴더조차 만들지 않는다")
+    }
+
+    /// iCloud Drive 가 꺼진 Mac(경로 없음) — 켜져 있어도 쓸 곳이 없다.
+    func testUnavailableMirrorNeverWrites() {
+        let m = ICloudSaveMirror(directory: nil, defaults: defaults)
+        m.isEnabled = true
+        XCTAssertFalse(m.isAvailable)
+        XCTAssertFalse(mirror(m, state(tokens: 10), at: mirrorNow))
+    }
+
+    /// 쓰기 실패(iCloud 용량 초과·권한)는 삼키되 **기록을 남기지 않는다** — 남기면 다음 틱이
+    /// 성공한 것으로 알고 건너뛰어, 그 변경이 영영 안 올라간다.
+    func testWriteFailureIsNotRecordedSoTheNextTickRetries() throws {
+        // 부모가 일반 파일이면 그 아래 디렉터리를 만들 수 없다 → createDirectory 가 실패한다.
+        let blocker = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ptb-blocker-\(UUID().uuidString)")
+        try Data("x".utf8).write(to: blocker)
+        defer { try? FileManager.default.removeItem(at: blocker) }
+
+        let m = ICloudSaveMirror(directory: blocker.appendingPathComponent("PokeTokenBar"),
+                                 defaults: defaults)
+        m.isEnabled = true
+        XCTAssertFalse(mirror(m, state(tokens: 1), at: mirrorNow))
+        // 같은 시각에 다시 불러도 간격 게이트에 막히지 않는다 = 실패가 기록되지 않았다.
+        XCTAssertFalse(mirror(m, state(tokens: 1), at: mirrorNow))
+    }
+
+    /// 토글은 재시작을 건너 살아남아야 한다(같은 defaults 로 새 인스턴스).
+    func testEnabledFlagPersistsAcrossInstances() {
+        makeMirror(enabled: true)
+        XCTAssertTrue(ICloudSaveMirror(directory: dir, defaults: defaults).isEnabled)
+    }
+
+    /// 기기 식별자는 한 번 만들면 고정 — 갈리면 같은 Mac 의 백업이 매번 새 파일이 되어 쌓인다.
+    func testDeviceIDIsStableAcrossInstances() {
+        let first = makeMirror().deviceID
+        XCTAssertEqual(ICloudSaveMirror(directory: dir, defaults: defaults).deviceID, first)
+    }
+
+    // MARK: 정규 인코딩 (내용 게이트의 근거)
+
+    /// 같은 내용이면 바이트가 같아야 한다. 기본 `JSONEncoder` 는 키 순서를 보장하지 않아
+    /// `inventory`·`candyGrantTier`·`collectedFinals` 가 같은 상태로도 다른 바이트를 낼 수 있고,
+    /// 그러면 내용 게이트가 항상 "바뀜"으로 읽혀 상한이 사라진다.
+    func testCanonicalEncodingIsStableForEqualState() throws {
+        var s = CompanionState()
+        s.inventory = ["rareCandy": 3, "mint": 1, "shinyCharm": 1]
+        s.candyGrantTier = ["w3": 2, "w1": 1, "w2": 3]
+        s.collectedFinals = ["1:3", "4:6", "7:9"]
+
+        let a = try XCTUnwrap(ICloudSaveMirror.canonicalStateEncoding(s))
+        for _ in 0..<20 {
+            // 재인코딩마다 Dictionary/Set 순회 순서가 달라질 수 있는 지점을 반복해서 밟는다.
+            var copy = CompanionState()
+            copy.inventory = s.inventory
+            copy.candyGrantTier = s.candyGrantTier
+            copy.collectedFinals = s.collectedFinals
+            XCTAssertEqual(ICloudSaveMirror.canonicalStateEncoding(copy), a)
+        }
+    }
+
+    func testCanonicalEncodingDiffersWhenStateDiffers() {
+        let a = ICloudSaveMirror.canonicalStateEncoding(state(tokens: 1))
+        let b = ICloudSaveMirror.canonicalStateEncoding(state(tokens: 2))
+        XCTAssertNotNil(a)
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: 원격 목록
+
+    private func writeRemote(deviceID: String, deviceName: String, exportedAt: Date,
+                             dexCount: Int, tokens: Int, fileName: String? = nil) throws {
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let data = try SaveTransfer.encode(state: state(dexCount: dexCount, tokens: tokens),
+                                           appVersion: "1.0.0", deviceName: deviceName, now: exportedAt)
+        let name = fileName ?? "\(ICloudSaveMirror.fileNamePrefix)\(deviceID)\(ICloudSaveMirror.fileNameSuffix)"
+        try data.write(to: dir.appendingPathComponent(name))
+    }
+
+    func testRemoteSavesExcludeThisDevicesOwnFile() throws {
+        let m = makeMirror()
+        XCTAssertTrue(mirror(m, state(dexCount: 5), at: mirrorNow))
+        try writeRemote(deviceID: "other", deviceName: "Other Mac", exportedAt: mirrorNow,
+                        dexCount: 3, tokens: 42)
+
+        let found = ICloudSaveMirror.remoteSaves(in: dir, excludingDeviceID: m.deviceID)
+        XCTAssertEqual(found.map(\.deviceName), ["Other Mac"])
+    }
+
+    func testRemoteSavesReportDeviceDateAndSummary() throws {
+        try writeRemote(deviceID: "a", deviceName: "Studio", exportedAt: mirrorNow,
+                        dexCount: 7, tokens: 12_345)
+
+        let found = ICloudSaveMirror.remoteSaves(in: dir, excludingDeviceID: "self")
+        XCTAssertEqual(found.count, 1)
+        XCTAssertEqual(found[0].deviceName, "Studio")
+        XCTAssertEqual(found[0].exportedAt.timeIntervalSince1970, mirrorNow.timeIntervalSince1970, accuracy: 1)
+        XCTAssertEqual(found[0].summary.dexCount, 7)
+        XCTAssertEqual(found[0].summary.lifetimeTokens, 12_345)
+    }
+
+    func testRemoteSavesAreSortedNewestFirst() throws {
+        try writeRemote(deviceID: "old", deviceName: "Old", exportedAt: mirrorNow, dexCount: 1, tokens: 1)
+        try writeRemote(deviceID: "new", deviceName: "New",
+                        exportedAt: mirrorNow.addingTimeInterval(86_400), dexCount: 1, tokens: 1)
+
+        XCTAssertEqual(ICloudSaveMirror.remoteSaves(in: dir, excludingDeviceID: "self").map(\.deviceName),
+                       ["New", "Old"])
+    }
+
+    /// 남의 JSON 이 그 폴더에 들어와도 목록에 뜨면 안 된다 — `SaveTransfer` 의 봉투 검사가 그 역할이고,
+    /// 여기서는 그게 실제로 걸리는지를 본다(관대 디코딩은 아무 JSON 이나 빈 상태로 흡수한다).
+    func testForeignJSONInTheFolderIsSkipped() throws {
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let name = "\(ICloudSaveMirror.fileNamePrefix)bogus\(ICloudSaveMirror.fileNameSuffix)"
+        try Data(#"{"hello":"world"}"#.utf8).write(to: dir.appendingPathComponent(name))
+        try writeRemote(deviceID: "good", deviceName: "Good", exportedAt: mirrorNow, dexCount: 1, tokens: 1)
+
+        XCTAssertEqual(ICloudSaveMirror.remoteSaves(in: dir, excludingDeviceID: "self").map(\.deviceName),
+                       ["Good"])
+    }
+
+    /// 관계없는 파일명은 애초에 후보가 아니다.
+    func testUnrelatedFileNamesAreIgnored() throws {
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: dir.appendingPathComponent("notes.txt"))
+        XCTAssertTrue(ICloudSaveMirror.remoteSaves(in: dir, excludingDeviceID: "self").isEmpty)
+    }
+
+    func testMissingDirectoryYieldsNoRemoteSaves() {
+        XCTAssertTrue(ICloudSaveMirror.remoteSaves(in: nil, excludingDeviceID: "self").isEmpty)
+        XCTAssertTrue(ICloudSaveMirror.remoteSaves(in: dir, excludingDeviceID: "self").isEmpty)
+    }
+
+    // MARK: CompanionStore 배선
+
+    /// 미러가 실제로 `save()` 에 걸려 있는지 — 게이트를 아무리 잘 만들어도 호출이 없으면 무의미하다.
+    func testCompanionStoreSaveMirrorsToICloud() throws {
+        let stateFile = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ptb-state-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: stateFile) }
+
+        let m = makeMirror()
+        let store = CompanionStore(provider: MirrorOfflineProvider(), clock: { mirrorNow },
+                                   fileURL: stateFile, iCloudMirror: m)
+        store.setLanguage(.en)   // 상태를 바꾸는 가장 짧은 save() 경로
+
+        let url = try XCTUnwrap(m.ownFileURL)
+        let envelope = try SaveTransfer.decode(try Data(contentsOf: url))
+        XCTAssertEqual(envelope.state.language, .en)
+    }
+
+    /// 그리고 꺼져 있으면 `save()` 가 아무것도 내보내지 않는다(옵트인이 실제로 옵트인인지).
+    func testCompanionStoreSaveWritesNothingWhenSyncIsOff() {
+        let stateFile = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ptb-state-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: stateFile) }
+
+        let m = makeMirror(enabled: false)
+        let store = CompanionStore(provider: MirrorOfflineProvider(), clock: { mirrorNow },
+                                   fileURL: stateFile, iCloudMirror: m)
+        store.setLanguage(.en)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: dir.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stateFile.path), "로컬 저장은 그대로 동작한다")
+    }
+
+    /// evicted 항목은 `.save-x.json.icloud` 플레이스홀더로 열거된다. 이름을 복원하지 않으면
+    /// 접두/접미 판정에 걸려 다른 Mac 의 백업이 통째로 안 보인다(조용한 0건).
+    func testEvictedPlaceholderNamesResolveToTheRealFile() {
+        XCTAssertEqual(ICloudSaveMirror.materializedName(".save-abc.json.icloud"), "save-abc.json")
+        XCTAssertEqual(ICloudSaveMirror.materializedName("save-abc.json"), "save-abc.json")
+        XCTAssertEqual(ICloudSaveMirror.materializedName("notes.txt"), "notes.txt")
+    }
+}

--- a/Tests/PokeTokenBarTests/SwiftUIIsolationTests.swift
+++ b/Tests/PokeTokenBarTests/SwiftUIIsolationTests.swift
@@ -37,4 +37,59 @@ final class SwiftUIIsolationTests: XCTestCase {
             Add @MainActor immediately above: \(offenders.joined(separator: ", "))
             """)
     }
+
+    /// `@MainActor` XCTestCase 의 **동기** `setUp`/`tearDown` 은 릴리스 Swift 에서 nonisolated 로
+    /// 취급돼, main-actor 프로퍼티를 만지면 컴파일 에러가 된다. 그래서 그런 클래스의 가변 저장
+    /// 프로퍼티는 `nonisolated(unsafe)` 여야 한다(XCTest 는 인스턴스별 직렬 실행이라 안전).
+    ///
+    /// 이 스캔이 필요한 이유는 **규칙이 이미 있었는데 못 막았기 때문**이다. 같은 내용이
+    /// `UsageStoreTests` 의 주석으로만 남아 있었고, 그 뒤에 추가된 `ICloudSaveMirrorTests` 가
+    /// 그대로 어겼다 — 로컬 툴체인(6.3+)은 통과시키고 **CI(6.1.2)에서만** 빨개져서 푸시 전엔
+    /// 아무 신호가 없었다. 산문 규칙은 그 파일을 읽는 사람에게만 작동한다.
+    func testMainActorTestClassesKeepMutableFixturesNonisolated() throws {
+        let testsDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let enumerator = try XCTUnwrap(FileManager.default.enumerator(
+            at: testsDir, includingPropertiesForKeys: nil))
+        var offenders: [String] = []
+
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let lines = try String(contentsOf: url, encoding: .utf8)
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+
+            for index in lines.indices where lines[index] == "@MainActor" {
+                // `@MainActor` 바로 아래의 XCTestCase 선언만 대상.
+                guard let declIndex = lines[(index + 1)...].indices.first(where: { !lines[$0].isEmpty }),
+                      lines[declIndex].contains("class"),
+                      lines[declIndex].contains(": XCTestCase") else { continue }
+
+                // 클래스 본문 = 다음 최상위 선언 전까지.
+                let bodyEnd = lines[(declIndex + 1)...].indices.first {
+                    lines[$0] == "@MainActor" || lines[$0].hasPrefix("final class")
+                        || lines[$0].hasPrefix("private final class")
+                } ?? lines.endIndex
+
+                // 동기 setUp/tearDown 이 없으면 이 부류의 문제가 없다 — async 오버라이드는 격리를 물려받는다.
+                let hasSyncFixtureHook = lines[(declIndex + 1)..<bodyEnd].contains {
+                    ($0.hasPrefix("override func setUp(") || $0.hasPrefix("override func tearDown("))
+                        && !$0.contains("async")
+                }
+                guard hasSyncFixtureHook else { continue }
+
+                for lineIndex in (declIndex + 1)..<bodyEnd {
+                    let line = lines[lineIndex]
+                    // 가변 저장 프로퍼티만 — `let` 상수와 계산 프로퍼티·함수는 대상이 아니다.
+                    guard line.contains("var "), line.hasSuffix("!"),
+                          !line.contains("nonisolated(unsafe)"), !line.contains("func ") else { continue }
+                    offenders.append("\(url.lastPathComponent):\(lineIndex + 1)  \(line)")
+                }
+            }
+        }
+
+        XCTAssertTrue(offenders.isEmpty, """
+            @MainActor XCTestCase 의 동기 setUp/tearDown 은 nonisolated 라 이 프로퍼티들을 못 만진다
+            (로컬은 통과, CI 6.1.2 에서 컴파일 실패). `nonisolated(unsafe) private var ...` 로 선언하세요:
+            \(offenders.joined(separator: "\n            "))
+            """)
+    }
 }

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -249,6 +249,21 @@ read_when:
   동기 클로저를 nonisolated 로 검사해, `@MainActor` `@Observable` store 접근이 수십 개의 오류로 연쇄된다.
   개별 프로퍼티에 `MainActor.assumeIsolated` 를 흩뿌리지 말고 UI 타입 선언 한 곳에 격리를 둔다.
   `SwiftUIIsolationTests.testEverySwiftUIViewAndAppIsMainActorIsolated` 가 새 View/App 선언 누락을 소스 스캔으로 막는다.
+- **로컬 Swift 가 CI 보다 새로우면 "로컬 초록"은 CI 초록의 증거가 아니다 — 같은 진단이 경고와 에러로
+  갈린다.** `@MainActor` XCTestCase 의 **동기** `setUp`/`tearDown` 은 릴리스 Swift 에서 nonisolated 로
+  취급돼 main-actor 저장 프로퍼티 접근이 막힌다. 실측: 로컬(6.3/6.5-dev)은 이걸 **warning** 으로 내고
+  `swift test` 가 통과하는데, CI(6.1.2)는 같은 줄을 **error** 로 내 컴파일이 죽는다. 즉 로컬에서는
+  빌드 로그에 묻힌 경고 한 줄이 유일한 신호였다.
+  규칙은 이미 있었다 — `UsageStoreTests` 에 `nonisolated(unsafe)` 와 그 이유가 주석으로 달려 있었다.
+  그런데도 다음에 추가된 `ICloudSaveMirrorTests` 가 그대로 어겼다. **산문 규칙은 그 파일을 여는
+  사람에게만 작동한다**(§외부 로그의 `UsageEnvironment` 건과 같은 부류 — 문서로 적어둔 규칙이
+  다음 파일에서 그대로 깨졌고, 해결은 구현이 아니라 강제 수단이었다).
+  → 가드는 소스 스캔이다: `SwiftUIIsolationTests.testMainActorTestClassesKeepMutableFixturesNonisolated`
+  가 `Tests/` 를 훑어 `@MainActor` + `: XCTestCase` + 동기 `setUp`/`tearDown` 조합에서
+  `nonisolated(unsafe)` 없는 가변 저장 프로퍼티를 실패시킨다. 주입 확인: 두 파일 각각에서
+  `nonisolated(unsafe)` 를 떼면 빨개진다(한 파일에만 반응하는 스캔이 아님을 확인).
+  일반화: **경고를 에러로 승격하는 축이 툴체인 버전이면, 로컬 경고 무시는 CI 실패와 같은 말이다.**
+  새 테스트 파일에 액터 격리가 얽히면 빌드 경고를 먼저 읽어라.
 - **coverage profile producer와 consumer는 같은 LLVM toolchain이어야 한다.** Homebrew Swift 6.3 이 만든
   `default.profdata` 를 구형 Xcode의 `xcrun llvm-cov` 로 읽으면 `unsupported instrumentation profile format
   version` 으로 테스트 성공 뒤 게이트만 실패한다. `test-gate.sh` 는 현재 `swift` 실경로 옆의 `llvm-cov` 를

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -576,6 +576,33 @@ read_when:
   `testTransferDayTokensStillCountAfterRebase` — 재정렬 없는 대조군을 같이 돌려 결함 조건이 살아 있는지도
   함께 확인한다(테스트가 트리거 브랜치를 실제로 밟는지 보증).
 
+- **iCloud 는 이 앱에서 "엔타이틀먼트 없는 파일 경로"만 쓸 수 있다 — CloudKit·KVS 는 조용한 no-op 다.**
+  `CloudKit`·`NSUbiquitousKeyValueStore`·`FileManager.url(forUbiquityContainerIdentifier:)` 는 모두
+  `com.apple.developer.icloud-*` 엔타이틀먼트를 요구하고, macOS 는 그걸 **유료 개발자 팀의 프로비저닝
+  프로파일**로 검증한다. 이 앱의 서명은 `scripts/create-signing-cert.sh` 가 만드는 자체서명 인증서라
+  (팀 ID 없음, `.entitlements` 파일 자체가 없음) 그 API 들은 에러가 아니라 **조용히 아무 일도 안 하고**
+  `nil` 을 돌려준다 — 빌드도 되고 실행도 되므로 리뷰로는 안 잡힌다. 대신 이 앱은 샌드박스가 아니라서
+  `~/Library/Mobile Documents/com~apple~CloudDocs/` 에 그냥 쓸 수 있고 iCloud Drive 데몬이 동기화한다
+  (`ICloudSaveMirror`). 서명 방식을 바꾸기 전까지 다른 경로를 시도하지 마라.
+- **여러 기기가 같은 iCloud 파일에 쓰면 그건 동기화가 아니라 기기 간 last-writer-wins 다.**
+  §프로세스·인스턴스의 중복 인스턴스 결함과 같은 부류이고, 그쪽엔 `SingleInstance` 라도 있지만 기기
+  사이엔 그마저 없다. `CompanionState` 에는 병합 불가 필드가 있다 — `active`·`eggTier`·`pendingHatchID`
+  는 단일값, `inventory`·`spentTokens` 는 개수라 델타 추적 없이 합치면 이중지출이다. 그래서
+  `ICloudSaveMirror` 는 **기기마다 다른 파일**(`save-<deviceID>.json`)에 쓰고 — 같은 이름을 쓰면 iCloud
+  가 충돌 사본을 만든다 — 적용은 항상 사용자가 고르는 복원이며 기존 `applySave` 경로(확인창·백업·
+  `rebasedForThisDevice`)를 그대로 지난다. 두 번째 적용 경로를 만들지 마라.
+- **`save()` 에 부수효과를 붙일 땐 그 호출 빈도를 먼저 보라.** `CompanionStore.save()` 는 dirty 체크
+  없이 120초 새로고침마다 호출된다. 백업 업로드를 그대로 따라 걸면 하루 최대 720회 × 수백 KB 다.
+  게이트는 둘이고 **순서가 중요하다** — 간격을 먼저 보고(창 안이면 인코딩 비용도 안 치른다) 그다음
+  내용을 본다. 내용 비교에 `save()` 가 만든 바이트를 재사용하면 안 된다: 기본 `JSONEncoder` 는 키
+  순서를 보장하지 않아 `inventory`·`candyGrantTier`·`collectedFinals` 가 같은 상태로도 다른 바이트를
+  내놓고(실측: `.sortedKeys` 를 빼면 `testCanonicalEncodingIsStableForEqualState` 가 빨개진다), 봉투를
+  비교하면 `exportedAt` 때문에 **항상** 다르다. 그리고 쓰기 실패는 기록하지 마라 — 기록하면 다음 틱이
+  성공한 줄 알고 건너뛰어 그 변경이 영영 안 올라간다. 가드:
+  `testChangedStateInsideTheIntervalIsHeld`(간격의 트리거 브랜치 — 내용 게이트만 있으면 통과해 버린다)·
+  `testUnchangedStateIsNotRewrittenEvenAfterTheInterval`·
+  `testWriteFailureIsNotRecordedSoTheNextTickRetries`.
+
 ## 렌더 기하 (스프라이트·이미지)
 
 - **`.resizable()` + `.frame(w:h:)` 는 "맞춤"이 아니라 "늘여 채움"이다.** 대조 없이 정사각 프레임에 넣으면

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -29,6 +29,7 @@ LOGIC_CORE=(
   "Sources/PokeTokenBar/Core/LocalUsageCache.swift"
   "Sources/PokeTokenBar/Core/ModelPricing.swift"
   "Sources/PokeTokenBar/Core/CustomScanRoots.swift"
+  "Sources/PokeTokenBar/Core/ICloudSaveMirror.swift"
 )
 
 echo "▶ swift test (--enable-code-coverage)"


### PR DESCRIPTION
## What

Adds an opt-in iCloud backup to Settings → Backup & Transfer. When it is on, this Mac
mirrors its save into iCloud Drive automatically; another Mac lists the backups it finds
there and restores one on an explicit click. Moving progress between Macs no longer means
carrying an exported file by hand.

Off by default.

## Why a plain file and not CloudKit

CloudKit, `NSUbiquitousKeyValueStore` and `FileManager.url(forUbiquityContainerIdentifier:)`
all require `com.apple.developer.icloud-*` entitlements, and macOS validates those against a
provisioning profile issued to a paid developer team. This app is signed with the self-signed
certificate from `scripts/create-signing-cert.sh`, has no Team ID and no `.entitlements` file
at all, so those APIs do not fail loudly — they return `nil` and no-op. The build succeeds and
the feature silently does nothing, which is exactly the kind of thing review does not catch.

The app is not sandboxed, so writing directly into
`~/Library/Mobile Documents/com~apple~CloudDocs/` works with zero entitlements and the iCloud
Drive daemon handles the sync. That is the transport here. I have written this up in
`docs/reference/defect-log.md` so the CloudKit route is not attempted again before the signing
setup changes.

## Why restore is manual, not automatic

`CompanionState` has fields that cannot be merged without per-device delta tracking that does
not exist: `active`, `eggTier` and `pendingHatchID` are single-valued, and `inventory` /
`spentTokens` are counts, so a naive merge double-spends. Auto-applying a remote save would
reproduce the last-writer-wins loss already recorded in the defect log for duplicate
instances — only across machines, and without even the `SingleInstance` guard to stop it.

So each Mac writes its own `save-<deviceID>.json` (a shared filename would make two Macs fight
over one path and produce iCloud conflict copies), and applying one is always a user action
that goes through the existing import path: `SaveTransfer.decode` → the confirm dialog with
Cancel as the default button → `backupStateBeforeImport` → `rebasedForThisDevice`. No second
apply path was created.

## Write cadence

`CompanionStore.save()` runs on the 120s refresh tick with no dirty check, so mirroring every
call would be up to 720 uploads a day. Two gates, in this order:

1. **Interval floor (5 min)**, checked *before* encoding so the common in-window tick costs
   nothing. No trailing timer is needed — the 120s heartbeat is the trailing timer, so a change
   made inside the window lands on the next tick after it expires.
2. **Content comparison** against a `.sortedKeys` encoding of the state. `save()`'s own bytes
   cannot be reused: the default `JSONEncoder` has no stable key order for `inventory`,
   `candyGrantTier` or `collectedFinals`, so identical state yields different bytes. The
   envelope cannot be compared either — its `exportedAt` differs on every call.

Write failures are deliberately not recorded, so the next tick retries instead of assuming
success and dropping the change.

## Not synced

`UserDefaults` settings, `session-key.json` (a plaintext credential), and every regenerable
cache (`usage-cache.json`, `base-index.json`, `sprites/`, `last-snapshot.json`). One file is
the save.

## Testing

20 new tests in `ICloudSaveMirrorTests`. `ICloudSaveMirror.swift` is added to `LOGIC_CORE` in
`test-gate.sh`; it sits at 98.6% line coverage (the only uncovered line is the SwiftUI
`Identifiable` `id`, exercised by `ForEach`), and `LOGIC_CORE` overall is 91.5% against the 75
floor.

Every gate was injection-checked — disabled one at a time, confirming the matching guard test
goes red rather than merely passing:

| Disabled | Test that fails |
| --- | --- |
| content gate | `testUnchangedStateIsNotRewrittenEvenAfterTheInterval` |
| interval floor | `testChangedStateInsideTheIntervalIsHeld` |
| `.sortedKeys` | `testCanonicalEncodingIsStableForEqualState` |
| `save()` call | `testCompanionStoreSaveMirrorsToICloud` |

### Two-instance simulation

Ran two real bundled instances on one machine with separate `PTB_STATE_DIR` values and a
shared `PTB_ICLOUD_DIR`, using distinct bundle identifiers so each gets its own `UserDefaults`
domain and therefore its own device ID.

```
save-28DA1F2E-…   ver=2.5.3-qaa   dex=2   lifetime=12345678
save-9FC5D54E-…   ver=2.5.3-qab   dex=0   lifetime=0
```

Two files, no conflict copies. `remoteSaves` run against that folder: B sees exactly one
remote save (A's, dex=2), A sees exactly one (B's, dex=0); each excludes its own.

Applying A's real envelope to a copy of B's live state file:

```
before: dex=0  lifetime=1245130   claimed=[claude_code: 42173338]
after:  dex=2  lifetime=12345678  claimed=[claude_code: 41000000]
pre-import backups: [companion-state.pre-import-2026-09-05-120303.json]
```

Progress carried over including the shiny; the device ledger rebased to this machine's number
instead of importing A's, which is the silent-usage-loss trap `rebasedForThisDevice` exists to
avoid; the pre-import backup was written.

Cadence sampled every 20s for 13 minutes while the instance was actively accruing tokens:
exactly two writes, 12:01:32 and 12:07:32. The 120s ticks in between were suppressed by the
floor, and the write landed on the first heartbeat past it.

## Notes for the reviewer

- The restore list shows `sourceDevice`, so two Macs sharing a name render identically and
  only the date disambiguates. Left as is; worth revisiting if it bites.
- `PTB_ICLOUD_DIR` lives in `AppStatePaths.swift` on purpose — that file is already on the
  allowlist in `UsageEnvironmentTests.testNoProviderReadsUsageLocationEnvDirectly`, so reading
  the variable from a new file would have failed that source scan.
- A screenshot under `assets/` is still needed before release; the release gate hard-fails a
  UI `feat:` commit without a newly added asset. README (en/ko/ja) and the landing page also
  need the feature added.
- `LocalUsageCacheTests.testDateHelpers` and
  `testEnrichmentScanStartCatchesWeekStraddlingMonthBoundary` fail on my machine before this
  branch (`en_TH` locale resolves 2026 as Buddhist-era 1483). Pre-existing and unrelated; CI on
  `macos-15` is unaffected.
