### PR TITLE
feat: break omp usage down per model in the popover

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageProvider.swift
@@ -131,16 +131,23 @@ struct LocalPiProvider: UsageProvider {
 struct LocalOmpProvider: UsageProvider {
     let id = "omp"
     let displayName = "omp"
+    /// 캐시 시임 — 기본은 공용 캐시(실 로그), 테스트만 픽스처 루트를 주입한다.
+    let cache: LocalUsageCache
+
+    init(cache: LocalUsageCache = .shared) { self.cache = cache }
 
     func fetchDaily() async throws -> DailyUsage? {
         let now = Date()
-        let entries = await LocalUsageCache.shared.ompEntries(modifiedSince: Calendar.current.startOfDay(for: now))
-        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey())
+        let entries = await cache.ompEntries(modifiedSince: Calendar.current.startOfDay(for: now))
+        // omp routes several models (e.g. OpenRouter) through one session log → opt into the
+        // per-model breakdown, matching Pi. Cost stays the parser's source-recorded amount.
+        return LocalUsageReader.daily(
+            entries: entries, localDay: LocalUsageReader.todayKey(), includeModels: true)
     }
 
     func fetchEnrichment() async -> ProviderEnrichment {
         let now = Date()
-        let entries = await LocalUsageCache.shared.ompEntries(
+        let entries = await cache.ompEntries(
             modifiedSince: LocalUsageReader.enrichmentScanStart(now: now))
         return .local(entries: entries, now: now)
     }

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -1627,7 +1627,7 @@ enum LocalUsageReader {
 
     /// 특정 로컬 날짜의 합계 → DailyUsage. 해당 날짜 데이터 없으면 nil.
     /// `includeModels` 를 켠 프로바이더만 per-model 내역을 채운다 — 끄면 `models` 는 nil 이라
-    /// 팝오버의 per-model 행이 그 프로바이더에서는 뜨지 않는다(현재는 Pi 만 opt-in).
+    /// 팝오버의 per-model 행이 그 프로바이더에서는 뜨지 않는다(현재는 Pi·omp 가 opt-in).
     static func daily(entries: [Entry], localDay: String, includeModels: Bool = false) -> DailyUsage? {
         var b = Bucket()
         var models: [String: Int]? = includeModels ? [:] : nil

--- a/Tests/PokeTokenBarTests/OmpUsageTests.swift
+++ b/Tests/PokeTokenBarTests/OmpUsageTests.swift
@@ -208,6 +208,42 @@ final class OmpUsageTests: XCTestCase {
         XCTAssertEqual(daily.totalCost, 0.005, accuracy: 1e-12)
     }
 
+    /// The change lives one layer up from `daily`: `LocalOmpProvider.fetchDaily` opts into the
+    /// per-model breakdown and must carry it through provider repackaging (parity with Pi's #225
+    /// provider test). omp records its own model-price estimate in `usage.cost.total`; the parser
+    /// preserves that amount and `fetchDaily` leaves it untouched — surfaced as an estimate, not a
+    /// billed charge. A fixture routed through `fetchDaily()` covers the repackaging and the cost.
+    func testProviderFetchDailyForwardsBreakdownAndKeepsSourceCost() async throws {
+        let iso = Self.isoUTC.string(from: Date())
+        let jsonl = """
+        {"type":"message","id":"m1","timestamp":"\(iso)","message":{"role":"assistant","content":[],"model":"moonshotai/Kimi-K3","usage":{"input":100,"output":200,"cacheRead":0,"cacheWrite":0,"totalTokens":300,"cost":{"total":0.01}}}}
+        {"type":"message","id":"m2","timestamp":"\(iso)","message":{"role":"assistant","content":[],"model":"modal/nvidia/GLM-5.2","usage":{"input":10,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":30,"cost":{"total":0.002}}}}
+        """
+        try jsonl.write(to: root.appendingPathComponent("-Users-x-Proj/today.jsonl"),
+                        atomically: true, encoding: .utf8)
+
+        let provider = LocalOmpProvider(cache: LocalUsageCache(ompRoots: [root], fileURL: cacheFile))
+        let fetched = try await provider.fetchDaily()
+        let daily = try XCTUnwrap(fetched)
+
+        XCTAssertEqual(daily.totalTokens, 330)
+        XCTAssertEqual(daily.totalCost, 0.012, accuracy: 1e-9,
+                       "the source-recorded amount passes through unchanged")
+        XCTAssertEqual(daily.costCoverage, .estimate,
+                       "omp's own model-price total is surfaced as an estimate, not a billed charge")
+        let models = try XCTUnwrap(daily.models, "the breakdown must survive provider repackaging")
+        XCTAssertEqual(models["moonshotai/Kimi-K3"], 300)
+        XCTAssertEqual(models["modal/nvidia/GLM-5.2"], 30)
+    }
+
+    private static let isoUTC: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        return f
+    }()
+
     func testPrintRealOmpAggregate() throws {
         guard ProcessInfo.processInfo.environment["PTB_PARITY"] == "1" else {
             throw XCTSkip("set PTB_PARITY=1 for the local omp smoke test")


### PR DESCRIPTION
## Summary

`omp` (oh-my-pi) has its own reader and provider (`~/.omp/agent/sessions`, `LocalOmpProvider`/`parseOmpLine`), separate from the Pi path that #225 gave a per-model breakdown. This brings `omp` to the same treatment, mirroring `LocalPiProvider`:

- **Per-model daily breakdown.** `LocalOmpProvider.fetchDaily` now calls `daily(includeModels:)`, so `DailyUsage.models` is populated and the popover's existing generic per-model rows render for `omp` too.
- **Injectable cache seam.** `init(cache:)` is added to `LocalOmpProvider`, mirroring `LocalPiProvider`, so `fetchDaily` can be exercised end to end.

Deliberately out of scope, per review:

- **No parser change.** Model attribution stays as-is: it comes from `message.model`, which the official OMP session writer records. No envelope-level override, so no cache-version migration.
- **Cost is left to the parser.** `omp` records its own model-price estimate in `usage.cost.total`. #289's parser preserves that recorded amount and surfaces it as an estimate (`costCoverage == .estimate`), not a billed charge, and `fetchDaily` passes it through untouched.

Rebased onto current `main` (`09fd600`); #289's cost handling and the shared enrichment path are preserved.

## Test plan

- New provider-level test `testProviderFetchDailyForwardsBreakdownAndKeepsSourceCost`: routes a fixture through `LocalOmpProvider.fetchDaily` and asserts the per-model breakdown survives provider repackaging and the source-recorded cost is preserved as an estimate.
- CI (macos-15): full suite 1078 tests, 11 skipped, 0 failures; logic-core line coverage 92.94% (gate 75%).
- `swift build` clean locally.
