### PR TITLE
fix: complete selected-language localization across the app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository instructions
+
+Read `CLAUDE.md` for the repository's contribution, testing, and release instructions.
+
+## Pull requests
+
+Before creating or updating a PR, read `.github/PULL_REQUEST_TEMPLATE.md` and use its sections and checklist in the description. Fill in the type of change and the actual validation results. For UI changes, include the before/after comparison; remove the UI section only when there are no UI changes. Mark checklist items complete only when supported by the work performed. Keep the PR title and description in English.

--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -13,18 +13,10 @@ enum AppLanguage: String, Codable, Sendable, CaseIterable {
         switch self {
         case .ko: return ["ko"]
         case .en: return ["en"]
-        case .ja: return ["ja-Hrkt", "ja"]
+        case .ja: return ["ja-hrkt", "ja"]
         case .es: return ["es"]
         case .fr: return ["fr"]
-        // PokéAPI has no `pt` in its language list, so this falls through to
-        // resolveName's English fallback. That fallback IS the expected result:
-        // the core series was never localised into Portuguese, so Brazilian
-        // players use the English species names anyway. The code is listed
-        // regardless, so the day PokéAPI adds it, it works with no edit here.
-        // PokéAPI 의 language 목록에 pt 는 없다 → resolveName 의 영어 폴백으로 내려간다.
-        // 본가 시리즈가 포르투갈어로 나온 적이 없어 브라질에서도 종 이름은 영어를 쓰므로 폴백이 곧 기대값이다.
-        // 그래도 코드를 적어두는 건 PokéAPI 가 pt 를 추가하는 순간 분기 수정 없이 반영되게 하기 위해서다.
-        case .pt: return ["pt"]
+        case .pt: return ["pt-br", "pt"]
         case .de: return ["de"]
         }
     }
@@ -36,8 +28,7 @@ enum AppLanguage: String, Codable, Sendable, CaseIterable {
 
     /// byLang(langCode→name) 에서 이 언어의 이름을 고른다(apiCodes 첫 매칭 → 영어 폴백).
     func resolveName(_ byLang: [String: String]) -> String? {
-        for code in apiCodes { if let n = byLang[code] { return n } }
-        return byLang["en"]
+        PokemonNameLocalization.resolve(byLang, preferredCodes: apiCodes)
     }
 
     /// 신규 설치 기본 언어 — 시스템 선호 언어에서 유추(글로벌 출시: 한국어 강제 금지).

--- a/Sources/PokeTokenBar/Core/CompanionModel.swift
+++ b/Sources/PokeTokenBar/Core/CompanionModel.swift
@@ -512,6 +512,8 @@ struct MonState: Codable, Sendable {
 
 /// 도감 항목 — 라인 전체(초기→최종) 순서 보존.
 struct DexEntry: Codable, Sendable, Identifiable {
+    /// Version 1 preserves every API language; earlier saves retained only app-supported names.
+    static let currentNamesVersion = 1
     var id = UUID().uuidString
     var baseID: Int
     var finalID: Int
@@ -526,6 +528,11 @@ struct DexEntry: Codable, Sendable, Identifiable {
     /// 도감의 단계별 스프라이트 밑 이름 표시가 네트워크 없이 즉시 + 언어 전환 대응. 구버전 저장분엔
     /// 없어(nil) 뷰가 line fetch 로 조회 후 백필한다.
     var names: [Int: [String: String]]?
+    var namesVersion: Int?
+    var needsNamesRefresh: Bool {
+        namesVersion != Self.currentNamesVersion
+            || chainOrder.contains { names?[$0]?.isEmpty != false }
+    }
     /// 놓아준 시각 — 알을 새로 사서 육성을 포기한 기록. nil = 졸업분(구버전 저장분 포함).
     ///
     /// 두 기록을 한 배열에 두는 이유: 도감(`dexSpecies`)은 종이 어떻게 확보됐는지와 무관하게
@@ -549,6 +556,8 @@ struct DexEntry: Codable, Sendable, Identifiable {
         self.nature = nature
         self.profile = profile
         self.names = names
+        self.namesVersion = chainOrder.allSatisfy { names?[$0]?.isEmpty == false }
+            ? Self.currentNamesVersion : nil
         self.releasedAt = releasedAt
     }
 
@@ -568,6 +577,7 @@ struct DexEntry: Codable, Sendable, Identifiable {
         // try? — 구버전(최종체 단일 [String:String]) 형식이 남아 있어도 종별 맵 디코딩 실패 시 nil 로
         // 강등(항목 전체 로드는 유지). 뷰가 line 조회로 백필한다.
         names = (try? c.decodeIfPresent([Int: [String: String]].self, forKey: .names)) ?? nil
+        namesVersion = try? c.decodeIfPresent(Int.self, forKey: .namesVersion)
         // 이 필드 이전에 저장된 항목은 전부 졸업분이다 — nil 이 곧 "졸업"이라 마이그레이션이 필요 없다.
         releasedAt = try c.decodeIfPresent(Date.self, forKey: .releasedAt)
     }

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -409,14 +409,14 @@ final class CompanionStore {
         }
     }
 
-    /// 이름이 없는 구버전 졸업 항목의 체인 이름을 채운다(도감 격자 진입 시 1회).
+    /// Refresh legacy names once, including saves that retained only app-supported languages.
     ///
     /// 격자는 저장된 이름만 읽으므로 백필이 없으면 칸이 종 번호(`#41`)로 남는다. 포획 로그는 행이
     /// 뜰 때 행 단위로 같은 일을 해 왔지만, 로그를 한 번도 안 열면 격자는 계속 번호다.
     /// 라인 조회는 `PokeAPIClient` 가 base 단위로 캐시하므로 같은 라인이 여러 항목이어도 네트워크는 1회.
     /// 오프라인이면 `dexResolveChainNames` 가 저장 없이 폴백만 돌려주므로 다음 진입에서 다시 시도한다.
     func backfillMissingDexNames() async {
-        for entry in state.dex where entry.names == nil {
+        for entry in state.dex where entry.needsNamesRefresh {
             _ = await dexResolveChainNames(entry)   // 성공분만 내부에서 state.dex 에 저장
         }
     }
@@ -428,20 +428,40 @@ final class CompanionStore {
         return names.compactMapValues { state.language.resolveName($0) }
     }
 
-    /// 이름 미저장(구버전) 항목용 — line 을 1회 조회해 체인 전 종의 다국어 이름을 얻고 항목에 백필한다
-    /// (다음부터 네트워크 0). 저장돼 있으면 그대로(fetch 없음). 오프라인이면 종 번호(#id)로 폴백.
+    /// Refresh missing/legacy multilingual names; current versions require no lookup.
+    /// Offline, keep saved names and use species numbers only where no name is available.
     /// 반환은 chainOrder 전 종을 채운 [speciesID: 현재 언어 이름].
     func dexResolveChainNames(_ entry: DexEntry) async -> [Int: String] {
-        if let stored = dexStoredChainNames(entry) { return stored }
+        // Another row of this evolution line may already have refreshed the stored entry.
+        let entry = state.dex.first { $0.id == entry.id } ?? entry
+        if !entry.needsNamesRefresh, let stored = dexStoredChainNames(entry) { return stored }
+        let oldNames = dexStoredChainNames(entry) ?? [:]
         guard let line = try? await provider.line(baseSpeciesID: entry.baseID) else {
-            return Dictionary(uniqueKeysWithValues: entry.chainOrder.map { ($0, "#\($0)") })
+            return Dictionary(uniqueKeysWithValues: entry.chainOrder.map { ($0, oldNames[$0] ?? "#\($0)") })
         }
-        let chainNames = Dictionary(uniqueKeysWithValues:
-            entry.chainOrder.compactMap { id in line.names[id].map { (id, $0) } })
-        if !chainNames.isEmpty, let idx = state.dex.firstIndex(where: { $0.id == entry.id }) {
-            state.dex[idx].names = chainNames   // 백필 저장
-            save()
+        // Preserve usable older names if a response is partial. Only a complete chain gets
+        // the new version, so partial/offline responses remain eligible for retry.
+        func refreshed(_ original: DexEntry) -> DexEntry {
+            var result = original
+            var merged = original.names ?? [:]
+            for id in original.chainOrder {
+                if let incoming = line.names[id], !incoming.isEmpty {
+                    merged[id] = (merged[id] ?? [:]).merging(incoming) { _, new in new }
+                }
+            }
+            result.names = merged.isEmpty ? nil : merged
+            if original.chainOrder.allSatisfy({ line.names[$0]?.isEmpty == false }) {
+                result.namesVersion = DexEntry.currentNamesVersion
+            }
+            return result
         }
+        // One successful lookup also refreshes duplicate catches of the same evolution line.
+        for index in state.dex.indices where state.dex[index].baseID == entry.baseID
+            && state.dex[index].needsNamesRefresh {
+            state.dex[index] = refreshed(state.dex[index])
+        }
+        save()
+        let chainNames = refreshed(entry).names ?? [:]
         return Dictionary(uniqueKeysWithValues: entry.chainOrder.map { id in
             (id, chainNames[id].flatMap { state.language.resolveName($0) } ?? "#\(id)")
         })

--- a/Sources/PokeTokenBar/Core/CompanionStore.swift
+++ b/Sources/PokeTokenBar/Core/CompanionStore.swift
@@ -38,6 +38,7 @@ final class CompanionStore {
     func consumeMintFeedback() { mintFeedbackNature = nil }
 
     private let provider: any PokeProviding
+    private var dexNameRequests: [Int: Task<EvoLine, Error>] = [:]
     private let detailProvider: (any PokemonDetailProviding)?
     private let clock: () -> Date
     private let fileURL: URL
@@ -431,12 +432,21 @@ final class CompanionStore {
     /// Refresh missing/legacy multilingual names; current versions require no lookup.
     /// Offline, keep saved names and use species numbers only where no name is available.
     /// 반환은 chainOrder 전 종을 채운 [speciesID: 현재 언어 이름].
+    private func dexNameLine(baseID: Int) async throws -> EvoLine {
+        if let request = dexNameRequests[baseID] { return try await request.value }
+        let provider = self.provider
+        let request = Task { try await provider.line(baseSpeciesID: baseID) }
+        dexNameRequests[baseID] = request
+        defer { dexNameRequests[baseID] = nil }
+        return try await request.value
+    }
+
     func dexResolveChainNames(_ entry: DexEntry) async -> [Int: String] {
         // Another row of this evolution line may already have refreshed the stored entry.
         let entry = state.dex.first { $0.id == entry.id } ?? entry
         if !entry.needsNamesRefresh, let stored = dexStoredChainNames(entry) { return stored }
         let oldNames = dexStoredChainNames(entry) ?? [:]
-        guard let line = try? await provider.line(baseSpeciesID: entry.baseID) else {
+        guard let line = try? await dexNameLine(baseID: entry.baseID) else {
             return Dictionary(uniqueKeysWithValues: entry.chainOrder.map { ($0, oldNames[$0] ?? "#\($0)") })
         }
         // Preserve usable older names if a response is partial. Only a complete chain gets

--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -7,7 +7,7 @@ struct L {
     let lang: AppLanguage
     init(_ lang: AppLanguage) { self.lang = lang }
 
-    private func t(_ ko: String, _ en: String, _ ja: String, _ es: String, _ fr: String, _ pt: String, _ de: String) -> String {
+    func t(_ ko: String, _ en: String, _ ja: String, _ es: String, _ fr: String, _ pt: String, _ de: String) -> String {
         switch lang {
         case .ko: return ko
         case .en: return en
@@ -125,6 +125,15 @@ struct L {
     var refreshNow: String { t("지금 새로고침", "Refresh now", "今すぐ更新", "Actualizar ahora", "Actualiser maintenant", "Atualizar agora", "Jetzt aktualisieren") }
     var updated: String { t("갱신", "Updated", "更新", "Actualizado", "Mis à jour", "Atualizado", "Aktualisiert") }
     var settings: String { t("설정", "Settings", "設定", "Ajustes", "Réglages", "Ajustes", "Einstellungen") }
+    var tokenInput: String { t("입력", "Input", "入力", "Entrada", "Entrée", "Entrada", "Eingabe") }
+    var tokenOutput: String { t("출력", "Output", "出力", "Salida", "Sortie", "Saída", "Ausgabe") }
+    var tokenCacheWrite: String { t("캐시 쓰기", "Cache write", "キャッシュ書込", "Escritura caché", "Écriture cache", "Gravação cache", "Cache schreiben") }
+    var tokenCacheRead: String { t("캐시 읽기", "Cache read", "キャッシュ読込", "Lectura caché", "Lecture cache", "Leitura cache", "Cache lesen") }
+    var website: String { t("웹사이트", "Website", "ウェブサイト", "Sitio web", "Site web", "Site", "Website") }
+    var sponsor: String { t("후원", "Sponsor", "支援", "Apoyar", "Soutenir", "Apoiar", "Unterstützen") }
+    var evolutionScrollPrevious: String { t("이전 진화 보기", "Show previous evolutions", "前の進化を見る", "Ver evoluciones anteriores", "Voir les évolutions précédentes", "Ver evoluções anteriores", "Vorherige Entwicklungen anzeigen") }
+    var evolutionScrollNext: String { t("다음 진화 보기", "Show next evolutions", "次の進化を見る", "Ver evoluciones siguientes", "Voir les évolutions suivantes", "Ver próximas evoluções", "Nächste Entwicklungen anzeigen") }
+
     var back: String { t("뒤로", "Back", "戻る", "Atrás", "Retour", "Voltar", "Zurück") }
     var generalSectionTitle: String { t("일반", "General", "一般", "General", "Général", "Geral", "Allgemein") }
     var menuBarSectionTitle: String { t("메뉴바에 표시", "Show in menu bar", "メニューバーに表示", "Mostrar en la barra de menús", "Afficher dans la barre des menus", "Mostrar na barra de menus", "In der Menüleiste anzeigen") }
@@ -498,7 +507,7 @@ struct L {
         case SaveTransferError.newerSchema:   return importErrorNewerSchema
         case SaveTransferError.fileTooLarge:  return importErrorTooLarge
         case SaveTransferError.backupFailed:  return importErrorBackupFailed
-        default: return error.localizedDescription
+        default: return userFacingError(error)
         }
     }
     var importErrorTooLarge: String {
@@ -718,6 +727,8 @@ struct L {
         case "level-up": return detail.level > 0 ? "Lv. \(detail.level)" : t("시작", "Start", "基本", "Inicio", "Départ", "Inicial", "Start")
         case "machine": return "TM"
         case "egg": return t("교배", "Egg", "タマゴ", "Huevo", "Œuf", "Ovo", "Ei")
+        case "light-ball-egg": return t("전기구 교배", "Light Ball breeding", "でんきだま遺伝", "Crianza con Bola Luminosa", "Reproduction avec Balle Lumière", "Cruzamento com Bola de Luz", "Zucht mit Kugelblitz")
+        case "form-change": return t("폼 체인지", "Form change", "フォルムチェンジ", "Cambio de forma", "Changement de forme", "Mudança de forma", "Formwechsel")
         case "tutor": return t("가르침", "Tutor", "教え", "Tutor", "Maître", "Tutor", "Tutor")
         default: return detail.method.replacingOccurrences(of: "-", with: " ")
         }

--- a/Sources/PokeTokenBar/Core/LocalizationErrors.swift
+++ b/Sources/PokeTokenBar/Core/LocalizationErrors.swift
@@ -5,35 +5,24 @@ extension L {
     func userFacingError(_ error: any Error) -> String {
         let value = error as NSError
         if value.domain == NSURLErrorDomain {
-            return errorText("네트워크 요청에 실패했습니다. 연결을 확인하고 다시 시도해 주세요.", "The network request failed. Check your connection and try again.", "通信に失敗しました。接続を確認して再試行してください。", "La solicitud de red falló. Comprueba la conexión e inténtalo de nuevo.", "La requête réseau a échoué. Vérifiez la connexion et réessayez.", "A solicitação de rede falhou. Verifique a conexão e tente novamente.", "Die Netzwerkanfrage ist fehlgeschlagen. Prüfe die Verbindung und versuche es erneut.")
+            return t("네트워크 요청에 실패했습니다. 연결을 확인하고 다시 시도해 주세요.", "The network request failed. Check your connection and try again.", "通信に失敗しました。接続を確認して再試行してください。", "La solicitud de red falló. Comprueba la conexión e inténtalo de nuevo.", "La requête réseau a échoué. Vérifiez la connexion et réessayez.", "A solicitação de rede falhou. Verifique a conexão e tente novamente.", "Die Netzwerkanfrage ist fehlgeschlagen. Prüfe die Verbindung und versuche es erneut.")
         }
         if value.domain == NSCocoaErrorDomain {
             switch value.code {
             case NSFileReadNoPermissionError, NSFileWriteNoPermissionError:
-                return errorText("파일 접근 권한이 없습니다. 권한이나 저장 위치를 확인해 주세요.", "File access was denied. Check permissions or choose another location.", "ファイルにアクセスできません。権限または保存先を確認してください。", "Acceso al archivo denegado. Revisa los permisos o elige otra ubicación.", "Accès au fichier refusé. Vérifiez les autorisations ou choisissez un autre emplacement.", "Acesso ao arquivo negado. Verifique as permissões ou escolha outro local.", "Dateizugriff verweigert. Prüfe die Berechtigungen oder wähle einen anderen Speicherort.")
+                return t("파일 접근 권한이 없습니다. 권한이나 저장 위치를 확인해 주세요.", "File access was denied. Check permissions or choose another location.", "ファイルにアクセスできません。権限または保存先を確認してください。", "Acceso al archivo denegado. Revisa los permisos o elige otra ubicación.", "Accès au fichier refusé. Vérifiez les autorisations ou choisissez un autre emplacement.", "Acesso ao arquivo negado. Verifique as permissões ou escolha outro local.", "Dateizugriff verweigert. Prüfe die Berechtigungen oder wähle einen anderen Speicherort.")
             case NSFileWriteOutOfSpaceError:
-                return errorText("저장 공간이 부족합니다. 공간을 확보하고 다시 시도해 주세요.", "There is not enough disk space. Free up space and try again.", "空き容量が不足しています。容量を確保して再試行してください。", "No hay espacio suficiente. Libera espacio e inténtalo de nuevo.", "L’espace disque est insuffisant. Libérez de l’espace et réessayez.", "Não há espaço suficiente. Libere espaço e tente novamente.", "Nicht genügend Speicherplatz. Gib Speicherplatz frei und versuche es erneut.")
+                return t("저장 공간이 부족합니다. 공간을 확보하고 다시 시도해 주세요.", "There is not enough disk space. Free up space and try again.", "空き容量が不足しています。容量を確保して再試行してください。", "No hay espacio suficiente. Libera espacio e inténtalo de nuevo.", "L’espace disque est insuffisant. Libérez de l’espace et réessayez.", "Não há espaço suficiente. Libere espaço e tente novamente.", "Nicht genügend Speicherplatz. Gib Speicherplatz frei und versuche es erneut.")
             case NSFileReadNoSuchFileError, NSFileNoSuchFileError:
-                return errorText("파일을 찾을 수 없습니다. 위치를 확인하고 다시 선택해 주세요.", "The file could not be found. Check its location and select it again.", "ファイルが見つかりません。場所を確認して選び直してください。", "No se encontró el archivo. Comprueba su ubicación y selecciónalo de nuevo.", "Fichier introuvable. Vérifiez son emplacement et sélectionnez-le à nouveau.", "Arquivo não encontrado. Verifique o local e selecione novamente.", "Die Datei wurde nicht gefunden. Prüfe den Speicherort und wähle sie erneut aus.")
+                return t("파일을 찾을 수 없습니다. 위치를 확인하고 다시 선택해 주세요.", "The file could not be found. Check its location and select it again.", "ファイルが見つかりません。場所を確認して選び直してください。", "No se encontró el archivo. Comprueba su ubicación y selecciónalo de nuevo.", "Fichier introuvable. Vérifiez son emplacement et sélectionnez-le à nouveau.", "Arquivo não encontrado. Verifique o local e selecione novamente.", "Die Datei wurde nicht gefunden. Prüfe den Speicherort und wähle sie erneut aus.")
             default: break
             }
         }
-        return errorText("작업을 완료하지 못했습니다. 다시 시도해 주세요.", "The operation could not be completed. Please try again.", "操作を完了できませんでした。再試行してください。", "No se pudo completar la operación. Inténtalo de nuevo.", "L’opération n’a pas pu être terminée. Veuillez réessayer.", "Não foi possível concluir a operação. Tente novamente.", "Der Vorgang konnte nicht abgeschlossen werden. Bitte versuche es erneut.")
+        return t("작업을 완료하지 못했습니다. 다시 시도해 주세요.", "The operation could not be completed. Please try again.", "操作を完了できませんでした。再試行してください。", "No se pudo completar la operación. Inténtalo de nuevo.", "L’opération n’a pas pu être terminée. Veuillez réessayer.", "Não foi possível concluir a operação. Tente novamente.", "Der Vorgang konnte nicht abgeschlossen werden. Bitte versuche es erneut.")
     }
 
     var usageRefreshError: String {
-        errorText("일부 사용량을 불러오지 못했습니다. 다시 새로고침해 주세요.", "Some usage could not be loaded. Please refresh again.", "一部の使用量を読み込めませんでした。再度更新してください。", "No se pudo cargar parte del uso. Actualiza de nuevo.", "Certaines données d’utilisation n’ont pas pu être chargées. Actualisez à nouveau.", "Não foi possível carregar parte do uso. Atualize novamente.", "Einige Nutzungsdaten konnten nicht geladen werden. Bitte aktualisiere erneut.")
+        t("일부 사용량을 불러오지 못했습니다. 다시 새로고침해 주세요.", "Some usage could not be loaded. Please refresh again.", "一部の使用量を読み込めませんでした。再度更新してください。", "No se pudo cargar parte del uso. Actualiza de nuevo.", "Certaines données d’utilisation n’ont pas pu être chargées. Actualisez à nouveau.", "Não foi possível carregar parte do uso. Atualize novamente.", "Einige Nutzungsdaten konnten nicht geladen werden. Bitte aktualisiere erneut.")
     }
 
-    private func errorText(_ ko: String, _ en: String, _ ja: String, _ es: String, _ fr: String, _ pt: String, _ de: String) -> String {
-        switch lang {
-        case .ko: return ko
-        case .en: return en
-        case .ja: return ja
-        case .es: return es
-        case .fr: return fr
-        case .pt: return pt
-        case .de: return de
-        }
-    }
 }

--- a/Sources/PokeTokenBar/Core/LocalizationErrors.swift
+++ b/Sources/PokeTokenBar/Core/LocalizationErrors.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension L {
+    // Resolve at display time so an existing error follows language changes.
+    func userFacingError(_ error: any Error) -> String {
+        let value = error as NSError
+        if value.domain == NSURLErrorDomain {
+            return errorText("네트워크 요청에 실패했습니다. 연결을 확인하고 다시 시도해 주세요.", "The network request failed. Check your connection and try again.", "通信に失敗しました。接続を確認して再試行してください。", "La solicitud de red falló. Comprueba la conexión e inténtalo de nuevo.", "La requête réseau a échoué. Vérifiez la connexion et réessayez.", "A solicitação de rede falhou. Verifique a conexão e tente novamente.", "Die Netzwerkanfrage ist fehlgeschlagen. Prüfe die Verbindung und versuche es erneut.")
+        }
+        if value.domain == NSCocoaErrorDomain {
+            switch value.code {
+            case NSFileReadNoPermissionError, NSFileWriteNoPermissionError:
+                return errorText("파일 접근 권한이 없습니다. 권한이나 저장 위치를 확인해 주세요.", "File access was denied. Check permissions or choose another location.", "ファイルにアクセスできません。権限または保存先を確認してください。", "Acceso al archivo denegado. Revisa los permisos o elige otra ubicación.", "Accès au fichier refusé. Vérifiez les autorisations ou choisissez un autre emplacement.", "Acesso ao arquivo negado. Verifique as permissões ou escolha outro local.", "Dateizugriff verweigert. Prüfe die Berechtigungen oder wähle einen anderen Speicherort.")
+            case NSFileWriteOutOfSpaceError:
+                return errorText("저장 공간이 부족합니다. 공간을 확보하고 다시 시도해 주세요.", "There is not enough disk space. Free up space and try again.", "空き容量が不足しています。容量を確保して再試行してください。", "No hay espacio suficiente. Libera espacio e inténtalo de nuevo.", "L’espace disque est insuffisant. Libérez de l’espace et réessayez.", "Não há espaço suficiente. Libere espaço e tente novamente.", "Nicht genügend Speicherplatz. Gib Speicherplatz frei und versuche es erneut.")
+            case NSFileReadNoSuchFileError, NSFileNoSuchFileError:
+                return errorText("파일을 찾을 수 없습니다. 위치를 확인하고 다시 선택해 주세요.", "The file could not be found. Check its location and select it again.", "ファイルが見つかりません。場所を確認して選び直してください。", "No se encontró el archivo. Comprueba su ubicación y selecciónalo de nuevo.", "Fichier introuvable. Vérifiez son emplacement et sélectionnez-le à nouveau.", "Arquivo não encontrado. Verifique o local e selecione novamente.", "Die Datei wurde nicht gefunden. Prüfe den Speicherort und wähle sie erneut aus.")
+            default: break
+            }
+        }
+        return errorText("작업을 완료하지 못했습니다. 다시 시도해 주세요.", "The operation could not be completed. Please try again.", "操作を完了できませんでした。再試行してください。", "No se pudo completar la operación. Inténtalo de nuevo.", "L’opération n’a pas pu être terminée. Veuillez réessayer.", "Não foi possível concluir a operação. Tente novamente.", "Der Vorgang konnte nicht abgeschlossen werden. Bitte versuche es erneut.")
+    }
+
+    var usageRefreshError: String {
+        errorText("일부 사용량을 불러오지 못했습니다. 다시 새로고침해 주세요.", "Some usage could not be loaded. Please refresh again.", "一部の使用量を読み込めませんでした。再度更新してください。", "No se pudo cargar parte del uso. Actualiza de nuevo.", "Certaines données d’utilisation n’ont pas pu être chargées. Actualisez à nouveau.", "Não foi possível carregar parte do uso. Atualize novamente.", "Einige Nutzungsdaten konnten nicht geladen werden. Bitte aktualisiere erneut.")
+    }
+
+    private func errorText(_ ko: String, _ en: String, _ ja: String, _ es: String, _ fr: String, _ pt: String, _ de: String) -> String {
+        switch lang {
+        case .ko: return ko
+        case .en: return en
+        case .ja: return ja
+        case .es: return es
+        case .fr: return fr
+        case .pt: return pt
+        case .de: return de
+        }
+    }
+}

--- a/Sources/PokeTokenBar/Core/PokeAPIClient.swift
+++ b/Sources/PokeTokenBar/Core/PokeAPIClient.swift
@@ -26,12 +26,7 @@ protocol PokemonDetailProviding: Sendable {
 actor PokeAPIClient: PokeProviding, PokemonDetailProviding {
     static let shared = PokeAPIClient()
     private let base = URL(string: "https://pokeapi.co/api/v2")!
-    // Lockstep with the union of AppLanguage.apiCodes. "pt" collects nothing today
-    // (PokéAPI has no such language) but is listed so it is picked up the moment
-    // one appears — omit it and EvoLine.names never carries it, pinning English.
-    // AppLanguage.apiCodes 의 합집합과 lockstep. "pt" 는 아직 PokéAPI 에 없어 수집되지 않지만,
-    // 추가되는 즉시 잡히도록 함께 둔다(없으면 EvoLine.names 에 안 담겨 영어 폴백이 고정된다).
-    static let langCodes = ["ko", "en", "ja-Hrkt", "ja", "es", "fr", "pt", "de"]
+    static var langCodes: [String] { AppLanguage.allCases.flatMap(\.apiCodes) }
     private var speciesCache: [Int: SpeciesDTO] = [:]
     private var lineCache: [Int: EvoLine] = [:]   // 프리패칭 → 부화 순간 네트워크 0
     private var detailsCache: [Int: PokemonDetails] = [:]
@@ -112,13 +107,11 @@ actor PokeAPIClient: PokeProviding, PokemonDetailProviding {
         let rarity = Rarity.from(captureRate: baseSpecies.capture_rate,
                                  isLegendary: baseSpecies.is_legendary,
                                  isMythical: baseSpecies.is_mythical)
-        // 라인의 모든 종 이름(지원 언어만)
+        // Keep all API languages so later app-language additions can reuse persisted names.
         var names: [Int: [String: String]] = [:]
         for id in allIDs(tree) {
             let sp = try await species(id)
-            var byLang: [String: String] = [:]
-            for n in sp.names where Self.langCodes.contains(n.language.name) { byLang[n.language.name] = n.name }
-            names[id] = byLang
+            names[id] = PokemonNameLocalization.collect(sp.names)
         }
         let line = EvoLine(baseID: baseSpeciesID, tree: tree, rarity: rarity, names: names)
         lineCache[baseSpeciesID] = line

--- a/Sources/PokeTokenBar/Core/PokemonNameLocalization.swift
+++ b/Sources/PokeTokenBar/Core/PokemonNameLocalization.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Shared by species names and battle metadata. Keep every language returned by the API;
+/// adding an app language must not require changing a second allowlist or redownloading names.
+enum PokemonNameLocalization {
+    static func languageCode(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().replacingOccurrences(of: "_", with: "-")
+    }
+
+    static func collect(_ entries: [NameDTO]) -> [String: String] {
+        var names: [String: String] = [:]
+        for entry in entries {
+            let code = languageCode(entry.language.name)
+            let name = entry.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !code.isEmpty && !name.isEmpty { names[code] = name }
+        }
+        return names
+    }
+
+    static func resolve(_ names: [String: String], preferredCodes: [String]) -> String? {
+        // Old saves may contain mixed-case PokéAPI language codes (for example ja-Hrkt).
+        var normalized: [String: String] = [:]
+        for key in names.keys.sorted() {
+            let value = names[key]!.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !value.isEmpty { normalized[languageCode(key)] = value }
+        }
+        for code in preferredCodes + ["en"] {
+            if let name = normalized[languageCode(code)] { return name }
+        }
+        return nil
+    }
+
+    /// Last resort while offline or before the first translation response arrives.
+    static func identifier(_ raw: String) -> String {
+        raw.split(separator: "-").map { $0.prefix(1).uppercased() + $0.dropFirst() }.joined(separator: " ")
+    }
+}
+
+struct PokemonNameResource: Hashable, Sendable {
+    enum Kind: String, Sendable { case type, ability, move }
+    let kind: Kind
+    let name: String
+
+    var cacheKey: String { kind.rawValue + "-" + name }
+    var isValid: Bool {
+        !name.isEmpty && name.utf8.allSatisfy { (97...122).contains($0) || (48...57).contains($0) || $0 == 45 }
+    }
+}
+
+protocol PokemonNameProviding: Sendable {
+    func names(for resource: PokemonNameResource) async throws -> [String: String]
+}
+
+/// On-demand metadata names, independent of battle-data/profile loading.
+/// Shared resources (e.g. the same move on two species) share their request and 30-day cache.
+actor PokemonNameClient: PokemonNameProviding {
+    static let shared = PokemonNameClient()
+    private struct Snapshot: Codable, Sendable {
+        let fetchedAt: Date
+        let names: [String: String]
+    }
+    private struct NamesDTO: Decodable { let names: [NameDTO] }
+    private let directory: URL?
+    private let fetch: @Sendable (URL) async throws -> Data
+    private let now: @Sendable () -> Date
+    private var cache: [PokemonNameResource: Snapshot] = [:]
+    private var inFlight: [PokemonNameResource: Task<Snapshot, Error>] = [:]
+
+    init(directory: URL? = AppStatePaths.directory().appendingPathComponent("pokemon-names-v1", isDirectory: true),
+         now: @escaping @Sendable () -> Date = Date.init,
+         fetch: @escaping @Sendable (URL) async throws -> Data = PokemonNameClient.download) {
+        self.directory = directory
+        self.now = now
+        self.fetch = fetch
+    }
+
+    static func download(_ url: URL) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else { throw URLError(.badServerResponse) }
+        return data
+    }
+
+    func names(for resource: PokemonNameResource) async throws -> [String: String] {
+        guard resource.isValid else { throw URLError(.badURL) }
+        if let pending = inFlight[resource] { return try await pending.value.names }
+        let file = directory?.appendingPathComponent(resource.cacheKey + ".json")
+        let previous = cache[resource] ?? file.flatMap { try? Data(contentsOf: $0) }
+            .flatMap { try? JSONDecoder().decode(Snapshot.self, from: $0) }
+        if let previous, now().timeIntervalSince(previous.fetchedAt) < 30 * 86400 {
+            cache[resource] = previous
+            return previous.names
+        }
+        let url = URL(string: "https://pokeapi.co/api/v2/\(resource.kind.rawValue)/\(resource.name)/")!
+        let fetch = self.fetch
+        let clock = self.now
+        let task = Task<Snapshot, Error> {
+            do {
+                let response = try await fetch(url)
+                let names = PokemonNameLocalization.collect(try JSONDecoder().decode(NamesDTO.self, from: response).names)
+                return Snapshot(fetchedAt: clock(), names: names)
+            } catch {
+                if let previous { return previous }
+                throw error
+            }
+        }
+        inFlight[resource] = task
+        defer { inFlight[resource] = nil }
+        let snapshot = try await task.value
+        cache[resource] = snapshot
+        if let file, let data = try? JSONEncoder().encode(snapshot) {
+            try? FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? data.write(to: file, options: .atomic)
+        }
+        return snapshot.names
+    }
+}

--- a/Sources/PokeTokenBar/Core/UsageStore.swift
+++ b/Sources/PokeTokenBar/Core/UsageStore.swift
@@ -38,7 +38,14 @@ final class UsageStore {
     private(set) var isRefreshingLimitToken = false
     private(set) var isRefreshingAntigravityLimits = false
     private(set) var lastErrorDescription: String?
-    private(set) var limitTokenRefreshError: String?
+    private var limitTokenRefreshFailure: (any Error)?
+    var limitTokenRefreshError: String? {
+        limitTokenRefreshFailure.map { Self.friendlyLimitError($0, L(localizationLanguage)) }
+    }
+
+    func lastErrorMessage(_ l: L) -> String? {
+        lastErrorDescription.map { l.usageRefreshError + "\n" + $0 }
+    }
 
     // MARK: Bubble Alert State
     /// Transient speech-bubble payload for the floating pet. Cleared after the TTL.
@@ -869,12 +876,12 @@ final class UsageStore {
             limitsAvailable = true
             limitsUpdatedAt = Date()
             limitsAuthExpiry = nil
-            limitTokenRefreshError = nil
+            limitTokenRefreshFailure = nil
             resetLimitsBackoff()
             AppLog.write("limits refreshed by user action fiveHour=\(limits?.fiveHour?.utilization?.description ?? "nil") sevenDay=\(limits?.sevenDay?.utilization?.description ?? "nil")")
             AppLog.write("limits refreshed from keychain by user action")
         } catch {
-            limitTokenRefreshError = Self.friendlyLimitError(error, L(localizationLanguage))
+            limitTokenRefreshFailure = error
             if limits == nil { limitsAvailable = false }
             updateAuthExpired(from: error)
             applyLimitsBackoffIfRateLimited(error)
@@ -893,7 +900,10 @@ final class UsageStore {
     /// 마지막 검증에서 확인된 후보 조직 — 2개 이상일 때만 설정에 선택 UI 를 띄운다.
     var sessionKeyOrganizations: [SessionKeyOrganization] = []
     var sessionKeySelectedOrgID: String?
-    var sessionKeyError: String?
+    private var sessionKeyFailure: (any Error)?
+    var sessionKeyError: String? {
+        sessionKeyFailure.map { Self.friendlyLimitError($0, L(localizationLanguage)) }
+    }
     var isValidatingSessionKey = false
 
     /// 붙여넣은 키를 검증하고 저장한다. 검증은 조직 목록 조회 — 성공하면 볼 수 있는 조직이 확정되므로,
@@ -901,7 +911,7 @@ final class UsageStore {
     func saveSessionKey(_ raw: String) async {
         guard !isValidatingSessionKey else { return }
         isValidatingSessionKey = true
-        sessionKeyError = nil
+        sessionKeyFailure = nil
         defer { isValidatingSessionKey = false }
 
         do {
@@ -917,7 +927,7 @@ final class UsageStore {
             AppLog.write("session key saved (orgs=\(organizations.count) picked=\(picked.id))")
             await refresh()
         } catch {
-            sessionKeyError = Self.friendlyLimitError(error, L(localizationLanguage))
+            sessionKeyFailure = error
             AppLog.write("session key save failed: \(error)")
         }
     }
@@ -944,7 +954,7 @@ final class UsageStore {
         sessionKeyConfigured = false
         sessionKeyOrganizations = []
         sessionKeySelectedOrgID = nil
-        sessionKeyError = nil
+        sessionKeyFailure = nil
         AppLog.write("session key cleared")
         Task { await refresh() }   // OAuth 경로로 되돌아간다(또는 한도 섹션을 숨긴다)
     }
@@ -958,7 +968,7 @@ final class UsageStore {
             AppLog.write("session key org switched to \(id)")
             await refresh()
         } catch {
-            sessionKeyError = Self.friendlyLimitError(error, L(localizationLanguage))
+            sessionKeyFailure = error
         }
     }
 

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -249,6 +249,7 @@ struct SpriteView: View {
 struct EvoLineView: View {
     let nodes: [EvoLineItem]
     let mysteryLabel: String
+    var language: AppLanguage = .systemDefault
     var thumb: CGFloat = 40
     var shiny: Bool = false     // 개체가 shiny 면 라인 전체를 shiny 스프라이트로
     var names: [Int: String]? = nil   // 제공되면 각 스프라이트 밑에 작은 이름 라벨(도감 단계별 이름)
@@ -380,6 +381,7 @@ struct EvoLineView: View {
                     .overlay(Circle().strokeBorder(Color.primary.opacity(0.12)))
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(forward ? L(language).evolutionScrollNext : L(language).evolutionScrollPrevious)
             .padding(forward ? .trailing : .leading, 1)
             .padding(.top, max(0, thumb / 2 - 8))   // 16pt 버튼의 중심을 스프라이트 중심에
             .transition(.opacity)
@@ -574,7 +576,7 @@ struct CompanionHeader: View {
             }
             if store.hasActive, !store.lineNodes.isEmpty {
                 // 폭을 안 주면 분기 라인(이브이)이 넘쳐 팝오버 콘텐츠 전체가 좌우로 잘린다.
-                EvoLineView(nodes: store.lineNodes, mysteryLabel: store.l.unknownNextEvolution, shiny: store.currentIsShiny,
+                EvoLineView(nodes: store.lineNodes, mysteryLabel: store.l.unknownNextEvolution, language: store.language, shiny: store.currentIsShiny,
                             maxWidth: PopoverMetrics.contentWidth)
             }
             if let g = store.justGraduated {
@@ -1347,7 +1349,7 @@ private struct DexEntryRow: View {
 
     var body: some View {
         // 저장분 우선(즉시·언어대응), 없으면 async 로 채운 resolved 사용.
-        let names = resolved.isEmpty ? store.dexStoredChainNames(entry) : resolved
+        let names = store.dexStoredChainNames(entry) ?? (resolved.isEmpty ? nil : resolved)
         VStack(alignment: .leading, spacing: 3) {
             HStack {
                 Text(store.l.rarityLabel(entry.rarity).uppercased())
@@ -1384,7 +1386,7 @@ private struct DexEntryRow: View {
                 }
             }
             EvoLineView(nodes: entry.chainOrder.map { EvoLineItem(.species($0), .done) },
-                        mysteryLabel: store.l.unknownNextEvolution, thumb: 56,
+                        mysteryLabel: store.l.unknownNextEvolution, language: store.language, thumb: 56,
                         shiny: entry.isShiny, names: names,
                         maxWidth: PopoverMetrics.contentWidth - Self.cardPadding * 2)
             if let caughtAt = entry.caughtAt {
@@ -1395,9 +1397,7 @@ private struct DexEntryRow: View {
         .background(Color.secondary.opacity(0.06))
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .task(id: "\(entry.id)-\(store.language.rawValue)") {
-            if store.dexStoredChainNames(entry) == nil {   // 저장분 없으면(구버전) 조회
-                resolved = await store.dexResolveChainNames(entry)
-            }
+            resolved = await store.dexResolveChainNames(entry)
         }
     }
 }

--- a/Sources/PokeTokenBar/UI/CompanionView.swift
+++ b/Sources/PokeTokenBar/UI/CompanionView.swift
@@ -1085,9 +1085,16 @@ private struct PokemonDetailView: View {
                 valuePair(store.l.gender, store.l.genderLabel(profile.gender))
                 valuePair(store.l.nature, entry.nature?.name(store.language) ?? "—")
             }
-            valuePair(store.l.ability,
-                      profile.abilityName.map(displayIdentifier) ?? "—",
-                      suffix: profile.abilityIsHidden ? store.l.hiddenAbility : nil)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(store.l.ability).font(.system(size: 9)).foregroundStyle(.secondary)
+                if let name = profile.abilityName {
+                    PokemonNameLabel(.ability, name, language: store.language,
+                                     suffix: profile.abilityIsHidden ? " · " + store.l.hiddenAbility : "")
+                        .font(.caption.weight(.semibold))
+                } else {
+                    Text("—").font(.caption.weight(.semibold))
+                }
+            }
             statsSection(PokemonStatCalculator.stats(details: details, profile: profile, nature: entry.nature))
             detailTitle(store.l.activeMoves)
             if profile.moves.isEmpty {
@@ -1095,7 +1102,7 @@ private struct PokemonDetailView: View {
             } else {
                 ForEach(profile.moves) { move in
                     HStack {
-                        Text(displayIdentifier(move.name))
+                        PokemonNameLabel(.move, move.name, language: store.language)
                         Spacer()
                         Text("Lv. \(move.learnedAtLevel)").foregroundStyle(.secondary)
                     }
@@ -1143,7 +1150,7 @@ private struct PokemonDetailView: View {
             detailTitle(store.l.speciesData)
             HStack(spacing: 5) {
                 ForEach(details.types, id: \.self) { type in
-                    Text(displayIdentifier(type).uppercased())
+                    PokemonNameLabel(.type, type, language: store.language).textCase(.uppercase)
                         .font(.system(size: 9, weight: .bold))
                         .padding(.horizontal, 6).padding(.vertical, 3)
                         .background(Color.accentColor.opacity(0.16), in: Capsule())
@@ -1155,9 +1162,10 @@ private struct PokemonDetailView: View {
                 valuePair(store.l.baseStatTotal, "\(details.baseStatTotal)")
             }
             detailTitle(store.l.possibleAbilities)
-            Text(details.abilities.map { option in
-                displayIdentifier(option.name) + (option.isHidden ? " (\(store.l.hidden))" : "")
-            }.joined(separator: " · "))
+            PokemonNameLabel(items: details.abilities.map { option in
+                PokemonNameItem(resource: .init(kind: .ability, name: option.name),
+                                suffix: option.isHidden ? " (\(store.l.hidden))" : "")
+            }, language: store.language)
             .font(.caption).foregroundStyle(.secondary)
         }
         .detailCard()
@@ -1168,7 +1176,7 @@ private struct PokemonDetailView: View {
             detailTitle(store.l.completeMoveList(details.moves.count))
             ForEach(details.moves) { move in
                 HStack(alignment: .firstTextBaseline) {
-                    Text(displayIdentifier(move.name))
+                    PokemonNameLabel(.move, move.name, language: store.language)
                     Spacer()
                     Text(move.learnMethods.map(store.l.moveMethod).uniqued().joined(separator: " · "))
                         .foregroundStyle(.secondary).multilineTextAlignment(.trailing)
@@ -1191,9 +1199,6 @@ private struct PokemonDetailView: View {
         }
     }
 
-    private func displayIdentifier(_ raw: String) -> String {
-        raw.split(separator: "-").map { $0.prefix(1).uppercased() + $0.dropFirst() }.joined(separator: " ")
-    }
 }
 
 private extension View {

--- a/Sources/PokeTokenBar/UI/PokemonNameLabel.swift
+++ b/Sources/PokeTokenBar/UI/PokemonNameLabel.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct PokemonNameItem: Hashable, Sendable {
+    let resource: PokemonNameResource
+    var suffix = ""
+}
+
+/// A plain Text preserves wrapping of joined ability names and all parent typography.
+@MainActor
+struct PokemonNameText: View {
+    let items: [PokemonNameItem]
+    let language: AppLanguage
+    let names: [PokemonNameResource: [String: String]]
+
+    var text: String {
+        items.map { item in
+            (language.resolveName(names[item.resource] ?? [:])
+             ?? PokemonNameLocalization.identifier(item.resource.name)) + item.suffix
+        }.joined(separator: " · ")
+    }
+    var body: some View { Text(text) }
+}
+
+/// Only mounted rows fetch names, following the LazyVStack's lazy row creation.
+/// Language changes resolve the already-loaded multilingual response without restarting I/O.
+@MainActor
+struct PokemonNameLabel: View {
+    let items: [PokemonNameItem]
+    let language: AppLanguage
+    var provider: any PokemonNameProviding = PokemonNameClient.shared
+    @State private var names: [PokemonNameResource: [String: String]] = [:]
+
+    init(_ kind: PokemonNameResource.Kind, _ name: String, language: AppLanguage, suffix: String = "") {
+        items = [PokemonNameItem(resource: .init(kind: kind, name: name), suffix: suffix)]
+        self.language = language
+    }
+
+    init(items: [PokemonNameItem], language: AppLanguage) {
+        self.items = items
+        self.language = language
+    }
+
+    var body: some View {
+        PokemonNameText(items: items, language: language, names: names)
+            .task(id: items.map(\.resource)) {
+                await withTaskGroup(of: (PokemonNameResource, [String: String]?).self) { group in
+                    for resource in Set(items.map(\.resource)) {
+                        group.addTask { (resource, try? await provider.names(for: resource)) }
+                    }
+                    for await (resource, translations) in group {
+                        guard !Task.isCancelled else { return }
+                        if let translations { names[resource] = translations }
+                    }
+                }
+            }
+    }
+}

--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -242,11 +242,15 @@ struct PopoverView: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            HStack(spacing: 10) {
-                tokenTypeLabel("in", today.inputTokens)
-                tokenTypeLabel("out", today.outputTokens)
-                tokenTypeLabel("cache w", today.cacheCreationTokens)
-                tokenTypeLabel("cache r", today.cacheReadTokens)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 10) {
+                    tokenTypeLabel(l.tokenInput, today.inputTokens)
+                    tokenTypeLabel(l.tokenOutput, today.outputTokens)
+                }
+                HStack(spacing: 10) {
+                    tokenTypeLabel(l.tokenCacheWrite, today.cacheCreationTokens)
+                    tokenTypeLabel(l.tokenCacheRead, today.cacheReadTokens)
+                }
             }
             if let models = today.models, models.count > 1 {
                 ForEach(models.sorted(by: { $0.value > $1.value }), id: \.key) { model, tokens in
@@ -822,7 +826,7 @@ struct PopoverView: View {
                 if store.lastErrorDescription != nil {
                     Image(systemName: "exclamationmark.triangle")
                         .foregroundStyle(.orange)
-                        .help(store.lastErrorDescription ?? "")
+                        .help(store.lastErrorMessage(l) ?? "")
                 }
             }
             Spacer()

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -14,8 +14,8 @@ struct SettingsView: View {
     /// 접힌 채로 열면 고칠 입력란이 안 보여 안내가 막다른 길이 된다.
     var startExpanded = false
     @State private var launchAtLogin = LoginItem.isEnabled
-    @State private var launchAtLoginError: String?
-    @State private var reportError: String?
+    @State private var launchAtLoginError: Error?
+    @State private var reportFailed = false
     @State private var advancedExpanded = false
     /// startExpanded 를 @State 초기값으로 못 쓴다 — 뷰가 재사용되면 초기화가 다시 안 돌아
     /// 두 번째 진입부터 접힌 채로 열린다. onAppear 에서 1회 반영한다.
@@ -128,10 +128,10 @@ struct SettingsView: View {
             Text("·")
             footerLink("GitHub", "https://github.com/chattymin/PokeTokenBar")
             Text("·")
-            footerLink("Web", "https://chattymin.github.io/PokeTokenBar/")
+            footerLink(l.website, "https://chattymin.github.io/PokeTokenBar/")
             Text("·")
             // 개발자 후원 — 기능 잠금·너지 없는 푸터 링크
-            footerLink("♥ Sponsor", "https://github.com/sponsors/chattymin")
+            footerLink("♥ " + l.sponsor, "https://github.com/sponsors/chattymin")
             Spacer()
         }
         .font(.caption2)
@@ -149,7 +149,7 @@ struct SettingsView: View {
             groupRow {
                 Text(l.language)
                 Spacer()
-                Picker("", selection: Binding(
+                Picker(l.language, selection: Binding(
                     get: { companion.language },
                     set: { companion.setLanguage($0); store.localizationLanguage = $0 })) {
                     ForEach(AppLanguage.allCases, id: \.self) { Text($0.label).tag($0) }
@@ -183,7 +183,7 @@ struct SettingsView: View {
             groupRow {
                 Text(l.refreshInterval)
                 Spacer()
-                Picker("", selection: $store.refreshInterval) {
+                Picker(l.refreshInterval, selection: $store.refreshInterval) {
                     ForEach(UsageStore.intervalPresets, id: \.value) { Text(l.intervalLabel($0.value)).tag($0.value) }
                 }
                 .labelsHidden().pickerStyle(.menu).fixedSize()
@@ -196,7 +196,7 @@ struct SettingsView: View {
                     Text(l.animationQualityHint).font(.caption2).foregroundStyle(.tertiary)
                 }
                 Spacer()
-                Picker("", selection: $store.animationQuality) {
+                Picker(l.animationQualityLabel, selection: $store.animationQuality) {
                     Text(l.animationPowerSaver).tag(UsageStore.AnimationQuality.powerSaver)
                     Text(l.animationBalanced).tag(UsageStore.AnimationQuality.balanced)
                     Text(l.animationSmooth).tag(UsageStore.AnimationQuality.smooth)
@@ -207,7 +207,7 @@ struct SettingsView: View {
             groupRow {
                 Text(l.limitDisplayModeLabel)
                 Spacer()
-                Picker("", selection: $store.limitDisplayMode) {
+                Picker(l.limitDisplayModeLabel, selection: $store.limitDisplayMode) {
                     Text(l.limitDisplayUsed).tag(UsageStore.LimitDisplayMode.used)
                     Text(l.limitDisplayRemaining).tag(UsageStore.LimitDisplayMode.remaining)
                 }
@@ -221,11 +221,11 @@ struct SettingsView: View {
                         Text(l.bundledOnly).font(.caption2).foregroundStyle(.tertiary)
                     }
                     if let launchAtLoginError {
-                        Text(launchAtLoginError).font(.caption2).foregroundStyle(.red)
+                        Text(l.userFacingError(launchAtLoginError)).font(.caption2).foregroundStyle(.red)
                     }
                 }
                 Spacer()
-                Toggle("", isOn: $launchAtLogin)
+                Toggle(l.launchAtLogin, isOn: $launchAtLogin)
                     .labelsHidden().toggleStyle(.switch).controlSize(.small)
                     .disabled(!isBundledApp)
                     .onChange(of: launchAtLogin) { _, newValue in
@@ -233,7 +233,7 @@ struct SettingsView: View {
                             try LoginItem.setEnabled(newValue)   // KeepAlive 에이전트(로그인 실행+크래시 재실행)
                             launchAtLoginError = nil
                         } catch {
-                            launchAtLoginError = "\(error.localizedDescription)"
+                            launchAtLoginError = error
                             launchAtLogin = LoginItem.isEnabled
                         }
                     }
@@ -270,7 +270,7 @@ struct SettingsView: View {
                     Text(l.floatingPetHint).font(.caption2).foregroundStyle(.tertiary)
                 }
                 Spacer()
-                Toggle("", isOn: $store.floatingPetEnabled)
+                Toggle(l.floatingPetEnableLabel, isOn: $store.floatingPetEnabled)
                     .labelsHidden().toggleStyle(.switch).controlSize(.small)
             }
             if store.floatingPetEnabled {
@@ -278,6 +278,7 @@ struct SettingsView: View {
                 groupRow {
                     Text(l.floatingPetSizeLabel).font(.callout)
                     Slider(value: $store.floatingPetSize, in: 48...384, step: 8)
+                        .accessibilityLabel(l.floatingPetSizeLabel)
                     Text("\(Int(store.floatingPetSize))px")
                         .font(.caption).monospacedDigit().frame(width: 44, alignment: .trailing)
                 }
@@ -297,6 +298,7 @@ struct SettingsView: View {
                 groupRow {
                     Text(l.warning).font(.callout)
                     Slider(value: $store.warnThreshold, in: 50...95, step: 5)
+                        .accessibilityLabel(l.warning)
                     Text(TokenFormatter.percent(store.warnThreshold))
                         .font(.caption).monospacedDigit().frame(width: 38, alignment: .trailing)
                 }
@@ -304,6 +306,7 @@ struct SettingsView: View {
                 groupRow {
                     Text(l.critical).font(.callout)
                     Slider(value: $store.critThreshold, in: 80...100, step: 5)
+                        .accessibilityLabel(l.critical)
                     Text(TokenFormatter.percent(store.critThreshold))
                         .font(.caption).monospacedDigit().frame(width: 38, alignment: .trailing)
                 }
@@ -317,7 +320,7 @@ struct SettingsView: View {
                     Text(l.statusChecksHint).font(.caption2).foregroundStyle(.tertiary)
                 }
                 Spacer()
-                Toggle("", isOn: $store.statusChecksEnabled)
+                Toggle(l.statusChecksLabel, isOn: $store.statusChecksEnabled)
                     .labelsHidden().toggleStyle(.switch).controlSize(.small)
             }
         }
@@ -443,7 +446,7 @@ struct SettingsView: View {
             groupRow {
                 Text(l.sessionKeyOrganizationLabel)
                 Spacer()
-                Picker("", selection: Binding(
+                Picker(l.sessionKeyOrganizationLabel, selection: Binding(
                     get: { store.sessionKeySelectedOrgID ?? "" },
                     set: { id in Task { await store.selectSessionOrganization(id) } })
                 ) {
@@ -514,7 +517,7 @@ struct SettingsView: View {
                         Text(l.disableKeychainHint).font(.caption2).foregroundStyle(.tertiary)
                     }
                     Spacer()
-                    Toggle("", isOn: $store.disableKeychainAccess)
+                    Toggle(l.disableKeychain, isOn: $store.disableKeychainAccess)
                         .labelsHidden().toggleStyle(.switch).controlSize(.small)
                 }
                 Divider()
@@ -548,7 +551,7 @@ struct SettingsView: View {
                         HStack {
                             Text(l.customScanProviderLabel).font(.caption)
                             Spacer()
-                            Picker("", selection: $selectedScanProviderID) {
+                            Picker(l.customScanProviderLabel, selection: $selectedScanProviderID) {
                                 ForEach(store.registeredProviders, id: \.id) { provider in
                                     Text(provider.displayName).tag(provider.id)
                                 }
@@ -613,8 +616,8 @@ struct SettingsView: View {
                     NSWorkspace.shared.activateFileViewerSelecting([AppLog.logFileURL])
                 }
             }
-            if let reportError {
-                Text(reportError)
+            if reportFailed {
+                Text(l.reportMailFallback(SupportMail.address))
                     .font(.caption2).foregroundStyle(.orange).textSelection(.enabled)
                     .padding(.horizontal, 12).padding(.bottom, 6)
             }
@@ -651,7 +654,7 @@ struct SettingsView: View {
         groupRow {
             Text(label)
             Spacer()
-            Toggle("", isOn: isOn).labelsHidden().toggleStyle(.switch).controlSize(.small)
+            Toggle(label, isOn: isOn).labelsHidden().toggleStyle(.switch).controlSize(.small)
         }
     }
 
@@ -701,10 +704,10 @@ struct SettingsView: View {
             os: ProcessInfo.processInfo.operatingSystemVersionString)
         guard let url = SupportMail.mailtoURL(subject: subject, body: body),
               NSWorkspace.shared.open(url) else {
-            reportError = l.reportMailFallback(SupportMail.address)
+            reportFailed = true
             return
         }
-        reportError = nil
+        reportFailed = false
     }
 
     // MARK: 세이브 이전
@@ -732,7 +735,7 @@ struct SettingsView: View {
             try data.write(to: url, options: .atomic)
             NSWorkspace.shared.activateFileViewerSelecting([url])
         } catch {
-            presentAlert(title: l.exportSaveLabel, message: error.localizedDescription, style: .warning)
+            presentAlert(title: l.exportSaveLabel, message: l.userFacingError(error), style: .warning)
         }
     }
 
@@ -762,7 +765,7 @@ struct SettingsView: View {
         confirm.informativeText = l.importConfirmBody(
             incomingDex: incoming.dexCount,
             incomingTokens: TokenFormatter.compact(incoming.lifetimeTokens),
-            exportedAt: Self.exportedAtText(envelope.exportedAt),
+            exportedAt: Self.exportedAtText(envelope.exportedAt, language: companion.language),
             sourceDevice: envelope.sourceDevice,
             currentDex: current.dexCount,
             currentTokens: TokenFormatter.compact(current.lifetimeTokens))
@@ -792,8 +795,9 @@ struct SettingsView: View {
     }
 
     /// 확인창에 보일 내보낸 시각 — 사용자 로케일 기준 짧은 표기.
-    private static func exportedAtText(_ date: Date) -> String {
+    static func exportedAtText(_ date: Date, language: AppLanguage) -> String {
         let f = DateFormatter()
+        f.locale = language.displayLocale
         f.dateStyle = .medium
         f.timeStyle = .short
         return f.string(from: date)

--- a/Sources/PokeTokenBar/UI/SettingsView.swift
+++ b/Sources/PokeTokenBar/UI/SettingsView.swift
@@ -233,6 +233,7 @@ struct SettingsView: View {
                             try LoginItem.setEnabled(newValue)   // KeepAlive 에이전트(로그인 실행+크래시 재실행)
                             launchAtLoginError = nil
                         } catch {
+                            AppLog.write("login item update failed: \(error)")
                             launchAtLoginError = error
                             launchAtLogin = LoginItem.isEnabled
                         }
@@ -735,6 +736,7 @@ struct SettingsView: View {
             try data.write(to: url, options: .atomic)
             NSWorkspace.shared.activateFileViewerSelecting([url])
         } catch {
+            AppLog.write("save export failed: \(error)")
             presentAlert(title: l.exportSaveLabel, message: l.userFacingError(error), style: .warning)
         }
     }
@@ -752,6 +754,7 @@ struct SettingsView: View {
         do {
             envelope = try SaveTransfer.decode(try Data(contentsOf: url))
         } catch {
+            AppLog.write("save import read failed: \(error)")
             presentAlert(title: l.importSaveLabel, message: l.importErrorMessage(error), style: .warning)
             return
         }
@@ -785,6 +788,7 @@ struct SettingsView: View {
                                     todayDate: LocalUsageReader.todayKey(),
                                     hasUsageData: store.hasUsageData)
         } catch {
+            AppLog.write("save import apply failed: \(error)")
             presentAlert(title: l.importSaveLabel, message: l.importErrorMessage(error), style: .warning)
             return
         }

--- a/Tests/PokeTokenBarTests/DexNameMigrationTests.swift
+++ b/Tests/PokeTokenBarTests/DexNameMigrationTests.swift
@@ -15,6 +15,7 @@ private actor MigratingNameProvider: PokeProviding {
     }
     func line(baseSpeciesID: Int) async throws -> EvoLine {
         calls += 1
+        try await Task.sleep(nanoseconds: 20_000_000)
         if offline { throw URLError(.notConnectedToInternet) }
         return value
     }
@@ -97,6 +98,23 @@ final class DexNameMigrationTests: XCTestCase {
         await store.backfillMissingDexNames()
         XCTAssertEqual(store.dexStoredChainNames(store.state.dex[0])?[2], "이상해풀")
         XCTAssertFalse(store.state.dex[0].needsNamesRefresh)
+    }
+
+    func testSimultaneouslyMountedCatchRowsShareOneRequest() async throws {
+        let url = try fixture([entry(), entry("second-catch")])
+        defer { try? FileManager.default.removeItem(at: url) }
+        let provider = MigratingNameProvider(allNames)
+        let store = CompanionStore(provider: provider, fileURL: url)
+        let first = store.state.dex[0]
+        let second = store.state.dex[1]
+        async let a = store.dexResolveChainNames(first)
+        async let b = store.dexResolveChainNames(second)
+        let names = await (a, b)
+        XCTAssertEqual(names.0, names.1)
+        XCTAssertEqual(names.0[1], "이상해씨")
+        let calls = await provider.calls
+        XCTAssertEqual(calls, 1)
+        XCTAssertTrue(store.state.dex.allSatisfy { !$0.needsNamesRefresh })
     }
 
     func testPartialResponsePreservesOldNamesWithoutMarkingMigrationComplete() async throws {

--- a/Tests/PokeTokenBarTests/DexNameMigrationTests.swift
+++ b/Tests/PokeTokenBarTests/DexNameMigrationTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import PokeTokenBar
+
+private actor MigratingNameProvider: PokeProviding {
+    var value: EvoLine
+    var offline = false
+    private(set) var calls = 0
+    init(_ names: [Int: [String: String]]) {
+        value = EvoLine(baseID: 1, tree: EvoNode(speciesID: 1, children: [EvoNode(speciesID: 2, children: [])]),
+                        rarity: .common, names: names)
+    }
+    func configure(names: [Int: [String: String]], offline: Bool = false) {
+        value = EvoLine(baseID: 1, tree: value.tree, rarity: .common, names: names)
+        self.offline = offline
+    }
+    func line(baseSpeciesID: Int) async throws -> EvoLine {
+        calls += 1
+        if offline { throw URLError(.notConnectedToInternet) }
+        return value
+    }
+    func baseSpeciesIndex() async throws -> [BaseSpecies] { [] }
+}
+
+@MainActor
+final class DexNameMigrationTests: XCTestCase {
+    let allNames = [1: ["ko": "이상해씨", "en": "Bulbasaur", "it": "Bulbasaur"],
+                    2: ["ko": "이상해풀", "en": "Ivysaur", "it": "Ivysaur"]]
+
+    private func entry(_ id: String = "old-catch") -> DexEntry {
+        DexEntry(id: id, baseID: 1, finalID: 2, chainOrder: [1, 2], rarity: .common,
+                 caughtAt: Date(timeIntervalSince1970: 123), isShiny: true, nature: .brave,
+                 names: [1: ["en": "Bulbasaur"], 2: ["en": "Ivysaur"]])
+    }
+
+    private func fixture(_ entries: [DexEntry], legacy: Bool = true) throws -> URL {
+        var state = CompanionState()
+        state.dex = entries
+        state.language = .ko
+        state.usedSinceInstall = 1234567
+        state.inventory = ["rareCandy": 3]
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: JSONEncoder().encode(state)) as? [String: Any])
+        if legacy {
+            json["dex"] = try XCTUnwrap(json["dex"] as? [[String: Any]]).map { row in
+                var row = row
+                row.removeValue(forKey: "namesVersion")
+                return row
+            }
+        }
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("dex-language-\(UUID()).json")
+        try JSONSerialization.data(withJSONObject: json).write(to: url)
+        return url
+    }
+
+    func testLegacyNamedEntriesRefreshAllLanguagesOnceAndPreserveProgress() async throws {
+        let url = try fixture([entry(), entry("second-catch")])
+        defer { try? FileManager.default.removeItem(at: url) }
+        let provider = MigratingNameProvider(allNames)
+        let store = CompanionStore(provider: provider, fileURL: url)
+        let old = try XCTUnwrap(store.state.dex.first)
+        XCTAssertNil(old.namesVersion, "Old JSON did not encode a name version")
+        XCTAssertEqual(store.dexStoredChainNames(old)?[1], "Bulbasaur")
+        await store.backfillMissingDexNames()
+        XCTAssertEqual(store.state.dex.count, 2)
+        XCTAssertEqual(store.state.dex[0].id, old.id)
+        XCTAssertEqual(store.state.dex[0].caughtAt, old.caughtAt)
+        XCTAssertEqual(store.state.dex[0].isShiny, old.isShiny)
+        XCTAssertEqual(store.state.dex[0].nature, old.nature)
+        XCTAssertEqual(store.state.usedSinceInstall, 1234567)
+        XCTAssertEqual(store.state.inventory["rareCandy"], 3)
+        XCTAssertTrue(store.state.dex.allSatisfy { !$0.needsNamesRefresh })
+        XCTAssertEqual(store.dexStoredChainNames(store.state.dex[0])?[1], "이상해씨")
+        XCTAssertEqual(PokemonNameLocalization.resolve(store.state.dex[0].names![2]!, preferredCodes: ["it"]), "Ivysaur")
+        _ = await store.dexResolveChainNames(old) // A mounted row can still hold its old value.
+        await store.backfillMissingDexNames()
+        let calls = await provider.calls
+        XCTAssertEqual(calls, 1, "Duplicate catches and stale row values must reuse the refreshed names")
+
+        let restored = CompanionStore(provider: provider, fileURL: url)
+        restored.setLanguage(.pt) // No Portuguese names in the API response: English is complete fallback.
+        await restored.backfillMissingDexNames()
+        XCTAssertEqual(restored.dexStoredChainNames(restored.state.dex[0])?[1], "Bulbasaur")
+        let restoredCalls = await provider.calls
+        XCTAssertEqual(restoredCalls, 1, "Absent translation is not an expired cache")
+    }
+
+    func testOfflineLegacyCacheRemainsVisibleAndRetriesAfterRecovery() async throws {
+        let url = try fixture([entry()])
+        defer { try? FileManager.default.removeItem(at: url) }
+        let provider = MigratingNameProvider(allNames)
+        await provider.configure(names: allNames, offline: true)
+        let store = CompanionStore(provider: provider, fileURL: url)
+        let old = store.state.dex[0]
+        let fallback = await store.dexResolveChainNames(old)
+        XCTAssertEqual(fallback, [1: "Bulbasaur", 2: "Ivysaur"])
+        XCTAssertNil(store.state.dex[0].namesVersion)
+        await provider.configure(names: allNames)
+        await store.backfillMissingDexNames()
+        XCTAssertEqual(store.dexStoredChainNames(store.state.dex[0])?[2], "이상해풀")
+        XCTAssertFalse(store.state.dex[0].needsNamesRefresh)
+    }
+
+    func testPartialResponsePreservesOldNamesWithoutMarkingMigrationComplete() async throws {
+        let url = try fixture([entry()])
+        defer { try? FileManager.default.removeItem(at: url) }
+        let provider = MigratingNameProvider([1: allNames[1]!])
+        let store = CompanionStore(provider: provider, fileURL: url)
+        await store.backfillMissingDexNames()
+        XCTAssertEqual(store.dexStoredChainNames(store.state.dex[0]), [1: "이상해씨", 2: "Ivysaur"])
+        XCTAssertTrue(store.state.dex[0].needsNamesRefresh)
+        await provider.configure(names: allNames)
+        await store.backfillMissingDexNames()
+        XCTAssertFalse(store.state.dex[0].needsNamesRefresh)
+        XCTAssertEqual(store.state.dex[0].names?[2]?["it"], "Ivysaur")
+    }
+
+    func testNewNamesSkipMigrationButEmptyAndMissingSpeciesRetry() throws {
+        var fresh = entry()
+        XCTAssertFalse(fresh.needsNamesRefresh)
+        let roundTrip = try JSONDecoder().decode(DexEntry.self, from: JSONEncoder().encode(fresh))
+        XCTAssertFalse(roundTrip.needsNamesRefresh)
+        fresh.names = [:]
+        XCTAssertTrue(fresh.needsNamesRefresh)
+        fresh.names = [1: ["en": "Bulbasaur"]]
+        XCTAssertTrue(fresh.needsNamesRefresh)
+        fresh.namesVersion = nil
+        XCTAssertTrue(fresh.needsNamesRefresh)
+    }
+}

--- a/Tests/PokeTokenBarTests/LanguageSurfaceRegressionTests.swift
+++ b/Tests/PokeTokenBarTests/LanguageSurfaceRegressionTests.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import PokeTokenBar
+
+final class LanguageSurfaceRegressionTests: XCTestCase {
+    @MainActor
+    func testBackupTimestampUsesSelectedLanguageAndEveryLanguageRenders() throws {
+        let date = Date(timeIntervalSince1970: 1_783_680_000)
+        var images: [NSImage] = []
+        for language in AppLanguage.allCases {
+            let l = L(language)
+            let formatter = DateFormatter()
+            formatter.locale = language.displayLocale
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .short
+            let stamp = SettingsView.exportedAtText(date, language: language)
+            XCTAssertEqual(stamp, formatter.string(from: date))
+            let labels = [l.tokenInput, l.tokenOutput, l.tokenCacheWrite, l.tokenCacheRead,
+                          l.website, l.sponsor, l.evolutionScrollPrevious, l.evolutionScrollNext,
+                          l.moveMethod(.init(method: "light-ball-egg", level: 0)),
+                          l.moveMethod(.init(method: "form-change", level: 0))]
+            XCTAssertFalse(labels.contains(where: { $0.isEmpty }))
+            XCTAssertFalse(labels.contains("light ball egg"))
+            XCTAssertFalse(labels.contains("form change"))
+            let renderer = ImageRenderer(content: VStack(alignment: .leading, spacing: 6) {
+                Text(language.label).bold()
+                ForEach(Array(labels.enumerated()), id: \.offset) { _, label in Text(label) }
+                Text(stamp)
+            }.padding().frame(width: 332).background(.white).foregroundStyle(.black)
+                .environment(\.locale, language.displayLocale))
+            let image = try XCTUnwrap(renderer.nsImage)
+            XCTAssertGreaterThan(image.size.height, 100)
+            images.append(image)
+        }
+        XCTAssertNotEqual(SettingsView.exportedAtText(date, language: .ko),
+                          SettingsView.exportedAtText(date, language: .en))
+        if let path = ProcessInfo.processInfo.environment["PTB_LANGUAGE_SURFACES_PREVIEW"] {
+            let sheet = NSImage(size: NSSize(width: CGFloat(332 * images.count), height: 420))
+            sheet.lockFocus()
+            NSColor.white.setFill()
+            NSRect(origin: .zero, size: sheet.size).fill()
+            for (index, image) in images.enumerated() {
+                image.draw(at: NSPoint(x: CGFloat(index * 332), y: 420 - image.size.height),
+                           from: .zero, operation: .sourceOver, fraction: 1)
+            }
+            sheet.unlockFocus()
+            let bitmap = try XCTUnwrap(NSBitmapImageRep(data: XCTUnwrap(sheet.tiffRepresentation)))
+            try XCTUnwrap(bitmap.representation(using: .png, properties: [:])).write(to: URL(fileURLWithPath: path))
+        }
+    }
+
+    func testVisibleCopyAndSettingsControlsAreRoutedToLocalization() throws {
+        let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
+        let settings = try String(contentsOf: root.appendingPathComponent("Sources/PokeTokenBar/UI/SettingsView.swift"), encoding: .utf8)
+        XCTAssertFalse(settings.contains("Picker(\"\""), "Hidden visual labels must retain accessible localized names")
+        XCTAssertFalse(settings.contains("Toggle(\"\""), "Hidden visual labels must retain accessible localized names")
+        XCTAssertFalse(settings.contains("footerLink(\"Web\""))
+        XCTAssertFalse(settings.contains("footerLink(\"♥ Sponsor\""))
+        let popover = try String(contentsOf: root.appendingPathComponent("Sources/PokeTokenBar/UI/PopoverView.swift"), encoding: .utf8)
+        for label in ["in", "out", "cache w", "cache r"] {
+            XCTAssertFalse(popover.contains("tokenTypeLabel(\"\(label)\""))
+        }
+        let companion = try String(contentsOf: root.appendingPathComponent("Sources/PokeTokenBar/UI/CompanionView.swift"), encoding: .utf8)
+        XCTAssertTrue(companion.contains(".accessibilityLabel(forward ? L(language).evolutionScrollNext"))
+    }
+}

--- a/Tests/PokeTokenBarTests/LocalizationErrorsTests.swift
+++ b/Tests/PokeTokenBarTests/LocalizationErrorsTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import PokeTokenBar
+
+private struct ErrorUsageProvider: UsageProvider {
+    let id = "test"
+    let displayName = "Test"
+    func fetchDaily() async throws -> DailyUsage? { throw URLError(.notConnectedToInternet) }
+    func fetchEnrichment() async -> ProviderEnrichment { ProviderEnrichment() }
+}
+private struct ErrorClaudeProvider: ClaudeLimitsProviding {
+    func fetch(allowKeychainPrompt: Bool) async throws -> LimitStatus { throw LimitsError.sessionKeyInvalid }
+}
+private struct ErrorCodexProvider: CodexLimitsProviding {
+    func fetch() async throws -> CodexRateLimitStatus? { nil }
+}
+private struct ErrorAntigravityProvider: AntigravityLimitsProviding {
+    func fetch(allowKeychainPrompt: Bool) async throws -> AntigravityRateLimitStatus { throw URLError(.notConnectedToInternet) }
+}
+private struct ErrorSessionKeys: SessionKeyManaging {
+    func credential() -> SessionKeyCredential? { nil }
+    func organizations(sessionKey: String) async throws -> [SessionKeyOrganization] { [] }
+    func save(key: String, organizationID: String?) throws { }
+    func clear() { }
+}
+
+final class LocalizationErrorsTests: XCTestCase {
+    func testErrorsHaveSelectedLanguageMessagesWithoutSystemDescription() {
+        let errors: [any Error] = [URLError(.notConnectedToInternet),
+            NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoPermissionError),
+            NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError),
+            NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoSuchFileError),
+            NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "RAW SYSTEM MESSAGE"])]
+        for error in errors {
+            let messages = AppLanguage.allCases.map { L($0).userFacingError(error) }
+            XCTAssertEqual(Set(messages).count, AppLanguage.allCases.count)
+            XCTAssertTrue(messages.allSatisfy { !$0.isEmpty && !$0.contains("RAW SYSTEM MESSAGE") })
+        }
+        XCTAssertTrue(L(.ko).userFacingError(errors[0]).contains("네트워크"))
+        XCTAssertTrue(L(.en).userFacingError(errors[1]).contains("access was denied"))
+        XCTAssertTrue(L(.en).userFacingError(errors[2]).contains("disk space"))
+    }
+
+    @MainActor func testStoredErrorsFollowLanguageChangesAndKeepDiagnostics() async {
+        let suite = "localization-errors-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(0, forKey: "refreshInterval")
+        defaults.set(false, forKey: "statusChecksEnabled")
+        let store = UsageStore(providers: [ErrorUsageProvider()],
+            claudeLimitsProvider: ErrorClaudeProvider(), codexLimitsProvider: ErrorCodexProvider(),
+            antigravityLimitsProvider: ErrorAntigravityProvider(), sessionKeys: ErrorSessionKeys(),
+            autoRefresh: false, defaults: defaults)
+        XCTAssertNil(store.lastErrorMessage(L(.ko)))
+        store.localizationLanguage = .ko
+        await store.saveSessionKey("not-a-key")
+        await store.refreshLimitTokenFromKeychain()
+        XCTAssertEqual(store.sessionKeyError, L(.ko).sessionKeyMalformedError)
+        XCTAssertEqual(store.limitTokenRefreshError, L(.ko).sessionKeyExpiredError)
+        store.localizationLanguage = .ja
+        XCTAssertEqual(store.sessionKeyError, L(.ja).sessionKeyMalformedError)
+        XCTAssertEqual(store.limitTokenRefreshError, L(.ja).sessionKeyExpiredError)
+        await store.refresh(scheduleEmptyRetry: false)
+        let diagnostic = store.lastErrorDescription!
+        XCTAssertEqual(store.lastErrorMessage(L(.ko)), L(.ko).usageRefreshError + "\n" + diagnostic)
+        XCTAssertEqual(store.lastErrorMessage(L(.de)), L(.de).usageRefreshError + "\n" + diagnostic)
+        XCTAssertEqual(store.lastErrorDescription, diagnostic)
+    }
+}

--- a/Tests/PokeTokenBarTests/PokemonNameLocalizationTests.swift
+++ b/Tests/PokeTokenBarTests/PokemonNameLocalizationTests.swift
@@ -1,0 +1,161 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import PokeTokenBar
+
+private actor NameServer {
+    private(set) var calls = 0
+    var response: Data
+    var fails = false
+    init(_ response: Data) { self.response = response }
+    func setFailure(_ value: Bool) { fails = value }
+    func fetch(_ url: URL) async throws -> Data {
+        calls += 1
+        try await Task.sleep(nanoseconds: 20_000_000)
+        if fails { throw URLError(.notConnectedToInternet) }
+        return response
+    }
+}
+
+final class PokemonNameLocalizationTests: XCTestCase {
+    private let resource = PokemonNameResource(kind: .move, name: "tackle")
+    private func response(_ values: [String: String]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: ["names": values.map { ["name": $0.value, "language": ["name": $0.key]] }])
+    }
+    private func tempDirectory() throws -> URL {
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent("PokemonNames-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+        return path
+    }
+
+    func testSelectedLanguageThenEnglishWithCurrentAndLegacyCodes() {
+        let names = ["en": "Tackle", "ko": "몸통박치기", "ja-Hrkt": "たいあたり", "ja": "体当たり", "pt_BR": "Investida"]
+        XCTAssertEqual(AppLanguage.ko.resolveName(names), "몸통박치기")
+        XCTAssertEqual(AppLanguage.ja.resolveName(names), "たいあたり")
+        XCTAssertEqual(AppLanguage.pt.resolveName(names), "Investida")
+        XCTAssertEqual(AppLanguage.de.resolveName(names), "Tackle")
+        XCTAssertEqual(AppLanguage.ko.resolveName(["ko": " \n", "en": " Tackle "]), "Tackle")
+        XCTAssertNil(AppLanguage.ko.resolveName(["fr": "Charge"]))
+        XCTAssertEqual(AppLanguage.pt.apiCodes, ["pt-br", "pt"])
+        XCTAssertEqual(AppLanguage.ja.apiCodes, ["ja-hrkt", "ja"])
+        XCTAssertEqual(PokeAPIClient.langCodes, AppLanguage.allCases.flatMap(\.apiCodes))
+    }
+
+    func testParserPreservesFutureLanguagesAndIgnoresEmptyValues() throws {
+        struct Envelope: Decodable { let names: [NameDTO] }
+        let data = try response(["ko": "몸통박치기", "en": "Tackle", "it": "Azione", "pt_BR": "Investida", "": "Bad", "fr": " "])
+        let decoded = try JSONDecoder().decode(Envelope.self, from: data)
+        let names = PokemonNameLocalization.collect(decoded.names)
+        XCTAssertEqual(names["it"], "Azione", "Keep languages outside the current AppLanguage enum")
+        XCTAssertEqual(names["pt-br"], "Investida")
+        XCTAssertNil(names[""])
+        XCTAssertNil(names["fr"])
+        XCTAssertEqual(PokemonNameLocalization.resolve(names, preferredCodes: ["it"]), "Azione")
+        XCTAssertEqual(PokemonNameLocalization.resolve(names, preferredCodes: ["not-yet-supported"]), "Tackle")
+    }
+
+    func testMemoryAndDiskCacheKeepAllLanguagesWithoutRefetchOnLanguageChange() async throws {
+        let directory = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let server = NameServer(try response(["en": "Tackle", "ko": "몸통박치기", "it": "Azione"]))
+        let client = PokemonNameClient(directory: directory, fetch: { try await server.fetch($0) })
+        let first = try await client.names(for: resource)
+        XCTAssertEqual(AppLanguage.ko.resolveName(first), "몸통박치기")
+        let second = try await client.names(for: resource)
+        XCTAssertEqual(AppLanguage.en.resolveName(second), "Tackle")
+        let restored = PokemonNameClient(directory: directory, fetch: { try await server.fetch($0) })
+        let disk = try await restored.names(for: resource)
+        XCTAssertEqual(PokemonNameLocalization.resolve(disk, preferredCodes: ["it"]), "Azione")
+        let calls = await server.calls
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testDuplicateVisibleRowsShareOneRequest() async throws {
+        let resource = self.resource
+        let server = NameServer(try response(["en": "Tackle", "ko": "몸통박치기"]))
+        let client = PokemonNameClient(directory: nil, fetch: { try await server.fetch($0) })
+        async let a = client.names(for: resource)
+        async let b = client.names(for: resource)
+        let values = try await (a, b)
+        XCTAssertEqual(values.0, values.1)
+        let calls = await server.calls
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testExpiredDiskSurvivesOfflineAndDoesNotBecomeFresh() async throws {
+        let directory = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let time = Date(timeIntervalSince1970: 1_800_000_000)
+        let server = NameServer(try response(["en": "Tackle", "ko": "몸통박치기"]))
+        let initial = PokemonNameClient(directory: directory, now: { time }, fetch: { try await server.fetch($0) })
+        _ = try await initial.names(for: resource)
+        await server.setFailure(true)
+        let stale = PokemonNameClient(directory: directory, now: { time.addingTimeInterval(31 * 86400) }, fetch: { try await server.fetch($0) })
+        let offline = try await stale.names(for: resource)
+        XCTAssertEqual(AppLanguage.ko.resolveName(offline), "몸통박치기")
+        await server.setFailure(false)
+        _ = try await stale.names(for: resource)
+        let calls = await server.calls
+        XCTAssertEqual(calls, 3, "Offline fallback must preserve the original timestamp so it can recover")
+    }
+
+    func testColdFailureCanRetryAndInvalidResourceNeverFetches() async throws {
+        let server = NameServer(try response(["en": "Tackle"]))
+        await server.setFailure(true)
+        let client = PokemonNameClient(directory: nil, fetch: { try await server.fetch($0) })
+        do { _ = try await client.names(for: resource); XCTFail("Expected network failure") } catch { }
+        await server.setFailure(false)
+        let recovered = try await client.names(for: resource)
+        XCTAssertEqual(recovered["en"], "Tackle")
+        for name in ["", "../move/tackle", "tackle?language=ko", "tackle/../../"] {
+            do {
+                _ = try await client.names(for: .init(kind: .move, name: name))
+                XCTFail("Invalid resource must fail")
+            } catch { }
+        }
+        let calls = await server.calls
+        XCTAssertEqual(calls, 2)
+    }
+
+    func testResourceKindsDoNotCollideAndCorruptCacheRefetches() async throws {
+        let directory = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Data("broken".utf8).write(to: directory.appendingPathComponent("move-tackle.json"))
+        let server = NameServer(try response(["en": "Tackle"]))
+        let client = PokemonNameClient(directory: directory, fetch: { try await server.fetch($0) })
+        _ = try await client.names(for: resource)
+        _ = try await client.names(for: .init(kind: .ability, name: "tackle"))
+        _ = try await client.names(for: .init(kind: .type, name: "tackle"))
+        let calls = await server.calls
+        XCTAssertEqual(calls, 3)
+    }
+
+    @MainActor
+    func testRenderedNamesResolveLanguageAndEnglishFallbackWithoutChangingKeys() throws {
+        let ability = PokemonNameResource(kind: .ability, name: "overgrow")
+        let type = PokemonNameResource(kind: .type, name: "grass")
+        let maps = [resource: ["en": "Tackle", "ko": "몸통박치기", "ja-hrkt": "たいあたり", "es": "Placaje", "fr": "Charge", "de": "Tackle"],
+                    ability: ["en": "Overgrow", "ko": "심록"], type: ["en": "Grass", "ko": "풀"]]
+        let items = [PokemonNameItem(resource: ability), PokemonNameItem(resource: resource), PokemonNameItem(resource: type)]
+        let korean = PokemonNameText(items: items, language: .ko, names: maps)
+        XCTAssertEqual(korean.text, "심록 · 몸통박치기 · 풀")
+        XCTAssertEqual(PokemonNameText(items: items, language: .pt, names: maps).text, "Overgrow · Tackle · Grass")
+        XCTAssertEqual(PokemonNameText(items: items, language: .ko, names: [:]).text, "Overgrow · Tackle · Grass")
+        let hidden = PokemonNameText(items: [.init(resource: ability, suffix: " (숨겨진 특성)")], language: .ko, names: maps)
+        XCTAssertEqual(hidden.text, "심록 (숨겨진 특성)")
+        XCTAssertEqual(items[0].resource.name, "overgrow", "Translated labels never replace persistent identifiers")
+        for language in AppLanguage.allCases {
+            let view = PokemonNameText(items: items, language: language, names: maps)
+                .padding(16).frame(width: 320).foregroundStyle(.black).background(Color.white)
+            let renderer = ImageRenderer(content: view)
+            renderer.scale = 2
+            let image = try XCTUnwrap(renderer.cgImage)
+            XCTAssertEqual(image.width, 640)
+            XCTAssertGreaterThan(image.height, 40)
+            if language == .ko, let path = ProcessInfo.processInfo.environment["PTB_NAMES_PREVIEW"] {
+                let bitmap = NSBitmapImageRep(cgImage: image)
+                try XCTUnwrap(bitmap.representation(using: .png, properties: [:])).write(to: URL(fileURLWithPath: path))
+            }
+        }
+    }
+}

--- a/Tests/PokeTokenBarTests/SaveTransferTests.swift
+++ b/Tests/PokeTokenBarTests/SaveTransferTests.swift
@@ -721,9 +721,9 @@ final class SaveTransferTests: XCTestCase {
                 XCTAssertFalse(message.contains("couldn't be completed"), "원문 노출: \(message)")
             }
         }
-        // 그 외 오류는 시스템 문구로 폴백(파일 읽기 실패 등).
+        // File errors also use the selected app language.
         let other = NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoSuchFileError)
-        XCTAssertEqual(L(.en).importErrorMessage(other), other.localizedDescription)
+        XCTAssertEqual(L(.en).importErrorMessage(other), L(.en).userFacingError(other))
     }
 
     func testSuggestedFileNameCarriesDate() {

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -25,6 +25,16 @@ read_when:
 
 ## 판정·데이터
 
+- **Localized metadata names must not replace persistent API identifiers.** The dex rendered
+  ability, move, and type slugs directly, while existing tests covered species names and profile
+  metadata rather than these visible labels. All five detail-view name sites now use a shared
+  selected-language → English resolver, with a formatted identifier only before names are available.
+  Preserve every API language in the cache, normalize legacy language-code casing, and derive
+  supported API codes from `AppLanguage` so future languages need no second allowlist.
+  Fetch names from mounted detail rows rather than profile preparation. `PokemonNameLocalizationTests`
+  covers locale selection, missing translations, future languages, native text rendering, request
+  reuse, disk restoration, and offline retry without changing profile identifiers.
+
 - **Cost availability is not a numeric zero.** Codex providers overwrote priced totals with zero
   while leaving cost UI enabled; earlier tests asserted that subscription policy instead of
   comparing the public provider result with priced log entries. Preserve explicit source zero,

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -38,6 +38,16 @@ read_when:
   are not complete multilingual responses. `DexNameMigrationTests` covers legacy JSON, duplicate
   catches, offline/partial recovery, progress preservation, and an unavailable language that must
   not trigger repeated fetches. Restoring the old nil-only backfill filter makes the regression fail.
+  Catch-log rows must resolve legacy entries even when old names exist, and prefer persisted
+  multilingual names over previously rendered strings after a language change.
+
+- **Translate at display time, including errors and accessibility labels.** Storing translated
+  error strings left session-key and quota-refresh failures in the previous language. Store the
+  failure and resolve it through the shared language selector. `LocalizationErrorsTests` switches
+  languages while a real store error remains visible and checks diagnostic preservation.
+  English UI literals bypassed the Hangul-only source guard; `LanguageSurfaceRegressionTests`
+  now covers usage labels, hidden control labels, selected-language backup dates, and Gen-V
+  `light-ball-egg`/`form-change` methods alongside native rendering in all supported languages.
 
 - **Cost availability is not a numeric zero.** Codex providers overwrote priced totals with zero
   while leaving cost UI enabled; earlier tests asserted that subscription policy instead of

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -34,6 +34,10 @@ read_when:
   Fetch names from mounted detail rows rather than profile preparation. `PokemonNameLocalizationTests`
   covers locale selection, missing translations, future languages, native text rendering, request
   reuse, disk restoration, and offline retry without changing profile identifiers.
+  Existing saves need a name-cache version as well: nonempty dictionaries from the old allowlist
+  are not complete multilingual responses. `DexNameMigrationTests` covers legacy JSON, duplicate
+  catches, offline/partial recovery, progress preservation, and an unavailable language that must
+  not trigger repeated fetches. Restoring the old nil-only backfill filter makes the regression fail.
 
 - **Cost availability is not a numeric zero.** Codex providers overwrote priced totals with zero
   while leaving cost UI enabled; earlier tests asserted that subscription policy instead of

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -23,6 +23,7 @@ LOGIC_CORE=(
   "Sources/PokeTokenBar/Core/CompanionStore.swift"
   "Sources/PokeTokenBar/Core/PokemonProfile.swift"
   "Sources/PokeTokenBar/Core/PokemonNameLocalization.swift"
+  "Sources/PokeTokenBar/Core/LocalizationErrors.swift"
   "Sources/PokeTokenBar/Core/UsageStore.swift"
   "Sources/PokeTokenBar/Core/Models.swift"
   "Sources/PokeTokenBar/Core/UsageCost.swift"

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -22,6 +22,7 @@ LOGIC_CORE=(
   "Sources/PokeTokenBar/Core/CompanionModel.swift"
   "Sources/PokeTokenBar/Core/CompanionStore.swift"
   "Sources/PokeTokenBar/Core/PokemonProfile.swift"
+  "Sources/PokeTokenBar/Core/PokemonNameLocalization.swift"
   "Sources/PokeTokenBar/Core/UsageStore.swift"
   "Sources/PokeTokenBar/Core/Models.swift"
   "Sources/PokeTokenBar/Core/UsageCost.swift"


### PR DESCRIPTION
## Summary

Pokemon detail names now use the selected language, falling back to English when a translation is unavailable. Ability, move, and type names are loaded on demand and cached with every language returned by the API.

Legacy dex names are refreshed once without changing collection progress. Offline and partial responses preserve saved names, and duplicate catch rows share their request. Remaining UI labels, backup dates, errors, and accessible control names now follow the selected language. Repository instructions also require using the PR template for future descriptions.

Validation: `swift build` passed. The full Swift test gate completed 1,065 tests with 12 opt-in tests skipped and zero failures; core line coverage was 92.74%. Native rendering was checked in all seven supported languages. Regression tests cover legacy saves, offline recovery, concurrent rows, cache reuse, and language changes with visible errors. Temporarily restoring English-first lookup and the old nil-only migration filter caused the corresponding regression tests to fail.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## UI changes

| Before | After |
| ------ | ----- |
| Ability, move, and type names displayed English identifiers. | Names use the selected language, with English fallback; cached names remain available offline. |
| Special move-learning methods displayed `light ball egg` and `form change`. | Both methods have labels in all seven supported languages. |
| Usage categories and website/sponsor links were fixed English strings. | Labels are localized; usage categories occupy two rows to accommodate translated text. |
| Legacy saved dex names never fetched newly supported languages. | Existing entries refresh their multilingual names once while preserving collection progress. |
| Backup dates could use the system language, and existing errors retained the previous language. | Backup dates use the selected language; persistent errors update when the language changes, with original diagnostics preserved. |
| Several hidden control labels and evolution navigation buttons lacked localized accessible names. | Settings controls and navigation buttons expose localized accessible names. |

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change
