### PR TITLE
fix: align quota percentages at the trailing edge

### DIFF
--- a/Sources/PokeTokenBar/UI/PopoverView.swift
+++ b/Sources/PokeTokenBar/UI/PopoverView.swift
@@ -452,27 +452,9 @@ struct PopoverView: View {
         }
     }
 
-    @ViewBuilder
     private func antigravityBucketRow(_ bucket: AntigravityQuotaBucket) -> some View {
-        let name = l.antigravityWindow(window: bucket.window, bucketId: bucket.bucketId)
-        let utilization = bucket.usedPercent
-        VStack(alignment: .leading, spacing: 2) {
-            HStack {
-                Text(name)
-                    .font(.callout)
-                Spacer()
-                Text(limitPercentText(utilization))
-                    .font(.callout)
-                    .monospacedDigit()
-                    .foregroundStyle(limitColor(utilization))
-                if let reset = bucket.resetDate {
-                    resetLabel(reset)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-            }
-            LimitProgressBar(usedPercent: utilization, tint: limitColor(utilization))
-        }
+        quotaRow(name: l.antigravityWindow(window: bucket.window, bucketId: bucket.bucketId),
+                 utilization: bucket.usedPercent, reset: bucket.resetDate)
     }
 
     @ViewBuilder
@@ -550,29 +532,40 @@ struct PopoverView: View {
         return Text(" (\(f.string(from: reset)))")
     }
     private func resetLabel(_ reset: Date) -> Text {
-        Text("· \(reset, style: .relative)") + resetClockSuffix(reset)
+        Text("\(reset, style: .relative)") + resetClockSuffix(reset)
     }
 
     @ViewBuilder
     private func limitRow(name: String, window: LimitWindow?) -> some View {
         if let window, let utilization = window.utilization {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack {
-                    Text(name)
-                        .font(.callout)
-                    Spacer()
-                    Text(limitPercentText(utilization))
-                        .font(.callout)
+            quotaRow(name: name, utilization: utilization, reset: window.resetDate)
+        }
+    }
+
+    /// All quota types share the same trailing percentage alignment.
+    private func quotaRow(name: String, utilization: Double, reset: Date?,
+                          detail: String? = nil) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(name).font(.callout)
+                Spacer()
+                if let detail {
+                    Text(detail)
+                        .font(.caption)
                         .monospacedDigit()
-                        .foregroundStyle(limitColor(utilization))
-                    if let reset = window.resetDate {
-                        resetLabel(reset)
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
+                        .foregroundStyle(.secondary)
                 }
-                LimitProgressBar(usedPercent: utilization, tint: limitColor(utilization))
+                if let reset {
+                    resetLabel(reset)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                Text(limitPercentText(utilization))
+                    .font(.callout)
+                    .monospacedDigit()
+                    .foregroundStyle(limitColor(utilization))
             }
+            LimitProgressBar(usedPercent: utilization, tint: limitColor(utilization))
         }
     }
 
@@ -724,50 +717,15 @@ struct PopoverView: View {
     @ViewBuilder
     private func codexLimitRow(name: String, window: CodexRateLimitWindow?) -> some View {
         if let window {
-            let utilization = Double(window.usedPercent)
-            VStack(alignment: .leading, spacing: 2) {
-                HStack {
-                    Text(name)
-                        .font(.callout)
-                    Spacer()
-                    Text(limitPercentText(utilization))
-                        .font(.callout)
-                        .monospacedDigit()
-                        .foregroundStyle(limitColor(utilization))
-                    if let reset = window.resetDate {
-                        resetLabel(reset)
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
-                }
-                LimitProgressBar(usedPercent: utilization, tint: limitColor(utilization))
-            }
+            quotaRow(name: name, utilization: Double(window.usedPercent), reset: window.resetDate)
         }
     }
 
     @ViewBuilder
     private func codexSpendLimitRow(_ limit: CodexSpendControlLimit?) -> some View {
         if let limit {
-            let utilization = Double(limit.usedPercent)
-            VStack(alignment: .leading, spacing: 2) {
-                HStack {
-                    Text(l.personalSpendLimit)
-                        .font(.callout)
-                    Spacer()
-                    Text("\(limit.used) / \(limit.limit)")
-                        .font(.caption)
-                        .monospacedDigit()
-                        .foregroundStyle(.secondary)
-                    Text(limitPercentText(utilization))
-                        .font(.callout)
-                        .monospacedDigit()
-                        .foregroundStyle(limitColor(utilization))
-                    resetLabel(limit.resetDate)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-                LimitProgressBar(usedPercent: utilization, tint: limitColor(utilization))
-            }
+            quotaRow(name: l.personalSpendLimit, utilization: Double(limit.usedPercent),
+                     reset: limit.resetDate, detail: "\(limit.used) / \(limit.limit)")
         }
     }
 


### PR DESCRIPTION
## Summary

Keep the colored quota percentage at the right edge of every popover quota row, regardless of reset-time length. Consolidate the existing Claude, Codex, Antigravity, model-specific, and spend-limit rows into one shared layout.

Percentage calculations, colors, and progress-bar behavior remain unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## UI changes

| Before | After |
| ------ | ----- |
| The percentage appeared before the reset time, so its horizontal position varied with the time label. | The reset time appears before the percentage, which stays at the right edge. |
| Each quota type duplicated its row layout. | All existing quota rows use the same layout, including spend limits and model-specific windows. |

## Validation

- Full test gate: 1,065 tests, 12 skipped, 0 failures; core line coverage 92.74% (75% minimum).
- Rendered the actual SwiftUI popover with synthetic Claude, Codex, and Antigravity data, short and long reset times, and a spend limit; checked percentage alignment.
- Release build passed. Installed and launched on macOS; code signature verification passed and the installed executable matched the built executable.
- No permanent tests were added for this layout-only change; the rendering check used a temporary test harness.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [ ] Tests were added or updated for this change
