### PR TITLE
fix: remove floating pet toggle from popover footer

### DIFF
--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -444,8 +444,6 @@ final class PetHostingView: NSHostingView<AnyView> {
 
 @MainActor
 struct FloatingPetView: View {
-    /// 푸터 토글의 SF Symbol — 지금 상태를 그린다(보이는 중 = 뜬 눈). 순수 판정이라 뒤집힘을 테스트로 잠근다.
-    static func visibilitySymbol(visible: Bool) -> String { visible ? "eye" : "eye.slash" }
     var animated: Bool = true
     @Environment(UsageStore.self) private var store
     @Environment(CompanionStore.self) private var companion

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -831,15 +831,6 @@ struct PopoverView: View {
                 }
             }
             Spacer()
-            // 데스크톱 펫 표시 토글 — 설정창의 스위치와 **같은 값**(store.floatingPetEnabled)을 읽고 쓴다.
-            // @Observable 이라 어느 쪽에서 바꾸든 다른 쪽이 즉시 따라온다(별도 동기화 없음).
-            Button {
-                store.floatingPetEnabled.toggle()
-            } label: {
-                Image(systemName: FloatingPetView.visibilitySymbol(visible: store.floatingPetEnabled))
-            }
-            .buttonStyle(.borderless)
-            .help(store.floatingPetEnabled ? l.floatingPetHideLabel : l.floatingPetEnableLabel)
             Button {
                 nav.showSettings = true
             } label: {

--- a/Tests/PokeTokenBarTests/PerformanceTests.swift
+++ b/Tests/PokeTokenBarTests/PerformanceTests.swift
@@ -283,14 +283,6 @@ final class FloatingPetEnergyTests: XCTestCase {
         XCTAssertTrue(UsageStore.AnimationQuality.allCases.allSatisfy { $0.frameFloor > 0 })
     }
 
-    /// 푸터 눈 아이콘은 **현재 상태**를 그린다 — 뒤집히면 "숨김"인데 켜진 것처럼 보인다.
-    /// 아이콘/툴팁이 설정창 스위치와 같은 값에서 파생되는지는 두 곳 모두 store.floatingPetEnabled 를
-    /// 읽는 것으로 보장되고(별도 상태 없음), 여기선 그 값 → 심볼 매핑만 잠근다.
-    func testFooterEyeSymbolFollowsVisibility() {
-        XCTAssertEqual(FloatingPetView.visibilitySymbol(visible: true), "eye")
-        XCTAssertEqual(FloatingPetView.visibilitySymbol(visible: false), "eye.slash")
-    }
-
     /// Bubble needs headroom + width beyond the square pet size — otherwise content is clipped.
     func testPanelGrowsForBubbleWithoutChangingPetOrigin() {
         let pet: CGFloat = 96


### PR DESCRIPTION
## Summary

Remove the eye button that toggles the floating pet from the popover footer. Remove its unused symbol helper and obsolete mapping test. Floating pet visibility remains configurable in Settings, and the pet's context-menu hide action remains available.

## Type of change

- [x] Refactor / cleanup

## UI changes

| Before | After |
| ------ | ----- |
| The footer has an eye icon next to Settings that toggles the floating pet. | The footer has no floating pet visibility button. |

## Checklist

- [x] Build and full test gate pass locally: 1,021 tests, 11 skipped, 0 failures; core coverage 92.02%.
- [x] PR title and description are written in English.
- [x] UI changes are described above.
- [x] No copyrighted assets, secrets, or private tooling references are committed.
- [x] Removed the test for the deleted symbol helper; existing rendering and navigation tests pass.
