### PR TITLE
feat: propose collecting all 28 Unown forms

### DIFF
--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -451,6 +451,7 @@ struct MonState: Codable, Sendable {
     var totalForms: Int
     var isShiny = false             // 부화 시 확정, 진화해도 유지
     var nature: PokemonNature?      // 부화 시 확정 (구버전 저장은 nil)
+    var unownForm: UnownForm?
     /// 개체 고유 전투 프로필. 구버전 저장은 nil이며 `CompanionStore`가 한 번만 마이그레이션한다.
     var profile: PokemonProfile?
     var hasGrowthBoost = false
@@ -470,7 +471,7 @@ struct MonState: Codable, Sendable {
     init(baseID: Int, pathIDs: [Int], plannedPathIDs: [Int]? = nil, stageIndex: Int, usedAtStage: Int,
          rarity: Rarity, totalForms: Int, isShiny: Bool = false, nature: PokemonNature? = nil,
          profile: PokemonProfile? = nil, hasGrowthBoost: Bool = false,
-         dittoDisguise: Int? = nil, dittoRevealed: Bool = false) {
+         dittoDisguise: Int? = nil, dittoRevealed: Bool = false, unownForm: UnownForm? = nil) {
         self.baseID = baseID
         self.pathIDs = pathIDs
         if let plannedPathIDs, !plannedPathIDs.isEmpty {
@@ -488,6 +489,7 @@ struct MonState: Codable, Sendable {
         self.hasGrowthBoost = hasGrowthBoost
         self.dittoDisguise = dittoDisguise
         self.dittoRevealed = dittoRevealed
+        self.unownForm = UnownForm.resolved(speciesID: baseID, form: unownForm)
     }
 
     // 하위호환 디코딩: 구버전 저장에 없는 부화 속성은 기본값.
@@ -516,6 +518,8 @@ struct MonState: Codable, Sendable {
         hasGrowthBoost = try c.decodeIfPresent(Bool.self, forKey: .hasGrowthBoost) ?? false
         dittoDisguise = try c.decodeIfPresent(Int.self, forKey: .dittoDisguise)
         dittoRevealed = try c.decodeIfPresent(Bool.self, forKey: .dittoRevealed) ?? false
+        unownForm = UnownForm.resolved(speciesID: baseID,
+                                       form: try? c.decode(UnownForm.self, forKey: .unownForm))
     }
 }
 
@@ -529,6 +533,7 @@ struct DexEntry: Codable, Sendable, Identifiable {
     var caughtAt: Date?
     var isShiny = false
     var nature: PokemonNature?
+    var unownForm: UnownForm?
     /// The individual profile at graduation/release. Nil only for pre-profile saves until migration.
     var profile: PokemonProfile?
     /// 진화 체인 각 종의 다국어 이름(speciesID → langCode → name). 졸업 시 로드된 라인에서 저장 →
@@ -547,7 +552,8 @@ struct DexEntry: Codable, Sendable, Identifiable {
     init(id: String = UUID().uuidString,
          baseID: Int, finalID: Int, chainOrder: [Int], rarity: Rarity,
          caughtAt: Date?, isShiny: Bool = false, nature: PokemonNature? = nil,
-         profile: PokemonProfile? = nil, names: [Int: [String: String]]? = nil, releasedAt: Date? = nil) {
+         profile: PokemonProfile? = nil, names: [Int: [String: String]]? = nil, releasedAt: Date? = nil,
+         unownForm: UnownForm? = nil) {
         self.id = id
         self.baseID = baseID
         self.finalID = finalID
@@ -559,6 +565,7 @@ struct DexEntry: Codable, Sendable, Identifiable {
         self.profile = profile
         self.names = names
         self.releasedAt = releasedAt
+        self.unownForm = UnownForm.resolved(speciesID: baseID, form: unownForm)
     }
 
     // 하위호환 디코딩 (MonState 와 동일 이유).
@@ -579,6 +586,8 @@ struct DexEntry: Codable, Sendable, Identifiable {
         names = (try? c.decodeIfPresent([Int: [String: String]].self, forKey: .names)) ?? nil
         // 이 필드 이전에 저장된 항목은 전부 졸업분이다 — nil 이 곧 "졸업"이라 마이그레이션이 필요 없다.
         releasedAt = try c.decodeIfPresent(Date.self, forKey: .releasedAt)
+        unownForm = UnownForm.resolved(speciesID: baseID,
+                                       form: try? c.decode(UnownForm.self, forKey: .unownForm))
     }
 }
 
@@ -616,6 +625,8 @@ struct CompanionState: Codable, Sendable {
     var eggTier: Rarity?
     // 알 상태에서 미리 롤해둔 부화 종(프리패칭) — 부화 순간 네트워크 딜레이 제거. 재시작에도 유지.
     var pendingHatchID: Int?
+    /// The letter is chosen with the species so prefetch warms the exact sprite that will hatch.
+    var pendingUnownForm: UnownForm?
     /// 오늘 사용량 적립 기준값 — 프로바이더별로 독립 관리한다.
     ///
     /// `nil`은 aggregate `claimedTodayTokens`만 가지고 있던 구버전 세이브가 아직 첫 유효
@@ -631,6 +642,7 @@ struct CompanionState: Codable, Sendable {
     // 종 단위 선택이라 성격 같은 개체 정보는 들고 있지 않는다. 선택 가능한 범위는 도감과 동일하게
     // 졸업분 + 현재 개체의 도달 단계이며, 그 범위에서 빠지면 reconcileRepresentativeSelection 이 nil 로 복구한다.
     var representativeSpeciesID: Int? = nil
+    var representativeUnownForm: UnownForm? = nil
     // 도감
     var dex: [DexEntry] = []
     // 소유한 (base,final) 쌍 — 분기 다양성용
@@ -657,6 +669,8 @@ struct CompanionState: Codable, Sendable {
         // 모르는 rawValue 는 nil(보증 없음)로 강등 — 관대 디코딩의 안전한 방향(있지도 않은 보증을 만들지 않는다).
         eggTier            = c.lenientOptional(Rarity.self, forKey: .eggTier)
         pendingHatchID     = c.lenientOptional(Int.self, forKey: .pendingHatchID)
+        pendingUnownForm   = UnownForm.resolved(speciesID: pendingHatchID ?? 0,
+            form: c.lenientOptional(UnownForm.self, forKey: .pendingUnownForm))
         if c.contains(.claimedTodayTokensByProvider) {
             claimedTodayTokensByProvider = c.lenient([String: Int].self,
                                                       forKey: .claimedTodayTokensByProvider,
@@ -670,6 +684,8 @@ struct CompanionState: Codable, Sendable {
         // active 손상(빈 pathIDs 등) → 알로 폴백하되 도감·인벤토리는 보존.
         active             = c.lenientOptional(MonState.self, forKey: .active)
         representativeSpeciesID = c.lenientOptional(Int.self, forKey: .representativeSpeciesID)
+        representativeUnownForm = UnownForm.resolved(speciesID: representativeSpeciesID ?? 0,
+            form: c.lenientOptional(UnownForm.self, forKey: .representativeUnownForm))
         // 도감은 항목별 격리 — 손상 항목 하나가 도감 전체를 날리지 않게.
         dex                = c.lenient([Lossy<DexEntry>].self, forKey: .dex, default: []).compactMap(\.value)
         collectedFinals    = c.lenient(Set<String>.self, forKey: .collectedFinals, default: [])
@@ -681,10 +697,15 @@ struct CompanionState: Codable, Sendable {
 
     /// 졸업 기록 또는 현재 개체가 실제로 도달한 단계에 이 종이 포함되는가.
     /// 도감 전체 표시 모델을 만들지 않고 대표 종 하나만 확인하는 경량 경로다.
-    func ownsSpecies(_ speciesID: Int) -> Bool {
-        if dex.contains(where: { $0.chainOrder.contains(speciesID) }) { return true }
+    func ownsSpecies(_ speciesID: Int, unownForm: UnownForm? = nil) -> Bool {
+        let form = UnownForm.resolved(speciesID: speciesID, form: unownForm)
+        if dex.contains(where: {
+            $0.chainOrder.contains(speciesID)
+                && UnownForm.resolved(speciesID: speciesID, form: $0.unownForm) == form
+        }) { return true }
         guard let active else { return false }
         return active.pathIDs.prefix(active.stageIndex + 1).contains(speciesID)
+            && UnownForm.resolved(speciesID: speciesID, form: active.unownForm) == form
     }
 
     func hasCollectedFinal(forBaseID baseID: Int) -> Bool {
@@ -693,10 +714,15 @@ struct CompanionState: Codable, Sendable {
 
     /// 보유한 특정 종의 이로치 여부. 졸업 기록과 현재 도달 단계만 훑으며 이름·정렬·희귀도 등
     /// 도감 표시 모델은 계산하지 않는다. 위장 중인 메타몽의 이로치는 리빌 전까지 숨긴다.
-    func ownsShinySpecies(_ speciesID: Int) -> Bool {
-        if dex.contains(where: { $0.isShiny && $0.chainOrder.contains(speciesID) }) { return true }
+    func ownsShinySpecies(_ speciesID: Int, unownForm: UnownForm? = nil) -> Bool {
+        let form = UnownForm.resolved(speciesID: speciesID, form: unownForm)
+        if dex.contains(where: {
+            $0.isShiny && $0.chainOrder.contains(speciesID)
+                && UnownForm.resolved(speciesID: speciesID, form: $0.unownForm) == form
+        }) { return true }
         guard let active,
               active.pathIDs.prefix(active.stageIndex + 1).contains(speciesID),
+              UnownForm.resolved(speciesID: speciesID, form: active.unownForm) == form,
               active.isShiny else { return false }
         return active.dittoDisguise == nil || active.dittoRevealed
     }
@@ -704,8 +730,15 @@ struct CompanionState: Codable, Sendable {
     /// 대표 포켓몬은 사용자가 현재 보유한 종만 가리킨다. Fresh Egg·메타몽 리빌·손편집 세이브가
     /// 유령 종을 메뉴바와 플로팅 펫에 영구히 남기지 않게 한다.
     mutating func reconcileRepresentativeSelection() {
-        guard let selected = representativeSpeciesID else { return }
-        if !ownsSpecies(selected) { representativeSpeciesID = nil }
+        guard let selected = representativeSpeciesID else {
+            representativeUnownForm = nil
+            return
+        }
+        representativeUnownForm = UnownForm.resolved(speciesID: selected, form: representativeUnownForm)
+        if !ownsSpecies(selected, unownForm: representativeUnownForm) {
+            representativeSpeciesID = nil
+            representativeUnownForm = nil
+        }
     }
 }
 

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -187,9 +187,11 @@ final class CompanionStore {
     struct RepresentativeSubject: Equatable, Sendable {
         let speciesID: Int?
         let isShiny: Bool
+        var unownForm: UnownForm? = nil
     }
 
     var representativeSpeciesID: Int? { state.representativeSpeciesID }
+    var representativeUnownForm: UnownForm? { state.representativeUnownForm }
 
     /// 관련 상태가 바뀌어 저장되는 경계에서만 갱신한다. 고정 종 하나의 이로치 여부만 조회하므로
     /// 이름 해석·정렬을 포함한 `dexSpecies` 계산을 메뉴바/플로팅 펫 렌더마다 반복하지 않는다.
@@ -197,9 +199,11 @@ final class CompanionStore {
         let next: RepresentativeSubject
         if let selected = state.representativeSpeciesID {
             next = RepresentativeSubject(speciesID: selected,
-                                         isShiny: state.ownsShinySpecies(selected))
+                isShiny: state.ownsShinySpecies(selected, unownForm: state.representativeUnownForm),
+                unownForm: UnownForm.resolved(speciesID: selected, form: state.representativeUnownForm))
         } else {
-            next = RepresentativeSubject(speciesID: currentSpeciesID, isShiny: currentIsShiny)
+            next = RepresentativeSubject(speciesID: currentSpeciesID, isShiny: currentIsShiny,
+                                         unownForm: currentUnownForm)
         }
         if representativeSubject != next { representativeSubject = next }
     }
@@ -207,11 +211,18 @@ final class CompanionStore {
     /// nil 은 자동 추적. 도감에 없는 id 는 저장하지 않는다 — UI 밖 호출이나 손상된 입력도 같은
     /// 불변식을 지키며, 실패한 요청이 기존 선택을 조용히 해제하지 않도록 false 만 반환한다.
     @discardableResult
-    func setRepresentativeSpeciesID(_ id: Int?) -> Bool {
-        if let id, !state.ownsSpecies(id) { return false }
+    func setRepresentativeSpeciesID(_ id: Int?, unownForm: UnownForm? = nil) -> Bool {
+        if let id, !state.ownsSpecies(id, unownForm: unownForm) { return false }
         state.representativeSpeciesID = id
+        state.representativeUnownForm = UnownForm.resolved(speciesID: id ?? 0, form: unownForm)
         save()
         return true
+    }
+
+    func isRepresentative(_ species: DexSpecies) -> Bool {
+        state.representativeSpeciesID == species.id
+            && UnownForm.resolved(speciesID: species.id, form: state.representativeUnownForm)
+                == UnownForm.resolved(speciesID: species.id, form: species.unownForm)
     }
 
     // 알 인큐베이션 (active 없을 때)
@@ -222,9 +233,13 @@ final class CompanionStore {
 
     var displayName: String {
         guard let a = state.active, let line = currentLine else { return "Token Egg" }
-        return line.localizedName(a.currentID, state.language)
+        return UnownForm.displayName(line.localizedName(a.currentID, state.language),
+                                     speciesID: a.currentID, form: currentUnownForm)
     }
     var currentSpeciesID: Int? { state.active?.currentID }
+    var currentUnownForm: UnownForm? {
+        UnownForm.resolved(speciesID: currentSpeciesID ?? 0, form: state.active?.unownForm)
+    }
     var isFinalStage: Bool {
         guard let a = state.active, let line = currentLine else { return false }
         return line.tree.node(withID: a.currentID)?.children.isEmpty ?? true
@@ -290,7 +305,8 @@ final class CompanionStore {
             names: currentLine.map { line in
                 Dictionary(uniqueKeysWithValues:
                     active.pathIDs.compactMap { id in line.names[id].map { (id, $0) } })
-            }
+            },
+            unownForm: active.unownForm
         )
     }
 
@@ -321,7 +337,7 @@ final class CompanionStore {
                 Dictionary(uniqueKeysWithValues:
                     chain.compactMap { id in line.names[id].map { (id, $0) } })
             },
-            releasedAt: now)
+            releasedAt: now, unownForm: a.unownForm)
     }
 
     var dexEntries: [DexEntry] {
@@ -352,15 +368,32 @@ final class CompanionStore {
     /// 희귀도별 포획 로그 개수(요약 헤더용) — 개체 수 기준. 도감(종 단위)은 dexSpecies 를 쓴다.
     func dexCount(_ rarity: Rarity) -> Int { dexEntries.lazy.filter { $0.rarity == rarity }.count }
 
-    /// 도감 한 칸 — 종 1개로 접힌 수집 기록. 같은 라인을 여러 번 키워도 종은 한 칸이다.
+    /// 도감 한 칸 — 같은 종·안농 폼의 중복 기록을 합친다.
     /// **종 정보만 담는다** — 성격·획득 횟수처럼 개체에 딸린 것은 포획 로그가 개체 단위로 보여준다.
-    struct DexSpecies: Identifiable, Sendable {
+    struct DexSpecies: Sendable {
         let id: Int                     // speciesID = 도감 번호(정렬 키)
         let name: String
         let rarity: Rarity
         let isShiny: Bool               // 이 종을 이로치로 보유한 적이 있는가
         /// 이 종이 현재 키우는 개체의 **현재 형태**인가. 지나온 진화 단계에는 서지 않는다.
         let isRaising: Bool
+        var unownForm: UnownForm? = nil
+
+        /// Species IDs remain Pokédex numbers; selection also includes the Unown letter.
+        var collectionID: String {
+            guard let form = UnownForm.resolved(speciesID: id, form: unownForm) else { return String(id) }
+            return "\(id)-\(form.rawValue)"
+        }
+    }
+
+    private struct DexKey: Hashable {
+        let speciesID: Int
+        let unownForm: UnownForm?
+
+        init(_ speciesID: Int, unownForm: UnownForm?) {
+            self.speciesID = speciesID
+            self.unownForm = UnownForm.resolved(speciesID: speciesID, form: unownForm)
+        }
     }
 
     /// 종 하나가 모으는 것 — 누적 전용. 병렬 딕셔너리를 여러 개 두면 키 집합이 서로 어긋날 수 있고
@@ -380,32 +413,39 @@ final class CompanionStore {
     /// 아직 진화하지 않은 종이 보유로 잡힌다.
     var dexSpecies: [DexSpecies] {
         // 종별 누적을 한 번에 훑는다(뷰가 body 에서 1회 소비 — 메모이즈 없이 충분).
-        var acc: [Int: DexAccumulator] = [:]
+        var acc: [DexKey: DexAccumulator] = [:]
         for entry in state.dex {
             for id in entry.chainOrder {
-                var a = acc[id] ?? DexAccumulator(rarity: entry.rarity)
+                let key = DexKey(id, unownForm: entry.unownForm)
+                var a = acc[key] ?? DexAccumulator(rarity: entry.rarity)
                 if let n = entry.names?[id] { a.names = n }   // 이름 없는 구버전 항목이 덮어쓰지 않게
                 if entry.isShiny { a.isShiny = true }
-                acc[id] = a
+                acc[key] = a
             }
         }
         if let active = state.active {
             // 도달분만 — stageIndex 가 pathIDs 범위 안임은 두 입구가 보장한다:
             // MonState.init(from:) 의 clamp, 그리고 SaveTransfer 의 가져오기 정규화.
             for id in active.pathIDs.prefix(active.stageIndex + 1) {
-                var a = acc[id] ?? DexAccumulator(rarity: active.rarity)
+                let key = DexKey(id, unownForm: active.unownForm)
+                var a = acc[key] ?? DexAccumulator(rarity: active.rarity)
                 if let n = currentLine?.names[id] { a.names = n }
                 if currentIsShiny { a.isShiny = true }   // 위장 중 숨김 규칙 재사용
-                acc[id] = a
+                acc[key] = a
             }
         }
-        return acc.sorted { $0.key < $1.key }.map { id, a in
-            DexSpecies(
-                id: id,
-                name: a.names.flatMap { state.language.resolveName($0) } ?? "#\(id)",
+        return acc.sorted {
+            ($0.key.speciesID, $0.key.unownForm?.sortOrder ?? 0)
+                < ($1.key.speciesID, $1.key.unownForm?.sortOrder ?? 0)
+        }.map { key, a in
+            let name = a.names.flatMap { state.language.resolveName($0) } ?? "#\(key.speciesID)"
+            return DexSpecies(
+                id: key.speciesID,
+                name: UnownForm.displayName(name, speciesID: key.speciesID, form: key.unownForm),
                 rarity: a.rarity,
                 isShiny: a.isShiny,
-                isRaising: id == state.active?.currentID)
+                isRaising: key.speciesID == state.active?.currentID && key.unownForm == currentUnownForm,
+                unownForm: key.unownForm)
         }
     }
 
@@ -709,8 +749,9 @@ final class CompanionStore {
                                   names: currentLine.map { line in   // 체인 각 종의 다국어 이름 저장(표시 즉시)
                                       Dictionary(uniqueKeysWithValues:
                                           a.pathIDs.compactMap { id in line.names[id].map { (id, $0) } })
-                                  }))
-        let name = currentLine?.localizedName(finalID, state.language) ?? ""
+                                  }, unownForm: a.unownForm))
+        let name = UnownForm.displayName(currentLine?.localizedName(finalID, state.language) ?? "",
+                                         speciesID: finalID, form: a.unownForm)
         justGraduated = name
         notifyCompanionEvent(l.notifGraduateTitle, l.notifGraduateBody(name))
         eventUntil = clock().addingTimeInterval(6)
@@ -899,6 +940,7 @@ final class CompanionStore {
         state.eggUsage = 0            // 새 알은 처음부터 인큐베이션(재부화에 5M 필요)
         state.eggTier = tier          // 등급 보증(nil = 보증 없음)
         state.pendingHatchID = nil    // 새 보증으로 처음부터 롤(활성 포켓몬이 있는 동안엔 원래 비어 있다)
+        state.pendingUnownForm = nil
         prefetchedLineID = nil
         justGraduated = nil; justEvolvedTo = nil; eventUntil = nil
         AppLog.write("egg purchased: discarded active, tier=\(tier?.rawValue ?? "none")")
@@ -1003,8 +1045,8 @@ final class CompanionStore {
             kickLineLoadIfNeeded()
             return
         }
-        state.pendingHatchID = nil
-        await hatchCore(baseID: base)
+        let pendingForm = state.pendingHatchID == base ? state.pendingUnownForm : nil
+        await hatchCore(baseID: base, unownForm: pendingForm)
     }
 
     /// 부화가 폐기된 뒤 남은 개체(대개 방금 불러온 개체)의 진화 라인을 다시 로드한다.
@@ -1036,17 +1078,24 @@ final class CompanionStore {
             // 이 롤을 버린다 — 안 그러면 불러온 알의 pre-roll 을 남의 롤로 덮어쓴다.
             guard state.active == nil, activeGeneration == generation else { return }
             state.pendingHatchID = id
+            state.pendingUnownForm = id == UnownForm.speciesID ? .roll(rng.next()) : nil
             save()
         }
         guard let id = state.pendingHatchID, prefetchedLineID != id else { return }
+        let form = state.pendingUnownForm
         guard let line = try? await provider.line(baseSpeciesID: id) else { return }   // 라인 예열
+        guard state.active == nil, activeGeneration == generation, state.pendingHatchID == id else { return }
         // 스프라이트 예열 — 부화 직후 보일 것들: base 정적+애니메이션, shiny 롤(1/64) 대비 shiny 애니메이션.
         // .app 번들에서만(단위 테스트가 실네트워크에 닿지 않도록 — 알림과 동일한 게이트).
         if AppEnv.isBundledApp {
-            _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: false, shiny: false)
-            _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: true, shiny: false)
-            _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: true, shiny: true)
+            _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: false, shiny: false, unownForm: form)
+            _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: true, shiny: false, unownForm: form)
+            _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: true, shiny: true, unownForm: form)
+            if line.baseID == UnownForm.speciesID {
+                _ = await SpriteStore.shared.data(speciesID: line.baseID, animated: false, shiny: true, unownForm: form)
+            }
         }
+        guard state.active == nil, activeGeneration == generation, state.pendingHatchID == id else { return }
         prefetchedLineID = id
     }
 
@@ -1070,7 +1119,7 @@ final class CompanionStore {
     }
 
     /// 실제 부화 로직 — isHatching 락은 호출자(hatch / hatchIfNeeded)가 소유·해제한다.
-    private func hatchCore(baseID: Int) async {
+    private func hatchCore(baseID: Int, unownForm pendingForm: UnownForm? = nil) async {
         let generation = activeGeneration
         guard let line = try? await provider.line(baseSpeciesID: baseID) else {
             AppLog.write("hatch: line fetch failed for base \(baseID) — egg kept, retry next tick")
@@ -1090,10 +1139,15 @@ final class CompanionStore {
         if let tier = state.eggTier, line.rarity.sortRank < tier.sortRank {
             AppLog.write("hatch: rolled \(line.rarity) below guaranteed \(tier) — discarded, re-roll next tick")
             state.pendingHatchID = nil
+            state.pendingUnownForm = nil
             prefetchedLineID = nil
             save()
             return
         }
+        state.pendingHatchID = nil
+        state.pendingUnownForm = nil
+        // A later egg can roll the same species with another letter and must warm its own sprite.
+        prefetchedLineID = nil
         currentLine = line
         // 부화 임계 초과분은 부화체 성장에 이월(낭비 없음).
         let overflow = max(0, state.eggUsage - eggHatchThreshold)
@@ -1113,15 +1167,17 @@ final class CompanionStore {
         var profile = PokemonProfile.generate(seed: rng.next())
         if let details = pokemonDetailsByID[line.baseID] { profile.enrich(with: details) }
         let hasGrowthBoost = state.hasCollectedFinal(forBaseID: line.baseID)
+        let unownForm: UnownForm? = line.baseID == UnownForm.speciesID ? (pendingForm ?? .roll(rng.next())) : nil
         // 위장 중엔 이로치를 숨긴다 — 부화 알림·연출도 일반체로(정체는 리빌 때 공개).
         let showShiny = isShiny && dittoDisguise == nil
         activeGeneration += 1
         state.active = MonState(baseID: line.baseID, pathIDs: [line.baseID], plannedPathIDs: evolutionPlan,
                                 stageIndex: 0, usedAtStage: 0, rarity: line.rarity, totalForms: evolutionPlan.count,
                                 isShiny: isShiny, nature: nature, profile: profile, hasGrowthBoost: hasGrowthBoost,
-                                dittoDisguise: dittoDisguise)
+                                dittoDisguise: dittoDisguise, unownForm: unownForm)
         AppLog.write("hatch: base=\(line.baseID) rarity=\(line.rarity) shiny=\(isShiny) forms=\(evolutionPlan.count) boost=\(hasGrowthBoost) ditto=\(dittoDisguise != nil)")
-        let name = line.localizedName(line.baseID, state.language)
+        let name = UnownForm.displayName(line.localizedName(line.baseID, state.language),
+                                         speciesID: line.baseID, form: unownForm)
         notifyCompanionEvent(showShiny ? l.notifShinyHatchTitle : l.notifHatchTitle,
                              showShiny ? l.notifShinyHatchBody(name) : l.notifHatchBody(name))
         justEvolvedTo = nil        // 새 부화는 "성장" 문구(진화 아님) — 직전 진화명이 남아 표시되지 않게
@@ -1359,8 +1415,12 @@ final class CompanionStore {
 
     /// Exact current/final individuals for a Pokédex species. Earlier evolution stages remain
     /// species reference pages; the same evolved individual is not duplicated as a second creature.
-    func pokemonIndividuals(speciesID: Int) -> [DexEntry] {
-        dexEntriesSorted.filter { $0.finalID == speciesID && $0.profile != nil }
+    func pokemonIndividuals(speciesID: Int, unownForm: UnownForm? = nil) -> [DexEntry] {
+        let form = UnownForm.resolved(speciesID: speciesID, form: unownForm)
+        return dexEntriesSorted.filter {
+            $0.finalID == speciesID && $0.profile != nil
+                && UnownForm.resolved(speciesID: speciesID, form: $0.unownForm) == form
+        }
     }
 
     /// Loads immutable PokéAPI metadata and persists any deferred profile fields exactly once.

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -652,6 +652,11 @@ struct L {
     var catchLogTitle: String { t("포획 로그", "Catch log", "捕獲ログ", "Registro de capturas", "Journal de captures", "Registro de capturas", "Fangprotokoll") }
     /// 도감 총계는 개체가 아니라 종 수 — 로그의 dexTotal("총 N마리")과 단위가 다르다.
     func dexSpeciesTotal(_ n: Int) -> String { t("\(n)종", "\(n) species", "\(n)種", "\(n) especies", "\(n) espèces", "\(n) espécies", "\(n) Spezies") }
+    func unownFormsCollected(_ count: Int) -> String {
+        t("안농 글자 \(count)/28", "Unown forms \(count)/28", "アンノーン \(count)/28文字",
+          "Formas Unown \(count)/28", "Formes Zarbi \(count)/28", "Formas Unown \(count)/28",
+          "Icognito-Formen \(count)/28")
+    }
     func dexPageLabel(_ page: Int, _ total: Int) -> String {
         t("\(total)페이지 중 \(page)페이지", "Page \(page) of \(total)", "\(total)ページ中 \(page)ページ", "Página \(page) de \(total)", "Page \(page) sur \(total)", "Página \(page) de \(total)", "Seite \(page) von \(total)")
     }

--- a/Sources/PokeTokenBar/Core/SaveTransfer.swift
+++ b/Sources/PokeTokenBar/Core/SaveTransfer.swift
@@ -154,6 +154,7 @@ enum SaveTransfer {
         // 그 보증으로 미리 뽑아둔 종(pendingHatchID)도 함께 버린다 — 보증만 지우면 졸업 후 받는 **무료**
         // 알이 그 pre-roll 로 부화해, 아무도 사지 않은 프리미엄 결과가 나온다.
         if s.active != nil { s.eggTier = nil; s.pendingHatchID = nil }
+        s.pendingUnownForm = UnownForm.resolved(speciesID: s.pendingHatchID ?? 0, form: s.pendingUnownForm)
         // 만족시킬 수 없는 보증은 알을 영구히 못 깨게 만든다 — 전설은 capture_rate 로 표현할 수 없어
         // (captureRateCeiling == nil) 두 롤 경로 모두 후보를 0개로 만들고, 부화가 없으니 보증도 소비되지
         // 않으며, 새 알 구매는 `hasActive` 게이트에 막혀 빠져나갈 수단이 없다. 디코드는 *성공*하므로
@@ -177,7 +178,7 @@ enum SaveTransfer {
     ///
     /// `CompanionState` 의 필드는 이전 관점에서 세 부류다.
     ///  - **진행**: 어느 기기에서든 참(`usedSinceInstall`·`dex`·`inventory`·`active`·`eggUsage`·`eggTier`·
-    ///    `representativeSpeciesID`…)
+    ///    `pendingHatchID`·`pendingUnownForm`·`representativeSpeciesID`·`representativeUnownForm`…)
     ///    → 그대로. 알 보증(`eggTier`)은 산 물건이지 이 기기의 장부가 아니라 기기를 옮겨도 따라간다.
     ///  - **로컬 장부**: *그 기기가* 어디까지 적립했나(`claimedTodayTokensByProvider`·`lastDate`·`installBaselineSet`)
     ///    → 새 기기 기준으로 다시 잡는다. 그대로 들여오면 옛 기기의 오늘 총량이 문턱이 되어

--- a/Sources/PokeTokenBar/Core/UnownForm.swift
+++ b/Sources/PokeTokenBar/Core/UnownForm.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Unown's letter is an individual attribute, independent of its species and shiny color.
+enum UnownForm: String, CaseIterable, Codable, Hashable, Sendable {
+    case a, b, c, d, e, f, g, h, i, j, k, l, m
+    case n, o, p, q, r, s, t, u, v, w, x, y, z
+    case exclamation, question
+
+    static let speciesID = 201
+
+    var symbol: String {
+        switch self {
+        case .exclamation: return "!"
+        case .question: return "?"
+        default: return rawValue.uppercased()
+        }
+    }
+
+    var sortOrder: Int { Self.allCases.firstIndex(of: self)! }
+
+    static func roll(_ roll: UInt64) -> UnownForm {
+        allCases[Int(roll % UInt64(allCases.count))]
+    }
+
+    /// Older saves displayed the default A sprite. Preserve that appearance when no form exists.
+    static func resolved(speciesID: Int, form: UnownForm?) -> UnownForm? {
+        speciesID == Self.speciesID ? (form ?? .a) : nil
+    }
+
+    static func displayName(_ name: String, speciesID: Int, form: UnownForm?) -> String {
+        guard let form = resolved(speciesID: speciesID, form: form) else { return name }
+        return "\(name) [\(form.symbol)]"
+    }
+}

--- a/Sources/PokeTokenBar/PokeTokenBarApp.swift
+++ b/Sources/PokeTokenBar/PokeTokenBarApp.swift
@@ -272,7 +272,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let subject = companion.representativeSubject
         let id = subject.speciesID
         let shiny = subject.isShiny
-        let key = id.map { Self.menuSpriteKey(id: $0, shiny: shiny, floor: menuFrameFloor) }
+        let unownForm = subject.unownForm
+        let key = id.map { Self.menuSpriteKey(id: $0, shiny: shiny, floor: menuFrameFloor, unownForm: unownForm) }
         if key == menuSpriteKey, !menuFrames.isEmpty { return }   // 이미 이 개체로 애니메이션 중
         menuSpriteKey = key
         menuLoadGen += 1
@@ -283,13 +284,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             return
         }
         // 정적 스프라이트 bob 을 먼저(없으면 받아와서). GIF 가 받아지면 아래에서 교체.
-        if let cached = SpriteLoader.cachedImage(speciesID: id, shiny: shiny) {
+        if let cached = SpriteLoader.cachedImage(speciesID: id, shiny: shiny, unownForm: unownForm) {
             setMenuFrames(Self.bobFrames(from: cached))
         } else {
             setMenuFrames(Self.eggFrames())
             Task { @MainActor [weak self] in
                 guard let self, gen == self.menuLoadGen,
-                      let sprite = await SpriteLoader.image(speciesID: id, shiny: shiny) else { return }
+                      let sprite = await SpriteLoader.image(speciesID: id, shiny: shiny, unownForm: unownForm) else { return }
                 guard gen == self.menuLoadGen else { return }
                 self.setMenuFrames(Self.bobFrames(from: sprite))
             }
@@ -300,9 +301,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         Task { @MainActor [weak self] in
             guard let self, gen == self.menuLoadGen else { return }
             // shiny GIF 미제공 종이면 일반 GIF 폴백
-            var data = await SpriteStore.shared.data(speciesID: id, animated: true, shiny: shiny)
+            var data = await SpriteStore.shared.data(speciesID: id, animated: true, shiny: shiny, unownForm: unownForm)
             if data == nil, shiny {
-                data = await SpriteStore.shared.data(speciesID: id, animated: true, shiny: false)
+                data = await SpriteStore.shared.data(speciesID: id, animated: true, shiny: false, unownForm: unownForm)
             }
             guard let data else { return }
             let raw = GIFDecoder.frames(from: data)
@@ -455,8 +456,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// **하한(fps 설정)이 반드시 들어가야 한다.** 프레임은 하한에 맞춰 솎아낸 결과물이라, 키가
     /// 종·이로치만 담으면 설정을 바꿔도 다음 진화까지 옛 fps 로 계속 돈다(설계 시 확인된 함정).
     /// 순수·테스트용: `testIdentityKeysIncludeTheFrameFloor`.
-    static func menuSpriteKey(id: Int, shiny: Bool, floor: TimeInterval) -> String {
-        "\(id)-\(shiny)-\(floor)"
+    static func menuSpriteKey(id: Int, shiny: Bool, floor: TimeInterval, unownForm: UnownForm? = nil) -> String {
+        let form = UnownForm.resolved(speciesID: id, form: unownForm)
+        return "\(id)-\(shiny)-\(floor)-\(form?.rawValue ?? "")"
     }
 
     // MARK: 프레임 합성 (22px)

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -56,6 +56,14 @@ struct SpriteSubject: Equatable {
     var image: NSImage?
     /// image 가 어느 speciesID 것인지. nil = 알(또는 로드된 개체 없음).
     var loadedID: Int?
+    var loadedShiny = false
+    var loadedUnownForm: UnownForm? = nil
+
+    /// Keep the cached pixels and their identity together, including when a pending load is cancelled.
+    func startingLoad(cachedImage: NSImage?, for id: Int, shiny: Bool, unownForm: UnownForm?) -> SpriteSubject {
+        SpriteSubject(image: cachedImage, loadedID: cachedImage == nil ? nil : id,
+                      loadedShiny: shiny, loadedUnownForm: UnownForm.resolved(speciesID: id, form: unownForm))
+    }
 
     /// 주체가 알로 바뀌었다(졸업·새 알). 이전 **개체**의 이미지는 다른 주체의 픽셀이라 버린다.
     /// 이미 알이던 경우(loadedID == nil)엔 손대지 않는다 — 시드된 알 이미지를 지워 🥚 글리프로 깜빡이게 하지 않기 위해.
@@ -70,8 +78,10 @@ struct SpriteSubject: Equatable {
     /// (#135 와 같은 증상), 실패한 로드가 `loadedID` 만 남기면 다음에 그 종이 다시 활성일 때
     /// "이미 로드됨"으로 판단해 🥚 글리프가 고정된다.
     /// (nil 로 돌려주는 이유: 같은 값을 되쓰면 @State 무효화가 한 번 더 돌아 항상 떠 있는 펫에 불필요한 재렌더가 생긴다.)
-    func applyingLoad(_ image: NSImage?, for id: Int, cancelled: Bool) -> SpriteSubject? {
-        cancelled ? nil : SpriteSubject(image: image, loadedID: id)
+    func applyingLoad(_ image: NSImage?, for id: Int, cancelled: Bool,
+                      shiny: Bool = false, unownForm: UnownForm? = nil) -> SpriteSubject? {
+        cancelled ? nil : SpriteSubject(image: image, loadedID: id, loadedShiny: shiny,
+                                        loadedUnownForm: UnownForm.resolved(speciesID: id, form: unownForm))
     }
 
     /// 로드된 알 스프라이트를 반영한 결과(같은 이유로 취소면 nil). 알은 종이 없으므로 loadedID 는 그대로.
@@ -96,17 +106,16 @@ struct SpriteView: View {
     /// 22px 메뉴바보다 큰 펫은 같은 fps 에서도 끊김이 더 보인다.
     /// 팝오버 등 일시적 표시는 0(기본)으로 두어 네이티브 fps 유지.
     var minFrameDelay: TimeInterval = 0
+    var unownForm: UnownForm? = nil
     private let spriteStore: SpriteStore
-    @State private var img: NSImage?
+    @State private var subject: SpriteSubject
     @State private var up = false
-    @State private var loadedID: Int?   // img 가 어느 speciesID 것인지(id 변경 시 갱신 판단)
-    /// img 가 이로치 스프라이트인지 — 재로드 판정의 두 번째 축(근거는 needsReload).
-    @State private var loadedShiny = false
     @State private var frames: [(image: NSImage, delay: TimeInterval)] = []
     @State private var frameIndex = 0
 
     init(speciesID: Int?, size: CGFloat = 84, bob: Bool = false, animated: Bool = false,
-         shiny: Bool = false, minFrameDelay: TimeInterval = 0, spriteStore: SpriteStore = .shared) {
+         shiny: Bool = false, minFrameDelay: TimeInterval = 0, spriteStore: SpriteStore = .shared,
+         unownForm: UnownForm? = nil) {
         self.speciesID = speciesID
         self.spriteStore = spriteStore
         self.size = size
@@ -114,21 +123,32 @@ struct SpriteView: View {
         self.animated = animated
         self.shiny = shiny
         self.minFrameDelay = minFrameDelay
+        self.unownForm = unownForm
         // 캐시에 있으면 즉시(동기) 표시 — 재렌더 플래시 방지 + 정적 스냅샷에서도 보임.
         // speciesID==nil(알 상태)이면 알 스프라이트를 시드(없으면 body 가 🥚 폴백).
-        let cached = speciesID.map { SpriteLoader.cachedImage(speciesID: $0, shiny: shiny, directory: spriteStore.directory) } ?? SpriteLoader.cachedEggImage()
-        let cachedFrames = animated ? speciesID.map { SpriteLoader.cachedFrames(speciesID: $0, shiny: shiny, directory: spriteStore.directory) } ?? [] : []
+        let form = speciesID.flatMap { UnownForm.resolved(speciesID: $0, form: unownForm) }
+        let cached = speciesID.map { SpriteLoader.cachedImage(speciesID: $0, shiny: shiny, directory: spriteStore.directory,
+                                                            unownForm: form) } ?? SpriteLoader.cachedEggImage()
+        let cachedFrames = animated ? speciesID.map {
+            SpriteLoader.cachedFrames(speciesID: $0, shiny: shiny, directory: spriteStore.directory, unownForm: form)
+        } ?? [] : []
         _frames = State(initialValue: GIFDecoder.capFrameRate(cachedFrames, floor: minFrameDelay))
-        _img = State(initialValue: cached)
-        _loadedID = State(initialValue: (speciesID != nil && cached != nil) ? speciesID : nil)
-        _loadedShiny = State(initialValue: shiny)
+        _subject = State(initialValue: SpriteSubject(image: cached,
+                                                    loadedID: (speciesID != nil && cached != nil) ? speciesID : nil,
+                                                    loadedShiny: shiny, loadedUnownForm: form))
+    }
+
+    private var resolvedUnownForm: UnownForm? {
+        speciesID.flatMap { UnownForm.resolved(speciesID: $0, form: unownForm) }
     }
 
     /// GIF 프레임 로드 task 의 정체성 — 바뀌면 재디코드·재솎아내기. **하한을 포함한다**:
     /// 프레임은 하한에 맞춰 솎아낸 결과물이라, 빠지면 fps 설정 변경이 종 교체까지 안 먹는다
     /// (`AppDelegate.menuSpriteKey` 와 같은 이유). 순수·테스트용.
-    static func frameTaskID(speciesID: Int?, shiny: Bool, floor: TimeInterval, animated: Bool = true) -> String {
-        "\(speciesID.map(String.init) ?? "nil")-\(shiny)-\(floor)-\(animated)"
+    static func frameTaskID(speciesID: Int?, shiny: Bool, floor: TimeInterval, animated: Bool = true,
+                            unownForm: UnownForm? = nil) -> String {
+        let form = speciesID.flatMap { UnownForm.resolved(speciesID: $0, form: unownForm) }
+        return "\(speciesID.map(String.init) ?? "nil")-\(shiny)-\(floor)-\(animated)-\(form?.rawValue ?? "")"
     }
 
     /// 디코드된 GIF 프레임 중 실제로 재생할 것 — 취소됐거나 2프레임 미만이면 빈 배열(정적 폴백).
@@ -139,21 +159,20 @@ struct SpriteView: View {
         (cancelled || decoded.count < 2) ? [] : decoded
     }
 
-    /// 현재 그리는 주체(순수 전이 입력).
-    private var subject: SpriteSubject { SpriteSubject(image: img, loadedID: loadedID) }
-
     /// 전이 결과를 @State 로 되돌린다(State 세터는 nonmutating). 값이 그대로면 쓰지 않는다 —
     /// @State 는 같은 값을 써도 무효화가 돌아, 항상 떠 있는 펫에 불필요한 재렌더가 생긴다.
     private func apply(_ next: SpriteSubject) {
         guard next != subject else { return }
-        img = next.image
-        loadedID = next.loadedID
+        subject = next
     }
     /// 정적 스프라이트를 다시 불러야 하는가 — 종이 바뀌었거나 **이로치 여부가 뒤집혔을 때**.
     /// 순수·테스트용(`GIFDecoder.capFrameRate` 와 같은 이유). 종만 비교하던 과거 판정은 도감의 이로치 토글에서
     /// .task 가 다시 돌아도 "이미 그 종을 로드했다"로 판정해 색이 안 바뀌는 회귀를 낳았다.
-    static func needsReload(loadedID: Int?, loadedShiny: Bool, id: Int, shiny: Bool) -> Bool {
+    static func needsReload(loadedID: Int?, loadedShiny: Bool, id: Int, shiny: Bool,
+                            loadedUnownForm: UnownForm? = nil, unownForm: UnownForm? = nil) -> Bool {
         loadedID != id || loadedShiny != shiny
+            || UnownForm.resolved(speciesID: id, form: loadedUnownForm)
+                != UnownForm.resolved(speciesID: id, form: unownForm)
     }
 
     /// size×size 슬롯 안에서 이 이미지가 실제로 차지할 크기 — 원본 비율 유지(SpriteFit).
@@ -179,7 +198,7 @@ struct SpriteView: View {
                 // GIF 애니메이션 경로 — 현재 프레임만 렌더. Gen-V GIF 캔버스는 종마다 비정사각이라
                 // (잭키 36×66) 정사각으로 늘리면 뚱뚱해진다 → fitted 로 비율 유지.
                 fitted(frames[frameIndex % frames.count].image)
-            } else if let img {
+            } else if let img = subject.image {
                 fitted(animated && speciesID != nil ? SpriteLoader.animationPlaceholder(img) : img)
             } else {
                 Text("🥚").font(.system(size: size * 0.62)).frame(width: size, height: size)
@@ -187,10 +206,12 @@ struct SpriteView: View {
         }
         // GIF 재생 중엔 bob 정지(프레임 자체가 움직임) — 폴백/정적일 때만 상하 움직임
         .offset(y: bob && frames.isEmpty && up ? -3 : 0)
-        .task(id: Self.frameTaskID(speciesID: speciesID, shiny: shiny, floor: minFrameDelay, animated: animated)) {
+        .task(id: Self.frameTaskID(speciesID: speciesID, shiny: shiny, floor: minFrameDelay,
+                                  animated: animated, unownForm: resolvedUnownForm)) {
             // animated 프레임은 id/shiny 변경 시 항상 초기화(이전 개체 프레임 잔상 방지)
             frames = animated ? GIFDecoder.capFrameRate(
-                speciesID.map { SpriteLoader.cachedFrames(speciesID: $0, shiny: shiny, directory: spriteStore.directory) } ?? [],
+                speciesID.map { SpriteLoader.cachedFrames(speciesID: $0, shiny: shiny, directory: spriteStore.directory,
+                                                          unownForm: resolvedUnownForm) } ?? [],
                 floor: minFrameDelay) : []
             frameIndex = 0
             guard let id = speciesID else {
@@ -198,23 +219,36 @@ struct SpriteView: View {
                 // 종 → 알(졸업·새 알)이면 이전 개체 이미지를 버려야 한다 — img 는 뷰 identity 가 살아있는 동안
                 // 유지되고 플로팅 펫 패널은 졸업 때 재생성되지 않아, 안 버리면 옛 포켓몬이 계속 떠 있다.
                 apply(subject.becomingEgg(cachedEgg: SpriteLoader.cachedEggImage()))
-                if img == nil {
+                if subject.image == nil {
                     let egg = await SpriteLoader.eggImage()
                     if let next = subject.applyingEgg(egg, cancelled: Task.isCancelled) { apply(next) }
                 }
                 return
             }
+            // Drop the previous letter before any await; cached pixels and metadata change atomically.
+            let reloadNeeded = Self.needsReload(loadedID: subject.loadedID, loadedShiny: subject.loadedShiny,
+                                                id: id, shiny: shiny, loadedUnownForm: subject.loadedUnownForm,
+                                                unownForm: resolvedUnownForm)
+            if reloadNeeded {
+                let cached = SpriteLoader.cachedImage(speciesID: id, shiny: shiny, directory: spriteStore.directory,
+                                                       unownForm: resolvedUnownForm)
+                apply(subject.startingLoad(cachedImage: cached, for: id, shiny: shiny, unownForm: resolvedUnownForm))
+            }
             // Request animation before a missing static PNG can hold playback behind a network fetch.
             if animated && frames.isEmpty {
-                let decoded = await SpriteLoader.animationFrames(speciesID: id, shiny: shiny, store: spriteStore)
+                let decoded = await SpriteLoader.animationFrames(speciesID: id, shiny: shiny, store: spriteStore,
+                                                                 unownForm: resolvedUnownForm)
                 guard !Task.isCancelled else { return }
                 frames = GIFDecoder.capFrameRate(Self.framesToApply(decoded, cancelled: false), floor: minFrameDelay)
             }
-            if frames.isEmpty && Self.needsReload(loadedID: loadedID, loadedShiny: loadedShiny, id: id, shiny: shiny) {
-                let loaded = await SpriteLoader.image(speciesID: id, animated: false, shiny: shiny, store: spriteStore)
-                if let next = subject.applyingLoad(loaded, for: id, cancelled: Task.isCancelled) {
+            // A normal-color cache fallback is only a placeholder, including on initial render.
+            // The async loader returns an exact cached image immediately or requests the shiny variant.
+            if frames.isEmpty {
+                let loaded = await SpriteLoader.image(speciesID: id, animated: false, shiny: shiny, store: spriteStore,
+                                                      unownForm: resolvedUnownForm)
+                if let next = subject.applyingLoad(loaded, for: id, cancelled: Task.isCancelled,
+                                                   shiny: shiny, unownForm: resolvedUnownForm) {
                     apply(next)
-                    loadedShiny = shiny
                 }
             }
             guard !frames.isEmpty, !Task.isCancelled else { return }
@@ -254,6 +288,7 @@ struct EvoLineView: View {
     var names: [Int: String]? = nil   // 제공되면 각 스프라이트 밑에 작은 이름 라벨(도감 단계별 이름)
     /// 한 줄이 쓸 수 있는 가로 폭. 기본 .infinity = 제한 없음(스크롤 없이 나열).
     var maxWidth: CGFloat = .infinity
+    var unownForm: UnownForm? = nil
 
     private static let spacing: CGFloat = 2
     /// 화살표 칸 폭 = 썸네일 × 이 비율. 고정 frame 을 줘 SF Symbol 글리프 폭에 의존하지 않게 한다 —
@@ -417,7 +452,7 @@ struct EvoLineView: View {
                     Group {
                         switch node.content {
                         case .species(let id):
-                            SpriteView(speciesID: id, size: thumb, shiny: shiny)
+                            SpriteView(speciesID: id, size: thumb, shiny: shiny, unownForm: unownForm)
                         case .mystery:
                             Text("?")
                                 .font(.system(size: thumb * 0.55, weight: .bold, design: .rounded))
@@ -433,7 +468,7 @@ struct EvoLineView: View {
                             }
                         }
                     if let names, case .species(let id) = node.content {
-                        Text(names[id] ?? "…")
+                        Text(UnownForm.displayName(names[id] ?? "…", speciesID: id, form: unownForm))
                             .font(.system(size: 8)).foregroundStyle(.secondary)
                             .lineLimit(1).minimumScaleFactor(0.7).frame(maxWidth: thumb + Self.nameSlack)
                     }
@@ -471,7 +506,7 @@ struct CompanionHeader: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .center, spacing: 12) {
                 SpriteView(speciesID: store.currentSpeciesID, size: 76, bob: true, animated: true,
-                           shiny: store.currentIsShiny)
+                           shiny: store.currentIsShiny, unownForm: store.currentUnownForm)
                     .frame(width: 76, height: 76)
                     .background(Color.secondary.opacity(0.06))
                     .clipShape(RoundedRectangle(cornerRadius: 12))
@@ -575,7 +610,7 @@ struct CompanionHeader: View {
             if store.hasActive, !store.lineNodes.isEmpty {
                 // 폭을 안 주면 분기 라인(이브이)이 넘쳐 팝오버 콘텐츠 전체가 좌우로 잘린다.
                 EvoLineView(nodes: store.lineNodes, mysteryLabel: store.l.unknownNextEvolution, shiny: store.currentIsShiny,
-                            maxWidth: PopoverMetrics.contentWidth)
+                            maxWidth: PopoverMetrics.contentWidth, unownForm: store.currentUnownForm)
             }
             if let g = store.justGraduated {
                 Text(store.l.graduated(g))
@@ -735,7 +770,7 @@ struct DexSummaryHeader: View {
 /// 컬렉션 탭 — 도감과 포획 로그를 하위 세그먼트로 전환한다.
 ///
 /// 두 화면은 같은 데이터를 다른 축으로 본다:
-///  - **도감**: 종 1개 = 1칸. 같은 라인을 여러 번 키워도 한 칸으로 접힌다(종 정보만).
+///  - **도감**: 종 1개 = 1칸(안농은 글자별). 같은 라인을 여러 번 키우면 같은 칸으로 접힌다.
 ///  - **로그**: 개체 1마리 = 1행. 같은 라인이 여러 행으로 나오는 게 정상 — 성격·획득 시각처럼
 ///    개체에 딸린 정보는 여기에만 있다.
 /// 상위 탭(PopoverTab)은 그대로 4개 — 세그먼트 폭(332/2)이 넉넉해 탭바를 늘릴 필요가 없다.
@@ -847,7 +882,7 @@ struct RepresentativeFooterButton: View {
     }
 }
 
-/// 도감 — 보유 종만 도감 번호순으로, 한 페이지 24칸(4열×6행) 고정 격자.
+/// 도감 — 보유 종·안농 글자를 도감 번호순으로, 한 페이지 24칸(4열×6행) 고정 격자.
 ///
 /// 페이지식이라 ScrollView 를 쓰지 않는다 — 팝오버 재오픈 시 fitting size 가 줄어드는 기존 결함을
 /// 우회(고정 높이 + maxHeight)가 아니라 회피로 피한다. 페이지 크기가 고정이라 모든 칸이 항상
@@ -860,8 +895,8 @@ private struct DexGridView: View {
     @State private var page = 0
 
     /// 선택한 칸 — 하단 줄에 희귀도를 띄우고, 이로치를 잡은 종이면 스프라이트를 그 색으로 바꾼다.
-    @State private var selectedID: Int?
-    @State private var detailSpeciesID: Int?
+    @State private var selectedID: String?
+    @State private var detailCollectionID: String?
 
     private static let columns = 4
     private static let rows = 6
@@ -876,8 +911,9 @@ private struct DexGridView: View {
         let current = min(page, pageCount - 1)   // 보유 종이 줄어든 경우(필터 등) 범위 방어
         let slice = Array(visible.dropFirst(current * Self.pageSize).prefix(Self.pageSize))
         Group {
-            if let id = detailSpeciesID, let species = all.first(where: { $0.id == id }) {
-                PokemonDetailView(store: store, species: species) { detailSpeciesID = nil }
+            if let id = detailCollectionID, let species = all.first(where: { $0.collectionID == id }) {
+                PokemonDetailView(store: store, species: species) { detailCollectionID = nil }
+                    .id(species.collectionID)
             } else {
                 VStack(alignment: .leading, spacing: 8) {
                     header(all)
@@ -900,11 +936,17 @@ private struct DexGridView: View {
                 Text(store.l.dexTitle).font(.callout.weight(.semibold))
                 // 총계는 필터와 무관한 전체 종 수 — 로그 헤더(dexTotal)와 같은 규칙.
                 // 필터 중인 희귀도의 개수는 아래 캡슐이 이미 보여준다.
-                Text(store.l.dexSpeciesTotal(all.count)).font(.caption2).foregroundStyle(.secondary)
+                Text(store.l.dexSpeciesTotal(Set(all.map(\.id)).count)).font(.caption2).foregroundStyle(.secondary)
+                let unownCount = all.lazy.filter { $0.id == 201 }.count
+                if unownCount > 0 {
+                    Spacer(minLength: 0)
+                    Text(store.l.unownFormsCollected(unownCount))
+                        .font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                }
             }
             HStack(spacing: 4) {
                 ForEach(rarityDisplayOrder, id: \.self) { r in
-                    let count = all.lazy.filter { $0.rarity == r }.count
+                    let count = Set(all.lazy.filter { $0.rarity == r }.map(\.id)).count
                     Button {
                         withAnimation(.easeInOut(duration: 0.15)) {
                             selectedRarity = (selectedRarity == r) ? nil : r
@@ -935,10 +977,10 @@ private struct DexGridView: View {
                         if i < slice.count {
                             let sp = slice[i]
                             DexSpeciesCell(store: store, species: sp,
-                                           isSelected: selectedID == sp.id,
-                                           isRepresentative: store.representativeSpeciesID == sp.id) {
-                                selectedID = sp.id
-                                detailSpeciesID = sp.id
+                                           isSelected: selectedID == sp.collectionID,
+                                           isRepresentative: store.isRepresentative(sp)) {
+                                selectedID = sp.collectionID
+                                detailCollectionID = sp.collectionID
                             }
                             .frame(maxWidth: .infinity)
                         } else {
@@ -958,14 +1000,14 @@ private struct DexGridView: View {
     private func footer(_ slice: [CompanionStore.DexSpecies],
                         current: Int, pageCount: Int) -> some View {
         HStack(spacing: 8) {
-            if let sel = slice.first(where: { $0.id == selectedID }) {
+            if let sel = slice.first(where: { $0.collectionID == selectedID }) {
                 // 칸은 번호·스프라이트·이름만 보여주므로 희귀도가 선택으로 얻는 정보다.
                 Text("#\(sel.id) \(sel.name) · \(store.l.rarityLabel(sel.rarity))")
                     .font(.system(size: 9)).foregroundStyle(.secondary).lineLimit(1)
-                let isRepresentative = store.representativeSpeciesID == sel.id
+                let isRepresentative = store.isRepresentative(sel)
                 RepresentativeFooterButton(localization: store.l,
                                            isRepresentative: isRepresentative) {
-                    _ = store.setRepresentativeSpeciesID(isRepresentative ? nil : sel.id)
+                    _ = store.setRepresentativeSpeciesID(isRepresentative ? nil : sel.id, unownForm: sel.unownForm)
                 }
             }
             Spacer(minLength: 4)
@@ -1000,7 +1042,9 @@ private struct PokemonDetailView: View {
     let onBack: () -> Void
     @State private var selectedInstanceID = ""
 
-    private var individuals: [DexEntry] { store.pokemonIndividuals(speciesID: species.id) }
+    private var individuals: [DexEntry] {
+        store.pokemonIndividuals(speciesID: species.id, unownForm: species.unownForm)
+    }
     private var individual: DexEntry? {
         individuals.first { $0.id == selectedInstanceID } ?? individuals.first
     }
@@ -1050,7 +1094,7 @@ private struct PokemonDetailView: View {
     private var identityHeader: some View {
         HStack(spacing: 14) {
             SpriteView(speciesID: species.id, size: 82, animated: true,
-                       shiny: individual?.isShiny ?? species.isShiny)
+                       shiny: individual?.isShiny ?? species.isShiny, unownForm: species.unownForm)
                 .frame(width: 82, height: 82)
             VStack(alignment: .leading, spacing: 5) {
                 Text(species.name).font(.title3.weight(.bold))
@@ -1058,10 +1102,11 @@ private struct PokemonDetailView: View {
                     .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
                 if species.isShiny { Text("✨ \(store.l.dexShinyLabel)").font(.caption2) }
                 if species.isRaising { Text(store.l.dexRaising).font(.caption2).foregroundStyle(Color.accentColor) }
-                let isRepresentative = store.representativeSpeciesID == species.id
+                let isRepresentative = store.isRepresentative(species)
                 RepresentativeFooterButton(localization: store.l,
                                            isRepresentative: isRepresentative) {
-                    _ = store.setRepresentativeSpeciesID(isRepresentative ? nil : species.id)
+                    _ = store.setRepresentativeSpeciesID(isRepresentative ? nil : species.id,
+                                                         unownForm: species.unownForm)
                 }
             }
         }
@@ -1230,7 +1275,7 @@ private struct DexSpeciesCell: View {
                 // 기본은 일반색. 이로치를 잡은 종은 선택하면 이로치색으로 바뀐다 —
                 // 일반·이로치를 둘 다 가진 종도 두 모습을 다 볼 수 있다(본가 HOME 의 이로치 토글과 같은 결).
                 SpriteView(speciesID: species.id, size: Self.thumb,
-                           shiny: species.isShiny && isSelected)
+                           shiny: species.isShiny && isSelected, unownForm: species.unownForm)
                     .frame(width: Self.thumb, height: Self.thumb)
                     // 표식은 스프라이트 아래가 아니라 위에 겹친다 — 별도 줄로 빼면 칸 높이가 넘친다.
                     // 이 줄은 번호·이로치와 폭을 다투지 않아 네 언어 모두 8pt 그대로 들어간다
@@ -1277,7 +1322,8 @@ private struct DexSpeciesCell: View {
         .accessibilityLabel(tooltip)
         .contextMenu {
             Button {
-                _ = store.setRepresentativeSpeciesID(isRepresentative ? nil : species.id)
+                _ = store.setRepresentativeSpeciesID(isRepresentative ? nil : species.id,
+                                                     unownForm: species.unownForm)
             } label: {
                 Label(isRepresentative ? store.l.representativeFollowCurrent
                                        : store.l.representativeSet,
@@ -1381,7 +1427,7 @@ private struct DexEntryRow: View {
             EvoLineView(nodes: entry.chainOrder.map { EvoLineItem(.species($0), .done) },
                         mysteryLabel: store.l.unknownNextEvolution, thumb: 56,
                         shiny: entry.isShiny, names: names,
-                        maxWidth: PopoverMetrics.contentWidth - Self.cardPadding * 2)
+                        maxWidth: PopoverMetrics.contentWidth - Self.cardPadding * 2, unownForm: entry.unownForm)
             if let caughtAt = entry.caughtAt {
                 Text(caughtAt, style: .relative).font(.system(size: 9)).foregroundStyle(.tertiary)
             }

--- a/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
+++ b/Sources/PokeTokenBar/UI/FloatingPetPanel.swift
@@ -460,7 +460,7 @@ struct FloatingPetView: View {
 
             SpriteView(speciesID: subject.speciesID, size: size, animated: animated,
                        shiny: subject.isShiny,
-                       minFrameDelay: store.animationQuality.frameFloor)
+                       minFrameDelay: store.animationQuality.frameFloor, unownForm: subject.unownForm)
                 .frame(width: size, height: size)
                 .zIndex(0)
         }

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -39,8 +39,7 @@ struct SettingsView: View {
     private var isBundledApp: Bool { AppEnv.isBundledApp }
 
     private var representativeSelectionText: String {
-        guard let selected = companion.representativeSpeciesID,
-              let species = companion.dexSpecies.first(where: { $0.id == selected }) else {
+        guard let species = companion.dexSpecies.first(where: { companion.isRepresentative($0) }) else {
             return l.representativeFollowCurrent
         }
         return "#\(species.id) \(species.name)\(species.isShiny ? " ✨" : "")"

--- a/Sources/PokeTokenBar/UI/SpriteLoader.swift
+++ b/Sources/PokeTokenBar/UI/SpriteLoader.swift
@@ -3,7 +3,7 @@ import AppKit
 /// 포켓몬 스프라이트를 런타임에 받아 로컬(Application Support)에 캐시. 레포/번들에 미포함.
 actor SpriteStore {
     static let shared = SpriteStore()
-    private let base = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon"
+    private static let base = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon"
     private let itemBase = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/items"
     private var mem: [String: Data] = [:]
     private var memOrder: [String] = []   // LRU 순서(최근 접근이 뒤). 상한 초과 시 앞(오래된 것)부터 evict
@@ -19,27 +19,37 @@ actor SpriteStore {
         try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
     }
 
-    /// 캐시 파일명 키 — 기존 "\(id)-a"/"\(id)-s" 유지, shiny 는 "sh" 접두(구캐시 그대로 유효).
-    static func cacheKey(speciesID: Int, animated: Bool, shiny: Bool) -> String {
-        "\(speciesID)-\(shiny ? "sh" : "")\(animated ? "a" : "s")"
+    /// A/기존 종은 구캐시 그대로 유지. 다른 안농은 폼·이로치·애니메이션을 모두 구분한다.
+    static func cacheKey(speciesID: Int, animated: Bool, shiny: Bool, unownForm: UnownForm? = nil) -> String {
+        "\(assetName(speciesID: speciesID, unownForm: unownForm))-\(shiny ? "sh" : "")\(animated ? "a" : "s")"
     }
 
-    func data(speciesID: Int, animated: Bool, shiny: Bool = false) async -> Data? {
+    /// PokeAPI는 A를 `201`, 나머지 폼을 `201-b`/`201-exclamation`/`201-question`으로 제공한다.
+    private static func assetName(speciesID: Int, unownForm: UnownForm?) -> String {
+        guard let form = UnownForm.resolved(speciesID: speciesID, form: unownForm), form != .a else {
+            return String(speciesID)
+        }
+        return "\(speciesID)-\(form.rawValue)"
+    }
+
+    /// 캐시와 다운로드가 같은 폼 이름을 사용한다. 네트워크 없이 요청 경로를 검증할 수 있다.
+    static func spriteURL(speciesID: Int, animated: Bool, shiny: Bool, unownForm: UnownForm? = nil) -> URL {
+        let name = assetName(speciesID: speciesID, unownForm: unownForm)
+        let path = animated ? "versions/generation-v/black-white/animated/" : ""
+        let color = shiny ? "shiny/" : ""
+        let ext = animated ? "gif" : "png"
+        return URL(string: "\(base)/\(path)\(color)\(name).\(ext)")!
+    }
+
+    func data(speciesID: Int, animated: Bool, shiny: Bool = false, unownForm: UnownForm? = nil) async -> Data? {
         if animated, !PokemonAssets.hasAnimatedSprite(speciesID: speciesID) { return nil }
-        let key = Self.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny)
+        let key = Self.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny, unownForm: unownForm)
         if let d = mem[key] { touch(key); return d }
         let ext = animated ? "gif" : "png"
         let file = directory.appendingPathComponent("\(key).\(ext)")
         if let d = try? Data(contentsOf: file) { remember(key, d); return d }
-        let urlStr: String
-        switch (animated, shiny) {
-        case (true, false):  urlStr = "\(base)/versions/generation-v/black-white/animated/\(speciesID).gif"
-        case (true, true):   urlStr = "\(base)/versions/generation-v/black-white/animated/shiny/\(speciesID).gif"
-        case (false, false): urlStr = "\(base)/\(speciesID).png"
-        case (false, true):  urlStr = "\(base)/shiny/\(speciesID).png"
-        }
-        guard let url = URL(string: urlStr),
-              let (d, resp) = try? await URLSession.shared.data(from: url),
+        let url = Self.spriteURL(speciesID: speciesID, animated: animated, shiny: shiny, unownForm: unownForm)
+        guard let (d, resp) = try? await URLSession.shared.data(from: url),
               (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
         try? d.write(to: file, options: .atomic)   // torn write 방지 — 크래시/강제종료 시 손상 캐시가 남지 않게
         remember(key, d)
@@ -67,7 +77,7 @@ actor SpriteStore {
         if let d = mem[key] { touch(key); return d }
         let file = directory.appendingPathComponent("egg.png")
         if let d = try? Data(contentsOf: file) { remember(key, d); return d }
-        guard let url = URL(string: "\(base)/egg.png"),
+        guard let url = URL(string: "\(Self.base)/egg.png"),
               let (d, resp) = try? await URLSession.shared.data(from: url),
               (resp as? HTTPURLResponse)?.statusCode == 200, !d.isEmpty else { return nil }
         try? d.write(to: file, options: .atomic)
@@ -109,9 +119,9 @@ enum SpriteLoader {
     /// 메모리·디스크 캐시에 이미 있으면 동기 반환(네트워크 없음). 없으면 nil.
     /// shiny 캐시 미스는 일반 캐시로 폴백 — 오프라인에서 live mon 이 알 글리프로 보이는 것 방지.
     static func cachedImage(speciesID: Int, animated: Bool = false, shiny: Bool = false,
-                            directory: URL = cacheDir) -> NSImage? {
+                            directory: URL = cacheDir, unownForm: UnownForm? = nil) -> NSImage? {
         let ext = animated ? "gif" : "png"
-        let key = SpriteStore.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny)
+        let key = SpriteStore.cacheKey(speciesID: speciesID, animated: animated, shiny: shiny, unownForm: unownForm)
         let f = directory.appendingPathComponent("\(key).\(ext)")
         let imageKey = f.path as NSString
         if let img = imageCache.object(forKey: imageKey) { return img }
@@ -121,7 +131,8 @@ enum SpriteLoader {
         }
         guard shiny else { return nil }
         // 폴백은 일반색 키에만 저장한다 — 나중에 받은 이로치 이미지를 가리지 않게.
-        return cachedImage(speciesID: speciesID, animated: animated, shiny: false, directory: directory)
+        return cachedImage(speciesID: speciesID, animated: animated, shiny: false,
+                           directory: directory, unownForm: unownForm)
     }
 
     private final class AnimationFrames {
@@ -136,9 +147,9 @@ enum SpriteLoader {
     }()
 
     /// First render and playback share the exact GIF pixels, including its canvas and delays.
-    static func cachedFrames(speciesID: Int, shiny: Bool, directory: URL = cacheDir)
+    static func cachedFrames(speciesID: Int, shiny: Bool, directory: URL = cacheDir, unownForm: UnownForm? = nil)
         -> [(image: NSImage, delay: TimeInterval)] {
-        let key = SpriteStore.cacheKey(speciesID: speciesID, animated: true, shiny: shiny)
+        let key = SpriteStore.cacheKey(speciesID: speciesID, animated: true, shiny: shiny, unownForm: unownForm)
         let file = directory.appendingPathComponent("\(key).gif")
         if let cached = animationCache.object(forKey: file.path as NSString) { return cached.frames }
         guard let data = try? Data(contentsOf: file) else { return [] }
@@ -151,13 +162,17 @@ enum SpriteLoader {
         return frames
     }
 
-    static func animationFrames(speciesID: Int, shiny: Bool, store: SpriteStore = .shared) async
+    static func animationFrames(speciesID: Int, shiny: Bool, store: SpriteStore = .shared,
+                                unownForm: UnownForm? = nil) async
         -> [(image: NSImage, delay: TimeInterval)] {
         for variant in shiny ? [true, false] : [false] {
-            let cached = cachedFrames(speciesID: speciesID, shiny: variant, directory: store.directory)
+            let cached = cachedFrames(speciesID: speciesID, shiny: variant,
+                                      directory: store.directory, unownForm: unownForm)
             if !cached.isEmpty { return cached }
-            guard let data = await store.data(speciesID: speciesID, animated: true, shiny: variant) else { continue }
-            let key = SpriteStore.cacheKey(speciesID: speciesID, animated: true, shiny: variant)
+            guard let data = await store.data(speciesID: speciesID, animated: true,
+                                             shiny: variant, unownForm: unownForm) else { continue }
+            let key = SpriteStore.cacheKey(speciesID: speciesID, animated: true,
+                                            shiny: variant, unownForm: unownForm)
             let frames = rememberFrames(data, file: store.directory.appendingPathComponent("\(key).gif"))
             if !frames.isEmpty { return frames }
         }
@@ -181,13 +196,14 @@ enum SpriteLoader {
     /// 정적 스프라이트. animated=true 면 Gen-V 움직이는 스프라이트(없으면 정적으로 폴백).
     /// shiny=true 는 색이 다른 스프라이트 — 미제공 종이면 일반으로 폴백.
     static func image(speciesID: Int, animated: Bool = false, shiny: Bool = false,
-                      store: SpriteStore = .shared) async -> NSImage? {
+                      store: SpriteStore = .shared, unownForm: UnownForm? = nil) async -> NSImage? {
         for moving in animated ? [true, false] : [false] {
-            let key = SpriteStore.cacheKey(speciesID: speciesID, animated: moving, shiny: shiny)
+            let key = SpriteStore.cacheKey(speciesID: speciesID, animated: moving, shiny: shiny, unownForm: unownForm)
             let ext = moving ? "gif" : "png"
             let imageKey = store.directory.appendingPathComponent("\(key).\(ext)").path as NSString
             if let img = imageCache.object(forKey: imageKey) { return img }
-            guard let d = await store.data(speciesID: speciesID, animated: moving, shiny: shiny) else { continue }
+            guard let d = await store.data(speciesID: speciesID, animated: moving,
+                                          shiny: shiny, unownForm: unownForm) else { continue }
             // await 중 같은 종의 다른 행이 로드를 끝냈으면 그 객체를 재사용한다.
             if let img = imageCache.object(forKey: imageKey) { return img }
             guard let img = NSImage(data: d) else { continue }
@@ -196,7 +212,7 @@ enum SpriteLoader {
         }
         // shiny 미제공 → 일반 폴백
         guard shiny else { return nil }
-        return await image(speciesID: speciesID, animated: animated, shiny: false, store: store)
+        return await image(speciesID: speciesID, animated: animated, shiny: false, store: store, unownForm: unownForm)
     }
 
     /// 아이템 스프라이트 — 메모리·디스크 캐시 동기 조회(없으면 nil). 아이콘 즉시 표시용.

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -528,7 +528,8 @@ final class SaveTransferTests: XCTestCase {
     func testEveryCompanionStateFieldIsClassifiedForTransfer() {
         // eggTier(알 등급 보증) = 진행 — 산 물건이지 이 기기의 장부가 아니라 기기를 옮겨도 따라간다.
         let progress: Set<String> = ["usedSinceInstall", "spentTokens", "eggUsage", "eggTier",
-                                     "pendingHatchID", "active", "representativeSpeciesID", "dex",
+                                     "pendingHatchID", "pendingUnownForm", "active",
+                                     "representativeSpeciesID", "representativeUnownForm", "dex",
                                      "collectedFinals", "inventory"]
         let deviceLedger: Set<String> = ["installBaselineSet", "claimedTodayTokensByProvider", "lastDate"]
         let accountLedger: Set<String> = ["candyGrantTier", "candyFeatureSeeded"]

--- a/Tests/PokeTokenBarTests/UnownSpriteTests.swift
+++ b/Tests/PokeTokenBarTests/UnownSpriteTests.swift
@@ -1,0 +1,235 @@
+import AppKit
+import ImageIO
+import UniformTypeIdentifiers
+import XCTest
+@testable import PokeTokenBar
+
+final class UnownSpriteTests: XCTestCase {
+    func testExistingUnownAndExplicitAKeepLegacyCacheKeys() {
+        for (animated, shiny, expected) in [
+            (false, false, "201-s"), (true, false, "201-a"),
+            (false, true, "201-shs"), (true, true, "201-sha"),
+        ] {
+            XCTAssertEqual(SpriteStore.cacheKey(speciesID: 201, animated: animated, shiny: shiny), expected)
+            XCTAssertEqual(SpriteStore.cacheKey(speciesID: 201, animated: animated, shiny: shiny,
+                                                 unownForm: .a), expected)
+        }
+    }
+
+    /// 종 ID가 같아도 다른 글자·색·형식의 이미지를 캐시에서 꺼내면 안 된다.
+    func testAll28FormsHaveIndependentNormalShinyAndAnimatedCaches() {
+        var keys: Set<String> = []
+        for form in UnownForm.allCases {
+            for animated in [false, true] {
+                for shiny in [false, true] {
+                    let key = SpriteStore.cacheKey(speciesID: 201, animated: animated,
+                                                   shiny: shiny, unownForm: form)
+                    XCTAssertTrue(keys.insert(key).inserted, "Cache collision for \(form), \(animated), \(shiny)")
+                }
+            }
+        }
+        XCTAssertEqual(keys.count, 28 * 4)
+    }
+
+    /// PokeAPI에서 확인한 파일명. A는 접미사가 없고, 문장부호는 영문 이름을 쓴다.
+    func testFormURLsMatchPokeAPIAssetsInAllFourDirectories() {
+        let base = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon"
+        let examples: [(UnownForm?, String)] = [
+            (nil, "201"), (.a, "201"), (.b, "201-b"), (.z, "201-z"),
+            (.exclamation, "201-exclamation"), (.question, "201-question"),
+        ]
+        for (form, asset) in examples {
+            XCTAssertEqual(SpriteStore.spriteURL(speciesID: 201, animated: false, shiny: false,
+                                                  unownForm: form).absoluteString,
+                           "\(base)/\(asset).png")
+            XCTAssertEqual(SpriteStore.spriteURL(speciesID: 201, animated: false, shiny: true,
+                                                  unownForm: form).absoluteString,
+                           "\(base)/shiny/\(asset).png")
+            XCTAssertEqual(SpriteStore.spriteURL(speciesID: 201, animated: true, shiny: false,
+                                                  unownForm: form).absoluteString,
+                           "\(base)/versions/generation-v/black-white/animated/\(asset).gif")
+            XCTAssertEqual(SpriteStore.spriteURL(speciesID: 201, animated: true, shiny: true,
+                                                  unownForm: form).absoluteString,
+                           "\(base)/versions/generation-v/black-white/animated/shiny/\(asset).gif")
+        }
+    }
+
+    func testOtherSpeciesIgnoreAnUnownForm() {
+        for animated in [false, true] {
+            for shiny in [false, true] {
+                XCTAssertEqual(SpriteStore.cacheKey(speciesID: 25, animated: animated, shiny: shiny,
+                                                     unownForm: .question),
+                               SpriteStore.cacheKey(speciesID: 25, animated: animated, shiny: shiny))
+                XCTAssertEqual(SpriteStore.spriteURL(speciesID: 25, animated: animated, shiny: shiny,
+                                                      unownForm: .question),
+                               SpriteStore.spriteURL(speciesID: 25, animated: animated, shiny: shiny))
+            }
+        }
+    }
+}
+
+/// Exercise the current byte, image and decoded-animation caches using generated pixels only.
+/// A correct filename helper alone cannot prove the production loaders forward the selected form.
+@MainActor
+final class UnownSpriteCacheTests: XCTestCase {
+    private let forms: [(UnownForm, String)] = [
+        (.a, "201"), (.b, "201-b"), (.exclamation, "201-exclamation"), (.question, "201-question"),
+    ]
+
+    private func directory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("unown-sprites-\(UUID())")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func pixels(width: Int, height: Int) throws -> NSBitmapImageRep {
+        let bitmap = try XCTUnwrap(NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height, bitsPerSample: 8,
+            samplesPerPixel: 4, hasAlpha: true, isPlanar: false, colorSpaceName: .deviceRGB,
+            bytesPerRow: 0, bitsPerPixel: 0))
+        bitmap.bitmapData?.initialize(repeating: 255, count: bitmap.bytesPerRow * bitmap.pixelsHigh)
+        return bitmap
+    }
+
+    private func animatedPixels(width: Int, height: Int) throws -> Data {
+        let data = NSMutableData()
+        let destination = try XCTUnwrap(CGImageDestinationCreateWithData(
+            data, UTType.gif.identifier as CFString, 2, nil))
+        let image = try XCTUnwrap(pixels(width: width, height: height).cgImage)
+        for delay in [0.1, 0.2] {
+            CGImageDestinationAddImage(destination, image,
+                [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: delay]] as CFDictionary)
+        }
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+        return data as Data
+    }
+
+    func testByteAndImageCachesKeepLettersSeparateAcrossAllFormats() async throws {
+        let directory = try directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SpriteStore(directory: directory)
+        var images: [NSImage] = []
+
+        for (index, entry) in forms.enumerated() {
+            let (form, stem) = entry
+            for animated in [false, true] {
+                for shiny in [false, true] {
+                    let expectedSize = NSSize(width: 4 + index, height: shiny ? 9 : 6)
+                    let bitmap = try pixels(width: Int(expectedSize.width), height: Int(expectedSize.height))
+                    let bytes = try XCTUnwrap(bitmap.representation(using: animated ? .gif : .png, properties: [:]))
+                    let file = directory.appendingPathComponent(
+                        "\(stem)-\(shiny ? "sh" : "")\(animated ? "a.gif" : "s.png")")
+                    try bytes.write(to: file)
+                    let loadedBytes = await store.data(speciesID: 201, animated: animated,
+                                                        shiny: shiny, unownForm: form)
+                    XCTAssertEqual(loadedBytes, bytes, "The byte cache must include the selected letter")
+                    let loaded = await SpriteLoader.image(speciesID: 201, animated: animated,
+                                                           shiny: shiny, store: store, unownForm: form)
+                    let image = try XCTUnwrap(loaded)
+                    XCTAssertEqual(image.size, expectedSize)
+                    XCTAssertFalse(images.contains { $0 === image }, "Different variants must not share decoded images")
+                    images.append(image)
+                    try FileManager.default.removeItem(at: file)
+                    XCTAssertTrue(SpriteLoader.cachedImage(speciesID: 201, animated: animated, shiny: shiny,
+                                                             directory: directory, unownForm: form) === image)
+                    let repeatedBytes = await store.data(speciesID: 201, animated: animated,
+                                                          shiny: shiny, unownForm: form)
+                    XCTAssertEqual(repeatedBytes, bytes, "The warm byte lookup must survive removal of its file")
+                    let repeated = await SpriteLoader.image(speciesID: 201, animated: animated,
+                                                             shiny: shiny, store: store, unownForm: form)
+                    XCTAssertTrue(repeated === image)
+                }
+            }
+        }
+    }
+
+    func testShinyStaticFallbackKeepsLetterAndDoesNotHideALaterShiny() throws {
+        let directory = try directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let png = try XCTUnwrap(pixels(width: 4, height: 6).representation(using: .png, properties: [:]))
+        try png.write(to: directory.appendingPathComponent("201-s.png"))
+        let a = try XCTUnwrap(SpriteLoader.cachedImage(speciesID: 201, directory: directory))
+        XCTAssertNil(SpriteLoader.cachedImage(speciesID: 201, shiny: true, directory: directory, unownForm: .b),
+                     "Missing B must not fall back to A")
+        try png.write(to: directory.appendingPathComponent("201-b-s.png"))
+        let b = try XCTUnwrap(SpriteLoader.cachedImage(speciesID: 201, directory: directory, unownForm: .b))
+        XCTAssertFalse(a === b)
+        XCTAssertTrue(SpriteLoader.cachedImage(speciesID: 201, shiny: true,
+                                               directory: directory, unownForm: .b) === b)
+        try png.write(to: directory.appendingPathComponent("201-b-shs.png"))
+        let shinyB = try XCTUnwrap(SpriteLoader.cachedImage(speciesID: 201, shiny: true,
+                                                             directory: directory, unownForm: .b))
+        XCTAssertFalse(shinyB === b, "Normal B fallback must not poison the shiny B key")
+        XCTAssertTrue(SpriteLoader.cachedImage(speciesID: 201, directory: directory, unownForm: .a) === a)
+    }
+
+    func testAsyncAnimationAndShinyImageFallbacksKeepSelectedLetter() async throws {
+        let directory = try directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SpriteStore(directory: directory)
+        let png = try XCTUnwrap(pixels(width: 4, height: 7).representation(using: .png, properties: [:]))
+        try png.write(to: directory.appendingPathComponent("201-b-s.png"))
+        // Invalid local files exercise all fallback branches without making network requests.
+        for name in ["201-b-sha.gif", "201-b-shs.png", "201-b-a.gif"] {
+            try Data("invalid image".utf8).write(to: directory.appendingPathComponent(name))
+        }
+        let other = try XCTUnwrap(pixels(width: 12, height: 12).representation(using: .png, properties: [:]))
+        for name in ["201-s.png", "201-shs.png", "201-a.gif", "201-sha.gif"] {
+            try other.write(to: directory.appendingPathComponent(name))
+        }
+        let result = await SpriteLoader.image(speciesID: 201, animated: true, shiny: true,
+                                               store: store, unownForm: .b)
+        let b = try XCTUnwrap(result)
+        XCTAssertEqual(b.size, NSSize(width: 4, height: 7))
+        XCTAssertTrue(SpriteLoader.cachedImage(speciesID: 201, directory: directory, unownForm: .b) === b)
+        XCTAssertNil(SpriteLoader.imageCache.object(
+            forKey: directory.appendingPathComponent("201-b-shs.png").path as NSString))
+    }
+
+    func testDecodedAnimationCacheKeepsLettersColorsAndCanvasSeparate() async throws {
+        let directory = try directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SpriteStore(directory: directory)
+        var firstImages: [NSImage] = []
+        for (index, entry) in forms.enumerated() {
+            let (form, stem) = entry
+            for shiny in [false, true] {
+                let size = NSSize(width: 4 + index, height: shiny ? 10 : 6)
+                let file = directory.appendingPathComponent("\(stem)-\(shiny ? "sh" : "")a.gif")
+                try animatedPixels(width: Int(size.width), height: Int(size.height)).write(to: file)
+                let frames = SpriteLoader.cachedFrames(speciesID: 201, shiny: shiny,
+                                                         directory: directory, unownForm: form)
+                XCTAssertEqual(frames.count, 2)
+                let first = try XCTUnwrap(frames.first?.image)
+                XCTAssertEqual(first.size, size)
+                XCTAssertFalse(firstImages.contains { $0 === first }, "Decoded GIFs must include form and shiny identity")
+                firstImages.append(first)
+                try FileManager.default.removeItem(at: file)
+                let repeated = await SpriteLoader.animationFrames(speciesID: 201, shiny: shiny,
+                                                                    store: store, unownForm: form)
+                XCTAssertTrue(repeated.first?.image === first)
+                XCTAssertEqual(repeated.map(\.delay), [0.1, 0.2])
+            }
+        }
+    }
+
+    func testDecodedShinyFallbackUsesTheSameLetter() async throws {
+        let directory = try directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SpriteStore(directory: directory)
+        try animatedPixels(width: 4, height: 7).write(to: directory.appendingPathComponent("201-b-a.gif"))
+        try animatedPixels(width: 12, height: 12).write(to: directory.appendingPathComponent("201-a.gif"))
+        try animatedPixels(width: 12, height: 12).write(to: directory.appendingPathComponent("201-sha.gif"))
+        try Data("invalid image".utf8).write(to: directory.appendingPathComponent("201-b-sha.gif"))
+        let result = await SpriteLoader.animationFrames(speciesID: 201, shiny: true,
+                                                         store: store, unownForm: .b)
+        let first = try XCTUnwrap(result.first?.image)
+        XCTAssertEqual(first.size, NSSize(width: 4, height: 7))
+        let normal = SpriteLoader.cachedFrames(speciesID: 201, shiny: false,
+                                                directory: directory, unownForm: .b)
+        XCTAssertTrue(first === normal.first?.image)
+        XCTAssertTrue(SpriteLoader.cachedFrames(speciesID: 201, shiny: true,
+                                                 directory: directory, unownForm: .b).isEmpty)
+    }
+}

--- a/Tests/PokeTokenBarTests/UnownSpriteViewTests.swift
+++ b/Tests/PokeTokenBarTests/UnownSpriteViewTests.swift
@@ -1,0 +1,223 @@
+import XCTest
+import AppKit
+import SwiftUI
+import Observation
+@testable import PokeTokenBar
+
+private actor UnownSpriteLoadGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func wait() async {
+        if released { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        released = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+@MainActor
+private final class UnownSpriteSubjectBox {
+    var subject: SpriteSubject
+    var sawCancellation = false
+    init(_ subject: SpriteSubject) { self.subject = subject }
+}
+
+@MainActor
+@Observable
+private final class UnownSpriteSelection {
+    var shiny = false
+}
+
+@MainActor
+private struct UnownSpriteTogglePreview: View {
+    let selection: UnownSpriteSelection
+    let store: SpriteStore
+
+    var body: some View {
+        SpriteView(speciesID: 201, size: 64, shiny: selection.shiny, spriteStore: store, unownForm: .b)
+    }
+}
+
+@MainActor
+final class UnownSpriteViewTests: XCTestCase {
+    func testStaticShinyToggleLoadsShinyWhenOnlyNormalImageIsCached() async throws {
+        try await assertShinyLoaded(startingShiny: false)
+    }
+
+    func testStaticInitiallyShinyLoadsShinyWhenOnlyNormalImageIsCached() async throws {
+        try await assertShinyLoaded(startingShiny: true)
+    }
+
+    private func assertShinyLoaded(startingShiny: Bool) async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("unown-toggle-\(UUID())")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        func png(_ color: NSColor) throws -> Data {
+            let context = try XCTUnwrap(CGContext(data: nil, width: 4, height: 4,
+                bitsPerComponent: 8, bytesPerRow: 0, space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+            context.setFillColor(try XCTUnwrap(color.usingColorSpace(.deviceRGB)).cgColor)
+            context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+            let bitmap = NSBitmapImageRep(cgImage: try XCTUnwrap(context.makeImage()))
+            return try XCTUnwrap(bitmap.representation(using: .png, properties: [:]))
+        }
+        try png(.red).write(to: directory.appendingPathComponent("201-b-s.png"))
+        let shinyFile = directory.appendingPathComponent("201-b-shs.png")
+        let shinyBytes = try png(.blue)
+        try shinyBytes.write(to: shinyFile)
+        let spriteStore = SpriteStore(directory: directory)
+        // Keep the async loader deterministic and offline, while the synchronous shiny cache misses.
+        let warmed = await spriteStore.data(speciesID: 201, animated: false, shiny: true, unownForm: .b)
+        XCTAssertEqual(warmed, shinyBytes)
+        try FileManager.default.removeItem(at: shinyFile)
+        let normal = try XCTUnwrap(SpriteLoader.cachedImage(speciesID: 201, directory: directory, unownForm: .b))
+        XCTAssertTrue(SpriteLoader.cachedImage(speciesID: 201, shiny: true,
+                                               directory: directory, unownForm: .b) === normal)
+
+        _ = NSApplication.shared
+        let selection = UnownSpriteSelection()
+        selection.shiny = startingShiny
+        let host = NSHostingController(rootView: UnownSpriteTogglePreview(selection: selection, store: spriteStore))
+        let window = NSWindow(contentRect: NSRect(x: -10000, y: -10000, width: 64, height: 64),
+                              styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentViewController = host
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+        host.view.layoutSubtreeIfNeeded()
+        try await Task.sleep(for: .milliseconds(100))
+
+        if !startingShiny { selection.shiny = true }
+        let shinyKey = shinyFile.path as NSString
+        for _ in 0..<40 {
+            host.view.layoutSubtreeIfNeeded()
+            if SpriteLoader.imageCache.object(forKey: shinyKey) != nil { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let loaded = try XCTUnwrap(SpriteLoader.imageCache.object(forKey: shinyKey),
+                                  "The static view must still request shiny bytes after seeding a normal fallback")
+        XCTAssertFalse(loaded === normal)
+        let pixels = NSBitmapImageRep(cgImage: try XCTUnwrap(loaded.cgImage(forProposedRect: nil, context: nil, hints: nil)))
+        let color = try XCTUnwrap(pixels.colorAt(x: 2, y: 2)?.usingColorSpace(.deviceRGB))
+        XCTAssertGreaterThan(color.blueComponent, 0.9)
+        XCTAssertLessThan(color.redComponent, 0.1)
+    }
+
+    func testAnimationIdentitiesSeparateAllLettersAndShinyVariants() {
+        var viewIDs = Set<String>()
+        var menuIDs = Set<String>()
+        for form in UnownForm.allCases {
+            for shiny in [false, true] {
+                viewIDs.insert(SpriteView.frameTaskID(speciesID: 201, shiny: shiny, floor: 0.4,
+                                                      unownForm: form))
+                menuIDs.insert(AppDelegate.menuSpriteKey(id: 201, shiny: shiny, floor: 0.4,
+                                                         unownForm: form))
+            }
+        }
+        XCTAssertEqual(viewIDs.count, 56)
+        XCTAssertEqual(menuIDs.count, 56)
+    }
+
+    func testAnimationIdentitiesNormalizeLegacyAAndIgnoreFormsForOtherSpecies() {
+        XCTAssertEqual(SpriteView.frameTaskID(speciesID: 201, shiny: false, floor: 0.4),
+                       SpriteView.frameTaskID(speciesID: 201, shiny: false, floor: 0.4, unownForm: .a))
+        XCTAssertEqual(AppDelegate.menuSpriteKey(id: 201, shiny: false, floor: 0.4),
+                       AppDelegate.menuSpriteKey(id: 201, shiny: false, floor: 0.4, unownForm: .a))
+        XCTAssertEqual(SpriteView.frameTaskID(speciesID: 25, shiny: false, floor: 0.4),
+                       SpriteView.frameTaskID(speciesID: 25, shiny: false, floor: 0.4, unownForm: .z))
+        XCTAssertEqual(AppDelegate.menuSpriteKey(id: 25, shiny: false, floor: 0.4),
+                       AppDelegate.menuSpriteKey(id: 25, shiny: false, floor: 0.4, unownForm: .z))
+    }
+
+    func testChangingUnownLetterReloadsEvenWhenSpeciesAndShinyMatch() {
+        for previous in UnownForm.allCases {
+            for next in UnownForm.allCases {
+                XCTAssertEqual(
+                    SpriteView.needsReload(loadedID: 201, loadedShiny: false, id: 201, shiny: false,
+                                           loadedUnownForm: previous, unownForm: next),
+                    previous != next,
+                    "Changing \(previous.symbol) to \(next.symbol) must display the correct letter")
+            }
+        }
+    }
+
+    func testLegacyUnownFormUsesTheSameSpriteAsExplicitA() {
+        XCTAssertFalse(SpriteView.needsReload(loadedID: 201, loadedShiny: false, id: 201, shiny: false,
+                                             loadedUnownForm: nil, unownForm: .a))
+        XCTAssertFalse(SpriteView.needsReload(loadedID: 201, loadedShiny: false, id: 201, shiny: false,
+                                             loadedUnownForm: .a, unownForm: nil))
+        XCTAssertTrue(SpriteView.needsReload(loadedID: 201, loadedShiny: false, id: 201, shiny: false,
+                                            loadedUnownForm: nil, unownForm: .question))
+    }
+
+    func testSameUnownLetterStillReloadsOnShinyToggle() {
+        XCTAssertTrue(SpriteView.needsReload(loadedID: 201, loadedShiny: false, id: 201, shiny: true,
+                                            loadedUnownForm: .exclamation, unownForm: .exclamation))
+        XCTAssertFalse(SpriteView.needsReload(loadedID: 201, loadedShiny: true, id: 201, shiny: true,
+                                             loadedUnownForm: .question, unownForm: .question))
+    }
+
+    func testUnownFormDoesNotAffectOtherSpeciesSprites() {
+        XCTAssertFalse(SpriteView.needsReload(loadedID: 25, loadedShiny: false, id: 25, shiny: false,
+                                             loadedUnownForm: .a, unownForm: .z))
+        XCTAssertTrue(SpriteView.needsReload(loadedID: 201, loadedShiny: false, id: 25, shiny: false,
+                                            loadedUnownForm: .a, unownForm: nil))
+    }
+
+    func testCachedAToBToAReturnsToAWhileBLoadIsPending() async {
+        await assertCachedRoundTrip(intermediateForm: .b, intermediateShiny: false)
+    }
+
+    func testCachedNormalToShinyToNormalReturnsToNormalWhileShinyLoadIsPending() async {
+        await assertCachedRoundTrip(intermediateForm: .a, intermediateShiny: true)
+    }
+
+    /// 실제 await 구간을 게이트로 유지한다. 중간 캐시 이미지를 표시한 뒤 첫 모습으로 돌아가고,
+    /// 취소된 중간 로드가 늦게 끝나도 이미지·폼·이로치가 함께 첫 모습으로 남아야 한다.
+    private func assertCachedRoundTrip(intermediateForm: UnownForm, intermediateShiny: Bool,
+                                       file: StaticString = #filePath, line: UInt = #line) async {
+        let original = NSImage(size: NSSize(width: 4, height: 4))
+        let intermediate = NSImage(size: NSSize(width: 8, height: 8))
+        let box = UnownSpriteSubjectBox(SpriteSubject(image: original, loadedID: 201,
+                                                       loadedShiny: false, loadedUnownForm: .a))
+        let gate = UnownSpriteLoadGate()
+        let (started, startSignal) = AsyncStream<Void>.makeStream()
+        let pendingLoad = Task { @MainActor in
+            box.subject = box.subject.startingLoad(cachedImage: intermediate, for: 201,
+                                                   shiny: intermediateShiny, unownForm: intermediateForm)
+            startSignal.yield(())
+            startSignal.finish()
+            await gate.wait()
+            box.sawCancellation = Task.isCancelled
+            if let next = box.subject.applyingLoad(intermediate, for: 201, cancelled: Task.isCancelled,
+                                                   shiny: intermediateShiny, unownForm: intermediateForm) {
+                box.subject = next
+            }
+        }
+        for await _ in started {}
+        XCTAssertTrue(box.subject.image === intermediate, file: file, line: line)
+        XCTAssertEqual(box.subject.loadedUnownForm, intermediateForm, file: file, line: line)
+        XCTAssertEqual(box.subject.loadedShiny, intermediateShiny, file: file, line: line)
+
+        pendingLoad.cancel()
+        let needsOriginal = SpriteView.needsReload(loadedID: box.subject.loadedID,
+                                                   loadedShiny: box.subject.loadedShiny, id: 201, shiny: false,
+                                                   loadedUnownForm: box.subject.loadedUnownForm, unownForm: .a)
+        XCTAssertTrue(needsOriginal, "The intermediate cache must not be mistaken for the original sprite",
+                      file: file, line: line)
+        if needsOriginal {
+            box.subject = box.subject.startingLoad(cachedImage: original, for: 201, shiny: false, unownForm: .a)
+        }
+        await gate.release()
+        await pendingLoad.value
+
+        XCTAssertTrue(box.sawCancellation, file: file, line: line)
+        XCTAssertTrue(box.subject.image === original, file: file, line: line)
+        XCTAssertEqual(box.subject.loadedUnownForm, .a, file: file, line: line)
+        XCTAssertFalse(box.subject.loadedShiny, file: file, line: line)
+    }
+}

--- a/Tests/PokeTokenBarTests/UnownTests.swift
+++ b/Tests/PokeTokenBarTests/UnownTests.swift
@@ -1,0 +1,504 @@
+import XCTest
+@testable import PokeTokenBar
+
+private enum UnownTestError: Error { case offline }
+
+/// 부화 라인은 메모리에서 반환하고, 새 알 프리패치는 실패시켜 네트워크를 사용하지 않는다.
+private struct UnownTestProvider: PokeProviding {
+    func line(baseSpeciesID: Int) async throws -> EvoLine {
+        EvoLine(baseID: baseSpeciesID, tree: EvoNode(speciesID: baseSpeciesID, children: []),
+                rarity: .common,
+                names: [baseSpeciesID: ["ko": "안농", "en": "Unown", "ja": "アンノーン"]])
+    }
+
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { throw UnownTestError.offline }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { throw UnownTestError.offline }
+}
+
+private actor UnownPrefetchSignal {
+    private var fired = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func fire() {
+        fired = true
+        waiters.forEach { $0.resume() }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        if fired { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+private struct UnownPrefetchProvider: PokeProviding {
+    let lineRequested: UnownPrefetchSignal
+
+    func line(baseSpeciesID: Int) async throws -> EvoLine {
+        await lineRequested.fire()
+        return try await UnownTestProvider().line(baseSpeciesID: baseSpeciesID)
+    }
+
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [BaseSpecies(id: 201, captureRate: 255)] }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { BaseSpecies(id: 201, captureRate: 255) }
+}
+
+private actor UnownRetryProvider: PokeProviding {
+    private var lineAttempts = 0
+
+    func line(baseSpeciesID: Int) async throws -> EvoLine {
+        lineAttempts += 1
+        if lineAttempts == 1 { throw UnownTestError.offline }
+        return try await UnownTestProvider().line(baseSpeciesID: baseSpeciesID)
+    }
+
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { throw UnownTestError.offline }
+    func baseSpecies(id: Int) async throws -> BaseSpecies? { throw UnownTestError.offline }
+}
+
+@MainActor
+final class UnownTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func mon(_ form: UnownForm?, shiny: Bool = false, speciesID: Int = 201) -> MonState {
+        MonState(baseID: speciesID, pathIDs: [speciesID], stageIndex: 0, usedAtStage: 123,
+                 rarity: .common, totalForms: 1, isShiny: shiny, nature: .brave, unownForm: form)
+    }
+
+    private func entry(_ form: UnownForm?, shiny: Bool = false, speciesID: Int = 201) -> DexEntry {
+        DexEntry(baseID: speciesID, finalID: speciesID, chainOrder: [speciesID], rarity: .common,
+                 caughtAt: now, isShiny: shiny, nature: .brave,
+                 names: [speciesID: ["ko": "안농", "en": "Unown"]], unownForm: form)
+    }
+
+    private func stateURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("unown-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return directory.appendingPathComponent("companion-state.json")
+    }
+
+    private func store(_ state: CompanionState = CompanionState(), seed: UInt64 = 7,
+                       at url: URL? = nil,
+                       provider: any PokeProviding = UnownTestProvider()) throws -> CompanionStore {
+        let destination = try url ?? stateURL()
+        try JSONEncoder().encode(state).write(to: destination)
+        return reload(at: destination, seed: seed, provider: provider)
+    }
+
+    private func reload(at url: URL, seed: UInt64 = 7,
+                        provider: any PokeProviding = UnownTestProvider()) -> CompanionStore {
+        let date = now
+        let suite = "unown-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(1.0, forKey: "growthDifficulty")
+        defaults.set(1.0, forKey: "shopDifficulty")
+        addTeardownBlock { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        return CompanionStore(provider: provider, clock: { date },
+                              fileURL: url, rng: SeededRNG(seed: seed),
+                              dittoDisguiseRollingEnabled: false, defaults: defaults)
+    }
+
+    func testAllLettersAndPunctuationAreSelectable() {
+        let symbols = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ").map(String.init) + ["!", "?"]
+        XCTAssertEqual(UnownForm.allCases.map(\.symbol), symbols)
+        XCTAssertEqual((0..<28).map { UnownForm.roll(UInt64($0)).symbol }, symbols)
+        XCTAssertEqual(UnownForm.roll(28), .a)
+        XCTAssertTrue(UnownForm.allCases.contains(UnownForm.roll(UInt64.max)))
+    }
+
+    /// 형태 필드 하나가 없거나 잘못돼도 기존 개체·도감·재화가 유실되면 안 된다.
+    func testLegacyAndInvalidFormFieldsDefaultToAWithoutLosingProgress() throws {
+        let invalidFields: [Any?] = [nil, NSNull(), "future-form", 42]
+        for invalid in invalidFields {
+            var original = CompanionState()
+            original.active = mon(.z, shiny: true)
+            original.dex = [entry(.question, shiny: true)]
+            original.representativeSpeciesID = 201
+            original.representativeUnownForm = .question
+            original.usedSinceInstall = 123_456_789
+            original.inventory = ["rareCandy": 3]
+            let data = try JSONEncoder().encode(original)
+            var json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            var active = try XCTUnwrap(json["active"] as? [String: Any])
+            var dex = try XCTUnwrap(json["dex"] as? [[String: Any]])
+            active["unownForm"] = invalid
+            dex[0]["unownForm"] = invalid
+            json["active"] = active
+            json["dex"] = dex
+            json["representativeUnownForm"] = invalid
+
+            let restored = try JSONDecoder().decode(CompanionState.self,
+                from: JSONSerialization.data(withJSONObject: json))
+            XCTAssertEqual(restored.active?.unownForm, .a)
+            XCTAssertEqual(restored.active?.usedAtStage, 123)
+            XCTAssertEqual(restored.active?.isShiny, true)
+            XCTAssertEqual(restored.dex.count, 1)
+            XCTAssertEqual(restored.dex.first?.id, original.dex.first?.id)
+            XCTAssertEqual(restored.dex.first?.unownForm, .a)
+            XCTAssertEqual(restored.dex.first?.isShiny, true)
+            XCTAssertEqual(restored.representativeUnownForm, .a)
+            XCTAssertEqual(restored.usedSinceInstall, original.usedSinceInstall)
+            XCTAssertEqual(restored.inventory, original.inventory)
+        }
+    }
+
+    func testEveryFormRoundTripsAndKeepsItsOwnDexCell() throws {
+        for form in UnownForm.allCases {
+            let restored = try JSONDecoder().decode(MonState.self,
+                from: JSONEncoder().encode(mon(form, shiny: true)))
+            XCTAssertEqual(restored.unownForm, form)
+            XCTAssertTrue(restored.isShiny)
+        }
+
+        var original = CompanionState()
+        original.language = .ko
+        original.dex = UnownForm.allCases.map { entry($0, shiny: true) }
+        let s = try store(original)
+        XCTAssertEqual(s.state.dex.compactMap(\.unownForm), UnownForm.allCases)
+        XCTAssertEqual(s.dexSpecies.compactMap(\.unownForm), UnownForm.allCases)
+        XCTAssertEqual(Set(s.dexSpecies.map(\.collectionID)).count, 28)
+        XCTAssertTrue(s.dexSpecies.allSatisfy { $0.id == 201 && $0.isShiny && !$0.isRaising })
+        XCTAssertEqual(s.dexSpecies.map(\.name), UnownForm.allCases.map { "안농 [\($0.symbol)]" })
+    }
+
+    func testFormIsOnlyAppliedToUnown() throws {
+        XCTAssertEqual(mon(nil).unownForm, .a)
+        XCTAssertEqual(entry(nil).unownForm, .a)
+        let otherMon = mon(.question, speciesID: 25)
+        let otherEntry = entry(.question, speciesID: 25)
+        XCTAssertNil(otherMon.unownForm)
+        XCTAssertNil(otherEntry.unownForm)
+        XCTAssertNil(try JSONDecoder().decode(MonState.self,
+            from: JSONEncoder().encode(otherMon)).unownForm)
+        XCTAssertNil(try JSONDecoder().decode(DexEntry.self,
+            from: JSONEncoder().encode(otherEntry)).unownForm)
+        XCTAssertEqual(UnownForm.displayName("Pikachu", speciesID: 25, form: .question), "Pikachu")
+    }
+
+    func testHatchGraduationAndReloadPreserveLetterAndShiny() async throws {
+        for shiny in [false, true] {
+            let seed = try XCTUnwrap((UInt64(0)..<20_000).first { seed in
+                var rng = SeededRNG(seed: seed)
+                let matchesShiny = (rng.next() % PokemonOdds.shinyDenominator == 0) == shiny
+                _ = rng.next() // nature
+                _ = rng.next() // profile seed
+                return matchesShiny && rng.next() % 28 != 0
+            })
+            var rng = SeededRNG(seed: seed)
+            _ = rng.next()
+            let nature = PokemonNature.allCases[Int(rng.next() % UInt64(PokemonNature.allCases.count))]
+            let profileSeed = rng.next()
+            let form = UnownForm.allCases[Int(rng.next() % 28)]
+            let url = try stateURL()
+            let s = try store(seed: seed, at: url)
+
+            await s.hatch(baseID: 201)
+            XCTAssertEqual(s.currentUnownForm, form)
+            XCTAssertEqual(s.currentIsShiny, shiny)
+            XCTAssertEqual(s.currentNature, nature)
+            let profile = try XCTUnwrap(s.state.active?.profile)
+            XCTAssertEqual(profile.seed, profileSeed)
+            XCTAssertTrue(s.setRepresentativeSpeciesID(201, unownForm: form))
+            XCTAssertEqual(reload(at: url).state.active?.unownForm, form)
+
+            s.applyUsage(PokemonBalance.graduationTotal(.common))
+            XCTAssertNil(s.state.active)
+            XCTAssertEqual(s.state.dex.count, 1)
+            XCTAssertEqual(s.state.dex.first?.unownForm, form)
+            XCTAssertEqual(s.state.dex.first?.isShiny, shiny)
+            XCTAssertEqual(s.state.dex.first?.nature, nature)
+            XCTAssertEqual(s.state.dex.first?.profile?.instanceID, profile.instanceID)
+            XCTAssertEqual(s.state.dex.first?.profile?.ivs, profile.ivs)
+            XCTAssertEqual(s.state.dex.first?.profile?.level, 100)
+            XCTAssertEqual(s.representativeUnownForm, form)
+
+            let restored = reload(at: url)
+            XCTAssertEqual(restored.state.dex.first?.unownForm, form)
+            XCTAssertEqual(restored.state.dex.first?.isShiny, shiny)
+            XCTAssertEqual(restored.representativeUnownForm, form)
+            XCTAssertEqual(restored.representativeSubject.isShiny, shiny)
+        }
+    }
+
+    /// 다른 종에는 추가 폼 롤이 없어야 이후 민트 등 기존 난수 결과도 바뀌지 않는다.
+    func testNonUnownHatchDoesNotConsumeAnExtraRandomDraw() async throws {
+        var original = CompanionState()
+        original.inventory = ["mint": 1]
+        let s = try store(original, seed: 17)
+        var rng = SeededRNG(seed: 17)
+        let shiny = rng.next() % PokemonOdds.shinyDenominator == 0
+        let nature = PokemonNature.allCases[Int(rng.next() % UInt64(PokemonNature.allCases.count))]
+        let profileSeed = rng.next()
+        let mintPool = PokemonNature.allCases.filter { $0 != nature }
+        let nextNature = mintPool[Int(rng.next() % UInt64(mintPool.count))]
+
+        await s.hatch(baseID: 25)
+        XCTAssertNil(s.currentUnownForm)
+        XCTAssertEqual(s.currentIsShiny, shiny)
+        XCTAssertEqual(s.currentNature, nature)
+        XCTAssertEqual(s.state.active?.profile?.seed, profileSeed)
+        XCTAssertEqual(s.useMint(), nextNature)
+    }
+
+    func testDexDeduplicatesPerLetterAndScopesShinyAndRaisingFlags() throws {
+        var original = CompanionState()
+        original.dex = [entry(.a), entry(.b), entry(.b, shiny: true)]
+        original.active = mon(.c)
+        let s = try store(original)
+        XCTAssertEqual(s.state.dex.count, 3, "같은 글자의 포획 기록은 각각 보존")
+        XCTAssertEqual(s.dexSpecies.compactMap(\.unownForm), [.a, .b, .c])
+        XCTAssertEqual(s.dexSpecies.map(\.isShiny), [false, true, false])
+        XCTAssertEqual(s.dexSpecies.map(\.isRaising), [false, false, true])
+        XCTAssertTrue(s.state.ownsSpecies(201, unownForm: .c))
+        XCTAssertFalse(s.state.ownsSpecies(201, unownForm: .z))
+        XCTAssertFalse(s.state.ownsShinySpecies(201, unownForm: .a))
+        XCTAssertTrue(s.state.ownsShinySpecies(201, unownForm: .b))
+        XCTAssertFalse(s.state.ownsShinySpecies(201, unownForm: .c))
+    }
+
+    func testRepresentativeUsesExactLetterAndPersistsSelection() throws {
+        var original = CompanionState()
+        original.dex = [entry(.a), entry(.b, shiny: true)]
+        let url = try stateURL()
+        let s = try store(original, at: url)
+
+        XCTAssertTrue(s.setRepresentativeSpeciesID(201, unownForm: .a))
+        XCTAssertFalse(s.representativeSubject.isShiny, "이로치 B가 일반 A의 색을 바꾸면 안 된다")
+        XCTAssertEqual(s.dexSpecies.map { s.isRepresentative($0) }, [true, false])
+        XCTAssertTrue(s.setRepresentativeSpeciesID(201, unownForm: .b))
+        XCTAssertTrue(s.representativeSubject.isShiny)
+        XCTAssertEqual(s.dexSpecies.map { s.isRepresentative($0) }, [false, true])
+        XCTAssertFalse(s.setRepresentativeSpeciesID(201, unownForm: .z))
+        XCTAssertEqual(s.representativeUnownForm, .b, "미보유 글자 요청은 기존 선택을 보존")
+
+        let restored = reload(at: url)
+        XCTAssertEqual(restored.representativeSpeciesID, 201)
+        XCTAssertEqual(restored.representativeUnownForm, .b)
+        XCTAssertTrue(restored.representativeSubject.isShiny)
+        XCTAssertTrue(restored.setRepresentativeSpeciesID(nil))
+        XCTAssertNil(restored.representativeUnownForm)
+    }
+
+    func testReleasingActiveLetterPreservesFormProfileAndRepresentative() throws {
+        var original = CompanionState()
+        original.dex = [entry(.a, shiny: true)]
+        original.active = mon(.b)
+        original.representativeSpeciesID = 201
+        original.representativeUnownForm = .b
+        original.usedSinceInstall = FreshEgg.price
+        let url = try stateURL()
+        let s = try store(original, at: url)
+        let profile = try XCTUnwrap(s.state.active?.profile)
+
+        XCTAssertTrue(s.buyFreshEgg())
+        XCTAssertEqual(s.representativeSpeciesID, 201)
+        XCTAssertEqual(s.representativeUnownForm, .b)
+        XCTAssertFalse(s.representativeSubject.isShiny)
+        XCTAssertEqual(s.state.dex.count, 2)
+        XCTAssertEqual(s.dexSpecies.compactMap(\.unownForm), [.a, .b])
+        XCTAssertTrue(s.dexSpecies.allSatisfy { !$0.isRaising })
+        XCTAssertTrue(s.state.ownsShinySpecies(201, unownForm: .a))
+        XCTAssertTrue(s.state.ownsSpecies(201, unownForm: .b))
+        let released = try XCTUnwrap(s.state.dex.last)
+        XCTAssertTrue(released.isReleased)
+        XCTAssertEqual(released.unownForm, .b)
+        XCTAssertEqual(released.profile, profile)
+        XCTAssertEqual(reload(at: url).representativeUnownForm, .b)
+        XCTAssertTrue(s.state.collectedFinals.isEmpty, "놓아줌은 졸업 완료로 세지 않는다")
+    }
+
+
+    func testDetailIndividualsAndRaisingFlagAreScopedToExactLetter() throws {
+        var original = CompanionState()
+        original.dex = [entry(.a), entry(.b), entry(.b, shiny: true)]
+        original.active = mon(.b)
+        let s = try store(original)
+
+        XCTAssertEqual(s.dexSpecies.map(\.isRaising), [false, true],
+                       "이미 졸업한 글자여도 같은 글자를 키우고 있으면 육성 중으로 표시")
+        XCTAssertEqual(s.pokemonIndividuals(speciesID: 201).count, 1)
+        let bIndividuals = s.pokemonIndividuals(speciesID: 201, unownForm: .b)
+        XCTAssertEqual(bIndividuals.count, 3)
+        XCTAssertTrue(s.isActiveDexEntry(try XCTUnwrap(bIndividuals.first)))
+        XCTAssertTrue(bIndividuals.allSatisfy { $0.unownForm == .b && $0.profile != nil })
+        XCTAssertEqual(Set(bIndividuals.compactMap { $0.profile?.instanceID }).count, 3)
+        XCTAssertTrue(s.pokemonIndividuals(speciesID: 201, unownForm: .question).isEmpty)
+    }
+
+    func testDifferentLettersKeepSpeciesBasedRepeatGrowthAtEveryDifficulty() async throws {
+        for difficulty in [0.1, 1.0, 2.0] {
+            let s = try store(seed: 17)
+            s.setGrowthDifficulty(difficulty)
+            await s.hatch(baseID: 201)
+            XCTAssertFalse(try XCTUnwrap(s.state.active).hasGrowthBoost)
+            let firstForm = try XCTUnwrap(s.currentUnownForm)
+            let unboostedThreshold = s.threshold
+            s.applyUsage(s.tokensToNext)
+            XCTAssertNil(s.state.active)
+            XCTAssertEqual(s.state.collectedFinals, ["201:201"])
+            var nextEgg = s.state
+            nextEgg.pendingHatchID = 201
+            nextEgg.pendingUnownForm = firstForm == .a ? .b : .a
+            nextEgg.eggUsage = PokemonBalance.eggHatchThreshold
+            let repeated = try store(nextEgg)
+            repeated.setGrowthDifficulty(difficulty)
+            await repeated.hatchIfNeeded()
+            XCTAssertEqual(repeated.currentUnownForm, nextEgg.pendingUnownForm)
+            XCTAssertNotEqual(repeated.currentUnownForm, firstForm)
+            XCTAssertTrue(try XCTUnwrap(repeated.state.active).hasGrowthBoost)
+            XCTAssertEqual(repeated.threshold, unboostedThreshold / PokemonBalance.repeatGrowthMultiplier)
+            XCTAssertEqual(repeated.state.dex.first?.unownForm, firstForm)
+            repeated.applyUsage(repeated.tokensToNext)
+            XCTAssertEqual(repeated.state.dex.count, 2)
+            XCTAssertTrue(repeated.state.dex.allSatisfy { $0.profile?.level == 100 })
+        }
+    }
+
+    func testSaveExportAndImportPreserveActiveDexAndRepresentativeForms() throws {
+        var original = CompanionState()
+        original.active = mon(.question, shiny: true)
+        original.dex = [entry(.a), entry(.exclamation, shiny: true)]
+        original.representativeSpeciesID = 201
+        original.representativeUnownForm = .exclamation
+        let source = try store(original)
+        let data = try source.exportedSaveData(appVersion: "test", deviceName: "Source")
+        let envelope = try SaveTransfer.decode(data)
+        let destinationURL = try stateURL()
+        let destination = try store(at: destinationURL)
+
+        try destination.applySave(envelope, todayTokensByProvider: [:], todayDate: "2026-09-11",
+                                  hasUsageData: false)
+        let restored = reload(at: destinationURL)
+        XCTAssertEqual(restored.state.active?.unownForm, .question)
+        XCTAssertEqual(restored.state.active?.isShiny, true)
+        XCTAssertEqual(restored.state.dex.compactMap(\.unownForm), [.a, .exclamation])
+        XCTAssertEqual(restored.state.dex.map(\.isShiny), [false, true])
+        XCTAssertEqual(restored.representativeUnownForm, .exclamation)
+        XCTAssertTrue(restored.representativeSubject.isShiny)
+    }
+
+    /// 실제 update → pre-roll 경로가 글자를 저장하고, 재실행 뒤에도 같은 글자로 부화해야 한다.
+    func testPrefetchPersistsLetterAndHatchConsumesItAfterRNGChanges() async throws {
+        var original = CompanionState()
+        original.installBaselineSet = true
+        original.lastDate = "d1"
+        let seed = try XCTUnwrap((UInt64(0)..<1_000).first { seed in
+            var rng = SeededRNG(seed: seed)
+            _ = rng.next()
+            return rng.next() % 28 != 0
+        })
+        var prefetchRNG = SeededRNG(seed: seed)
+        _ = prefetchRNG.next() // 종 선택
+        let expectedForm = UnownForm.allCases[Int(prefetchRNG.next() % 28)]
+        let signal = UnownPrefetchSignal()
+        let url = try stateURL()
+        let s = try store(original, seed: seed, at: url,
+                          provider: UnownPrefetchProvider(lineRequested: signal))
+
+        s.update(todayTokensByProvider: ["test": 1_000], todayDate: "d1", monthTotal: 0,
+                 burnTier: .idle, limitWarning: false, hasUsageData: true)
+        await signal.wait() // 프리패치가 종·글자 저장 후 라인 예열에 진입했다.
+        XCTAssertNil(s.state.active)
+        XCTAssertEqual(s.state.pendingHatchID, 201)
+        XCTAssertEqual(s.state.pendingUnownForm, expectedForm)
+        var persisted = try JSONDecoder().decode(CompanionState.self, from: Data(contentsOf: url))
+        XCTAssertEqual(persisted.pendingUnownForm, expectedForm)
+
+        // 새 RNG라면 원래 다른 글자가 나오는 시드로 재실행해도 pending 글자를 사용한다.
+        let restartedSeed = try XCTUnwrap((UInt64(0)..<1_000).first { seed in
+            var rng = SeededRNG(seed: seed)
+            _ = rng.next() // shiny
+            _ = rng.next() // nature
+            _ = rng.next() // profile seed
+            return UnownForm.allCases[Int(rng.next() % 28)] != expectedForm
+        })
+        persisted.eggUsage = PokemonBalance.eggHatchThreshold
+        persisted.usedSinceInstall = FreshEgg.price
+        let restarted = try store(persisted, seed: restartedSeed)
+        await restarted.hatchIfNeeded()
+
+        XCTAssertEqual(restarted.currentUnownForm, expectedForm)
+        XCTAssertNil(restarted.state.pendingHatchID)
+        XCTAssertNil(restarted.state.pendingUnownForm)
+        XCTAssertTrue(restarted.buyFreshEgg())
+        XCTAssertNil(restarted.state.active)
+        XCTAssertNil(restarted.state.pendingHatchID)
+        XCTAssertNil(restarted.state.pendingUnownForm, "새 알로 이전 글자가 이월되면 안 된다")
+    }
+
+    func testLegacyPendingUnownKeepsDefaultAAtHatch() async throws {
+        let legacy = Data(#"{"pendingHatchID":201,"eggUsage":5000000}"#.utf8)
+        let decoded = try JSONDecoder().decode(CompanionState.self, from: legacy)
+        XCTAssertEqual(decoded.pendingUnownForm, .a)
+        let s = try store(decoded, seed: 17)
+
+        await s.hatchIfNeeded()
+        XCTAssertEqual(s.currentUnownForm, .a)
+        XCTAssertNil(s.state.pendingUnownForm)
+    }
+
+    func testPendingLetterSurvivesFailedLineLoadAndHatchesOnRetry() async throws {
+        var original = CompanionState()
+        original.pendingHatchID = 201
+        original.pendingUnownForm = .question
+        original.eggUsage = PokemonBalance.eggHatchThreshold + 123
+        let url = try stateURL()
+        let s = try store(original, seed: 17, at: url, provider: UnownRetryProvider())
+
+        await s.hatchIfNeeded() // 첫 라인 요청은 오프라인 실패.
+        XCTAssertNil(s.state.active)
+        XCTAssertFalse(s.isHatching)
+        XCTAssertEqual(s.state.pendingHatchID, 201)
+        XCTAssertEqual(s.state.pendingUnownForm, .question)
+        XCTAssertEqual(s.state.eggUsage, original.eggUsage)
+        s.setLanguage(.ko) // 다음 일반 저장에서도 예열한 종·글자가 유실되지 않아야 한다.
+        let saved = reload(at: url)
+        XCTAssertEqual(saved.state.pendingHatchID, 201)
+        XCTAssertEqual(saved.state.pendingUnownForm, .question)
+
+        await s.hatchIfNeeded()
+        XCTAssertEqual(s.currentSpeciesID, 201)
+        XCTAssertEqual(s.currentUnownForm, .question)
+        XCTAssertEqual(s.state.active?.usedAtStage, 123)
+        XCTAssertNil(s.state.pendingHatchID)
+        XCTAssertNil(s.state.pendingUnownForm)
+    }
+
+    func testSanitizationClearsPendingLetterWithoutMatchingEgg() {
+        var original = CompanionState()
+        original.active = mon(.b)
+        original.pendingHatchID = 201
+        original.pendingUnownForm = .question
+        let activeState = SaveTransfer.sanitized(original)
+        XCTAssertEqual(activeState.active?.unownForm, .b)
+        XCTAssertNil(activeState.pendingHatchID)
+        XCTAssertNil(activeState.pendingUnownForm)
+
+        original.active = nil
+        original.pendingHatchID = 25
+        XCTAssertNil(SaveTransfer.sanitized(original).pendingUnownForm)
+        original.pendingHatchID = nil
+        XCTAssertNil(SaveTransfer.sanitized(original).pendingUnownForm)
+    }
+
+    func testSaveExportAndImportPreservePendingEggLetter() throws {
+        var original = CompanionState()
+        original.pendingHatchID = 201
+        original.pendingUnownForm = .exclamation
+        original.eggUsage = 1_234
+        let source = try store(original)
+        let data = try source.exportedSaveData(appVersion: "test", deviceName: "Source")
+        let destinationURL = try stateURL()
+        let destination = try store(at: destinationURL)
+
+        try destination.applySave(SaveTransfer.decode(data), todayTokensByProvider: [:],
+                                  todayDate: "2026-09-11", hasUsageData: false)
+        let restored = reload(at: destinationURL)
+        XCTAssertNil(restored.state.active)
+        XCTAssertEqual(restored.state.pendingHatchID, 201)
+        XCTAssertEqual(restored.state.pendingUnownForm, .exclamation)
+        XCTAssertEqual(restored.state.eggUsage, 1_234)
+    }
+}

--- a/docs/reference/unown-forms.md
+++ b/docs/reference/unown-forms.md
@@ -1,0 +1,28 @@
+# Unown forms
+
+Unown (#201) has 28 collectible forms: A–Z, ! and ?. A new Unown egg chooses
+its letter when the species is prepared, allowing the exact normal and shiny
+sprites to be cached before hatching. If an Unown hatches without preparation,
+the letter is chosen at hatch time. Other species keep their existing random
+draw sequence and hatching weights.
+
+The letter stays with the Pokémon through raising, graduation, release, restarts,
+and save export/import. Released Pokémon remain in the Pokédex under the existing
+collection rules. The Pokédex shows one cell per letter, combines duplicates
+of the same letter, and tracks shiny ownership separately for each letter. Its
+species total still counts Unown once; the form counter shows collection
+progress out of 28. A chosen representative keeps its letter in the menu bar
+and floating pet. The detail page lists individuals of the selected letter;
+species information, difficulty, and repeat-hatch growth bonuses keep their
+existing species-based behavior.
+
+Saves use `unownForm` on active Pokémon and Pokédex entries, `pendingUnownForm`
+on prepared eggs, and `representativeUnownForm` for the selected representative.
+Values are lowercase `a`–`z`, `exclamation`, or `question`. Older Unown records
+without a letter retain their former A appearance. Form fields on other species
+are ignored. Species IDs and evolution paths remain unchanged.
+
+Sprites come from the existing PokeAPI source: A uses `201.png`/`201.gif`, and
+the other letters use names such as `201-b.png` or `201-question.gif`. Cache
+keys distinguish the letter, shiny color, and animation format while retaining
+the original A cache keys.

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -20,6 +20,7 @@ THRESHOLD="${THRESHOLD:-75}"
 
 LOGIC_CORE=(
   "Sources/PokeTokenBar/Core/CompanionModel.swift"
+  "Sources/PokeTokenBar/Core/UnownForm.swift"
   "Sources/PokeTokenBar/Core/CompanionStore.swift"
   "Sources/PokeTokenBar/Core/PokemonProfile.swift"
   "Sources/PokeTokenBar/Core/UsageStore.swift"


### PR DESCRIPTION
## Summary

This PR proposes collecting all 28 Unown forms (A–Z, !, and ?) within a single Pokédex species entry (`#0201`). Feedback on the collection scope and presentation is welcome.

- Keep one Unown entry in the main Pokédex, with a form count such as `12/28`. The detail view shows all 28 forms and dims/disables uncollected ones.
- Selecting a collected form scopes the individual picker, shiny ownership, and representative selection to that form. Normal and shiny variants share the same completion count, capped at 28.
- Reuse `CollectionWeight.adjusted` for both species and form selection. Uncollected forms have weight 2 and collected forms weight 1; after completion, all forms are equally likely. There is no consecutive-duplicate counter or guaranteed-new-form rule.
- Apply form weighting only after Unown is selected. Existing species-selection weights, shiny odds, difficulty, and species-based repeat-hatch bonuses stay unchanged.
- Preserve the form through egg preparation, hatching, raising, graduation, release records, save transfers, and representative selection. Existing saves without form data keep the A appearance.

Sprites remain runtime PokeAPI assets. Cache keys distinguish form, shiny color, and PNG/GIF format while retaining existing A keys. Static shiny loading and rapid form changes also preserve the correct sprite identity.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## UI changes

| Before | After |
| ------ | ----- |
| Unown has one entry showing the default A sprite, without form collection progress. | The main Pokédex keeps one entry and shows `N/28`; the detail view lists A–Z, !, and ? with uncollected forms dimmed. |
| Individuals, shiny ownership, and representative selection are grouped only by species. | Collected forms have their own individual lists, shiny ownership, and representative selection. Settings retain the selected form's name and shiny status. |
| A cached normal image can prevent a static shiny image from loading. | Initially shiny views and normal-to-shiny transitions request the correct variant; rapid form changes discard stale images. |

### Screenshots

Actual SwiftUI screens from this implementation in an isolated preview, using synthetic collection data, profiles, and metadata. Sprites load from PokeAPI at runtime.

**One Pokédex entry, with all forms in the detail view**

| Main Pokédex: 12/28 | Detail: collected and dimmed forms |
| --- | --- |
| <img width="320" alt="Unown single Pokédex entry with 12 of 28 forms" src="https://github.com/user-attachments/assets/b1db2e06-35e1-4611-a06a-4d573af820f8" /> | <img width="320" alt="Unown detail with 12 collected forms and 16 dimmed forms; shiny B selected" src="https://github.com/user-attachments/assets/841a6bd4-4751-436f-aa7f-5a2ec823fe80" /> |

**Individuals and representative selection**

The individual picker contains only the selected form. Shiny badges reflect ownership of that form; the large sprite reflects the selected individual. Choosing a representative preserves its form and uses that form's shiny ownership, following the existing representative policy.

| Normal B individual | Question form set as representative |
| --- | --- |
| <img width="320" alt="Unown normal B individual in the form-specific picker" src="https://github.com/user-attachments/assets/6299993e-b682-4946-a00b-eb1db6a165f1" /> | <img width="320" alt="Unown question form selected as the representative" src="https://github.com/user-attachments/assets/d0703243-f60c-4815-b46d-3c977399c94b" /> |

**Completion stays at 28, including shiny variants**

| All 28 forms collected | Only the question form collected |
| --- | --- |
| <img width="320" alt="Unown complete collection with all 28 form buttons enabled" src="https://github.com/user-attachments/assets/24fd018b-9b32-4e48-bebe-45ee4624117f" /> | <img width="320" alt="Unown question-only collection with uncollected A dimmed and disabled" src="https://github.com/user-attachments/assets/0061026f-77be-4289-b81c-048c1487a34f" /> |

## Validation

- Integrated latest `main` at `ab6c768`, preserving both `language` and `unownForm` in the `EvoLineView` call sites.
- `swift build`: passed.
- `./scripts/test-gate.sh`: 1,121 tests, 11 environment-dependent skips, zero failures. Logic-core line coverage: 92.99% (required: 75%).
- `UnownForm.swift` and `CollectionWeight.swift`: 100% region and line coverage; inspected branch execution with `llvm-cov show --show-regions`.
- Deterministic tests cover exact 2:1 form weights, uniform selection after completion, both prefetch and direct-hatch paths, legacy/released/active ownership, species and shiny roll preservation, representative persistence, and form-specific individuals. Disabling the shared collected-weight adjustment made all three targeted selection regressions fail; it was restored before the final passing gate.
- Native SwiftUI checks verified a single species entry at 12/28 and 28/28, disabled missing forms, normal/shiny B selection, punctuation forms, saved question-form representative selection, and a question-only collection that leaves A uncollected. Fixture state was isolated from personal saves.
- The existing session-key scroll rendering test failed in one interim full run; its isolated rerun and the final full gate passed without changing that test.
- `gitleaks`: passed, no leaks found in the PR commits.
- GitHub CI: build/tests and secret scan passed on `c4d5ed5`. [Run](https://github.com/chattymin/PokeTokenBar/actions/runs/34810202232).

The native preview does not exercise the production menu-bar AppDelegate or floating-panel lifecycle, or import/hatch races during egg prefetch.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change
