### PR TITLE
fix: count Codex total-only turns and price Fable 5.1 cache reads

### DIFF
--- a/Sources/PokeTokenBar/Core/LocalUsageCache.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageCache.swift
@@ -78,7 +78,8 @@ actor LocalUsageCache {
     }
 
     /// fork replay 및 동일 상태 재기록 처리 변경 시 Codex blob만 재파싱한다.
-    private static let codexParserVersion = 4
+    /// v5: trust last.total_tokens when components are empty (#278).
+    private static let codexParserVersion = 5
     /// **세션 id 추출 규칙**(`session_meta` 의 id/session_id 해석·probe 종료 조건)이 바뀔 때만 올린다.
     /// resolver 변경으로 오르는 `codexParserVersion` 과 분리 — 같이 묶으면 replay 로직을 고칠 때마다
     /// 인덱스가 통째로 날아가 다음 고아 조회에서 전수 probe 가 되살아난다.

--- a/Sources/PokeTokenBar/Core/LocalUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalUsageReader.swift
@@ -518,6 +518,11 @@ enum LocalUsageReader {
             "\(input),\(cachedInput),\(cacheWriteInput),\(output),\(reasoningOutput),\(total)"
         }
 
+        /// Billable component sum used for Entry construction (mirrors parseCodexLine mapping).
+        var billableComponents: Int {
+            max(0, input - cachedInput) + cachedInput + output
+        }
+
         func isLower(than previous: Self) -> Bool {
             input < previous.input
                 || cachedInput < previous.cachedInput
@@ -578,6 +583,8 @@ enum LocalUsageReader {
     /// Codex 사용 엔트리. token_count 이벤트의 last_token_usage(턴 델타)를 4종 토큰으로 매핑.
     /// - input(비캐시) = input_tokens − cached_input_tokens, cacheRead = cached_input_tokens
     /// - output = output_tokens (reasoning 은 output 에 이미 포함), cacheWrite = 0
+    /// - components 가 모두 0 이고 total_tokens 만 있으면(#278): 세션이 total-only 이거나
+    ///   last.total == cumulative.total 일 때만 input 에 넣고, fork zero-context 턴은 0 유지.
     /// Codex 파일 하나를 파싱(세션 단위 — token_count 이벤트의 턴 델타). 캐시가 파일 단위로 호출.
     static func parseCodexFile(_ url: URL, fmt: DateFormatter) -> [Entry] {
         let rollout = parseCodexRollout(url, fmt: fmt)
@@ -1086,8 +1093,9 @@ enum LocalUsageReader {
                 previousCumulative = nil
                 previousOwner = owner
             }
+            let priorCumulative = previousCumulative
             if let cumulative = event.usageState?.cumulative {
-                if let previousCumulative, cumulative.isLower(than: previousCumulative) {
+                if let priorCumulative, cumulative.isLower(than: priorCumulative) {
                     epoch += 1
                 }
                 previousCumulative = cumulative
@@ -1097,8 +1105,11 @@ enum LocalUsageReader {
 
             let entry: Entry
             if let owner, let state = event.usageState {
+                let filled = Self.codexEntryTrustingTotalOnlyLast(
+                    event.entry, state: state, previousCumulative: priorCumulative
+                )
                 entry = replacingID(
-                    of: event.entry,
+                    of: filled,
                     with: "codex|\(owner)|\(epoch)|\(state.fingerprint)"
                 )
             } else {
@@ -1109,6 +1120,31 @@ enum LocalUsageReader {
             history.append(CodexResolvedEvent(entry: entry, usageState: event.usageState))
         }
         return CodexResolvedRollout(history: history, ownedEntries: ownedEntries)
+    }
+
+    /// Mid-session #278 turns: last components are 0 but cumulative.total grew since the
+    /// previous kept event. parseCodexLine cannot see the previous vector, so fill Entry here.
+    private static func codexEntryTrustingTotalOnlyLast(
+        _ entry: Entry,
+        state: CodexUsageState,
+        previousCumulative: CodexUsageVector?
+    ) -> Entry {
+        guard entry.total == 0,
+              state.last.billableComponents == 0,
+              state.last.total > 0,
+              let previous = previousCumulative,
+              state.cumulative.total > previous.total else { return entry }
+        return Entry(
+            id: entry.id,
+            date: entry.date,
+            localDay: entry.localDay,
+            model: entry.model,
+            input: state.last.total,
+            output: 0,
+            cacheWrite: 0,
+            cacheRead: 0,
+            explicitCost: entry.explicitCost
+        )
     }
 
     private static func replacingID(of entry: Entry, with id: String) -> Entry {
@@ -1139,14 +1175,49 @@ enum LocalUsageReader {
         let cached = intValue(last["cached_input_tokens"])
         let output = intValue(last["output_tokens"])
         let nonCachedInput = max(0, inputTotal - cached)
+        let lastTotal = intValue(last["total_tokens"])
+        // #278: some Codex turns leave every last_* component at 0 while total_tokens is set.
+        // Trust that total only when the event itself says the session is total-only, or when
+        // last.total equals the whole cumulative total (sole/first turn). Do NOT trust the
+        // post-replay "zero-context" shape in Fixtures/CodexFork/child.jsonl — cumulative
+        // already has a full component breakdown and last.total is not part of cum growth.
+        let input: Int
+        let out: Int
+        let cacheRead: Int
+        if nonCachedInput + cached + output == 0, lastTotal > 0,
+           Self.shouldTrustCodexTotalOnlyLast(
+               lastTotal: lastTotal,
+               cumulative: (info["total_token_usage"] as? [String: Any]).map(CodexUsageVector.init)
+           ) {
+            input = lastTotal
+            out = 0
+            cacheRead = 0
+        } else {
+            input = nonCachedInput
+            out = output
+            cacheRead = cached
+        }
         let entry = Entry(
             id: "codex|\(file)|\(turn)",
             date: date, localDay: fmt.string(from: date), model: model,
-            input: nonCachedInput, output: output, cacheWrite: 0, cacheRead: cached)
+            input: input, output: out, cacheWrite: 0, cacheRead: cacheRead)
         let usageState = (info["total_token_usage"] as? [String: Any]).map {
             CodexUsageState(cumulative: CodexUsageVector($0), last: CodexUsageVector(last))
         }
         return ParsedCodexToken(entry: entry, usageState: usageState)
+    }
+
+    /// Whether a zero-component `last_token_usage` should contribute `total_tokens` to Entry.
+    /// - No cumulative field: total is the only signal → trust.
+    /// - Cumulative also component-empty with a positive total → trust.
+    /// - `last.total == cumulative.total` → this turn accounts for the whole session → trust.
+    /// - Otherwise (fork post-replay zero-context turn): keep Entry at 0.
+    private static func shouldTrustCodexTotalOnlyLast(
+        lastTotal: Int, cumulative: CodexUsageVector?
+    ) -> Bool {
+        guard let cumulative else { return true }
+        if cumulative.billableComponents == 0, cumulative.total > 0 { return true }
+        return cumulative.total == lastTotal
     }
 
     // MARK: Gemini 파싱

--- a/Sources/PokeTokenBar/Core/ModelPricing.swift
+++ b/Sources/PokeTokenBar/Core/ModelPricing.swift
@@ -25,6 +25,9 @@ enum ModelPricing {
         "claude-sonnet-4-6":          .perMillion(3, 15, 3.75, 0.3),
         "claude-haiku-4-5-20251001":  .perMillion(1, 5, 1.25, 0.1),
         "claude-fable-5":             .perMillion(10, 50, 12.5, 1.0), // LiteLLM 스냅샷 가격 등재됨(2026-08) — 기존 미가격 $0 플레이스홀더 대체
+        // Fable 5.1: same base rates as Fable 5, cache read cut to $0.25/MTok (0.025× input).
+        // Without this row the `fable` family fallback applies Fable 5's $1.00 and overstates cost 4× (#277).
+        "claude-fable-5-1":           .perMillion(10, 50, 12.5, 0.25),
         "gpt-5.5":                    .perMillion(5, 30, 0, 0.5),
         // Gemini — 공식 API 단가(기본 티어, ≤200K 프롬프트). 캐시는 read 단가만(스토리지 시간요금 제외).
         "gemini-2.5-pro":             .perMillion(1.25, 10, 0, 0.3125),

--- a/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
+++ b/Tests/PokeTokenBarTests/LocalUsageReaderTests.swift
@@ -62,9 +62,17 @@ final class LocalUsageReaderTests: XCTestCase {
         XCTAssertEqual(ModelPricing.cost(model: "claude-opus-4-8", input: 0, output: 1_000_000, cacheWrite: 0, cacheRead: 0), 25.0, accuracy: 1e-6)
         XCTAssertEqual(ModelPricing.cost(model: "claude-haiku-4-5-20251001", input: 1_000_000, output: 0, cacheWrite: 0, cacheRead: 0), 1.0, accuracy: 1e-6)
         XCTAssertEqual(ModelPricing.cost(model: "claude-fable-5", input: 1_000_000, output: 1_000_000, cacheWrite: 1_000_000, cacheRead: 1_000_000), 73.5, accuracy: 1e-6)
+        // Fable 5.1 keeps Fable 5 base rates but cuts cache reads to $0.25/MTok (#277).
+        XCTAssertEqual(ModelPricing.rate(for: "claude-fable-5-1"), .perMillion(10, 50, 12.5, 0.25))
+        XCTAssertEqual(
+            ModelPricing.cost(model: "claude-fable-5-1", input: 0, output: 0, cacheWrite: 0, cacheRead: 1_000_000),
+            0.25, accuracy: 1e-6
+        )
         // 미지 모델 → 패밀리 폴백
         XCTAssertEqual(ModelPricing.cost(model: "claude-opus-4-99", input: 1_000_000, output: 0, cacheWrite: 0, cacheRead: 0), 5.0, accuracy: 1e-6)
         XCTAssertEqual(ModelPricing.cost(model: "claude-fable-6", input: 1_000_000, output: 0, cacheWrite: 0, cacheRead: 0), 10.0, accuracy: 1e-6)
+        // Opus 5 is absent from the table on purpose — the opus family fallback matches.
+        XCTAssertEqual(ModelPricing.rate(for: "claude-opus-5"), .perMillion(5, 25, 6.25, 0.5))
         XCTAssertEqual(ModelPricing.cost(model: "totally-unknown", input: 1_000_000, output: 0, cacheWrite: 0, cacheRead: 0), 0, accuracy: 1e-9)
     }
 
@@ -444,8 +452,10 @@ final class LocalUsageReaderTests: XCTestCase {
                 ts: "2026-07-29T01:00:01.000Z",
                 cumulativeInput: 100, cumulativeOutput: 10,
                 lastInput: 100, lastOutput: 10),
-            // 실제 fork fixture의 post-replay 이벤트와 같은 모양: cumulative는 그대로지만
-            // last.total_tokens만 비영(앱 회계 필드는 모두 0)인 상태는 동일 snapshot이 아니다.
+            // Real fork post-replay shape (Fixtures/CodexFork/child.jsonl L11): cumulative
+            // unchanged, last components all 0, only last.total_tokens set. Keep the event for
+            // fingerprint uniqueness, but do NOT count those tokens — they are not in Codex's
+            // cumulative growth (#278 must not inflate this into 6_742).
             codexStateLine(
                 ts: "2026-07-29T01:00:02.000Z",
                 cumulativeInput: 100, cumulativeOutput: 10,
@@ -455,6 +465,55 @@ final class LocalUsageReaderTests: XCTestCase {
         let entries = LocalUsageReader.codexEntries(modifiedSince: .distantPast, root: dir)
 
         XCTAssertEqual(entries.map(\.total), [110, 0])
+    }
+
+    /// #278: some Codex turns leave every last_* component at 0 while `total_tokens` is set.
+    /// When that total is the whole session total, it is real usage and must not silently vanish.
+    func testCodexTotalOnlyLastUsageCountsWhenItMatchesSessionTotal() {
+        let dir = tempDir()
+        // cumulative.total == last.total with every component field at 0 (reporter #278 shape).
+        let line = #"{"type":"event_msg","timestamp":"2026-09-04T01:29:58.417Z","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":51293},"last_token_usage":{"input_tokens":0,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":51293}}}}"#
+        write([
+            codexSessionMeta(id: "solo", ts: "2026-09-04T01:29:58.000Z"),
+            line,
+        ], to: dir)
+
+        let entries = LocalUsageReader.codexEntries(modifiedSince: .distantPast, root: dir)
+
+        XCTAssertEqual(entries.map(\.total), [51_293])
+        XCTAssertEqual(entries.first?.input, 51_293)
+        XCTAssertEqual(entries.first?.output, 0)
+        XCTAssertEqual(entries.first?.cacheRead, 0)
+    }
+
+    /// #278: events that omit `total_token_usage` entirely still expose `last.total_tokens`.
+    func testCodexTotalOnlyLastUsageCountsWhenCumulativeIsAbsent() {
+        let dir = tempDir()
+        let line = #"{"type":"event_msg","timestamp":"2026-09-04T01:29:58.417Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":0,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":51293}}}}"#
+        write([
+            codexSessionMeta(id: "solo", ts: "2026-09-04T01:29:58.000Z"),
+            line,
+        ], to: dir)
+
+        let entries = LocalUsageReader.codexEntries(modifiedSince: .distantPast, root: dir)
+
+        XCTAssertEqual(entries.map(\.total), [51_293])
+    }
+
+    /// #278: mid-session turn whose last breakdown is empty but cumulative.total advanced.
+    func testCodexTotalOnlyLastUsageCountsWhenCumulativeGrew() {
+        let dir = tempDir()
+        let first = #"{"type":"event_msg","timestamp":"2026-09-04T01:00:00.000Z","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":100,"reasoning_output_tokens":0,"total_tokens":1100},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":100,"reasoning_output_tokens":0,"total_tokens":1100}}}}"#
+        let second = #"{"type":"event_msg","timestamp":"2026-09-04T01:01:00.000Z","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":100,"reasoning_output_tokens":0,"total_tokens":6100},"last_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":5000}}}}"#
+        write([
+            codexSessionMeta(id: "grow", ts: "2026-09-04T00:59:00.000Z"),
+            first,
+            second,
+        ], to: dir)
+
+        let entries = LocalUsageReader.codexEntries(modifiedSince: .distantPast, root: dir)
+
+        XCTAssertEqual(entries.map(\.total), [1_100, 5_000])
     }
 
     func testCodexSessionChangeResetsSameStateComparison() {

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -96,6 +96,22 @@ read_when:
   방식으로 더하면 실사용량이 두 번 집계된다. 반대로 provider가 `thoughts`를 아직 output에 접지 않았다면
   빼면 안 된다. 회귀 픽스처는 `input + output + cacheRead + cacheWrite == totalTokens` 같은 **writer의
   불변식**을 함께 고정하고, 매핑을 고치면 해당 provider cache parser version을 올려 기존 blob도 재파싱한다.
+- **breakdown 이 비고 `total` 만 남은 이벤트는 "무조건 total 신뢰"도 "무조건 0"도 틀리다.** Codex
+  `last_token_usage` 가 성분 전부 0 이면서 `total_tokens` 만 채운 턴이 있다(#278, ~2.5%). 그 total 이
+  세션 전체와 같거나 cumulative 도 total-only 이거나(또는 직전 대비 cumulative.total 이 증가)하면
+  실사용이라 Entry 에 넣어야 하고, fork post-replay 의 zero-context 턴
+  (`Fixtures/CodexFork/child.jsonl` L11: cumulative 성분은 채워져 있고 last.total 만 고아)은
+  cumulative 성장에 안 들어가므로 0 으로 남겨야 한다. 가드:
+  `testCodexTotalOnlyLastUsageCountsWhenItMatchesSessionTotal`·
+  `…WhenCumulativeIsAbsent`·`…WhenCumulativeGrew`·
+  `testCodexUnchangedCumulativeWithDifferentLastVectorIsPreserved`·
+  `testCodexManualForkFixtureKeepsOnlyPostReplayUsage`. 매핑 변경 시 `codexParserVersion` 을 올린다.
+- **패밀리 단가 폴백은 "같은 패밀리 = 같은 네 단가"가 깨지는 순간 틀린다.** Fable 5.1 은
+  input/output/cache-write 는 Fable 5 와 같고 cache-read 만 $1.00 → $0.25 로 바뀌었는데,
+  `contains("fable")` 폴백이 Fable 5 단가를 적용해 캐시 위주 세션 비용을 4× 로 부풀렸다(#277).
+  패치·마이너가 단가 한 칸만 바꿀 수 있으면 **정확 매칭 행을 표에 추가**하고, 폴백이 우연히 맞는
+  모델(예: `claude-opus-5` → opus 폴백)은 건드리지 않는다. 가드: `testPricingExactAndFallbackAndZero`
+  의 `claude-fable-5-1` cache-read $0.25 단언.
 - **새 provider를 추가할 때 reader/cache만 연결하면 Settings의 custom-root contract가 조용히 빠진다.** `CustomScanRoots`는
   provider별 `curatedRoots(for:)`와 실제 reader의 `CustomScanRoots.storedValue(for:)` 조회를 모두 registry로
   취급한다. Pi 추가 때 reader/cache/provider는 등록했지만 이 두 지점을 빠뜨려 CI의


### PR DESCRIPTION
## Summary
- **#278:** Codex turns whose `last_token_usage` components are all `0` but `total_tokens` is set no longer vanish. We trust that total when it is the session’s only signal (no cumulative / cumulative also total-only / `last.total == cumulative.total`), or when mid-session `cumulative.total` grew since the previous event. Fork post-replay “zero-context” phantoms (`Fixtures/CodexFork/child.jsonl` L11 — filled cumulative, orphan `last.total`) stay at 0 so child totals remain `28138` / `28263`.
- **#277:** Add an exact `claude-fable-5-1` row at `$10 / $50 / $12.50 / $0.25` so the `fable` family fallback no longer prices cache reads at Fable 5’s `$1.00` (4× overstatement). `claude-opus-5` is left on the opus fallback on purpose.
- Bump `codexParserVersion` 4 → 5 so cached Codex blobs re-parse. Capture both classes in `docs/reference/defect-log.md`.

## Test plan
- [x] RED then GREEN on new guards: `testCodexTotalOnlyLastUsageCountsWhenItMatchesSessionTotal`, `…WhenCumulativeIsAbsent`, `…WhenCumulativeGrew`, plus updated Fable 5.1 asserts in `testPricingExactAndFallbackAndZero`
- [x] Phantom / fork guards still pass: `testCodexUnchangedCumulativeWithDifferentLastVectorIsPreserved` → `[110, 0]`; `testCodexManualForkFixtureKeepsOnlyPostReplayUsage` → `[0, 28138]`; sibling fork totals unchanged
- [x] Full suite: `swift test` → **908 tests, 0 failures** (11 skipped)
- [ ] Manual (optional): open a day that only has a Codex `token_count` with empty components + `total_tokens` > 0 and confirm the menu bar is non-zero; with `claude-fable-5-1` heavy cache reads, cost should be ~¼ of pre-fix

Closes #278
Closes #277