### PR TITLE
feat: tell shoppers what a released Pokémon keeps

### DIFF
--- a/Sources/PokeTokenBar/Core/Localization.swift
+++ b/Sources/PokeTokenBar/Core/Localization.swift
@@ -991,6 +991,24 @@ struct L {
           "Disponível quando seu ovo atual chocar.",
           "Verfügbar, sobald dein aktuelles Ei geschlüpft ist.")
     }
+    /// 놓아주면 무엇이 남는지 — `eggDescription` 바로 아래 줄(EggCard).
+    ///
+    /// 경고가 아니라 **안심**이 목적이다. `eggDescription` 이 "놓아준다"까지만 말해서 도감까지 잃는다고
+    /// 읽히지만, `buyEgg` 는 `releasedDexEntry` 로 도감에 남긴다.
+    ///
+    /// "같은 확률"은 비유가 아니라 실제 수치다. `chooseBase` 의 가중치는 이미 수집한 base 를 ½ 로
+    /// 깎는데(미수집 부스트), 그 판정인 `collectedFinals` 는 졸업에서만 채워지고 놓아줌에선 그대로다
+    /// → 놓아준 종의 부화 가중치는 100% 를 유지한다. 재인큐베이션은 말하지 않는다(`eggDescription`
+    /// 의 "새 알로 다시 시작해요" 와 중복).
+    var eggReleaseNote: String {
+        t("놓아준 포켓몬도 도감에 남고, 같은 확률로 다시 만날 수 있어요. 키운 진행도만 사라져요.",
+          "A released Pokémon stays in your Pokédex and can hatch again at the same odds — only the growth progress is lost.",
+          "手放したポケモンも図鑑に残り、同じ確率でまた出会えます。失われるのは育てた進み具合だけです。",
+          "El Pokémon liberado permanece en la Pokédex y puede volver a salir con la misma probabilidad; solo se pierde el progreso de crianza.",
+          "Un Pokémon relâché reste dans le Pokédex et peut réapparaître avec la même probabilité ; seule la progression est perdue.",
+          "O Pokémon solto continua na Pokédex e pode voltar a aparecer com a mesma chance; só o progresso de criação se perde.",
+          "Ein freigelassenes Pokémon bleibt im Pokédex und kann mit gleicher Wahrscheinlichkeit wieder schlüpfen; nur der Aufzuchtfortschritt geht verloren.")
+    }
     /// 인큐베이션 중 표시하는 보증 배지 — 어떤 알을 품고 있는지 한 줄로.
     func eggGuaranteeHint(_ tier: Rarity) -> String {
         let r = rarityLabel(tier)

--- a/Sources/PokeTokenBar/UI/ShopView.swift
+++ b/Sources/PokeTokenBar/UI/ShopView.swift
@@ -162,6 +162,15 @@ private struct EggCard: View {
                     Text(l.eggDescription(tier))
                         .font(.caption).foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
+                    // "놓아준다" 바로 아래 — 무엇을 잃는지 읽은 자리에서 무엇이 남는지 이어 읽게 한다.
+                    // 가격 줄이 아니라 여기인 이유: 이건 가격·구매 가능 여부와 무관한 상품 설명이고,
+                    // 아래쪽은 버튼과 `eggShopLockedHint`(왜 못 사는지) 가 쓰는 자리다.
+                    // 놓아줄 대상이 있을 때만 — 알 상태에선 할 말이 아니다.
+                    if store.hasActive {
+                        Text(l.eggReleaseNote)
+                            .font(.caption2).foregroundStyle(.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
                 Spacer()
             }


### PR DESCRIPTION
## Why

I bought an egg expecting to lose the Pokémon I was raising — and specifically expecting it to disappear from my Pokédex. Reading the code afterwards, I was wrong on both counts that matter.

The card says only *"Send off your current Pokémon and start fresh with a new egg."* Nothing follows it, so "send off" reads as "lose it", and the shiny warning sitting right next to it reinforces that something irreversible is happening.

What actually happens:

- `buyEgg()` appends `releasedDexEntry(from:)` before clearing the active Pokémon, so the species stays in the Pokédex. `FreshEggTests.testReleasedSpeciesStaysInTheDex` locks this in.
- `chooseBase()` halves the hatch weight of any base whose line you have already completed. That check reads `collectedFinals`, which only `graduate()` fills — releasing leaves it untouched, so a released Pokémon keeps its full weight and can hatch again at the same odds.

The one thing you do give up is the growth progress. The shop says none of this, so the card reads scarier than the feature is.


![Egg card, before and after](https://raw.githubusercontent.com/LuceteYang/PikaTokenBar/pr-assets/pr/egg-release-note.png)


And in Korean, where the description fits on one line so the note costs two:

![Egg card in Korean, before and after](https://raw.githubusercontent.com/LuceteYang/PikaTokenBar/pr-assets/pr/egg-release-note-ko.png)

<sub>Rendered the same way as `scripts/gen-settings-screenshots.py` does its assets — the popover cannot be opened from a script, so the card is drawn in HTML with the colours and metrics sampled from `assets/screenshot-shop.png` / `-ko.png`.</sub>

## What changes

Adds `eggReleaseNote` right under `eggDescription`:

> A released Pokémon stays in your Pokédex and can hatch again at the same odds — only the growth progress is lost.

It goes in the description column rather than the price row, which belongs to the price, the button and `eggShopLockedHint`. Rendered only while there is a Pokémon to release. Translated for all seven languages.

Re-incubation is deliberately left out — `eggDescription` already says the new egg starts from scratch, and repeating it pushed the German string to three lines.

## Testing

`swift build` and `swift test` (1048 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
