### PR TITLE
fix: avoid English flashes while loading Pokemon detail names

### DIFF
--- a/Sources/PokeTokenBar/UI/PokemonNameLabel.swift
+++ b/Sources/PokeTokenBar/UI/PokemonNameLabel.swift
@@ -11,14 +11,38 @@ struct PokemonNameText: View {
     let items: [PokemonNameItem]
     let language: AppLanguage
     let names: [PokemonNameResource: [String: String]]
+    var failed: Set<PokemonNameResource> = []
 
     var text: String {
         items.map { item in
-            (language.resolveName(names[item.resource] ?? [:])
-             ?? PokemonNameLocalization.identifier(item.resource.name)) + item.suffix
+            guard let translations = names[item.resource] else {
+                return (failed.contains(item.resource)
+                        ? PokemonNameLocalization.identifier(item.resource.name) : "…") + item.suffix
+            }
+            return (language.resolveName(translations)
+                    ?? PokemonNameLocalization.identifier(item.resource.name)) + item.suffix
         }.joined(separator: " · ")
     }
     var body: some View { Text(text) }
+}
+
+/// Synchronous presentation snapshot: reopening a detail starts with the last translated names.
+/// The API client still owns disk caching, request deduplication, and freshness checks.
+@MainActor @Observable
+final class PokemonNameDisplayStore {
+    static let shared = PokemonNameDisplayStore()
+    private(set) var names: [PokemonNameResource: [String: String]] = [:]
+
+    func load(_ resource: PokemonNameResource, provider: any PokemonNameProviding) async -> Bool {
+        do {
+            let translations = try await provider.names(for: resource)
+            guard !Task.isCancelled else { return false }
+            names[resource] = translations
+            return true
+        } catch {
+            return false
+        }
+    }
 }
 
 /// Only mounted rows fetch names, following the LazyVStack's lazy row creation.
@@ -28,7 +52,8 @@ struct PokemonNameLabel: View {
     let items: [PokemonNameItem]
     let language: AppLanguage
     var provider: any PokemonNameProviding = PokemonNameClient.shared
-    @State private var names: [PokemonNameResource: [String: String]] = [:]
+    var displayStore = PokemonNameDisplayStore.shared
+    @State private var failed: Set<PokemonNameResource> = []
 
     init(_ kind: PokemonNameResource.Kind, _ name: String, language: AppLanguage, suffix: String = "") {
         items = [PokemonNameItem(resource: .init(kind: kind, name: name), suffix: suffix)]
@@ -41,15 +66,16 @@ struct PokemonNameLabel: View {
     }
 
     var body: some View {
-        PokemonNameText(items: items, language: language, names: names)
+        PokemonNameText(items: items, language: language, names: displayStore.names, failed: failed)
             .task(id: items.map(\.resource)) {
-                await withTaskGroup(of: (PokemonNameResource, [String: String]?).self) { group in
+                failed.subtract(items.map(\.resource))
+                await withTaskGroup(of: (PokemonNameResource, Bool).self) { group in
                     for resource in Set(items.map(\.resource)) {
-                        group.addTask { (resource, try? await provider.names(for: resource)) }
+                        group.addTask { (resource, await displayStore.load(resource, provider: provider)) }
                     }
-                    for await (resource, translations) in group {
+                    for await (resource, loaded) in group {
                         guard !Task.isCancelled else { return }
-                        if let translations { names[resource] = translations }
+                        if !loaded { failed.insert(resource) }
                     }
                 }
             }

--- a/Tests/PokeTokenBarTests/PokemonNameLocalizationTests.swift
+++ b/Tests/PokeTokenBarTests/PokemonNameLocalizationTests.swift
@@ -17,6 +17,23 @@ private actor NameServer {
     }
 }
 
+private actor DelayedNameProvider: PokemonNameProviding {
+    private var continuation: CheckedContinuation<[String: String], Never>?
+    private var result: [String: String]?
+    private(set) var started = false
+    func names(for resource: PokemonNameResource) async throws -> [String: String] {
+        started = true
+        if let result { return result }
+        return await withCheckedContinuation { continuation = $0 }
+    }
+    func finish() {
+        let names = ["en": "Tackle", "ko": "몸통박치기"]
+        result = names
+        continuation?.resume(returning: names)
+        continuation = nil
+    }
+}
+
 final class PokemonNameLocalizationTests: XCTestCase {
     private let resource = PokemonNameResource(kind: .move, name: "tackle")
     private func response(_ values: [String: String]) throws -> Data {
@@ -131,6 +148,108 @@ final class PokemonNameLocalizationTests: XCTestCase {
     }
 
     @MainActor
+    func testMountedLabelLoadsTranslationsAndReopensWithoutEnglishFrame() async throws {
+        let provider = DelayedNameProvider()
+        let store = PokemonNameDisplayStore()
+        var label = PokemonNameLabel(.move, "tackle", language: .ko)
+        label.provider = provider
+        label.displayStore = store
+        let root = label.frame(width: 320, height: 80).foregroundStyle(.black).background(Color.white)
+        let host = NSHostingView(rootView: root)
+        host.frame = NSRect(x: 0, y: 0, width: 320, height: 80)
+        let window = NSWindow(contentRect: NSRect(x: -10000, y: -10000, width: 320, height: 80),
+                              styleMask: .borderless, backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentView = host
+        window.orderFront(nil)
+        defer { window.close() }
+        func snapshot(_ view: NSView) throws -> Data {
+            view.layoutSubtreeIfNeeded()
+            let bitmap = try XCTUnwrap(view.bitmapImageRepForCachingDisplay(in: view.bounds))
+            view.cacheDisplay(in: view.bounds, to: bitmap)
+            return try XCTUnwrap(bitmap.representation(using: .png, properties: [:]))
+        }
+        for _ in 0..<200 {
+            if await provider.started { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        let started = await provider.started
+        XCTAssertTrue(started, "The mounted label must execute its own task")
+        let pending = try snapshot(host)
+        XCTAssertTrue(store.names.isEmpty)
+        await provider.finish()
+        var translated = pending
+        for _ in 0..<200 {
+            try await Task.sleep(for: .milliseconds(5))
+            translated = try snapshot(host)
+            if translated != pending { break }
+        }
+        XCTAssertEqual(store.names[resource]?["ko"], "몸통박치기")
+        XCTAssertNotEqual(translated, pending, "Observable snapshot must update the mounted label")
+        let reopened = NSHostingView(rootView: root)
+        reopened.frame = host.frame
+        window.contentView = reopened
+        // Snapshot synchronously, before the new view's task can load anything.
+        XCTAssertEqual(try snapshot(reopened), translated)
+        if let path = ProcessInfo.processInfo.environment["PTB_NAMES_PREVIEW"] {
+            try pending.write(to: URL(fileURLWithPath: path + ".pending.png"))
+            try translated.write(to: URL(fileURLWithPath: path + ".loaded.png"))
+        }
+    }
+
+    @MainActor
+    func testCancelledLoadDoesNotPublishSnapshot() async throws {
+        let provider = DelayedNameProvider()
+        let store = PokemonNameDisplayStore()
+        let resource = self.resource
+        let task = Task { await store.load(resource, provider: provider) }
+        for _ in 0..<200 {
+            if await provider.started { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        task.cancel()
+        await provider.finish()
+        let loaded = await task.value
+        XCTAssertFalse(loaded)
+        XCTAssertTrue(store.names.isEmpty)
+    }
+
+    @MainActor
+    func testLoadingNamesNeverShowsEnglishAndReopeningUsesSnapshot() async throws {
+        let server = NameServer(try response(["en": "Tackle", "ko": "몸통박치기"]))
+        let client = PokemonNameClient(directory: nil, fetch: { try await server.fetch($0) })
+        let store = PokemonNameDisplayStore()
+        let items = [PokemonNameItem(resource: resource)]
+        let pending = PokemonNameText(items: items, language: .ko, names: store.names)
+        XCTAssertEqual(pending.text, "…")
+        let loaded = await store.load(resource, provider: client)
+        XCTAssertTrue(loaded)
+        // A newly created view can resolve the snapshot synchronously, before its .task runs.
+        XCTAssertEqual(PokemonNameText(items: items, language: .ko, names: store.names).text, "몸통박치기")
+        XCTAssertEqual(PokemonNameText(items: items, language: .en, names: store.names).text, "Tackle")
+        XCTAssertEqual(PokemonNameText(items: items, language: .pt, names: store.names).text, "Tackle")
+        let joined = items + [PokemonNameItem(resource: .init(kind: .type, name: "grass"))]
+        XCTAssertEqual(PokemonNameText(items: joined, language: .ko, names: store.names).text, "몸통박치기 · …")
+    }
+
+    @MainActor
+    func testFailedNameLoadFallsBackAndRetryRestoresTranslation() async throws {
+        let server = NameServer(try response(["en": "Tackle", "ko": "몸통박치기"]))
+        await server.setFailure(true)
+        let client = PokemonNameClient(directory: nil, fetch: { try await server.fetch($0) })
+        let store = PokemonNameDisplayStore()
+        let items = [PokemonNameItem(resource: resource)]
+        let loaded = await store.load(resource, provider: client)
+        XCTAssertFalse(loaded)
+        XCTAssertNil(store.names[resource], "A failed request must not poison the shared snapshot")
+        XCTAssertEqual(PokemonNameText(items: items, language: .ko, names: store.names, failed: [resource]).text, "Tackle")
+        await server.setFailure(false)
+        let retried = await store.load(resource, provider: client)
+        XCTAssertTrue(retried)
+        XCTAssertEqual(PokemonNameText(items: items, language: .ko, names: store.names, failed: [resource]).text, "몸통박치기")
+    }
+
+    @MainActor
     func testRenderedNamesResolveLanguageAndEnglishFallbackWithoutChangingKeys() throws {
         let ability = PokemonNameResource(kind: .ability, name: "overgrow")
         let type = PokemonNameResource(kind: .type, name: "grass")
@@ -140,7 +259,7 @@ final class PokemonNameLocalizationTests: XCTestCase {
         let korean = PokemonNameText(items: items, language: .ko, names: maps)
         XCTAssertEqual(korean.text, "심록 · 몸통박치기 · 풀")
         XCTAssertEqual(PokemonNameText(items: items, language: .pt, names: maps).text, "Overgrow · Tackle · Grass")
-        XCTAssertEqual(PokemonNameText(items: items, language: .ko, names: [:]).text, "Overgrow · Tackle · Grass")
+        XCTAssertEqual(PokemonNameText(items: items, language: .ko, names: [:]).text, "… · … · …")
         let hidden = PokemonNameText(items: [.init(resource: ability, suffix: " (숨겨진 특성)")], language: .ko, names: maps)
         XCTAssertEqual(hidden.text, "심록 (숨겨진 특성)")
         XCTAssertEqual(items[0].resource.name, "overgrow", "Translated labels never replace persistent identifiers")

--- a/docs/reference/defect-log.md
+++ b/docs/reference/defect-log.md
@@ -28,7 +28,11 @@ read_when:
 - **Localized metadata names must not replace persistent API identifiers.** The dex rendered
   ability, move, and type slugs directly, while existing tests covered species names and profile
   metadata rather than these visible labels. All five detail-view name sites now use a shared
-  selected-language → English resolver, with a formatted identifier only before names are available.
+  selected-language → English resolver, with a formatted identifier only after a completed response or failed request.
+  Pending metadata must show a neutral placeholder, not an English identifier that flashes before
+  translation. Keep a synchronous presentation snapshot for the first frame on detail reentry;
+  the API client remains responsible for freshness. Test pending, loaded, partial, and failed
+  states separately—the old test incorrectly asserted English during loading.
   Preserve every API language in the cache, normalize legacy language-code casing, and derive
   supported API codes from `AppLanguage` so future languages need no second allowlist.
   Fetch names from mounted detail rows rather than profile preparation. `PokemonNameLocalizationTests`


### PR DESCRIPTION
## Summary

Opening a Pokémon detail view briefly showed English identifiers for abilities, types, and moves before the selected-language names arrived. Each label started with an empty state, even when translations were already cached asynchronously.

Show a neutral loading placeholder until the first request completes and share a synchronous presentation snapshot so reopened details display translated names immediately. Keep selected-language → English fallback after a response, and retain identifier fallback on failure. The API client continues to own cache freshness and request deduplication.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## UI changes

| Before | After |
| ------ | ----- |
| Detail metadata initially showed English identifiers, then switched to the selected language. | Unloaded names show `…` until translated names arrive. |
| Reopening a detail could briefly show English again while reading the cache. | Previously loaded translations appear on the first frame. |

## Validation

- Full test gate: 1,069 tests, 12 skipped, 0 failures; core line coverage 92.74% (75% minimum).
- Final targeted run: all 12 name-localization tests passed after refining the delayed-response fixture.
- Mounted the actual label in an `NSHostingView` with a delayed provider; verified the loading-to-translated update and identical translated pixels on synchronous reentry.
- Covered missing-language fallback, partially loaded joined names, failed requests and retry, language changes, and cancellation without publishing stale results.
- Updated the defect log to distinguish pending translations from completed fallback states.

## Checklist

- [x] `swift build` and `swift test` pass locally
- [x] PR title and description are written in English
- [x] UI changes are described above (before/after — images optional)
- [x] No copyrighted assets, secrets, or private tooling references are committed (see [CONTRIBUTING](../CONTRIBUTING.md))
- [x] Tests were added or updated for this change
