### PR TITLE
feat: add Aside local token usage provider

### DIFF
--- a/Sources/PokeTokenBar/Core/CustomScanRoots.swift
+++ b/Sources/PokeTokenBar/Core/CustomScanRoots.swift
@@ -90,6 +90,8 @@ enum CustomScanRoots {
             return LocalAntigravityUsageReader.resolvedRoots(customRootsValue: nil)
         case "opencode":
             return LocalAdditionalUsageReader.openCodeRoots(customRootsValue: nil)
+        case "aside":
+            return LocalAsideUsageReader.roots()
         case "hermes":
             return LocalAdditionalUsageReader.hermesRoots(customRootsValue: nil)
         case "cursor":

--- a/Sources/PokeTokenBar/Core/CustomScanRoots.swift
+++ b/Sources/PokeTokenBar/Core/CustomScanRoots.swift
@@ -91,7 +91,7 @@ enum CustomScanRoots {
         case "opencode":
             return LocalAdditionalUsageReader.openCodeRoots(customRootsValue: nil)
         case "aside":
-            return LocalAsideUsageReader.roots()
+            return LocalAsideUsageReader.roots(customRootsValue: nil)
         case "hermes":
             return LocalAdditionalUsageReader.hermesRoots(customRootsValue: nil)
         case "cursor":

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SQLite3
 
-private enum LocalAdditionalSource: String, Sendable {
+enum LocalAdditionalSource: String, Sendable {
     case opencode
     case hermes
     case cursor
@@ -112,17 +112,21 @@ struct LocalKiroProvider: UsageProvider {
 /// mutable and sessions can be deleted (`ON DELETE CASCADE` drops their turns), so this
 /// provider merges each scan with previously-seen entries — see the `.aside` case in
 /// `LocalAdditionalUsageCache` and the reader's failure mapping in `LocalAsideUsageReader`.
+/// `includeModels` stays off: `sessions.model` is the session's *current* model, not a
+/// per-turn record, so a per-model breakdown would relabel earlier turns on every refill.
 struct LocalAsideProvider: UsageProvider {
     let id = "aside"
     let displayName = "Aside"
+    /// Injected by tests (`LocalAdditionalUsageCache(rootsOverride:clock:)`); production uses the shared cache.
+    var cache: LocalAdditionalUsageCache = .shared
 
     func fetchDaily() async throws -> DailyUsage? {
-        let entries = await LocalAdditionalUsageCache.shared.entries(for: .aside)
-        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey(), includeModels: true)
+        let entries = await cache.entries(for: .aside)
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey())
     }
 
     func fetchEnrichment() async -> ProviderEnrichment {
-        let entries = await LocalAdditionalUsageCache.shared.entries(for: .aside)
+        let entries = await cache.entries(for: .aside)
         return enrichment(entries: entries)
     }
 }
@@ -146,8 +150,18 @@ private func enrichment(entries: [LocalUsageReader.Entry]) -> ProviderEnrichment
 }
 
 /// Shares a single native read between a provider's daily and enrichment calls.
-private actor LocalAdditionalUsageCache {
+actor LocalAdditionalUsageCache {
     static let shared = LocalAdditionalUsageCache()
+
+    /// Test seams: fixed scan roots per source (production reads Settings / env inside the
+    /// readers) and a clock so a test can step past the 30 s entry without sleeping.
+    private let rootsOverride: [LocalAdditionalSource: [URL]]
+    private let clock: @Sendable () -> Date
+
+    init(rootsOverride: [LocalAdditionalSource: [URL]] = [:], clock: @escaping @Sendable () -> Date = Date.init) {
+        self.rootsOverride = rootsOverride
+        self.clock = clock
+    }
 
     private struct Cached: Sendable {
         let loadedAt: Date
@@ -180,7 +194,7 @@ private actor LocalAdditionalUsageCache {
     }
 
     func entries(for source: LocalAdditionalSource) async -> [LocalUsageReader.Entry] {
-        let now = Date()
+        let now = clock()
         let monthKey = LocalUsageReader.monthKey(now)
         let previous = cached[source].flatMap { $0.monthKey == monthKey ? $0 : nil }
         if let value = previous,
@@ -229,12 +243,14 @@ private actor LocalAdditionalUsageCache {
         case .aside:
             // Aside's `session_turns.token_usage` is rewritten in place while a turn runs
             // and deleting a session cascades to its turns, so like Kiro every scan
-            // re-derives entries and merges with `existing` below.
+            // re-derives entries and merges with `existing` below. A recreated state.db is
+            // told apart by the inode inside the reader's entry ids, so no watermark is kept.
             since = periodStart
             afterRowIDByPath = [:]
         }
         let existing = previous?.entries ?? []
         let knownKiro = previous?.kiroSignatures ?? [:]
+        let asideRoots = rootsOverride[.aside]
         let task = Task.detached(priority: .utility) {
             () async -> ScanResult in
             switch source {
@@ -250,7 +266,7 @@ private actor LocalAdditionalUsageCache {
                     entries: LocalUsageReader.dedupKeepMax(existing + loaded.entries),
                     kiroSignatures: loaded.signatures)
             case .aside:
-                let loaded = LocalAsideUsageReader.entries(modifiedSince: since)
+                let loaded = LocalAsideUsageReader.entries(modifiedSince: since, roots: asideRoots)
                 return ScanResult(entries: LocalUsageReader.dedupKeepMax(existing + loaded))
             case .cursor:
                 let loaded = await LocalAdditionalUsageReader.cursorEntriesAsync(

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -117,7 +117,7 @@ struct LocalKiroProvider: UsageProvider {
 struct LocalAsideProvider: UsageProvider {
     let id = "aside"
     let displayName = "Aside"
-    /// Injected by tests (`LocalAdditionalUsageCache(rootsOverride:clock:)`); production uses the shared cache.
+    /// Injected by tests (`LocalAdditionalUsageCache(asideRootsOverride:clock:)`); production uses the shared cache.
     var cache: LocalAdditionalUsageCache = .shared
 
     func fetchDaily() async throws -> DailyUsage? {
@@ -153,13 +153,14 @@ private func enrichment(entries: [LocalUsageReader.Entry]) -> ProviderEnrichment
 actor LocalAdditionalUsageCache {
     static let shared = LocalAdditionalUsageCache()
 
-    /// Test seams: fixed scan roots per source (production reads Settings / env inside the
-    /// readers) and a clock so a test can step past the 30 s entry without sleeping.
-    private let rootsOverride: [LocalAdditionalSource: [URL]]
+    /// Test seams: fixed Aside scan roots (production reads Settings inside the reader; the
+    /// other sources still read their own roots) and a clock so a test can step past the
+    /// 30 s entry without sleeping.
+    private let asideRootsOverride: [URL]?
     private let clock: @Sendable () -> Date
 
-    init(rootsOverride: [LocalAdditionalSource: [URL]] = [:], clock: @escaping @Sendable () -> Date = Date.init) {
-        self.rootsOverride = rootsOverride
+    init(asideRootsOverride: [URL]? = nil, clock: @escaping @Sendable () -> Date = Date.init) {
+        self.asideRootsOverride = asideRootsOverride
         self.clock = clock
     }
 
@@ -250,7 +251,7 @@ actor LocalAdditionalUsageCache {
         }
         let existing = previous?.entries ?? []
         let knownKiro = previous?.kiroSignatures ?? [:]
-        let asideRoots = rootsOverride[.aside]
+        let asideRoots = asideRootsOverride
         let task = Task.detached(priority: .utility) {
             () async -> ScanResult in
             switch source {

--- a/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAdditionalUsageProvider.swift
@@ -7,6 +7,7 @@ private enum LocalAdditionalSource: String, Sendable {
     case cursor
     case copilot
     case kiro
+    case aside
 }
 
 /// OpenCode usage from its local SQLite database and legacy message files.
@@ -103,6 +104,25 @@ struct LocalKiroProvider: UsageProvider {
 
     func fetchEnrichment() async -> ProviderEnrichment {
         let entries = await LocalAdditionalUsageCache.shared.entries(for: .kiro)
+        return enrichment(entries: entries)
+    }
+}
+
+/// Aside usage from the per-user `state.db` under `~/.aside/u`. Turn aggregates are
+/// mutable and sessions can be deleted (`ON DELETE CASCADE` drops their turns), so this
+/// provider merges each scan with previously-seen entries — see the `.aside` case in
+/// `LocalAdditionalUsageCache` and the reader's failure mapping in `LocalAsideUsageReader`.
+struct LocalAsideProvider: UsageProvider {
+    let id = "aside"
+    let displayName = "Aside"
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .aside)
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey(), includeModels: true)
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let entries = await LocalAdditionalUsageCache.shared.entries(for: .aside)
         return enrichment(entries: entries)
     }
 }
@@ -206,6 +226,12 @@ private actor LocalAdditionalUsageCache {
             // silently drop out of today's total.
             since = periodStart
             afterRowIDByPath = [:]
+        case .aside:
+            // Aside's `session_turns.token_usage` is rewritten in place while a turn runs
+            // and deleting a session cascades to its turns, so like Kiro every scan
+            // re-derives entries and merges with `existing` below.
+            since = periodStart
+            afterRowIDByPath = [:]
         }
         let existing = previous?.entries ?? []
         let knownKiro = previous?.kiroSignatures ?? [:]
@@ -223,6 +249,9 @@ private actor LocalAdditionalUsageCache {
                 return ScanResult(
                     entries: LocalUsageReader.dedupKeepMax(existing + loaded.entries),
                     kiroSignatures: loaded.signatures)
+            case .aside:
+                let loaded = LocalAsideUsageReader.entries(modifiedSince: since)
+                return ScanResult(entries: LocalUsageReader.dedupKeepMax(existing + loaded))
             case .cursor:
                 let loaded = await LocalAdditionalUsageReader.cursorEntriesAsync(
                     modifiedSince: since, afterRowIDByPath: afterRowIDByPath)

--- a/Sources/PokeTokenBar/Core/LocalAsideUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAsideUsageProvider.swift
@@ -5,18 +5,18 @@ struct LocalAsideProvider: UsageProvider {
     let id = "aside"
     let displayName = "Aside"
     let home: URL
-    let customRootsValue: String?
+    let customRoots: @Sendable () -> String?
 
     init(home: URL = FileManager.default.homeDirectoryForCurrentUser,
-         customRootsValue: String? = CustomScanRoots.storedValue(for: "aside")) {
+         customRoots: @escaping @Sendable () -> String? = { CustomScanRoots.storedValue(for: "aside") }) {
         self.home = home
-        self.customRootsValue = customRootsValue
+        self.customRoots = customRoots
     }
 
     func fetchDaily() async throws -> DailyUsage? {
         let now = Date()
         let entries = try LocalAsideUsageReader.entries(
-            databases: LocalAsideUsageReader.databases(home: home, customRootsValue: customRootsValue),
+            databases: LocalAsideUsageReader.databases(home: home, customRootsValue: customRoots()),
             since: Calendar.current.startOfDay(for: now))
         return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey(), includeModels: true)
     }
@@ -24,7 +24,7 @@ struct LocalAsideProvider: UsageProvider {
     func fetchEnrichment() async -> ProviderEnrichment {
         let now = Date()
         guard let entries = try? LocalAsideUsageReader.entries(
-            databases: LocalAsideUsageReader.databases(home: home, customRootsValue: customRootsValue),
+            databases: LocalAsideUsageReader.databases(home: home, customRootsValue: customRoots()),
             since: LocalUsageReader.enrichmentScanStart(now: now)) else { return ProviderEnrichment() }
         let fmt = LocalUsageReader.localDayFormatter()
         let week = fmt.string(from: LocalUsageReader.startOfWeek(now))
@@ -42,7 +42,7 @@ struct LocalAsideProvider: UsageProvider {
 /// Aside persists mutable turn aggregates, not append-only usage events.
 /// Only usage metadata is selected; conversation bodies and credentials are never read.
 enum LocalAsideUsageReader {
-    enum ReadError: Error { case databaseUnavailable, queryFailed }
+    enum ReadError: Error { case databaseUnavailable }
 
     static func roots(home: URL = FileManager.default.homeDirectoryForCurrentUser,
                       customRootsValue: String? = nil) -> [URL] {
@@ -63,50 +63,79 @@ enum LocalAsideUsageReader {
         return found.sorted { $0.path < $1.path }
     }
 
+    /// A database that cannot be opened or queried (an unmigrated second profile, a foreign
+    /// state.db under a custom root) is skipped so it never blanks out the healthy ones.
+    /// When *every* database fails the scan throws instead of reporting zero usage, so a
+    /// transient failure (busy WAL recovery, permissions) keeps the previous values.
     static func entries(databases: [URL], since: Date) throws -> [LocalUsageReader.Entry] {
         var result: [LocalUsageReader.Entry] = []
+        var skipped: [String] = []
         let fmt = LocalUsageReader.localDayFormatter()
         for url in databases {
             var db: OpaquePointer?
             guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
                 sqlite3_close(db)
-                throw ReadError.databaseUnavailable
+                skipped.append(url.path)
+                continue
             }
             defer { sqlite3_close(db) }
             sqlite3_busy_timeout(db, 1000)
             var statement: OpaquePointer?
+            // Turns run for a long time and `token_usage` grows while they run, so a turn is
+            // anchored on its last activity rather than `started_at`; tokens then land in the
+            // day / 5-hour block they were actually generated in.
             let query = """
-                SELECT t.id, t.token_usage, t.started_at, s.model
+                SELECT t.id, t.token_usage, COALESCE(t.finished_at, t.last_message_timestamp), s.model
                 FROM session_turns t LEFT JOIN sessions s ON s.id = t.session_id
-                WHERE t.started_at >= ?
+                WHERE COALESCE(t.finished_at, t.last_message_timestamp) >= ?
                 """
             guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
-                throw ReadError.queryFailed
+                skipped.append(url.path)
+                continue
             }
             defer { sqlite3_finalize(statement) }
             sqlite3_bind_double(statement, 1, since.timeIntervalSince1970)
+            var rows: [LocalUsageReader.Entry] = []
             var status = sqlite3_step(statement)
             while status == SQLITE_ROW {
                 if let text = sqlite3_column_text(statement, 1),
                    let usage = try? JSONSerialization.jsonObject(with: Data(String(cString: text).utf8)) as? [String: Any] {
                     let date = Date(timeIntervalSince1970: sqlite3_column_double(statement, 2))
+                    // The schema has no per-turn model: `sessions.model` is the session's *current*
+                    // setting, so switching a session's model relabels its earlier turns in the
+                    // per-model breakdown. Approximate by design.
                     var model = "aside"
                     if let text = sqlite3_column_text(statement, 3),
                        let metadata = try? JSONSerialization.jsonObject(with: Data(String(cString: text).utf8)) as? [String: Any],
                        let modelID = metadata["modelId"] as? String { model = modelID }
                     let cost = (usage["cost"] as? [String: Any])?["total"] as? Double
                     let hasBuckets = ["input", "output", "cacheRead", "cacheWrite"].contains { usage[$0] is NSNumber }
-                    result.append(.init(
-                        id: "\(url.path):\(sqlite3_column_int64(statement, 0))",
-                        date: date, localDay: fmt.string(from: date), model: model,
-                        input: tokens(hasBuckets ? usage["input"] : usage["totalTokens"]), output: tokens(usage["output"]),
-                        cacheWrite: tokens(usage["cacheWrite"]), cacheRead: tokens(usage["cacheRead"]),
-                        explicitCost: cost))
+                    let input = tokens(hasBuckets ? usage["input"] : usage["totalTokens"])
+                    let output = tokens(usage["output"])
+                    let cacheWrite = tokens(usage["cacheWrite"])
+                    let cacheRead = tokens(usage["cacheRead"])
+                    // Zero-token turns (aborted before a response) are not usage; recording them
+                    // would surface an empty active block and an Aside tab with nothing in it.
+                    if input + output + cacheWrite + cacheRead > 0 {
+                        rows.append(.init(
+                            id: "\(url.path):\(sqlite3_column_int64(statement, 0))",
+                            date: date, localDay: fmt.string(from: date), model: model,
+                            input: input, output: output, cacheWrite: cacheWrite, cacheRead: cacheRead,
+                            explicitCost: cost))
+                    }
                 }
                 status = sqlite3_step(statement)
             }
-            guard status == SQLITE_DONE else { throw ReadError.queryFailed }
+            guard status == SQLITE_DONE else {
+                skipped.append(url.path)
+                continue
+            }
+            result.append(contentsOf: rows)
         }
+        if !skipped.isEmpty {
+            AppLog.write("aside: skipped unreadable state.db: \(skipped.joined(separator: ", "))")
+        }
+        if !databases.isEmpty, skipped.count == databases.count { throw ReadError.databaseUnavailable }
         return result
     }
 

--- a/Sources/PokeTokenBar/Core/LocalAsideUsageProvider.swift
+++ b/Sources/PokeTokenBar/Core/LocalAsideUsageProvider.swift
@@ -1,0 +1,119 @@
+import Foundation
+import SQLite3
+
+struct LocalAsideProvider: UsageProvider {
+    let id = "aside"
+    let displayName = "Aside"
+    let home: URL
+    let customRootsValue: String?
+
+    init(home: URL = FileManager.default.homeDirectoryForCurrentUser,
+         customRootsValue: String? = CustomScanRoots.storedValue(for: "aside")) {
+        self.home = home
+        self.customRootsValue = customRootsValue
+    }
+
+    func fetchDaily() async throws -> DailyUsage? {
+        let now = Date()
+        let entries = try LocalAsideUsageReader.entries(
+            databases: LocalAsideUsageReader.databases(home: home, customRootsValue: customRootsValue),
+            since: Calendar.current.startOfDay(for: now))
+        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey(), includeModels: true)
+    }
+
+    func fetchEnrichment() async -> ProviderEnrichment {
+        let now = Date()
+        guard let entries = try? LocalAsideUsageReader.entries(
+            databases: LocalAsideUsageReader.databases(home: home, customRootsValue: customRootsValue),
+            since: LocalUsageReader.enrichmentScanStart(now: now)) else { return ProviderEnrichment() }
+        let fmt = LocalUsageReader.localDayFormatter()
+        let week = fmt.string(from: LocalUsageReader.startOfWeek(now))
+        let month = fmt.string(from: LocalUsageReader.startOfMonth(now))
+        var result = ProviderEnrichment()
+        result.activeBlock = LocalUsageReader.activeBlock(entries: entries, now: now)
+        result.blocksOK = true
+        result.weekTotal = LocalUsageReader.period(entries: entries, periodKey: week, fromDay: week, toDay: fmt.string(from: now))
+        result.monthTotal = LocalUsageReader.period(entries: entries, periodKey: LocalUsageReader.monthKey(now), fromDay: month, toDay: fmt.string(from: now))
+        result.periodsOK = true
+        return result
+    }
+}
+
+/// Aside persists mutable turn aggregates, not append-only usage events.
+/// Only usage metadata is selected; conversation bodies and credentials are never read.
+enum LocalAsideUsageReader {
+    enum ReadError: Error { case databaseUnavailable, queryFailed }
+
+    static func roots(home: URL = FileManager.default.homeDirectoryForCurrentUser,
+                      customRootsValue: String? = nil) -> [URL] {
+        CustomScanRoots.union(defaults: [home.appendingPathComponent(".aside/u")], extraRaw: customRootsValue)
+    }
+
+    /// Root folders may be `.aside/u` or individual user folders containing state.db.
+    static func databases(home: URL, customRootsValue: String?) -> [URL] {
+        let fm = FileManager.default
+        var found = Set<URL>()
+        for root in roots(home: home, customRootsValue: customRootsValue) {
+            let children = (try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)) ?? []
+            for directory in [root] + children {
+                let db = directory.appendingPathComponent("state.db").resolvingSymlinksInPath().standardizedFileURL
+                if fm.fileExists(atPath: db.path) { found.insert(db) }
+            }
+        }
+        return found.sorted { $0.path < $1.path }
+    }
+
+    static func entries(databases: [URL], since: Date) throws -> [LocalUsageReader.Entry] {
+        var result: [LocalUsageReader.Entry] = []
+        let fmt = LocalUsageReader.localDayFormatter()
+        for url in databases {
+            var db: OpaquePointer?
+            guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+                sqlite3_close(db)
+                throw ReadError.databaseUnavailable
+            }
+            defer { sqlite3_close(db) }
+            sqlite3_busy_timeout(db, 1000)
+            var statement: OpaquePointer?
+            let query = """
+                SELECT t.id, t.token_usage, t.started_at, s.model
+                FROM session_turns t LEFT JOIN sessions s ON s.id = t.session_id
+                WHERE t.started_at >= ?
+                """
+            guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
+                throw ReadError.queryFailed
+            }
+            defer { sqlite3_finalize(statement) }
+            sqlite3_bind_double(statement, 1, since.timeIntervalSince1970)
+            var status = sqlite3_step(statement)
+            while status == SQLITE_ROW {
+                if let text = sqlite3_column_text(statement, 1),
+                   let usage = try? JSONSerialization.jsonObject(with: Data(String(cString: text).utf8)) as? [String: Any] {
+                    let date = Date(timeIntervalSince1970: sqlite3_column_double(statement, 2))
+                    var model = "aside"
+                    if let text = sqlite3_column_text(statement, 3),
+                       let metadata = try? JSONSerialization.jsonObject(with: Data(String(cString: text).utf8)) as? [String: Any],
+                       let modelID = metadata["modelId"] as? String { model = modelID }
+                    let cost = (usage["cost"] as? [String: Any])?["total"] as? Double
+                    let hasBuckets = ["input", "output", "cacheRead", "cacheWrite"].contains { usage[$0] is NSNumber }
+                    result.append(.init(
+                        id: "\(url.path):\(sqlite3_column_int64(statement, 0))",
+                        date: date, localDay: fmt.string(from: date), model: model,
+                        input: tokens(hasBuckets ? usage["input"] : usage["totalTokens"]), output: tokens(usage["output"]),
+                        cacheWrite: tokens(usage["cacheWrite"]), cacheRead: tokens(usage["cacheRead"]),
+                        explicitCost: cost))
+                }
+                status = sqlite3_step(statement)
+            }
+            guard status == SQLITE_DONE else { throw ReadError.queryFailed }
+        }
+        return result
+    }
+
+    private static func tokens(_ value: Any?) -> Int {
+        guard let number = value as? NSNumber else { return 0 }
+        let value = number.doubleValue
+        guard value.isFinite, value > 0 else { return 0 }
+        return Int(min(value, Double(LocalUsageReader.maxParsedTokenValue)))
+    }
+}

--- a/Sources/PokeTokenBar/Core/LocalAsideUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalAsideUsageReader.swift
@@ -1,59 +1,27 @@
 import Foundation
 import SQLite3
 
-struct LocalAsideProvider: UsageProvider {
-    let id = "aside"
-    let displayName = "Aside"
-    let home: URL
-    let customRoots: @Sendable () -> String?
-
-    init(home: URL = FileManager.default.homeDirectoryForCurrentUser,
-         customRoots: @escaping @Sendable () -> String? = { CustomScanRoots.storedValue(for: "aside") }) {
-        self.home = home
-        self.customRoots = customRoots
-    }
-
-    func fetchDaily() async throws -> DailyUsage? {
-        let now = Date()
-        let entries = try LocalAsideUsageReader.entries(
-            databases: LocalAsideUsageReader.databases(home: home, customRootsValue: customRoots()),
-            since: Calendar.current.startOfDay(for: now))
-        return LocalUsageReader.daily(entries: entries, localDay: LocalUsageReader.todayKey(), includeModels: true)
-    }
-
-    func fetchEnrichment() async -> ProviderEnrichment {
-        let now = Date()
-        guard let entries = try? LocalAsideUsageReader.entries(
-            databases: LocalAsideUsageReader.databases(home: home, customRootsValue: customRoots()),
-            since: LocalUsageReader.enrichmentScanStart(now: now)) else { return ProviderEnrichment() }
-        let fmt = LocalUsageReader.localDayFormatter()
-        let week = fmt.string(from: LocalUsageReader.startOfWeek(now))
-        let month = fmt.string(from: LocalUsageReader.startOfMonth(now))
-        var result = ProviderEnrichment()
-        result.activeBlock = LocalUsageReader.activeBlock(entries: entries, now: now)
-        result.blocksOK = true
-        result.weekTotal = LocalUsageReader.period(entries: entries, periodKey: week, fromDay: week, toDay: fmt.string(from: now))
-        result.monthTotal = LocalUsageReader.period(entries: entries, periodKey: LocalUsageReader.monthKey(now), fromDay: month, toDay: fmt.string(from: now))
-        result.periodsOK = true
-        return result
-    }
-}
-
-/// Aside persists mutable turn aggregates, not append-only usage events.
+/// Aside persists mutable turn aggregates, not append-only usage events, and `ON DELETE
+/// CASCADE` removes a session's turns outright when the user deletes the session. The
+/// `.aside` case in `LocalAdditionalUsageCache` therefore merges each scan with the
+/// previously-seen entries (`dedupKeepMax(existing + loaded)`), exactly like Kiro.
 /// Only usage metadata is selected; conversation bodies and credentials are never read.
+///
+/// Failure mapping (see `provider-extension.md`): this reader never throws. A database
+/// that cannot be opened or queried is skipped, so the scan returns whatever the healthy
+/// ones held — and after the first successful scan, an all-failed rescan returns `[]`,
+/// which the keep-max merge treats as "nothing new" rather than "zero usage".
 enum LocalAsideUsageReader {
-    enum ReadError: Error { case databaseUnavailable }
-
-    static func roots(home: URL = FileManager.default.homeDirectoryForCurrentUser,
-                      customRootsValue: String? = nil) -> [URL] {
+    static func roots(customRootsValue: String? = nil,
+                      home: URL = FileManager.default.homeDirectoryForCurrentUser) -> [URL] {
         CustomScanRoots.union(defaults: [home.appendingPathComponent(".aside/u")], extraRaw: customRootsValue)
     }
 
     /// Root folders may be `.aside/u` or individual user folders containing state.db.
-    static func databases(home: URL, customRootsValue: String?) -> [URL] {
+    static func databases(roots: [URL]) -> [URL] {
         let fm = FileManager.default
         var found = Set<URL>()
-        for root in roots(home: home, customRootsValue: customRootsValue) {
+        for root in roots {
             let children = (try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)) ?? []
             for directory in [root] + children {
                 let db = directory.appendingPathComponent("state.db").resolvingSymlinksInPath().standardizedFileURL
@@ -64,10 +32,11 @@ enum LocalAsideUsageReader {
     }
 
     /// A database that cannot be opened or queried (an unmigrated second profile, a foreign
-    /// state.db under a custom root) is skipped so it never blanks out the healthy ones.
-    /// When *every* database fails the scan throws instead of reporting zero usage, so a
-    /// transient failure (busy WAL recovery, permissions) keeps the previous values.
-    static func entries(databases: [URL], since: Date) throws -> [LocalUsageReader.Entry] {
+    /// state.db under a custom root, a busy WAL recovery) is skipped so it never blanks out
+    /// the healthy ones. A scan that fails after yielding rows discards that database's
+    /// partial rows.
+    static func entries(modifiedSince since: Date, roots: [URL]? = nil) -> [LocalUsageReader.Entry] {
+        let databases = databases(roots: roots ?? self.roots(customRootsValue: CustomScanRoots.storedValue(for: "aside")))
         var result: [LocalUsageReader.Entry] = []
         var skipped: [String] = []
         let fmt = LocalUsageReader.localDayFormatter()
@@ -135,7 +104,6 @@ enum LocalAsideUsageReader {
         if !skipped.isEmpty {
             AppLog.write("aside: skipped unreadable state.db: \(skipped.joined(separator: ", "))")
         }
-        if !databases.isEmpty, skipped.count == databases.count { throw ReadError.databaseUnavailable }
         return result
     }
 

--- a/Sources/PokeTokenBar/Core/LocalAsideUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalAsideUsageReader.swift
@@ -4,7 +4,9 @@ import SQLite3
 /// Aside persists mutable turn aggregates, not append-only usage events, and `ON DELETE
 /// CASCADE` removes a session's turns outright when the user deletes the session. The
 /// `.aside` case in `LocalAdditionalUsageCache` therefore merges each scan with the
-/// previously-seen entries (`dedupKeepMax(existing + loaded)`), exactly like Kiro.
+/// previously-seen entries (`dedupKeepMax(existing + loaded)`), exactly like Kiro: a
+/// deleted session stays counted until the scan cache is dropped (Settings save, month
+/// rollover, relaunch), after which the rescan is the truth.
 /// Only usage metadata is selected; conversation bodies and credentials are never read.
 ///
 /// Failure mapping (see `provider-extension.md`): this reader never throws. A database
@@ -49,6 +51,10 @@ enum LocalAsideUsageReader {
             }
             defer { sqlite3_close(db) }
             sqlite3_busy_timeout(db, 1000)
+            // Entry ids carry the file's inode: a recreated state.db (profile removed and
+            // re-created) restarts AUTOINCREMENT at 1, and without the inode its new rows would
+            // share ids with the cached pre-reset turns and hide behind them in the keep-max merge.
+            let store = "\(url.path)#\(inode(of: url.path))"
             var statement: OpaquePointer?
             // Turns run for a long time and `token_usage` grows while they run, so a turn is
             // anchored on its last activity rather than `started_at`; tokens then land in the
@@ -87,7 +93,7 @@ enum LocalAsideUsageReader {
                     // would surface an empty active block and an Aside tab with nothing in it.
                     if input + output + cacheWrite + cacheRead > 0 {
                         rows.append(.init(
-                            id: "\(url.path):\(sqlite3_column_int64(statement, 0))",
+                            id: "\(store):\(sqlite3_column_int64(statement, 0))",
                             date: date, localDay: fmt.string(from: date), model: model,
                             input: input, output: output, cacheWrite: cacheWrite, cacheRead: cacheRead,
                             explicitCost: cost))
@@ -105,6 +111,11 @@ enum LocalAsideUsageReader {
             AppLog.write("aside: skipped unreadable state.db: \(skipped.joined(separator: ", "))")
         }
         return result
+    }
+
+    private static func inode(of path: String) -> UInt64 {
+        var info = stat()
+        return stat(path, &info) == 0 ? UInt64(info.st_ino) : 0
     }
 
     private static func tokens(_ value: Any?) -> Int {

--- a/Sources/PokeTokenBar/Core/LocalAsideUsageReader.swift
+++ b/Sources/PokeTokenBar/Core/LocalAsideUsageReader.swift
@@ -54,7 +54,7 @@ enum LocalAsideUsageReader {
             // Entry ids carry the file's inode: a recreated state.db (profile removed and
             // re-created) restarts AUTOINCREMENT at 1, and without the inode its new rows would
             // share ids with the cached pre-reset turns and hide behind them in the keep-max merge.
-            let store = "\(url.path)#\(inode(of: url.path))"
+            let store = "aside|\(url.path)#\(inode(of: url.path))"
             var statement: OpaquePointer?
             // Turns run for a long time and `token_usage` grows while they run, so a turn is
             // anchored on its last activity rather than `started_at`; tokens then land in the
@@ -77,8 +77,9 @@ enum LocalAsideUsageReader {
                    let usage = try? JSONSerialization.jsonObject(with: Data(String(cString: text).utf8)) as? [String: Any] {
                     let date = Date(timeIntervalSince1970: sqlite3_column_double(statement, 2))
                     // The schema has no per-turn model: `sessions.model` is the session's *current*
-                    // setting, so switching a session's model relabels its earlier turns in the
-                    // per-model breakdown. Approximate by design.
+                    // setting. It only feeds the `ModelPricing` fallback for rows without
+                    // `cost.total` (per-model rows are off for this provider), so the
+                    // approximation is acceptable.
                     var model = "aside"
                     if let text = sqlite3_column_text(statement, 3),
                        let metadata = try? JSONSerialization.jsonObject(with: Data(String(cString: text).utf8)) as? [String: Any],

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -497,7 +497,7 @@ final class UsageStore {
         LocalAntigravityProvider(), LocalOpenCodeProvider(), LocalHermesProvider(),
         LocalCursorProvider(), LocalGrokProvider(), LocalCopilotProvider(), LocalKiroProvider(),
         LocalPiProvider(),
-        LocalOmpProvider(),
+        LocalOmpProvider(), LocalAsideProvider(),
     ],
          // 세션 키 우선, 없거나 죽었으면 기존 Keychain/파일 OAuth 경로. 두 인자는 같은
          // SessionKeyLimitsProvider 인스턴스를 봐야 한다 — 설정 화면이 고른 조직을 조회 경로가 써야 하므로.

--- a/Tests/PokeTokenBarTests/AsideUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AsideUsageTests.swift
@@ -73,18 +73,21 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
         catch { XCTFail("threw \(error) — \(message)", file: file, line: line) }
     }
     private func today(_ provider: LocalAsideProvider) async throws -> Int? { try await provider.fetchDaily()?.totalTokens }
-    private func makeProvider() -> (LocalAsideProvider, Clock) {
+    private func makeProvider() throws -> (LocalAsideProvider, Clock) {
         let clock = Clock()
-        let cache = LocalAdditionalUsageCache(rootsOverride: [.aside: roots], clock: { clock.now })
+        // Stepping the clock 31 s must not cross a month boundary — the cache drops `existing` on a new month key.
+        let monthEnd = Calendar.current.dateInterval(of: .month, for: clock.now)!.end
+        try XCTSkipIf(monthEnd.timeIntervalSince(clock.now) < 60, "within a minute of the month boundary")
+        let cache = LocalAdditionalUsageCache(asideRootsOverride: roots, clock: { clock.now })
         return (LocalAsideProvider(cache: cache), clock)
     }
 
     /// One shared scan feeds daily and enrichment; no per-model rows because `sessions.model`
     /// is the session's current model, not a per-turn record (it would relabel earlier turns).
-    func testProviderSharesOneScanAndReportsNoPerModelBreakdown() async throws {
+    func testProviderReportsDailyAndEnrichmentWithoutPerModelBreakdown() async throws {
         _ = try fixture()
         _ = try fixture(user: "1")
-        let (provider, _) = makeProvider()
+        let (provider, _) = try makeProvider()
         let daily = try await provider.fetchDaily()
         XCTAssertEqual(daily?.totalTokens, 1573318)
         XCTAssertNil(daily?.models, "per-model rows would be relabelled whenever the session switches model")
@@ -101,7 +104,7 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
     func testDeletedSessionStaysCountedUntilCacheInvalidation() async throws {
         let db = try fixture()
         _ = try fixture(user: "1")
-        let (provider, clock) = makeProvider()
+        let (provider, clock) = try makeProvider()
         await XCTAssertEqualAsync(try await today(provider), 1573318)
         try sql("PRAGMA foreign_keys = ON; DELETE FROM sessions WHERE id = 'synthetic-session'", at: db)
         XCTAssertEqual(scan().count, 1, "cascade must have removed the turn — otherwise this test guards nothing")
@@ -114,7 +117,7 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
     /// Turns run for a long time and `token_usage` grows in place; the merge keeps the larger value.
     func testGrowingTurnReplacesTheCachedValue() async throws {
         let db = try fixture()
-        let (provider, clock) = makeProvider()
+        let (provider, clock) = try makeProvider()
         await XCTAssertEqualAsync(try await today(provider), 786659)
         try sql("UPDATE session_turns SET token_usage = '{\"input\":22744,\"output\":9999,\"cacheRead\":758400}' WHERE id = 1", at: db)
         await XCTAssertEqualAsync(try await today(provider), 786659, "inside the 30 s entry the cache answers")
@@ -129,7 +132,7 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
     /// as a deleted session).
     func testRecreatedDatabaseGetsFreshEntryIDs() async throws {
         let db = try fixture()
-        let (provider, clock) = makeProvider()
+        let (provider, clock) = try makeProvider()
         await XCTAssertEqualAsync(try await today(provider), 786659)
         try FileManager.default.removeItem(at: db)
         _ = try fixture(usage: "{\"input\":10,\"output\":20}")   // new file, id 1 again, far smaller
@@ -143,7 +146,7 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
     /// `fetchDaily` lands in `failedIDs` and freezes `lastUpdated` app-wide (`UsageStore.refresh`).
     func testUnreadableDatabaseKeepsPreviousValuesWithoutThrowing() async throws {
         let db = try fixture()
-        let (provider, clock) = makeProvider()
+        let (provider, clock) = try makeProvider()
         await XCTAssertEqualAsync(try await today(provider), 786659)
         try Data("not a database".utf8).write(to: db)
         clock.now += 31

--- a/Tests/PokeTokenBarTests/AsideUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AsideUsageTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import SQLite3
+@testable import PokeTokenBar
+
+/// Synthetic SQLite fixtures; no personal Aside data is used by these tests.
+final class AsideUsageTests: XCTestCase, @unchecked Sendable {
+    private var home: URL!
+    override func setUpWithError() throws {
+        home = FileManager.default.temporaryDirectory.appendingPathComponent("AsideTests-\(UUID())")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    }
+    override func tearDownWithError() throws { try FileManager.default.removeItem(at: home) }
+
+    private func sql(_ text: String, at url: URL) throws {
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        XCTAssertEqual(sqlite3_exec(db, text, nil, nil, nil), SQLITE_OK,
+                       db.map { String(cString: sqlite3_errmsg($0)) } ?? "open failed")
+    }
+    private func fixture(user: String = "0", date: Date = Date(), usage: String = "{\"input\":22744,\"output\":5515,\"cacheRead\":758400,\"cacheWrite\":0,\"totalTokens\":786659,\"cost\":{\"total\":0.65837}}") throws -> URL {
+        let root = home.appendingPathComponent(".aside/u/\(user)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let db = root.appendingPathComponent("state.db")
+        try sql("""
+            CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT);
+            CREATE TABLE session_turns (id INTEGER PRIMARY KEY, session_id TEXT, token_usage TEXT, started_at INTEGER, finished_at INTEGER);
+            INSERT INTO sessions VALUES ('synthetic-session', '{"modelId":"synthetic-model"}');
+            INSERT INTO session_turns VALUES (1, 'synthetic-session', '\(usage)', \(Int(date.timeIntervalSince1970)), NULL);
+            """, at: db)
+        return db
+    }
+
+    func testTotalOnlyUsageFallsBackWithoutInventingCache() throws {
+        let db = try fixture(usage: "{\"input\":null,\"totalTokens\":123}")
+        let entry = try XCTUnwrap(LocalAsideUsageReader.entries(databases: [db], since: .distantPast).first)
+        XCTAssertEqual(entry.total, 123)
+        XCTAssertEqual(entry.cacheRead, 0)
+    }
+
+    @MainActor
+    func testRegisteredAlongsideHermesWithCustomRootSupport() throws {
+        let suite = "AsideRegistration-\(UUID())"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let ids = UsageStore(autoRefresh: false, defaults: defaults).registeredProviderIDs
+        XCTAssertTrue(ids.contains("aside"))
+        XCTAssertTrue(ids.contains("hermes"))
+        XCTAssertEqual(CustomScanRoots.curatedRoots(for: "aside"), LocalAsideUsageReader.roots())
+    }
+
+    func testProviderDiscoversAllUsersAndRefreshesMutableTurns() async throws {
+        let db = try fixture()
+        _ = try fixture(user: "1")
+        let provider = LocalAsideProvider(home: home, customRootsValue: nil)
+        let first = try await provider.fetchDaily()
+        XCTAssertEqual(first?.totalTokens, 1573318)
+        try sql("UPDATE session_turns SET token_usage = '{\"input\":10,\"output\":20}' WHERE id = 1", at: db)
+        let second = try await provider.fetchDaily()
+        XCTAssertEqual(second?.totalTokens, 786689)
+        let enrichment = await provider.fetchEnrichment()
+        XCTAssertEqual(enrichment.weekTotal?.totalTokens, 786689)
+        XCTAssertEqual(enrichment.monthTotal?.totalTokens, 786689)
+        XCTAssertTrue(enrichment.periodsOK)
+    }
+
+    func testReadsTurnBucketsWithoutCountingTotalAgain() throws {
+        let db = try fixture()
+        let entries = try LocalAsideUsageReader.entries(databases: [db], since: .distantPast)
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entry.input, 22744)
+        XCTAssertEqual(entry.output, 5515)
+        XCTAssertEqual(entry.cacheRead, 758400)
+        XCTAssertEqual(entry.total, 786659)
+        XCTAssertEqual(entry.explicitCost, 0.65837)
+        XCTAssertEqual(entry.model, "synthetic-model")
+    }
+}

--- a/Tests/PokeTokenBarTests/AsideUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AsideUsageTests.swift
@@ -25,17 +25,19 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
                        db.map { String(cString: sqlite3_errmsg($0)) } ?? "open failed")
     }
     private func fixture(user: String = "0", directory: URL? = nil, date: Date = Date(), lastMessage: Date? = nil,
-                         finishedAt: Date? = nil,
+                         finishedAt: Date? = nil, abortedAt: Date? = nil,
                          usage: String = "{\"input\":22744,\"output\":5515,\"cacheRead\":758400,\"cacheWrite\":0,\"totalTokens\":786659,\"cost\":{\"total\":0.65837}}") throws -> URL {
         let root = directory ?? home.appendingPathComponent(".aside/u/\(user)")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let db = root.appendingPathComponent("state.db")
         let finished = finishedAt.map { String(Int($0.timeIntervalSince1970)) } ?? "NULL"
+        let aborted = abortedAt.map { String(Int($0.timeIntervalSince1970)) } ?? "NULL"
+        // Mirrors the real schema: AUTOINCREMENT (ids never reused inside one file) and `aborted_at`.
         try sql("""
             CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT);
-            CREATE TABLE session_turns (id INTEGER PRIMARY KEY, session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE, token_usage TEXT, started_at INTEGER, last_message_timestamp INTEGER NOT NULL, finished_at INTEGER);
+            CREATE TABLE session_turns (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE, token_usage TEXT, started_at INTEGER, last_message_timestamp INTEGER NOT NULL, finished_at INTEGER, aborted_at INTEGER);
             INSERT INTO sessions VALUES ('synthetic-session', '{"modelId":"synthetic-model"}');
-            INSERT INTO session_turns VALUES (1, 'synthetic-session', '\(usage)', \(Int(date.timeIntervalSince1970)), \(Int((lastMessage ?? date).timeIntervalSince1970)), \(finished));
+            INSERT INTO session_turns VALUES (1, 'synthetic-session', '\(usage)', \(Int(date.timeIntervalSince1970)), \(Int((lastMessage ?? date).timeIntervalSince1970)), \(finished), \(aborted));
             """, at: db)
         return db
     }
@@ -62,53 +64,98 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
                        [home.appendingPathComponent(".aside/u").path, extra.path])
     }
 
-    /// Aside sits on `LocalAdditionalUsageCache` like Kiro: one shared scan per refresh for
-    /// daily + enrichment, `existing + loaded` keep-max merge, and a reader that never throws
-    /// (a throw from `fetchDaily` freezes `lastUpdated` app-wide — see `provider-extension.md`).
-    func testAsideRidesTheSharedCacheAndNeverThrows() throws {
-        let core = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-            .appendingPathComponent("Sources/PokeTokenBar/Core")
-        let provider = try String(contentsOf: core.appendingPathComponent("LocalAdditionalUsageProvider.swift"), encoding: .utf8)
-        XCTAssertTrue(provider.contains("case aside"), "Aside must be a LocalAdditionalSource case")
-        XCTAssertTrue(provider.contains("LocalAdditionalUsageCache.shared.entries(for: .aside)"))
-        let asideCase = try XCTUnwrap(provider.range(of: "case .aside:\n                let loaded = LocalAsideUsageReader.entries("))
-        let merge = provider[asideCase.upperBound...].prefix(200)
-        XCTAssertTrue(merge.contains("dedupKeepMax(existing + loaded)"),
-                      "a deleted session's already-counted turns must stay counted (keep-max merge)")
-        let reader = try String(contentsOf: core.appendingPathComponent("LocalAsideUsageReader.swift"), encoding: .utf8)
-        let code = reader.split(separator: "\n").filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }.joined(separator: "\n")
-        XCTAssertNil(code.range(of: #"\bthrows?\b"#, options: .regularExpression),
-                     "a permanent schema mismatch must skip, never throw")
+    /// A cache the test owns: fixed roots instead of Settings, and a clock the test steps past
+    /// the 30 s entry so the second scan really merges with `existing`.
+    private final class Clock: @unchecked Sendable { var now = Date() }
+    private func XCTAssertEqualAsync(_ value: @autoclosure () async throws -> Int?, _ expected: Int, _ message: String = "",
+                                     file: StaticString = #filePath, line: UInt = #line) async {
+        do { let got = try await value(); XCTAssertEqual(got, expected, message, file: file, line: line) }
+        catch { XCTFail("threw \(error) — \(message)", file: file, line: line) }
+    }
+    private func today(_ provider: LocalAsideProvider) async throws -> Int? { try await provider.fetchDaily()?.totalTokens }
+    private func makeProvider() -> (LocalAsideProvider, Clock) {
+        let clock = Clock()
+        let cache = LocalAdditionalUsageCache(rootsOverride: [.aside: roots], clock: { clock.now })
+        return (LocalAsideProvider(cache: cache), clock)
     }
 
-    /// Turns run for a long time and `token_usage` grows in place; a rescan sees the new value
-    /// and the cache's keep-max merge keeps the larger one.
-    func testDiscoversAllUsersAndReflectsGrowingTurns() throws {
-        let db = try fixture()
+    /// One shared scan feeds daily and enrichment; no per-model rows because `sessions.model`
+    /// is the session's current model, not a per-turn record (it would relabel earlier turns).
+    func testProviderSharesOneScanAndReportsNoPerModelBreakdown() async throws {
+        _ = try fixture()
         _ = try fixture(user: "1")
-        let first = scan()
-        XCTAssertEqual(total(first), 1573318)
-        try sql("UPDATE session_turns SET token_usage = '{\"input\":22744,\"output\":9999,\"cacheRead\":758400}' WHERE id = 1", at: db)
-        let second = scan()
-        XCTAssertEqual(total(second), 1573318 + 9999 - 5515)
-        XCTAssertEqual(Set(first.map(\.id)), Set(second.map(\.id)), "ids must be stable or the merge doubles")
-        XCTAssertEqual(total(LocalUsageReader.dedupKeepMax(first + second)), total(second))
+        let (provider, _) = makeProvider()
+        let daily = try await provider.fetchDaily()
+        XCTAssertEqual(daily?.totalTokens, 1573318)
+        XCTAssertNil(daily?.models, "per-model rows would be relabelled whenever the session switches model")
+        let enrichment = await provider.fetchEnrichment()
+        XCTAssertTrue(enrichment.periodsOK && enrichment.blocksOK)
+        XCTAssertEqual(enrichment.weekTotal?.totalTokens, 1573318)
+        XCTAssertEqual(enrichment.monthTotal?.totalTokens, 1573318)
+        XCTAssertEqual(enrichment.activeBlock?.totalTokens, 1573318)
     }
 
-    /// Deleting an Aside session cascades to its turns. With a plain rescan, today's total
-    /// would drop by that session's tokens; the keep-max merge keeps them counted.
-    func testDeletedSessionStaysCountedThroughKeepMaxMerge() throws {
+    /// Deleting an Aside session cascades to its turns. A plain rescan would drop today's
+    /// total by that session's tokens; the cache's keep-max merge keeps them counted until
+    /// the cache is invalidated (Settings save / month rollover / relaunch).
+    func testDeletedSessionStaysCountedUntilCacheInvalidation() async throws {
         let db = try fixture()
         _ = try fixture(user: "1")
-        let before = scan()
-        XCTAssertEqual(before.count, 2)
+        let (provider, clock) = makeProvider()
+        await XCTAssertEqualAsync(try await today(provider), 1573318)
         try sql("PRAGMA foreign_keys = ON; DELETE FROM sessions WHERE id = 'synthetic-session'", at: db)
-        let after = scan()
-        XCTAssertEqual(after.count, 1, "cascade must have removed the turn — otherwise this test guards nothing")
-        let merged = LocalUsageReader.dedupKeepMax(before + after)
-        XCTAssertEqual(merged.count, 2)
-        XCTAssertEqual(total(merged), total(before))
+        XCTAssertEqual(scan().count, 1, "cascade must have removed the turn — otherwise this test guards nothing")
+        clock.now += 31
+        await XCTAssertEqualAsync(try await today(provider), 1573318, "already-counted usage must not regress")
+        await provider.cache.invalidate()
+        await XCTAssertEqualAsync(try await today(provider), 786659, "after invalidation the rescan is the truth")
+    }
+
+    /// Turns run for a long time and `token_usage` grows in place; the merge keeps the larger value.
+    func testGrowingTurnReplacesTheCachedValue() async throws {
+        let db = try fixture()
+        let (provider, clock) = makeProvider()
+        await XCTAssertEqualAsync(try await today(provider), 786659)
+        try sql("UPDATE session_turns SET token_usage = '{\"input\":22744,\"output\":9999,\"cacheRead\":758400}' WHERE id = 1", at: db)
+        await XCTAssertEqualAsync(try await today(provider), 786659, "inside the 30 s entry the cache answers")
+        clock.now += 31
+        await XCTAssertEqualAsync(try await today(provider), 786659 + 9999 - 5515)
+    }
+
+    /// A recreated state.db (profile removed and re-created) restarts AUTOINCREMENT at 1, so its
+    /// first new turn would share an id with the cached pre-reset turn and hide behind the larger
+    /// value in the keep-max merge. The inode in the entry id keeps the two apart: the new turn is
+    /// visible at once, and the old one lingers only until the cache is invalidated (same policy
+    /// as a deleted session).
+    func testRecreatedDatabaseGetsFreshEntryIDs() async throws {
+        let db = try fixture()
+        let (provider, clock) = makeProvider()
+        await XCTAssertEqualAsync(try await today(provider), 786659)
+        try FileManager.default.removeItem(at: db)
+        _ = try fixture(usage: "{\"input\":10,\"output\":20}")   // new file, id 1 again, far smaller
+        clock.now += 31
+        await XCTAssertEqualAsync(try await today(provider), 786659 + 30, "the recreated store's turn must not hide behind the stale id")
+        await provider.cache.invalidate()
+        await XCTAssertEqualAsync(try await today(provider), 30)
+    }
+
+    /// Every database failing must keep the previous values and never throw — a throw from
+    /// `fetchDaily` lands in `failedIDs` and freezes `lastUpdated` app-wide (`UsageStore.refresh`).
+    func testUnreadableDatabaseKeepsPreviousValuesWithoutThrowing() async throws {
+        let db = try fixture()
+        let (provider, clock) = makeProvider()
+        await XCTAssertEqualAsync(try await today(provider), 786659)
+        try Data("not a database".utf8).write(to: db)
+        clock.now += 31
+        await XCTAssertEqualAsync(try await today(provider), 786659, "a skipped store merges as nothing new")
+        let week = await provider.fetchEnrichment().weekTotal?.totalTokens
+        XCTAssertEqual(week, 786659)
+    }
+
+    /// An aborted turn that already consumed tokens is usage (real stores hold such rows).
+    func testAbortedTurnWithTokensIsCounted() throws {
+        _ = try fixture(abortedAt: Date())
+        XCTAssertEqual(total(scan()), 786659)
     }
 
     func testReadsTurnBucketsWithoutCountingTotalAgain() throws {
@@ -138,17 +185,6 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
         // A garbage file fails at prepare; a directory named state.db is what fails at open.
         try FileManager.default.createDirectory(at: home.appendingPathComponent(".aside/u/3/state.db"), withIntermediateDirectories: true)
         XCTAssertEqual(total(scan()), 786659)
-    }
-
-    /// Every database failing yields an empty scan, not a throw: the cache merges `[]` into
-    /// the previous entries, so a busy/unmigrated store keeps the last good values.
-    func testAllDatabasesUnreadableReturnsEmptyScan() throws {
-        XCTAssertTrue(scan().isEmpty, "no databases at all is genuinely no usage")
-        try FileManager.default.createDirectory(at: home.appendingPathComponent(".aside/u/0/state.db"), withIntermediateDirectories: true)
-        XCTAssertTrue(scan().isEmpty)
-        let previous = [LocalUsageReader.Entry(id: "kept", date: Date(), localDay: LocalUsageReader.todayKey(), model: "m",
-                                               input: 1, output: 2, cacheWrite: 0, cacheRead: 0, explicitCost: nil)]
-        XCTAssertEqual(LocalUsageReader.dedupKeepMax(previous + scan()).map(\.id), ["kept"])
     }
 
     /// A scan that fails after yielding rows (corrupted pages) must not leak those partial rows.

--- a/Tests/PokeTokenBarTests/AsideUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AsideUsageTests.swift
@@ -11,6 +11,12 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
     }
     override func tearDownWithError() throws { try FileManager.default.removeItem(at: home) }
 
+    private var roots: [URL] { LocalAsideUsageReader.roots(customRootsValue: nil, home: home) }
+    private func scan(since: Date = .distantPast) -> [LocalUsageReader.Entry] {
+        LocalAsideUsageReader.entries(modifiedSince: since, roots: roots)
+    }
+    private func total(_ entries: [LocalUsageReader.Entry]) -> Int { entries.reduce(0) { $0 + $1.total } }
+
     private func sql(_ text: String, at url: URL) throws {
         var db: OpaquePointer?
         XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
@@ -19,22 +25,24 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
                        db.map { String(cString: sqlite3_errmsg($0)) } ?? "open failed")
     }
     private func fixture(user: String = "0", directory: URL? = nil, date: Date = Date(), lastMessage: Date? = nil,
+                         finishedAt: Date? = nil,
                          usage: String = "{\"input\":22744,\"output\":5515,\"cacheRead\":758400,\"cacheWrite\":0,\"totalTokens\":786659,\"cost\":{\"total\":0.65837}}") throws -> URL {
         let root = directory ?? home.appendingPathComponent(".aside/u/\(user)")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let db = root.appendingPathComponent("state.db")
+        let finished = finishedAt.map { String(Int($0.timeIntervalSince1970)) } ?? "NULL"
         try sql("""
             CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT);
-            CREATE TABLE session_turns (id INTEGER PRIMARY KEY, session_id TEXT, token_usage TEXT, started_at INTEGER, last_message_timestamp INTEGER NOT NULL, finished_at INTEGER);
+            CREATE TABLE session_turns (id INTEGER PRIMARY KEY, session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE, token_usage TEXT, started_at INTEGER, last_message_timestamp INTEGER NOT NULL, finished_at INTEGER);
             INSERT INTO sessions VALUES ('synthetic-session', '{"modelId":"synthetic-model"}');
-            INSERT INTO session_turns VALUES (1, 'synthetic-session', '\(usage)', \(Int(date.timeIntervalSince1970)), \(Int((lastMessage ?? date).timeIntervalSince1970)), NULL);
+            INSERT INTO session_turns VALUES (1, 'synthetic-session', '\(usage)', \(Int(date.timeIntervalSince1970)), \(Int((lastMessage ?? date).timeIntervalSince1970)), \(finished));
             """, at: db)
         return db
     }
 
     func testTotalOnlyUsageFallsBackWithoutInventingCache() throws {
-        let db = try fixture(usage: "{\"input\":null,\"totalTokens\":123}")
-        let entry = try XCTUnwrap(try LocalAsideUsageReader.entries(databases: [db], since: .distantPast).first)
+        _ = try fixture(usage: "{\"input\":null,\"totalTokens\":123}")
+        let entry = try XCTUnwrap(scan().first)
         XCTAssertEqual(entry.total, 123)
         XCTAssertEqual(entry.cacheRead, 0)
     }
@@ -47,27 +55,65 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
         let ids = UsageStore(autoRefresh: false, defaults: defaults).registeredProviderIDs
         XCTAssertTrue(ids.contains("aside"))
         XCTAssertTrue(ids.contains("hermes"))
-        XCTAssertEqual(CustomScanRoots.curatedRoots(for: "aside"), LocalAsideUsageReader.roots())
+        XCTAssertEqual(CustomScanRoots.curatedRoots(for: "aside"), LocalAsideUsageReader.roots(customRootsValue: nil))
+        let extra = home.appendingPathComponent("extra")
+        try FileManager.default.createDirectory(at: extra, withIntermediateDirectories: true)
+        XCTAssertEqual(LocalAsideUsageReader.roots(customRootsValue: extra.path, home: home).map(\.path),
+                       [home.appendingPathComponent(".aside/u").path, extra.path])
     }
 
-    func testProviderDiscoversAllUsersAndRefreshesMutableTurns() async throws {
+    /// Aside sits on `LocalAdditionalUsageCache` like Kiro: one shared scan per refresh for
+    /// daily + enrichment, `existing + loaded` keep-max merge, and a reader that never throws
+    /// (a throw from `fetchDaily` freezes `lastUpdated` app-wide — see `provider-extension.md`).
+    func testAsideRidesTheSharedCacheAndNeverThrows() throws {
+        let core = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("Sources/PokeTokenBar/Core")
+        let provider = try String(contentsOf: core.appendingPathComponent("LocalAdditionalUsageProvider.swift"), encoding: .utf8)
+        XCTAssertTrue(provider.contains("case aside"), "Aside must be a LocalAdditionalSource case")
+        XCTAssertTrue(provider.contains("LocalAdditionalUsageCache.shared.entries(for: .aside)"))
+        let asideCase = try XCTUnwrap(provider.range(of: "case .aside:\n                let loaded = LocalAsideUsageReader.entries("))
+        let merge = provider[asideCase.upperBound...].prefix(200)
+        XCTAssertTrue(merge.contains("dedupKeepMax(existing + loaded)"),
+                      "a deleted session's already-counted turns must stay counted (keep-max merge)")
+        let reader = try String(contentsOf: core.appendingPathComponent("LocalAsideUsageReader.swift"), encoding: .utf8)
+        let code = reader.split(separator: "\n").filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }.joined(separator: "\n")
+        XCTAssertNil(code.range(of: #"\bthrows?\b"#, options: .regularExpression),
+                     "a permanent schema mismatch must skip, never throw")
+    }
+
+    /// Turns run for a long time and `token_usage` grows in place; a rescan sees the new value
+    /// and the cache's keep-max merge keeps the larger one.
+    func testDiscoversAllUsersAndReflectsGrowingTurns() throws {
         let db = try fixture()
         _ = try fixture(user: "1")
-        let provider = LocalAsideProvider(home: home, customRoots: { nil })
-        let first = try await provider.fetchDaily()
-        XCTAssertEqual(first?.totalTokens, 1573318)
-        try sql("UPDATE session_turns SET token_usage = '{\"input\":10,\"output\":20}' WHERE id = 1", at: db)
-        let second = try await provider.fetchDaily()
-        XCTAssertEqual(second?.totalTokens, 786689)
-        let enrichment = await provider.fetchEnrichment()
-        XCTAssertEqual(enrichment.weekTotal?.totalTokens, 786689)
-        XCTAssertEqual(enrichment.monthTotal?.totalTokens, 786689)
-        XCTAssertTrue(enrichment.periodsOK)
+        let first = scan()
+        XCTAssertEqual(total(first), 1573318)
+        try sql("UPDATE session_turns SET token_usage = '{\"input\":22744,\"output\":9999,\"cacheRead\":758400}' WHERE id = 1", at: db)
+        let second = scan()
+        XCTAssertEqual(total(second), 1573318 + 9999 - 5515)
+        XCTAssertEqual(Set(first.map(\.id)), Set(second.map(\.id)), "ids must be stable or the merge doubles")
+        XCTAssertEqual(total(LocalUsageReader.dedupKeepMax(first + second)), total(second))
+    }
+
+    /// Deleting an Aside session cascades to its turns. With a plain rescan, today's total
+    /// would drop by that session's tokens; the keep-max merge keeps them counted.
+    func testDeletedSessionStaysCountedThroughKeepMaxMerge() throws {
+        let db = try fixture()
+        _ = try fixture(user: "1")
+        let before = scan()
+        XCTAssertEqual(before.count, 2)
+        try sql("PRAGMA foreign_keys = ON; DELETE FROM sessions WHERE id = 'synthetic-session'", at: db)
+        let after = scan()
+        XCTAssertEqual(after.count, 1, "cascade must have removed the turn — otherwise this test guards nothing")
+        let merged = LocalUsageReader.dedupKeepMax(before + after)
+        XCTAssertEqual(merged.count, 2)
+        XCTAssertEqual(total(merged), total(before))
     }
 
     func testReadsTurnBucketsWithoutCountingTotalAgain() throws {
-        let db = try fixture()
-        let entries = try LocalAsideUsageReader.entries(databases: [db], since: .distantPast)
+        _ = try fixture()
+        let entries = scan()
         let entry = try XCTUnwrap(entries.first)
         XCTAssertEqual(entries.count, 1)
         XCTAssertEqual(entry.input, 22744)
@@ -79,43 +125,34 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
     }
 
     /// An unmigrated profile or a foreign state.db must not blank out the healthy databases.
-    func testSkipsUnreadableDatabaseAndKeepsHealthyOnes() async throws {
+    func testSkipsUnreadableDatabaseAndKeepsHealthyOnes() throws {
         let noTurns = home.appendingPathComponent(".aside/u/0")
         try FileManager.default.createDirectory(at: noTurns, withIntermediateDirectories: true)
         try sql("CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT);", at: noTurns.appendingPathComponent("state.db"))
         _ = try fixture(user: "1")
-        let provider = LocalAsideProvider(home: home, customRoots: { nil })
-        let withBadSchema = try await provider.fetchDaily()
-        XCTAssertEqual(withBadSchema?.totalTokens, 786659)
+        XCTAssertEqual(total(scan()), 786659)
         let notSQLite = home.appendingPathComponent(".aside/u/2")
         try FileManager.default.createDirectory(at: notSQLite, withIntermediateDirectories: true)
         try Data("not a database".utf8).write(to: notSQLite.appendingPathComponent("state.db"))
-        let withGarbage = try await provider.fetchDaily()
-        XCTAssertEqual(withGarbage?.totalTokens, 786659)
+        XCTAssertEqual(total(scan()), 786659)
         // A garbage file fails at prepare; a directory named state.db is what fails at open.
         try FileManager.default.createDirectory(at: home.appendingPathComponent(".aside/u/3/state.db"), withIntermediateDirectories: true)
-        let withDirectory = try await provider.fetchDaily()
-        XCTAssertEqual(withDirectory?.totalTokens, 786659)
+        XCTAssertEqual(total(scan()), 786659)
     }
 
-    /// Every database failing is a read failure, not zero usage: the previous snapshot must survive.
-    func testAllDatabasesUnreadableThrowsInsteadOfReportingZero() async throws {
-        let provider = LocalAsideProvider(home: home, customRoots: { nil })
-        let none = try await provider.fetchDaily()
-        XCTAssertNil(none, "no databases at all is genuinely no usage")
+    /// Every database failing yields an empty scan, not a throw: the cache merges `[]` into
+    /// the previous entries, so a busy/unmigrated store keeps the last good values.
+    func testAllDatabasesUnreadableReturnsEmptyScan() throws {
+        XCTAssertTrue(scan().isEmpty, "no databases at all is genuinely no usage")
         try FileManager.default.createDirectory(at: home.appendingPathComponent(".aside/u/0/state.db"), withIntermediateDirectories: true)
-        do {
-            _ = try await provider.fetchDaily()
-            XCTFail("expected throw")
-        } catch {}
-        let enrichment = await provider.fetchEnrichment()
-        XCTAssertFalse(enrichment.periodsOK)
-        XCTAssertFalse(enrichment.blocksOK)
-        XCTAssertNil(enrichment.weekTotal)
+        XCTAssertTrue(scan().isEmpty)
+        let previous = [LocalUsageReader.Entry(id: "kept", date: Date(), localDay: LocalUsageReader.todayKey(), model: "m",
+                                               input: 1, output: 2, cacheWrite: 0, cacheRead: 0, explicitCost: nil)]
+        XCTAssertEqual(LocalUsageReader.dedupKeepMax(previous + scan()).map(\.id), ["kept"])
     }
 
     /// A scan that fails after yielding rows (corrupted pages) must not leak those partial rows.
-    func testPartialScanFailureDiscardsThatDatabaseOnly() async throws {
+    func testPartialScanFailureDiscardsThatDatabaseOnly() throws {
         let corruptRoot = home.appendingPathComponent(".aside/u/0")
         try FileManager.default.createDirectory(at: corruptRoot, withIntermediateDirectories: true)
         let corrupt = corruptRoot.appendingPathComponent("state.db")
@@ -135,50 +172,43 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
         try handle.seek(toOffset: 4096 * 20)
         try handle.write(contentsOf: Data(repeating: 0xFF, count: 4096 * 100))
         try handle.close()
-        XCTAssertThrowsError(try LocalAsideUsageReader.entries(databases: [corrupt], since: .distantPast))
+        XCTAssertTrue(scan().isEmpty)
         _ = try fixture(user: "1")
-        let daily = try await LocalAsideProvider(home: home, customRoots: { nil }).fetchDaily()
-        XCTAssertEqual(daily?.totalTokens, 786659)
+        XCTAssertEqual(total(scan()), 786659)
     }
 
     /// Aborted turns carry all-zero buckets; they must not surface as a 0-token active block (phantom tab).
-    func testDropsZeroTokenTurnsSoTheyNeverFormAnActiveBlock() async throws {
-        let db = try fixture(usage: "{\"input\":0,\"output\":0,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":0}")
-        XCTAssertTrue(try LocalAsideUsageReader.entries(databases: [db], since: .distantPast).isEmpty)
-        let provider = LocalAsideProvider(home: home, customRoots: { nil })
-        let daily = try await provider.fetchDaily()
-        XCTAssertEqual(daily?.totalTokens ?? 0, 0)
-        let empty = await provider.fetchEnrichment()
-        XCTAssertNil(empty.activeBlock)
+    func testDropsZeroTokenTurnsSoTheyNeverFormAnActiveBlock() throws {
+        _ = try fixture(usage: "{\"input\":0,\"output\":0,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":0}")
+        XCTAssertTrue(scan().isEmpty)
+        XCTAssertNil(LocalUsageReader.activeBlock(entries: scan(), now: Date()))
         _ = try fixture(user: "1")
-        let active = await provider.fetchEnrichment()
-        XCTAssertEqual(active.activeBlock?.totalTokens, 786659)
+        XCTAssertEqual(LocalUsageReader.activeBlock(entries: scan(), now: Date())?.totalTokens, 786659)
     }
 
     /// Turns run for a long time and `token_usage` grows while they run; the tokens belong to the day of last activity.
     func testTurnSpanningMidnightCountsTowardLastActivityDay() throws {
         let startOfToday = Calendar.current.startOfDay(for: Date())
         let lateYesterday = startOfToday.addingTimeInterval(-600)
-        let spanning = try fixture(user: "0", date: lateYesterday, lastMessage: startOfToday.addingTimeInterval(600))
-        let entries = try LocalAsideUsageReader.entries(databases: [spanning], since: startOfToday)
+        _ = try fixture(user: "0", date: lateYesterday, lastMessage: startOfToday.addingTimeInterval(600))
+        let entries = scan(since: startOfToday)
         XCTAssertEqual(entries.count, 1)
         XCTAssertEqual(entries.first?.localDay, LocalUsageReader.todayKey())
         let finishedYesterday = try fixture(user: "1", date: lateYesterday, lastMessage: lateYesterday.addingTimeInterval(60))
-        XCTAssertEqual(try LocalAsideUsageReader.entries(databases: [finishedYesterday], since: startOfToday).count, 0)
+        XCTAssertEqual(LocalAsideUsageReader.entries(modifiedSince: startOfToday, roots: [finishedYesterday.deletingLastPathComponent()]).count, 0)
     }
 
-    /// Settings edits apply on the next refresh, not after a relaunch.
-    func testCustomRootsAreReadOnEveryFetch() async throws {
-        _ = try fixture()
-        let extraRoot = home.appendingPathComponent("extra")
-        _ = try fixture(directory: extraRoot)
-        final class Box: @unchecked Sendable { var value: String? }
-        let extra = Box()
-        let provider = LocalAsideProvider(home: home, customRoots: { extra.value })
-        let before = try await provider.fetchDaily()
-        XCTAssertEqual(before?.totalTokens, 786659)
-        extra.value = extraRoot.path
-        let after = try await provider.fetchDaily()
-        XCTAssertEqual(after?.totalTokens, 1573318)
+    /// `finished_at` outranks `last_message_timestamp` in both the SELECT and the WHERE: a turn that
+    /// finished today counts today even if its last message was yesterday, and the reverse is excluded.
+    func testFinishedAtOutranksLastMessageTimestamp() throws {
+        let startOfToday = Calendar.current.startOfDay(for: Date())
+        let yesterday = startOfToday.addingTimeInterval(-3600)
+        let today = startOfToday.addingTimeInterval(3600)
+        let finishedToday = try fixture(user: "0", date: yesterday, lastMessage: yesterday, finishedAt: today)
+        let counted = LocalAsideUsageReader.entries(modifiedSince: startOfToday, roots: [finishedToday.deletingLastPathComponent()])
+        XCTAssertEqual(counted.count, 1)
+        XCTAssertEqual(counted.first?.localDay, LocalUsageReader.todayKey())
+        let finishedYesterday = try fixture(user: "1", date: yesterday, lastMessage: today, finishedAt: yesterday)
+        XCTAssertTrue(LocalAsideUsageReader.entries(modifiedSince: startOfToday, roots: [finishedYesterday.deletingLastPathComponent()]).isEmpty)
     }
 }

--- a/Tests/PokeTokenBarTests/AsideUsageTests.swift
+++ b/Tests/PokeTokenBarTests/AsideUsageTests.swift
@@ -18,22 +18,23 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(sqlite3_exec(db, text, nil, nil, nil), SQLITE_OK,
                        db.map { String(cString: sqlite3_errmsg($0)) } ?? "open failed")
     }
-    private func fixture(user: String = "0", date: Date = Date(), usage: String = "{\"input\":22744,\"output\":5515,\"cacheRead\":758400,\"cacheWrite\":0,\"totalTokens\":786659,\"cost\":{\"total\":0.65837}}") throws -> URL {
-        let root = home.appendingPathComponent(".aside/u/\(user)")
+    private func fixture(user: String = "0", directory: URL? = nil, date: Date = Date(), lastMessage: Date? = nil,
+                         usage: String = "{\"input\":22744,\"output\":5515,\"cacheRead\":758400,\"cacheWrite\":0,\"totalTokens\":786659,\"cost\":{\"total\":0.65837}}") throws -> URL {
+        let root = directory ?? home.appendingPathComponent(".aside/u/\(user)")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let db = root.appendingPathComponent("state.db")
         try sql("""
             CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT);
-            CREATE TABLE session_turns (id INTEGER PRIMARY KEY, session_id TEXT, token_usage TEXT, started_at INTEGER, finished_at INTEGER);
+            CREATE TABLE session_turns (id INTEGER PRIMARY KEY, session_id TEXT, token_usage TEXT, started_at INTEGER, last_message_timestamp INTEGER NOT NULL, finished_at INTEGER);
             INSERT INTO sessions VALUES ('synthetic-session', '{"modelId":"synthetic-model"}');
-            INSERT INTO session_turns VALUES (1, 'synthetic-session', '\(usage)', \(Int(date.timeIntervalSince1970)), NULL);
+            INSERT INTO session_turns VALUES (1, 'synthetic-session', '\(usage)', \(Int(date.timeIntervalSince1970)), \(Int((lastMessage ?? date).timeIntervalSince1970)), NULL);
             """, at: db)
         return db
     }
 
     func testTotalOnlyUsageFallsBackWithoutInventingCache() throws {
         let db = try fixture(usage: "{\"input\":null,\"totalTokens\":123}")
-        let entry = try XCTUnwrap(LocalAsideUsageReader.entries(databases: [db], since: .distantPast).first)
+        let entry = try XCTUnwrap(try LocalAsideUsageReader.entries(databases: [db], since: .distantPast).first)
         XCTAssertEqual(entry.total, 123)
         XCTAssertEqual(entry.cacheRead, 0)
     }
@@ -52,7 +53,7 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
     func testProviderDiscoversAllUsersAndRefreshesMutableTurns() async throws {
         let db = try fixture()
         _ = try fixture(user: "1")
-        let provider = LocalAsideProvider(home: home, customRootsValue: nil)
+        let provider = LocalAsideProvider(home: home, customRoots: { nil })
         let first = try await provider.fetchDaily()
         XCTAssertEqual(first?.totalTokens, 1573318)
         try sql("UPDATE session_turns SET token_usage = '{\"input\":10,\"output\":20}' WHERE id = 1", at: db)
@@ -75,5 +76,109 @@ final class AsideUsageTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(entry.total, 786659)
         XCTAssertEqual(entry.explicitCost, 0.65837)
         XCTAssertEqual(entry.model, "synthetic-model")
+    }
+
+    /// An unmigrated profile or a foreign state.db must not blank out the healthy databases.
+    func testSkipsUnreadableDatabaseAndKeepsHealthyOnes() async throws {
+        let noTurns = home.appendingPathComponent(".aside/u/0")
+        try FileManager.default.createDirectory(at: noTurns, withIntermediateDirectories: true)
+        try sql("CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT);", at: noTurns.appendingPathComponent("state.db"))
+        _ = try fixture(user: "1")
+        let provider = LocalAsideProvider(home: home, customRoots: { nil })
+        let withBadSchema = try await provider.fetchDaily()
+        XCTAssertEqual(withBadSchema?.totalTokens, 786659)
+        let notSQLite = home.appendingPathComponent(".aside/u/2")
+        try FileManager.default.createDirectory(at: notSQLite, withIntermediateDirectories: true)
+        try Data("not a database".utf8).write(to: notSQLite.appendingPathComponent("state.db"))
+        let withGarbage = try await provider.fetchDaily()
+        XCTAssertEqual(withGarbage?.totalTokens, 786659)
+        // A garbage file fails at prepare; a directory named state.db is what fails at open.
+        try FileManager.default.createDirectory(at: home.appendingPathComponent(".aside/u/3/state.db"), withIntermediateDirectories: true)
+        let withDirectory = try await provider.fetchDaily()
+        XCTAssertEqual(withDirectory?.totalTokens, 786659)
+    }
+
+    /// Every database failing is a read failure, not zero usage: the previous snapshot must survive.
+    func testAllDatabasesUnreadableThrowsInsteadOfReportingZero() async throws {
+        let provider = LocalAsideProvider(home: home, customRoots: { nil })
+        let none = try await provider.fetchDaily()
+        XCTAssertNil(none, "no databases at all is genuinely no usage")
+        try FileManager.default.createDirectory(at: home.appendingPathComponent(".aside/u/0/state.db"), withIntermediateDirectories: true)
+        do {
+            _ = try await provider.fetchDaily()
+            XCTFail("expected throw")
+        } catch {}
+        let enrichment = await provider.fetchEnrichment()
+        XCTAssertFalse(enrichment.periodsOK)
+        XCTAssertFalse(enrichment.blocksOK)
+        XCTAssertNil(enrichment.weekTotal)
+    }
+
+    /// A scan that fails after yielding rows (corrupted pages) must not leak those partial rows.
+    func testPartialScanFailureDiscardsThatDatabaseOnly() async throws {
+        let corruptRoot = home.appendingPathComponent(".aside/u/0")
+        try FileManager.default.createDirectory(at: corruptRoot, withIntermediateDirectories: true)
+        let corrupt = corruptRoot.appendingPathComponent("state.db")
+        let pad = String(repeating: "x", count: 4000)
+        var seed = """
+            PRAGMA page_size=4096; PRAGMA journal_mode=DELETE;
+            CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT);
+            CREATE TABLE session_turns (id INTEGER PRIMARY KEY, session_id TEXT, token_usage TEXT, started_at INTEGER, last_message_timestamp INTEGER NOT NULL, finished_at INTEGER);
+            """
+        let now = Int(Date().timeIntervalSince1970)
+        for id in 1...200 {
+            seed += "INSERT INTO session_turns VALUES (\(id), 's', '{\"input\":1,\"output\":1,\"pad\":\"\(pad)\"}', \(now), \(now), NULL);"
+        }
+        try sql(seed, at: corrupt)
+        // Page 1 (schema) stays intact so prepare succeeds; interior leaf pages are trashed so step fails mid-scan.
+        let handle = try FileHandle(forWritingTo: corrupt)
+        try handle.seek(toOffset: 4096 * 20)
+        try handle.write(contentsOf: Data(repeating: 0xFF, count: 4096 * 100))
+        try handle.close()
+        XCTAssertThrowsError(try LocalAsideUsageReader.entries(databases: [corrupt], since: .distantPast))
+        _ = try fixture(user: "1")
+        let daily = try await LocalAsideProvider(home: home, customRoots: { nil }).fetchDaily()
+        XCTAssertEqual(daily?.totalTokens, 786659)
+    }
+
+    /// Aborted turns carry all-zero buckets; they must not surface as a 0-token active block (phantom tab).
+    func testDropsZeroTokenTurnsSoTheyNeverFormAnActiveBlock() async throws {
+        let db = try fixture(usage: "{\"input\":0,\"output\":0,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":0}")
+        XCTAssertTrue(try LocalAsideUsageReader.entries(databases: [db], since: .distantPast).isEmpty)
+        let provider = LocalAsideProvider(home: home, customRoots: { nil })
+        let daily = try await provider.fetchDaily()
+        XCTAssertEqual(daily?.totalTokens ?? 0, 0)
+        let empty = await provider.fetchEnrichment()
+        XCTAssertNil(empty.activeBlock)
+        _ = try fixture(user: "1")
+        let active = await provider.fetchEnrichment()
+        XCTAssertEqual(active.activeBlock?.totalTokens, 786659)
+    }
+
+    /// Turns run for a long time and `token_usage` grows while they run; the tokens belong to the day of last activity.
+    func testTurnSpanningMidnightCountsTowardLastActivityDay() throws {
+        let startOfToday = Calendar.current.startOfDay(for: Date())
+        let lateYesterday = startOfToday.addingTimeInterval(-600)
+        let spanning = try fixture(user: "0", date: lateYesterday, lastMessage: startOfToday.addingTimeInterval(600))
+        let entries = try LocalAsideUsageReader.entries(databases: [spanning], since: startOfToday)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.localDay, LocalUsageReader.todayKey())
+        let finishedYesterday = try fixture(user: "1", date: lateYesterday, lastMessage: lateYesterday.addingTimeInterval(60))
+        XCTAssertEqual(try LocalAsideUsageReader.entries(databases: [finishedYesterday], since: startOfToday).count, 0)
+    }
+
+    /// Settings edits apply on the next refresh, not after a relaunch.
+    func testCustomRootsAreReadOnEveryFetch() async throws {
+        _ = try fixture()
+        let extraRoot = home.appendingPathComponent("extra")
+        _ = try fixture(directory: extraRoot)
+        final class Box: @unchecked Sendable { var value: String? }
+        let extra = Box()
+        let provider = LocalAsideProvider(home: home, customRoots: { extra.value })
+        let before = try await provider.fetchDaily()
+        XCTAssertEqual(before?.totalTokens, 786659)
+        extra.value = extraRoot.path
+        let after = try await provider.fetchDaily()
+        XCTAssertEqual(after?.totalTokens, 1573318)
     }
 }

--- a/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
+++ b/Tests/PokeTokenBarTests/LocalAdditionalUsageTests.swift
@@ -137,7 +137,7 @@ final class LocalAdditionalUsageTests: XCTestCase {
         XCTAssertEqual(
             Set(store.registeredProviderIDs),
             Set(["claude_code", "codex", "gemini", "antigravity",
-                 "opencode", "hermes", "cursor", "grok", "copilot", "kiro", "pi", "omp"]))
+                 "opencode", "hermes", "cursor", "grok", "copilot", "kiro", "pi", "omp", "aside"]))
     }
 
     func testPrintRealOpenCodeAggregate() throws {

--- a/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
+++ b/Tests/PokeTokenBarTests/ProviderTabLayoutTests.swift
@@ -22,7 +22,7 @@ final class ProviderTabLayoutTests: XCTestCase {
         [("claude_code", "Claude Code"), ("codex", "Codex"), ("gemini", "Gemini"),
          ("antigravity", "Antigravity"), ("opencode", "OpenCode"), ("hermes", "Hermes Agent"),
          ("cursor", "Cursor"), ("grok", "Grok"), ("copilot", "Copilot"), ("kiro", "Kiro"),
-         ("pi", "Pi"), ("omp", "omp")]
+         ("pi", "Pi"), ("omp", "omp"), ("aside", "Aside")]
             .map { snapshot($0.0, $0.1) }
     }
 

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -62,7 +62,7 @@ read_when:
   최종 결정: 캐시 위의 로컬 소스 리더는 **throw 하지 않는다** — 못 여는/못 읽는 DB 는 스킵하고,
   전부 실패면 `[]` 를 돌려 `dedupKeepMax(existing + loaded)` 가 이전 값을 유지한다(캐시가 무효화될
   때까지 — Settings 저장·월 경계·재시작). 회귀 테스트는 **소스 텍스트가 아니라 캐시를 실제로
-  통과**시킨다: `LocalAdditionalUsageCache(rootsOverride:clock:)` + `LocalAsideProvider(cache:)` 로
+  통과**시킨다: `LocalAdditionalUsageCache(asideRootsOverride:clock:)` + `LocalAsideProvider(cache:)` 로
   30초 엔트리를 clock 으로 넘겨 두 번째 스캔이 정말 `existing` 과 병합하는지 본다(`AsideUsageTests`).
   소스 텍스트 검사로 병합을 "고정"했던 첫 버전은 리뷰에서 걸렸고, 행동 테스트로 바꾸자마자
   세션 삭제를 "DB 재생성"으로 오판하는 `MAX(id)` 리셋 감지 버그를 첫 실행에서 잡았다(2026-09-10).

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -59,9 +59,10 @@ read_when:
   enrichment OK=false → 이전 값 유지. Aside 에서 스킵을 `[]` 로 접어 BUSY 한 번에 탭이 사라지고
   주/월이 0 으로 덮였고(2라운드), "전부 실패면 throw" 로 고치자 `no such table` 같은 영구 조건이
   매 리프레시 throw 해서 다른 프로바이더 숫자는 갱신되는데 "Updated 5 hours ago" 가 굳었다(3라운드).
-  일시적 코드(`CANTOPEN`/`BUSY`/`LOCKED`/`IOERR*`/`CORRUPT`)만 throw 후보, prepare 단계의
-  `SQLITE_ERROR`/`NOTADB` 는 "이 소스의 DB 가 아님"으로 스킵. 회귀 테스트는 리더 단위가 아니라
-  provider 를 통해 `fetchDaily` throw 여부와 `fetchEnrichment` OK 플래그를 함께 본다.
+  최종 결정: 캐시 위의 로컬 소스 리더는 **throw 하지 않는다** — 못 여는/못 읽는 DB 는 스킵하고,
+  전부 실패면 `[]` 를 돌려 `dedupKeepMax(existing + loaded)` 가 이전 값을 유지한다(Aside 를
+  `LocalAdditionalUsageCache` 로 옮기며 적용). 회귀 테스트는 리더 파일에 `throw` 가 없는지와 캐시
+  케이스가 `existing +` 로 병합하는지를 소스 텍스트로 고정한다(`AsideUsageTests`).
 - **파싱 뒤에 걸린 필터는 출력을 줄이지 일을 줄이지 않는다.** `modifiedSince` 가 호출부에선
   스캔 창처럼 보이지만, 행 watermark 가 있는 리더에서만 창이다. 통문서 저장(Kiro 가 대화 JSON 을
   제자리 재기록)은 창을 파싱 *뒤에* 적용해서 읽기·`jsonObject` 비용이 그대로다(실측 30×80턴:

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -60,9 +60,16 @@ read_when:
   주/월이 0 으로 덮였고(2라운드), "전부 실패면 throw" 로 고치자 `no such table` 같은 영구 조건이
   매 리프레시 throw 해서 다른 프로바이더 숫자는 갱신되는데 "Updated 5 hours ago" 가 굳었다(3라운드).
   최종 결정: 캐시 위의 로컬 소스 리더는 **throw 하지 않는다** — 못 여는/못 읽는 DB 는 스킵하고,
-  전부 실패면 `[]` 를 돌려 `dedupKeepMax(existing + loaded)` 가 이전 값을 유지한다(Aside 를
-  `LocalAdditionalUsageCache` 로 옮기며 적용). 회귀 테스트는 리더 파일에 `throw` 가 없는지와 캐시
-  케이스가 `existing +` 로 병합하는지를 소스 텍스트로 고정한다(`AsideUsageTests`).
+  전부 실패면 `[]` 를 돌려 `dedupKeepMax(existing + loaded)` 가 이전 값을 유지한다(캐시가 무효화될
+  때까지 — Settings 저장·월 경계·재시작). 회귀 테스트는 **소스 텍스트가 아니라 캐시를 실제로
+  통과**시킨다: `LocalAdditionalUsageCache(rootsOverride:clock:)` + `LocalAsideProvider(cache:)` 로
+  30초 엔트리를 clock 으로 넘겨 두 번째 스캔이 정말 `existing` 과 병합하는지 본다(`AsideUsageTests`).
+  소스 텍스트 검사로 병합을 "고정"했던 첫 버전은 리뷰에서 걸렸고, 행동 테스트로 바꾸자마자
+  세션 삭제를 "DB 재생성"으로 오판하는 `MAX(id)` 리셋 감지 버그를 첫 실행에서 잡았다(2026-09-10).
+- **이전 코드의 opt-in 플래그를 옮길 때 형제가 왜 안 켰는지 먼저 본다.** Aside 를 캐시로 옮기며
+  원본의 `includeModels: true` 를 그대로 가져갔는데, `sessions.model` 은 세션의 *현재* 모델이라
+  캐시가 다시 채워질 때마다(무효화·월 경계·재시작) 이전 턴 전부가 새 모델로 재분류된다. 이 옵션은
+  per-turn 모델이 기록되는 Pi 만 켠다. 회귀: provider 경유 `fetchDaily()?.models == nil`.
 - **파싱 뒤에 걸린 필터는 출력을 줄이지 일을 줄이지 않는다.** `modifiedSince` 가 호출부에선
   스캔 창처럼 보이지만, 행 watermark 가 있는 리더에서만 창이다. 통문서 저장(Kiro 가 대화 JSON 을
   제자리 재기록)은 창을 파싱 *뒤에* 적용해서 읽기·`jsonObject` 비용이 그대로다(실측 30×80턴:

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -48,6 +48,20 @@ read_when:
   같은 `didReset` / `highWater == 0` 규칙을 두 벌로 들고 있으면 한쪽만 고친 수정이 다른 쪽에 남는다
   (#157). 루프는 `scanIncrementalStores` 한 곳, 포맷만 콜백. 회귀는 공유 헬퍼 테스트 **그리고**
   Copilot-only / Cursor-only 각 경로(A\|\|B 의 B 단독)를 모두 밟아야 한다.
+- **리뷰 라운드가 끝나지 않는 건 리뷰어 탓이 아니라 형제 인프라를 우회한 탓이다.** Aside 프로바이더는
+  `LocalAdditionalUsageCache` 를 안 타고 리더를 직접 완결해서 독립 리뷰가 3라운드 이어졌다(2026-09-10):
+  1라운드 파서·루트 스냅샷, 2라운드 0토큰 턴·실패를 `[]` 로 접기, 3라운드 세션 삭제 감소·영구 실패
+  throw. 뒤의 두 라운드 지적은 앞 라운드 *수정*이 만든 것이고(아래 항목), 캐시를 탔으면 부류 자체가
+  없었다. 규칙: 새 소스는 캐시 위에서 시작(`provider-extension.md`), 리뷰가 두 번째 라운드에서도
+  medium 을 내면 개별 fix 를 멈추고 "형제와 다른 경로가 어디냐"를 먼저 묻는다.
+- **실패 처리를 고칠 때는 소비자(`UsageStore.refresh`)의 세 가지 결과 처리를 먼저 읽는다.** throw →
+  `failedIDs`/`lastErrorDescription` + `lastUpdated` 정지(앱 전체), nil → 스냅샷 제거("안 썼음"),
+  enrichment OK=false → 이전 값 유지. Aside 에서 스킵을 `[]` 로 접어 BUSY 한 번에 탭이 사라지고
+  주/월이 0 으로 덮였고(2라운드), "전부 실패면 throw" 로 고치자 `no such table` 같은 영구 조건이
+  매 리프레시 throw 해서 다른 프로바이더 숫자는 갱신되는데 "Updated 5 hours ago" 가 굳었다(3라운드).
+  일시적 코드(`CANTOPEN`/`BUSY`/`LOCKED`/`IOERR*`/`CORRUPT`)만 throw 후보, prepare 단계의
+  `SQLITE_ERROR`/`NOTADB` 는 "이 소스의 DB 가 아님"으로 스킵. 회귀 테스트는 리더 단위가 아니라
+  provider 를 통해 `fetchDaily` throw 여부와 `fetchEnrichment` OK 플래그를 함께 본다.
 - **파싱 뒤에 걸린 필터는 출력을 줄이지 일을 줄이지 않는다.** `modifiedSince` 가 호출부에선
   스캔 창처럼 보이지만, 행 watermark 가 있는 리더에서만 창이다. 통문서 저장(Kiro 가 대화 JSON 을
   제자리 재기록)은 창을 파싱 *뒤에* 적용해서 읽기·`jsonObject` 비용이 그대로다(실측 30×80턴:

--- a/docs/reference/provider-extension.md
+++ b/docs/reference/provider-extension.md
@@ -44,8 +44,11 @@ read_when:
   loaded` keep-max 병합, `invalidateScanCache` 훅)를 타는데 Aside 만 `fetchDaily`/`fetchEnrichment` 가
   각자 전체 스캔을 하도록 직접 짰다. 그 결과가 독립 리뷰 3라운드였다 — 세션 삭제(`ON DELETE CASCADE`)로
   오늘 합계가 줄어드는 문제, 리프레시당 스캔 2회, 실패 처리 관례 불일치는 모두 "형제와 같은 경로를
-  안 탔다"에서 나온 부류다(2026-09-10). 새 소스는 `LocalAdditionalUsageCache.Source` 케이스 하나 +
-  리더 함수로 시작하고, 캐시를 우회할 이유가 있으면 doc comment 에 그 이유를 적는다.
+  안 탔다"에서 나온 부류다(2026-09-10). 새 소스는 `LocalAdditionalSource` 케이스 하나 + 리더
+  함수로 시작하고, 캐시를 우회할 이유가 있으면 doc comment 에 그 이유를 적는다. 테스트는 provider 에
+  `cache:` 를 주입해 캐시를 실제로 통과시킨다 — `LocalAdditionalUsageCache(rootsOverride: [.x: roots],
+  clock:)` 로 루트를 고정하고 clock 을 31초 넘겨 병합 경로(두 번째 스캔)를 밟는다(`AsideUsageTests`).
+  ID 가 파일 안에서만 유일한 소스(SQLite rowid)는 파일 재생성 충돌을 막기 위해 id 에 inode 를 넣는다.
 - **리더의 실패 의미(throw / nil / `[]`)를 바꾸면 소비자 `UsageStore.refresh` 까지 추적한다.**
   provider 파일 안에서만 보면 셋이 비슷해 보이지만 스토어는 다르게 처리한다: `fetchDaily` 가 throw
   → `failedIDs`·`lastErrorDescription`(팝오버 경고 아이콘)에 기록되고 **`lastUpdated` 가 앱 전체로

--- a/docs/reference/provider-extension.md
+++ b/docs/reference/provider-extension.md
@@ -39,6 +39,20 @@ read_when:
   `CustomScanRoots.curatedRoots(for:)` 에도 그 기본 루트 목록을 넣는다 — Settings 매치 카운트가
   이 두 번째 레지스트리를 본다. 빼먹으면 `default: []` 로 카운트만 0 이 되고 스캔은 리더 쪽
   기본값으로 돌아간다.
+- **로컬 파일을 읽는 새 사용량 소스는 `LocalAdditionalUsageCache` 위에 얹는다 — 리더를 손으로
+  완결하지 마라.** OpenCode/Hermes/Kiro/Cursor/Copilot 이 전부 이 캐시(30초 공유 엔트리, `existing +
+  loaded` keep-max 병합, `invalidateScanCache` 훅)를 타는데 Aside 만 `fetchDaily`/`fetchEnrichment` 가
+  각자 전체 스캔을 하도록 직접 짰다. 그 결과가 독립 리뷰 3라운드였다 — 세션 삭제(`ON DELETE CASCADE`)로
+  오늘 합계가 줄어드는 문제, 리프레시당 스캔 2회, 실패 처리 관례 불일치는 모두 "형제와 같은 경로를
+  안 탔다"에서 나온 부류다(2026-09-10). 새 소스는 `LocalAdditionalUsageCache.Source` 케이스 하나 +
+  리더 함수로 시작하고, 캐시를 우회할 이유가 있으면 doc comment 에 그 이유를 적는다.
+- **리더의 실패 의미(throw / nil / `[]`)를 바꾸면 소비자 `UsageStore.refresh` 까지 추적한다.**
+  provider 파일 안에서만 보면 셋이 비슷해 보이지만 스토어는 다르게 처리한다: `fetchDaily` 가 throw
+  → `failedIDs`·`lastErrorDescription`(팝오버 경고 아이콘)에 기록되고 **`lastUpdated` 가 앱 전체로
+  멎는다**; nil → "성공인데 사용량 없음"으로 스냅샷이 사라진다; `fetchEnrichment` 의 OK 플래그 false
+  → 이전 주/월/블록 값을 유지. Aside 리뷰에서 "나쁜 DB 스킵"을 `[]` 로 접어 실패가 0 사용량으로
+  보였고, 그걸 "전부 실패면 throw"로 고치자 영구 스키마 불일치가 `lastUpdated` 를 얼렸다 — 두 번
+  연달아 소비자를 안 읽고 고친 결과다. PR 에 "throw 는 X 일 때만, nil 은 Y" 매핑을 한 줄로 적는다.
 - **append-only SQLite 사용량 스토어** (Cursor `cursorDiskKV`, Copilot `assistant_usage_events`,
   앞으로 같은 형태의 세 번째 소스) = `LocalAdditionalUsageReader.scanIncrementalStores`. URL 매핑·
   `MAX` SQL·row query·parse 만 넘긴다. watermark 루프를 프로바이더마다 복사하지 마라 (#157).

--- a/docs/reference/provider-extension.md
+++ b/docs/reference/provider-extension.md
@@ -46,9 +46,10 @@ read_when:
   오늘 합계가 줄어드는 문제, 리프레시당 스캔 2회, 실패 처리 관례 불일치는 모두 "형제와 같은 경로를
   안 탔다"에서 나온 부류다(2026-09-10). 새 소스는 `LocalAdditionalSource` 케이스 하나 + 리더
   함수로 시작하고, 캐시를 우회할 이유가 있으면 doc comment 에 그 이유를 적는다. 테스트는 provider 에
-  `cache:` 를 주입해 캐시를 실제로 통과시킨다 — `LocalAdditionalUsageCache(rootsOverride: [.x: roots],
+  `cache:` 를 주입해 캐시를 실제로 통과시킨다 — `LocalAdditionalUsageCache(asideRootsOverride: roots,
   clock:)` 로 루트를 고정하고 clock 을 31초 넘겨 병합 경로(두 번째 스캔)를 밟는다(`AsideUsageTests`).
-  ID 가 파일 안에서만 유일한 소스(SQLite rowid)는 파일 재생성 충돌을 막기 위해 id 에 inode 를 넣는다.
+  ID 가 파일 안에서만 유일한 소스(SQLite rowid)는 파일 재생성 충돌을 막아야 한다 — 가변 행이면 id 에
+  inode 를 넣고(Aside), append-only 면 `MAX(id)` 가 watermark 아래로 떨어질 때 `didReset` 으로 재스캔(Copilot).
 - **리더의 실패 의미(throw / nil / `[]`)를 바꾸면 소비자 `UsageStore.refresh` 까지 추적한다.**
   provider 파일 안에서만 보면 셋이 비슷해 보이지만 스토어는 다르게 처리한다: `fetchDaily` 가 throw
   → `failedIDs`·`lastErrorDescription`(팝오버 경고 아이콘)에 기록되고 **`lastUpdated` 가 앱 전체로


### PR DESCRIPTION
## Summary

Add local token-usage support for Aside through the existing provider-agnostic aggregation pipeline.

- Discover `~/.aside/u/*/state.db` and optional custom scan roots, deduplicating resolved database paths.
- Read turn-level usage metadata with read-only SQLite connections; do not read conversation bodies or credentials.
- Count input, output, cache-read, and cache-write buckets without adding `totalTokens` a second time. Fall back to the reported total when bucket values are absent.
- Sit on the shared `LocalAdditionalUsageCache` like Kiro: one scan per refresh feeds daily and enrichment, and each scan merges with previously-seen entries (`dedupKeepMax(existing + loaded)`). Aside rewrites `token_usage` in place while a turn runs and `ON DELETE CASCADE` removes a deleted session's turns, so a plain rescan would make today's total go down.
- The reader never throws. Unreadable databases (unmigrated profile, foreign `state.db` under a custom root, busy WAL recovery) are skipped; an all-failed rescan returns `[]`, which the merge treats as "nothing new" rather than zero usage. A throw from `fetchDaily` would freeze `lastUpdated` app-wide.
- Entry ids carry the file's inode so a recreated profile store (AUTOINCREMENT restarting at 1) cannot hide its new turns behind cached ids.
- Include Aside in daily, weekly, monthly, and active-block aggregation while preserving existing providers.
- Add synthetic SQLite tests (real schema: AUTOINCREMENT, `aborted_at`) and update provider-registration/layout guards.

## Type of change

- [x] New feature

## Data semantics and limitations

- Usage is attributed to the local date of the turn's last activity, `COALESCE(finished_at, last_message_timestamp)`, so a long turn that crosses midnight lands on the day its tokens were generated.
- Zero-token turns (aborted before a response) are dropped; aborted turns that already consumed tokens are counted.
- No per-model breakdown: `sessions.model` is the session's current model, not a per-turn record, so a breakdown would relabel earlier turns whenever the session switches model.
- A deleted session's already-counted usage stays counted until the scan cache is dropped (Settings save, month rollover, relaunch), matching Kiro's documented behavior.
- This adds local usage accounting, not subscription-limit tracking.

## Review history

Two independent Opus review rounds on the final shape; the second found no defects. The rounds are recorded in `docs/reference/provider-extension.md` and `docs/reference/defect-log.md` (new local sources start on the cache; reader failure semantics must be traced to `UsageStore.refresh`; test through the cache with `LocalAdditionalUsageCache(asideRootsOverride:clock:)` rather than source-text assertions).

## Validation

- `./scripts/test-gate.sh`: 925 tests, 11 skipped, 0 failures; logic-core line coverage 84.65% (gate 75%).
- Each new guard was checked by injection: turning `includeModels` back on, removing the cache merge, dropping the inode from the id, and collapsing the `finished_at` COALESCE arm each fail exactly their test.
- Read-only probe of a live Aside store: timestamps are seconds, `token_usage` buckets sum to `totalTokens`, inode is unchanged by WAL checkpoint and VACUUM. No personal database or diagnostic snapshot is included in this PR.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] No UI source changes; the existing provider tab and aggregates display Aside
- [x] No copyrighted assets, secrets, or private tooling references are committed
- [x] Tests were added or updated for this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NE6t8EQAG3aZxEZtQ7ZVfY
